### PR TITLE
Add version.txt to instructions.

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -33,6 +33,7 @@ Description: `Conformance results for vX.Y/$dir`
 ```
 vX.Y/$dir/README.md: A script or human-readable description of how to reproduce
 your results.
+vX.Y/$dir/version.txt: Test and cluster versions.
 vX.Y/$dir/e2e.log: Test log output.
 vX.Y/$dir/junit_01.xml: Machine-readable test log.
 vX.Y/$dir/PRODUCT.yaml: See below.


### PR DESCRIPTION
@WilliamDenniss I was incorrect about the version info being in e2e.log.  Apparently it is `kubetest` producing that, and not `e2e.test`.

I have a PR to add the version info (https://github.com/heptio/kube-conformance/pull/6).  I think it's OK to merge this now, as I'd rather no one submit PRs with missing version info in the meantime.