### PR TITLE
Conformance results for v1.8/kube-up-gce

### DIFF
--- a/v1.8/kube-up-gce/PRODUCT.yaml
+++ b/v1.8/kube-up-gce/PRODUCT.yaml
@@ -1,0 +1,5 @@
+ vendor: Google
+ name: kube-up.sh on Google Compute Engine
+ version: v1.8.1
+ website_url: https://github.com/kubernetes/kubernetes/tree/master/cluster
+ documentation_url: https://github.com/kubernetes/kubernetes/tree/master/cluster

--- a/v1.8/kube-up-gce/README.md
+++ b/v1.8/kube-up-gce/README.md
@@ -1,0 +1,18 @@
+To reproduce, with `gcloud` configured, clone `kubernetes/kubernetes`, and then
+
+```console
+$ git checkout v1.8.1
+$ bazel build //build/release-tars
+$ cluster/kube-up.sh
+$ kubectl create -f c.yaml
+$ kubectl logs -f -n sonobuoy sonobuoy
+```
+
+I have included `c.yaml` in this PR.
+Now wait for `no-exit was specified, sonobuoy is now blocking`.
+
+```console
+$ kubectl cp sonobuoy/sonobuoy:/tmp/sonoubuoy ./results
+```
+
+Untar and grab `e2e.log`, `junit_01.xml` and `version.txt`.

--- a/v1.8/kube-up-gce/c.yaml
+++ b/v1.8/kube-up-gce/c.yaml
@@ -1,0 +1,194 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sonobuoy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sonobuoy-serviceaccount
+subjects:
+- kind: ServiceAccount
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: sonobuoy
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: sonobuoy
+data:
+  config.json: |
+    {
+        "Description": "EXAMPLE",
+        "Filters": {
+            "LabelSelector": "",
+            "Namespaces": ".*"
+        },
+        "PluginNamespace": "sonobuoy",
+        "Plugins": [
+            {
+                "name": "e2e"
+            }
+        ],
+        "Resources": [
+        ],
+        "ResultsDir": "/tmp/sonobuoy",
+        "Server": {
+            "advertiseaddress": "sonobuoy-master:8080",
+            "bindaddress": "0.0.0.0",
+            "bindport": 8080,
+            "timeoutseconds": 3600
+        },
+        "Version": "v0.8.0"
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: sonobuoy
+data:
+  e2e.yaml: |
+    driver: Job
+    name: e2e
+    resultType: e2e
+    spec:
+      containers:
+      - env:
+        - name: E2E_FOCUS
+          value: '\[Conformance\]'
+        image: gcr.io/mml-e2e/kube-conformance:v1.8
+        imagePullPolicy: Always
+        name: e2e
+        volumeMounts:
+        - mountPath: /tmp/results
+          name: results
+      - command:
+        - sh
+        - -c
+        - /sonobuoy worker global -v 5 --logtostderr
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: RESULTS_DIR
+          value: /tmp/results
+        image: gcr.io/heptio-images/sonobuoy:latest
+        imagePullPolicy: Always
+        name: sonobuoy-worker
+        volumeMounts:
+        - mountPath: /etc/sonobuoy
+          name: config
+        - mountPath: /tmp/results
+          name: results
+      restartPolicy: Never
+      serviceAccountName: sonobuoy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      volumes:
+      - emptyDir: {}
+        name: results
+      - configMap:
+          name: __SONOBUOY_CONFIGMAP__
+        name: config
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: sonobuoy
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /sonobuoy master --no-exit=true -v 3 --logtostderr
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: gcr.io/heptio-images/sonobuoy:latest
+    imagePullPolicy: Always
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /etc/sonobuoy/plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: sonobuoy
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP
+

--- a/v1.8/kube-up-gce/e2e.log
+++ b/v1.8/kube-up-gce/e2e.log
@@ -1,0 +1,6240 @@
+Oct 31 22:49:03.482: INFO: Overriding default scale value of zero to 1
+Oct 31 22:49:03.482: INFO: Overriding default milliseconds value of zero to 5000
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1509490143 - Will randomize all specs
+Will run 126 of 693 specs
+
+Oct 31 22:49:03.670: INFO: >>> kubeConfig: 
+Oct 31 22:49:03.671: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
+Oct 31 22:49:03.685: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Oct 31 22:49:03.759: INFO: 25 / 25 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Oct 31 22:49:03.759: INFO: expected 9 pod replicas in namespace 'kube-system', 9 are Running and Ready.
+Oct 31 22:49:03.764: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Oct 31 22:49:03.764: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+S
+------------------------------
+[k8s.io] Projected 
+  should provide podname only [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:788
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:49:03.767: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide podname only [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:788
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 22:49:03.797: INFO: Waiting up to 5m0s for pod "downwardapi-volume-b1a19cc1-be8d-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-tjqrt" to be "success or failure"
+Oct 31 22:49:03.807: INFO: Pod "downwardapi-volume-b1a19cc1-be8d-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 9.851895ms
+Oct 31 22:49:05.810: INFO: Pod "downwardapi-volume-b1a19cc1-be8d-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 2.012561388s
+Oct 31 22:49:07.813: INFO: Pod "downwardapi-volume-b1a19cc1-be8d-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016232574s
+STEP: Saw pod success
+Oct 31 22:49:07.813: INFO: Pod "downwardapi-volume-b1a19cc1-be8d-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:49:07.815: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-b1a19cc1-be8d-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 22:49:07.851: INFO: Waiting for pod downwardapi-volume-b1a19cc1-be8d-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:49:07.855: INFO: Pod downwardapi-volume-b1a19cc1-be8d-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:49:07.855: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-tjqrt" for this suite.
+Oct 31 22:49:13.945: INFO: namespace: e2e-tests-projected-tjqrt, resource: bindings, ignored listing per whitelist
+Oct 31 22:49:13.952: INFO: namespace e2e-tests-projected-tjqrt deletion completed in 6.094567798s
+
+• [SLOW TEST:10.185 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide podname only [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:788
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Downward API 
+  should provide pod and host IP as an env var [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:94
+[BeforeEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:49:13.952: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod and host IP as an env var [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:94
+STEP: Creating a pod to test downward api env vars
+Oct 31 22:49:13.981: INFO: Waiting up to 5m0s for pod "downward-api-b7b3ac9d-be8d-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-nm8l8" to be "success or failure"
+Oct 31 22:49:13.986: INFO: Pod "downward-api-b7b3ac9d-be8d-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.059554ms
+Oct 31 22:49:15.989: INFO: Pod "downward-api-b7b3ac9d-be8d-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008205846s
+STEP: Saw pod success
+Oct 31 22:49:15.989: INFO: Pod "downward-api-b7b3ac9d-be8d-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:49:15.990: INFO: Trying to get logs from node kubernetes-minion-group-rv1l pod downward-api-b7b3ac9d-be8d-11e7-82e0-0a580a400306 container dapi-container: <nil>
+STEP: delete the pod
+Oct 31 22:49:16.023: INFO: Waiting for pod downward-api-b7b3ac9d-be8d-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:49:16.025: INFO: Pod downward-api-b7b3ac9d-be8d-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:49:16.025: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-nm8l8" for this suite.
+Oct 31 22:49:22.077: INFO: namespace: e2e-tests-downward-api-nm8l8, resource: bindings, ignored listing per whitelist
+Oct 31 22:49:22.118: INFO: namespace e2e-tests-downward-api-nm8l8 deletion completed in 6.090383855s
+
+• [SLOW TEST:8.166 seconds]
+[k8s.io] Downward API
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide pod and host IP as an env var [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:94
+------------------------------
+S
+------------------------------
+[k8s.io] Downward API 
+  should provide default limits.cpu/memory from node allocatable [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:185
+[BeforeEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:49:22.118: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:185
+STEP: Creating a pod to test downward api env vars
+Oct 31 22:49:22.145: INFO: Waiting up to 5m0s for pod "downward-api-bc9159b1-be8d-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-chs75" to be "success or failure"
+Oct 31 22:49:22.150: INFO: Pod "downward-api-bc9159b1-be8d-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.550255ms
+Oct 31 22:49:24.153: INFO: Pod "downward-api-bc9159b1-be8d-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008377385s
+STEP: Saw pod success
+Oct 31 22:49:24.153: INFO: Pod "downward-api-bc9159b1-be8d-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:49:24.155: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downward-api-bc9159b1-be8d-11e7-82e0-0a580a400306 container dapi-container: <nil>
+STEP: delete the pod
+Oct 31 22:49:24.168: INFO: Waiting for pod downward-api-bc9159b1-be8d-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:49:24.171: INFO: Pod downward-api-bc9159b1-be8d-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:49:24.171: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-chs75" for this suite.
+Oct 31 22:49:30.219: INFO: namespace: e2e-tests-downward-api-chs75, resource: bindings, ignored listing per whitelist
+Oct 31 22:49:30.263: INFO: namespace e2e-tests-downward-api-chs75 deletion completed in 6.090167164s
+
+• [SLOW TEST:8.145 seconds]
+[k8s.io] Downward API
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide default limits.cpu/memory from node allocatable [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:185
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service_latency.go:117
+[BeforeEach] [sig-network] Service endpoints latency
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:49:30.264: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service_latency.go:117
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-46l94
+Oct 31 22:49:31.401: INFO: Created: latency-svc-xw9d2
+Oct 31 22:49:31.403: INFO: Got endpoints: latency-svc-xw9d2 [11.780368ms]
+Oct 31 22:49:31.417: INFO: Created: latency-svc-fsv9g
+Oct 31 22:49:31.419: INFO: Created: latency-svc-cgw4r
+Oct 31 22:49:31.420: INFO: Got endpoints: latency-svc-fsv9g [16.714439ms]
+Oct 31 22:49:31.425: INFO: Created: latency-svc-48x8b
+Oct 31 22:49:31.429: INFO: Got endpoints: latency-svc-cgw4r [25.480599ms]
+Oct 31 22:49:31.431: INFO: Created: latency-svc-vk95r
+Oct 31 22:49:31.434: INFO: Got endpoints: latency-svc-48x8b [29.951368ms]
+Oct 31 22:49:31.436: INFO: Got endpoints: latency-svc-vk95r [32.89487ms]
+Oct 31 22:49:31.439: INFO: Created: latency-svc-sgl6v
+Oct 31 22:49:31.444: INFO: Created: latency-svc-nkprk
+Oct 31 22:49:31.446: INFO: Got endpoints: latency-svc-sgl6v [42.03627ms]
+Oct 31 22:49:31.450: INFO: Created: latency-svc-6lpr9
+Oct 31 22:49:31.452: INFO: Got endpoints: latency-svc-nkprk [47.558602ms]
+Oct 31 22:49:31.457: INFO: Created: latency-svc-wlln6
+Oct 31 22:49:31.459: INFO: Got endpoints: latency-svc-6lpr9 [55.039312ms]
+Oct 31 22:49:31.462: INFO: Got endpoints: latency-svc-wlln6 [57.033999ms]
+Oct 31 22:49:31.465: INFO: Created: latency-svc-gs7df
+Oct 31 22:49:31.468: INFO: Got endpoints: latency-svc-gs7df [64.278445ms]
+Oct 31 22:49:31.471: INFO: Created: latency-svc-6v6sx
+Oct 31 22:49:31.475: INFO: Created: latency-svc-pb8kc
+Oct 31 22:49:31.477: INFO: Got endpoints: latency-svc-6v6sx [72.801681ms]
+Oct 31 22:49:31.483: INFO: Created: latency-svc-jqh4r
+Oct 31 22:49:31.485: INFO: Got endpoints: latency-svc-pb8kc [81.107718ms]
+Oct 31 22:49:31.488: INFO: Got endpoints: latency-svc-jqh4r [83.335245ms]
+Oct 31 22:49:31.492: INFO: Created: latency-svc-bvbhv
+Oct 31 22:49:31.496: INFO: Created: latency-svc-ftn85
+Oct 31 22:49:31.499: INFO: Got endpoints: latency-svc-bvbhv [94.299921ms]
+Oct 31 22:49:31.506: INFO: Created: latency-svc-jhb58
+Oct 31 22:49:31.509: INFO: Got endpoints: latency-svc-ftn85 [105.069541ms]
+Oct 31 22:49:31.515: INFO: Created: latency-svc-6z2rj
+Oct 31 22:49:31.516: INFO: Got endpoints: latency-svc-jhb58 [111.869958ms]
+Oct 31 22:49:31.522: INFO: Created: latency-svc-bghlw
+Oct 31 22:49:31.530: INFO: Got endpoints: latency-svc-6z2rj [110.847571ms]
+Oct 31 22:49:31.569: INFO: Created: latency-svc-482rt
+Oct 31 22:49:31.571: INFO: Got endpoints: latency-svc-bghlw [141.882766ms]
+Oct 31 22:49:31.606: INFO: Created: latency-svc-mqmsq
+Oct 31 22:49:31.618: INFO: Got endpoints: latency-svc-482rt [183.959403ms]
+Oct 31 22:49:31.618: INFO: Created: latency-svc-wt5x5
+Oct 31 22:49:31.626: INFO: Got endpoints: latency-svc-mqmsq [189.18602ms]
+Oct 31 22:49:31.635: INFO: Got endpoints: latency-svc-wt5x5 [189.476879ms]
+Oct 31 22:49:31.653: INFO: Created: latency-svc-7kqcd
+Oct 31 22:49:31.665: INFO: Created: latency-svc-rphkd
+Oct 31 22:49:31.709: INFO: Got endpoints: latency-svc-7kqcd [256.380812ms]
+Oct 31 22:49:31.709: INFO: Got endpoints: latency-svc-rphkd [249.743872ms]
+Oct 31 22:49:31.713: INFO: Created: latency-svc-lcvnr
+Oct 31 22:49:31.720: INFO: Created: latency-svc-lw2xl
+Oct 31 22:49:31.724: INFO: Got endpoints: latency-svc-lcvnr [262.227756ms]
+Oct 31 22:49:31.729: INFO: Got endpoints: latency-svc-lw2xl [260.386609ms]
+Oct 31 22:49:31.746: INFO: Created: latency-svc-kkr7m
+Oct 31 22:49:31.751: INFO: Created: latency-svc-ff9lp
+Oct 31 22:49:31.759: INFO: Created: latency-svc-xsw25
+Oct 31 22:49:31.764: INFO: Got endpoints: latency-svc-ff9lp [278.637865ms]
+Oct 31 22:49:31.764: INFO: Got endpoints: latency-svc-kkr7m [287.202782ms]
+Oct 31 22:49:31.771: INFO: Got endpoints: latency-svc-xsw25 [283.665631ms]
+Oct 31 22:49:31.772: INFO: Created: latency-svc-84tqt
+Oct 31 22:49:31.780: INFO: Created: latency-svc-wzz4p
+Oct 31 22:49:31.782: INFO: Got endpoints: latency-svc-84tqt [283.114596ms]
+Oct 31 22:49:31.800: INFO: Created: latency-svc-zwq9s
+Oct 31 22:49:31.800: INFO: Got endpoints: latency-svc-wzz4p [290.317387ms]
+Oct 31 22:49:31.808: INFO: Created: latency-svc-6cvvc
+Oct 31 22:49:31.810: INFO: Got endpoints: latency-svc-zwq9s [293.860804ms]
+Oct 31 22:49:31.814: INFO: Got endpoints: latency-svc-6cvvc [283.786997ms]
+Oct 31 22:49:31.820: INFO: Created: latency-svc-98dd7
+Oct 31 22:49:31.824: INFO: Created: latency-svc-j49wq
+Oct 31 22:49:31.827: INFO: Got endpoints: latency-svc-98dd7 [256.256222ms]
+Oct 31 22:49:31.830: INFO: Created: latency-svc-ldx7h
+Oct 31 22:49:31.832: INFO: Got endpoints: latency-svc-j49wq [214.354527ms]
+Oct 31 22:49:31.835: INFO: Created: latency-svc-rrbtv
+Oct 31 22:49:31.838: INFO: Got endpoints: latency-svc-ldx7h [212.034539ms]
+Oct 31 22:49:31.843: INFO: Created: latency-svc-8pj8k
+Oct 31 22:49:31.844: INFO: Got endpoints: latency-svc-rrbtv [209.178948ms]
+Oct 31 22:49:31.848: INFO: Created: latency-svc-pp2tp
+Oct 31 22:49:31.851: INFO: Got endpoints: latency-svc-8pj8k [141.79449ms]
+Oct 31 22:49:31.854: INFO: Created: latency-svc-tcsnc
+Oct 31 22:49:31.856: INFO: Got endpoints: latency-svc-pp2tp [147.397341ms]
+Oct 31 22:49:31.860: INFO: Got endpoints: latency-svc-tcsnc [136.52192ms]
+Oct 31 22:49:31.863: INFO: Created: latency-svc-ltg28
+Oct 31 22:49:31.867: INFO: Got endpoints: latency-svc-ltg28 [138.259097ms]
+Oct 31 22:49:31.871: INFO: Created: latency-svc-rfhmv
+Oct 31 22:49:31.874: INFO: Created: latency-svc-dpqdl
+Oct 31 22:49:31.878: INFO: Created: latency-svc-j45wm
+Oct 31 22:49:31.884: INFO: Created: latency-svc-bgjqg
+Oct 31 22:49:31.887: INFO: Created: latency-svc-b7s65
+Oct 31 22:49:31.893: INFO: Created: latency-svc-kbgm7
+Oct 31 22:49:31.897: INFO: Created: latency-svc-dx2bv
+Oct 31 22:49:31.901: INFO: Created: latency-svc-lj8nq
+Oct 31 22:49:31.904: INFO: Got endpoints: latency-svc-rfhmv [140.222301ms]
+Oct 31 22:49:31.909: INFO: Created: latency-svc-xktqp
+Oct 31 22:49:31.913: INFO: Created: latency-svc-m79x7
+Oct 31 22:49:31.919: INFO: Created: latency-svc-58fzx
+Oct 31 22:49:31.922: INFO: Created: latency-svc-xgdwf
+Oct 31 22:49:31.927: INFO: Created: latency-svc-bn9x8
+Oct 31 22:49:31.931: INFO: Created: latency-svc-gbk78
+Oct 31 22:49:31.936: INFO: Created: latency-svc-prvrt
+Oct 31 22:49:31.939: INFO: Created: latency-svc-xcwg6
+Oct 31 22:49:31.952: INFO: Got endpoints: latency-svc-dpqdl [180.193222ms]
+Oct 31 22:49:31.959: INFO: Created: latency-svc-mls2t
+Oct 31 22:49:32.002: INFO: Got endpoints: latency-svc-j45wm [237.567077ms]
+Oct 31 22:49:32.010: INFO: Created: latency-svc-sgwp4
+Oct 31 22:49:32.053: INFO: Got endpoints: latency-svc-bgjqg [271.148489ms]
+Oct 31 22:49:32.061: INFO: Created: latency-svc-2ck82
+Oct 31 22:49:32.102: INFO: Got endpoints: latency-svc-b7s65 [302.131747ms]
+Oct 31 22:49:32.110: INFO: Created: latency-svc-h64c7
+Oct 31 22:49:32.153: INFO: Got endpoints: latency-svc-kbgm7 [343.478703ms]
+Oct 31 22:49:32.162: INFO: Created: latency-svc-qk4zt
+Oct 31 22:49:32.201: INFO: Got endpoints: latency-svc-dx2bv [386.971098ms]
+Oct 31 22:49:32.211: INFO: Created: latency-svc-dpjtm
+Oct 31 22:49:32.252: INFO: Got endpoints: latency-svc-lj8nq [424.72487ms]
+Oct 31 22:49:32.259: INFO: Created: latency-svc-v88rf
+Oct 31 22:49:32.302: INFO: Got endpoints: latency-svc-xktqp [469.706713ms]
+Oct 31 22:49:32.314: INFO: Created: latency-svc-4zv99
+Oct 31 22:49:32.352: INFO: Got endpoints: latency-svc-m79x7 [514.605443ms]
+Oct 31 22:49:32.363: INFO: Created: latency-svc-x4bx5
+Oct 31 22:49:32.402: INFO: Got endpoints: latency-svc-58fzx [557.062687ms]
+Oct 31 22:49:32.411: INFO: Created: latency-svc-kwxjv
+Oct 31 22:49:32.454: INFO: Got endpoints: latency-svc-xgdwf [602.995487ms]
+Oct 31 22:49:32.464: INFO: Created: latency-svc-q2sd2
+Oct 31 22:49:32.502: INFO: Got endpoints: latency-svc-bn9x8 [645.421603ms]
+Oct 31 22:49:32.509: INFO: Created: latency-svc-2rkxn
+Oct 31 22:49:32.553: INFO: Got endpoints: latency-svc-gbk78 [692.01928ms]
+Oct 31 22:49:32.561: INFO: Created: latency-svc-x7jb7
+Oct 31 22:49:32.603: INFO: Got endpoints: latency-svc-prvrt [735.858954ms]
+Oct 31 22:49:32.610: INFO: Created: latency-svc-sq7t6
+Oct 31 22:49:32.653: INFO: Got endpoints: latency-svc-xcwg6 [748.57633ms]
+Oct 31 22:49:32.662: INFO: Created: latency-svc-2wjkc
+Oct 31 22:49:32.702: INFO: Got endpoints: latency-svc-mls2t [749.867067ms]
+Oct 31 22:49:32.709: INFO: Created: latency-svc-7wsfc
+Oct 31 22:49:32.752: INFO: Got endpoints: latency-svc-sgwp4 [750.214166ms]
+Oct 31 22:49:32.760: INFO: Created: latency-svc-zwc8s
+Oct 31 22:49:32.803: INFO: Got endpoints: latency-svc-2ck82 [749.798087ms]
+Oct 31 22:49:32.812: INFO: Created: latency-svc-4prqc
+Oct 31 22:49:32.851: INFO: Got endpoints: latency-svc-h64c7 [749.239956ms]
+Oct 31 22:49:32.861: INFO: Created: latency-svc-gcwlz
+Oct 31 22:49:32.902: INFO: Got endpoints: latency-svc-qk4zt [748.234345ms]
+Oct 31 22:49:32.910: INFO: Created: latency-svc-qlw9h
+Oct 31 22:49:32.955: INFO: Got endpoints: latency-svc-dpjtm [753.302581ms]
+Oct 31 22:49:32.962: INFO: Created: latency-svc-lslmp
+Oct 31 22:49:33.002: INFO: Got endpoints: latency-svc-v88rf [749.936933ms]
+Oct 31 22:49:33.011: INFO: Created: latency-svc-js4xd
+Oct 31 22:49:33.052: INFO: Got endpoints: latency-svc-4zv99 [749.749192ms]
+Oct 31 22:49:33.063: INFO: Created: latency-svc-dnf7m
+Oct 31 22:49:33.102: INFO: Got endpoints: latency-svc-x4bx5 [749.942646ms]
+Oct 31 22:49:33.111: INFO: Created: latency-svc-9qrhq
+Oct 31 22:49:33.152: INFO: Got endpoints: latency-svc-kwxjv [750.552891ms]
+Oct 31 22:49:33.163: INFO: Created: latency-svc-qnk8z
+Oct 31 22:49:33.202: INFO: Got endpoints: latency-svc-q2sd2 [747.988951ms]
+Oct 31 22:49:33.210: INFO: Created: latency-svc-7pc9z
+Oct 31 22:49:33.252: INFO: Got endpoints: latency-svc-2rkxn [750.020818ms]
+Oct 31 22:49:33.260: INFO: Created: latency-svc-jh2ft
+Oct 31 22:49:33.302: INFO: Got endpoints: latency-svc-x7jb7 [748.940496ms]
+Oct 31 22:49:33.311: INFO: Created: latency-svc-mx67h
+Oct 31 22:49:33.354: INFO: Got endpoints: latency-svc-sq7t6 [751.341934ms]
+Oct 31 22:49:33.364: INFO: Created: latency-svc-rx7kg
+Oct 31 22:49:33.403: INFO: Got endpoints: latency-svc-2wjkc [749.941903ms]
+Oct 31 22:49:33.409: INFO: Created: latency-svc-qj9h4
+Oct 31 22:49:33.458: INFO: Got endpoints: latency-svc-7wsfc [756.199836ms]
+Oct 31 22:49:33.469: INFO: Created: latency-svc-gbrwp
+Oct 31 22:49:33.502: INFO: Got endpoints: latency-svc-zwc8s [749.823788ms]
+Oct 31 22:49:33.510: INFO: Created: latency-svc-v4qmn
+Oct 31 22:49:33.553: INFO: Got endpoints: latency-svc-4prqc [749.919359ms]
+Oct 31 22:49:33.560: INFO: Created: latency-svc-fxgfm
+Oct 31 22:49:33.603: INFO: Got endpoints: latency-svc-gcwlz [751.217168ms]
+Oct 31 22:49:33.615: INFO: Created: latency-svc-wwz77
+Oct 31 22:49:33.653: INFO: Got endpoints: latency-svc-qlw9h [751.471278ms]
+Oct 31 22:49:33.663: INFO: Created: latency-svc-vfw48
+Oct 31 22:49:33.704: INFO: Got endpoints: latency-svc-lslmp [748.863328ms]
+Oct 31 22:49:33.711: INFO: Created: latency-svc-xtnnp
+Oct 31 22:49:33.753: INFO: Got endpoints: latency-svc-js4xd [751.041542ms]
+Oct 31 22:49:33.760: INFO: Created: latency-svc-c7n6p
+Oct 31 22:49:33.811: INFO: Got endpoints: latency-svc-dnf7m [759.084003ms]
+Oct 31 22:49:33.822: INFO: Created: latency-svc-mxqcv
+Oct 31 22:49:33.854: INFO: Got endpoints: latency-svc-9qrhq [751.394564ms]
+Oct 31 22:49:33.862: INFO: Created: latency-svc-tw25k
+Oct 31 22:49:33.901: INFO: Got endpoints: latency-svc-qnk8z [748.851027ms]
+Oct 31 22:49:33.909: INFO: Created: latency-svc-knwng
+Oct 31 22:49:33.952: INFO: Got endpoints: latency-svc-7pc9z [750.164966ms]
+Oct 31 22:49:33.959: INFO: Created: latency-svc-gxxzq
+Oct 31 22:49:34.002: INFO: Got endpoints: latency-svc-jh2ft [749.713832ms]
+Oct 31 22:49:34.009: INFO: Created: latency-svc-kw444
+Oct 31 22:49:34.052: INFO: Got endpoints: latency-svc-mx67h [750.135351ms]
+Oct 31 22:49:34.059: INFO: Created: latency-svc-9hbqt
+Oct 31 22:49:34.102: INFO: Got endpoints: latency-svc-rx7kg [747.644375ms]
+Oct 31 22:49:34.126: INFO: Created: latency-svc-q654s
+Oct 31 22:49:34.153: INFO: Got endpoints: latency-svc-qj9h4 [749.637503ms]
+Oct 31 22:49:34.160: INFO: Created: latency-svc-j44n9
+Oct 31 22:49:34.202: INFO: Got endpoints: latency-svc-gbrwp [743.327783ms]
+Oct 31 22:49:34.209: INFO: Created: latency-svc-5nxbj
+Oct 31 22:49:34.252: INFO: Got endpoints: latency-svc-v4qmn [749.77652ms]
+Oct 31 22:49:34.259: INFO: Created: latency-svc-n7v2l
+Oct 31 22:49:34.303: INFO: Got endpoints: latency-svc-fxgfm [749.853759ms]
+Oct 31 22:49:34.310: INFO: Created: latency-svc-s5nd7
+Oct 31 22:49:34.352: INFO: Got endpoints: latency-svc-wwz77 [748.935142ms]
+Oct 31 22:49:34.362: INFO: Created: latency-svc-qh4hm
+Oct 31 22:49:34.404: INFO: Got endpoints: latency-svc-vfw48 [750.017365ms]
+Oct 31 22:49:34.412: INFO: Created: latency-svc-w89c7
+Oct 31 22:49:34.453: INFO: Got endpoints: latency-svc-xtnnp [748.947417ms]
+Oct 31 22:49:34.460: INFO: Created: latency-svc-bgq8t
+Oct 31 22:49:34.503: INFO: Got endpoints: latency-svc-c7n6p [749.825989ms]
+Oct 31 22:49:34.512: INFO: Created: latency-svc-vhc4l
+Oct 31 22:49:34.552: INFO: Got endpoints: latency-svc-mxqcv [741.261316ms]
+Oct 31 22:49:34.560: INFO: Created: latency-svc-5hs5h
+Oct 31 22:49:34.605: INFO: Got endpoints: latency-svc-tw25k [750.678328ms]
+Oct 31 22:49:34.615: INFO: Created: latency-svc-xnx6n
+Oct 31 22:49:34.651: INFO: Got endpoints: latency-svc-knwng [749.842327ms]
+Oct 31 22:49:34.660: INFO: Created: latency-svc-5htb4
+Oct 31 22:49:34.701: INFO: Got endpoints: latency-svc-gxxzq [748.964439ms]
+Oct 31 22:49:34.709: INFO: Created: latency-svc-8hcp5
+Oct 31 22:49:34.753: INFO: Got endpoints: latency-svc-kw444 [750.801966ms]
+Oct 31 22:49:34.760: INFO: Created: latency-svc-2vcc9
+Oct 31 22:49:34.802: INFO: Got endpoints: latency-svc-9hbqt [749.817234ms]
+Oct 31 22:49:34.810: INFO: Created: latency-svc-2qz2m
+Oct 31 22:49:34.853: INFO: Got endpoints: latency-svc-q654s [750.661981ms]
+Oct 31 22:49:34.860: INFO: Created: latency-svc-2822h
+Oct 31 22:49:34.901: INFO: Got endpoints: latency-svc-j44n9 [748.748407ms]
+Oct 31 22:49:34.909: INFO: Created: latency-svc-4hfb7
+Oct 31 22:49:34.952: INFO: Got endpoints: latency-svc-5nxbj [750.197331ms]
+Oct 31 22:49:34.959: INFO: Created: latency-svc-b9rqn
+Oct 31 22:49:35.003: INFO: Got endpoints: latency-svc-n7v2l [750.89702ms]
+Oct 31 22:49:35.010: INFO: Created: latency-svc-ccs2w
+Oct 31 22:49:35.053: INFO: Got endpoints: latency-svc-s5nd7 [750.281352ms]
+Oct 31 22:49:35.061: INFO: Created: latency-svc-s8c6l
+Oct 31 22:49:35.101: INFO: Got endpoints: latency-svc-qh4hm [749.45199ms]
+Oct 31 22:49:35.109: INFO: Created: latency-svc-rrw2s
+Oct 31 22:49:35.152: INFO: Got endpoints: latency-svc-w89c7 [748.762934ms]
+Oct 31 22:49:35.159: INFO: Created: latency-svc-xcfkx
+Oct 31 22:49:35.203: INFO: Got endpoints: latency-svc-bgq8t [750.044653ms]
+Oct 31 22:49:35.210: INFO: Created: latency-svc-68pbr
+Oct 31 22:49:35.252: INFO: Got endpoints: latency-svc-vhc4l [749.574933ms]
+Oct 31 22:49:35.263: INFO: Created: latency-svc-9prjf
+Oct 31 22:49:35.302: INFO: Got endpoints: latency-svc-5hs5h [749.554336ms]
+Oct 31 22:49:35.309: INFO: Created: latency-svc-j4tkf
+Oct 31 22:49:35.353: INFO: Got endpoints: latency-svc-xnx6n [747.947487ms]
+Oct 31 22:49:35.360: INFO: Created: latency-svc-zcjz7
+Oct 31 22:49:35.402: INFO: Got endpoints: latency-svc-5htb4 [750.980371ms]
+Oct 31 22:49:35.410: INFO: Created: latency-svc-26wgv
+Oct 31 22:49:35.452: INFO: Got endpoints: latency-svc-8hcp5 [750.884638ms]
+Oct 31 22:49:35.459: INFO: Created: latency-svc-njg7s
+Oct 31 22:49:35.501: INFO: Got endpoints: latency-svc-2vcc9 [748.611481ms]
+Oct 31 22:49:35.510: INFO: Created: latency-svc-rg7dq
+Oct 31 22:49:35.556: INFO: Got endpoints: latency-svc-2qz2m [754.493836ms]
+Oct 31 22:49:35.564: INFO: Created: latency-svc-vlsrc
+Oct 31 22:49:35.603: INFO: Got endpoints: latency-svc-2822h [749.958719ms]
+Oct 31 22:49:35.611: INFO: Created: latency-svc-gl8mv
+Oct 31 22:49:35.653: INFO: Got endpoints: latency-svc-4hfb7 [751.04285ms]
+Oct 31 22:49:35.660: INFO: Created: latency-svc-c5mqp
+Oct 31 22:49:35.702: INFO: Got endpoints: latency-svc-b9rqn [750.119705ms]
+Oct 31 22:49:35.710: INFO: Created: latency-svc-brl69
+Oct 31 22:49:35.753: INFO: Got endpoints: latency-svc-ccs2w [750.686399ms]
+Oct 31 22:49:35.761: INFO: Created: latency-svc-m8sx7
+Oct 31 22:49:35.802: INFO: Got endpoints: latency-svc-s8c6l [748.555843ms]
+Oct 31 22:49:35.810: INFO: Created: latency-svc-btvbw
+Oct 31 22:49:35.852: INFO: Got endpoints: latency-svc-rrw2s [751.088519ms]
+Oct 31 22:49:35.860: INFO: Created: latency-svc-kkcwb
+Oct 31 22:49:35.902: INFO: Got endpoints: latency-svc-xcfkx [749.165454ms]
+Oct 31 22:49:35.910: INFO: Created: latency-svc-rg6rp
+Oct 31 22:49:35.953: INFO: Got endpoints: latency-svc-68pbr [750.31906ms]
+Oct 31 22:49:35.961: INFO: Created: latency-svc-v48qj
+Oct 31 22:49:36.002: INFO: Got endpoints: latency-svc-9prjf [749.462851ms]
+Oct 31 22:49:36.009: INFO: Created: latency-svc-hdbcb
+Oct 31 22:49:36.053: INFO: Got endpoints: latency-svc-j4tkf [750.908223ms]
+Oct 31 22:49:36.063: INFO: Created: latency-svc-mzhwq
+Oct 31 22:49:36.102: INFO: Got endpoints: latency-svc-zcjz7 [749.319558ms]
+Oct 31 22:49:36.108: INFO: Created: latency-svc-hs9b9
+Oct 31 22:49:36.153: INFO: Got endpoints: latency-svc-26wgv [750.782689ms]
+Oct 31 22:49:36.164: INFO: Created: latency-svc-d2fh8
+Oct 31 22:49:36.202: INFO: Got endpoints: latency-svc-njg7s [749.719405ms]
+Oct 31 22:49:36.209: INFO: Created: latency-svc-vdwhj
+Oct 31 22:49:36.252: INFO: Got endpoints: latency-svc-rg7dq [750.267808ms]
+Oct 31 22:49:36.259: INFO: Created: latency-svc-z47bg
+Oct 31 22:49:36.302: INFO: Got endpoints: latency-svc-vlsrc [745.330851ms]
+Oct 31 22:49:36.310: INFO: Created: latency-svc-5jpwq
+Oct 31 22:49:36.351: INFO: Got endpoints: latency-svc-gl8mv [748.396008ms]
+Oct 31 22:49:36.359: INFO: Created: latency-svc-ttjxm
+Oct 31 22:49:36.403: INFO: Got endpoints: latency-svc-c5mqp [749.813408ms]
+Oct 31 22:49:36.410: INFO: Created: latency-svc-vl67m
+Oct 31 22:49:36.453: INFO: Got endpoints: latency-svc-brl69 [751.025314ms]
+Oct 31 22:49:36.461: INFO: Created: latency-svc-xxk8b
+Oct 31 22:49:36.501: INFO: Got endpoints: latency-svc-m8sx7 [747.984141ms]
+Oct 31 22:49:36.511: INFO: Created: latency-svc-65gqj
+Oct 31 22:49:36.552: INFO: Got endpoints: latency-svc-btvbw [749.978048ms]
+Oct 31 22:49:36.563: INFO: Created: latency-svc-2clx7
+Oct 31 22:49:36.708: INFO: Got endpoints: latency-svc-kkcwb [855.418723ms]
+Oct 31 22:49:36.712: INFO: Got endpoints: latency-svc-rg6rp [809.859235ms]
+Oct 31 22:49:36.715: INFO: Got endpoints: latency-svc-v48qj [761.997965ms]
+Oct 31 22:49:36.723: INFO: Created: latency-svc-sxjw9
+Oct 31 22:49:36.724: INFO: Created: latency-svc-xs46b
+Oct 31 22:49:36.727: INFO: Created: latency-svc-qzh7x
+Oct 31 22:49:36.752: INFO: Got endpoints: latency-svc-hdbcb [750.49695ms]
+Oct 31 22:49:36.760: INFO: Created: latency-svc-nmxwp
+Oct 31 22:49:36.803: INFO: Got endpoints: latency-svc-mzhwq [749.984252ms]
+Oct 31 22:49:36.811: INFO: Created: latency-svc-jrtn9
+Oct 31 22:49:36.851: INFO: Got endpoints: latency-svc-hs9b9 [749.293669ms]
+Oct 31 22:49:36.861: INFO: Created: latency-svc-8x4b4
+Oct 31 22:49:36.902: INFO: Got endpoints: latency-svc-d2fh8 [748.534465ms]
+Oct 31 22:49:36.953: INFO: Got endpoints: latency-svc-vdwhj [750.867597ms]
+Oct 31 22:49:37.003: INFO: Got endpoints: latency-svc-z47bg [751.015848ms]
+Oct 31 22:49:37.025: INFO: Created: latency-svc-b57rc
+Oct 31 22:49:37.032: INFO: Created: latency-svc-ghl78
+Oct 31 22:49:37.038: INFO: Created: latency-svc-gm6sw
+Oct 31 22:49:37.053: INFO: Got endpoints: latency-svc-5jpwq [751.50123ms]
+Oct 31 22:49:37.061: INFO: Created: latency-svc-7877t
+Oct 31 22:49:37.103: INFO: Got endpoints: latency-svc-ttjxm [751.528455ms]
+Oct 31 22:49:37.109: INFO: Created: latency-svc-8w8lc
+Oct 31 22:49:37.153: INFO: Got endpoints: latency-svc-vl67m [749.946024ms]
+Oct 31 22:49:37.160: INFO: Created: latency-svc-nfjv8
+Oct 31 22:49:37.202: INFO: Got endpoints: latency-svc-xxk8b [748.846774ms]
+Oct 31 22:49:37.210: INFO: Created: latency-svc-57dlp
+Oct 31 22:49:37.253: INFO: Got endpoints: latency-svc-65gqj [751.387886ms]
+Oct 31 22:49:37.260: INFO: Created: latency-svc-pbb5x
+Oct 31 22:49:37.302: INFO: Got endpoints: latency-svc-2clx7 [749.965904ms]
+Oct 31 22:49:37.310: INFO: Created: latency-svc-jfbqj
+Oct 31 22:49:37.352: INFO: Got endpoints: latency-svc-sxjw9 [644.504709ms]
+Oct 31 22:49:37.363: INFO: Created: latency-svc-7hbbb
+Oct 31 22:49:37.405: INFO: Got endpoints: latency-svc-xs46b [693.753167ms]
+Oct 31 22:49:37.413: INFO: Created: latency-svc-bhpql
+Oct 31 22:49:37.452: INFO: Got endpoints: latency-svc-qzh7x [736.49499ms]
+Oct 31 22:49:37.460: INFO: Created: latency-svc-7jfn2
+Oct 31 22:49:37.501: INFO: Got endpoints: latency-svc-nmxwp [748.878207ms]
+Oct 31 22:49:37.513: INFO: Created: latency-svc-98xc5
+Oct 31 22:49:37.552: INFO: Got endpoints: latency-svc-jrtn9 [749.036982ms]
+Oct 31 22:49:37.559: INFO: Created: latency-svc-lmj9r
+Oct 31 22:49:37.602: INFO: Got endpoints: latency-svc-8x4b4 [750.167858ms]
+Oct 31 22:49:37.625: INFO: Created: latency-svc-ghqx2
+Oct 31 22:49:37.651: INFO: Got endpoints: latency-svc-b57rc [749.476101ms]
+Oct 31 22:49:37.659: INFO: Created: latency-svc-tq6rs
+Oct 31 22:49:37.702: INFO: Got endpoints: latency-svc-ghl78 [749.619543ms]
+Oct 31 22:49:37.709: INFO: Created: latency-svc-hm5b4
+Oct 31 22:49:37.752: INFO: Got endpoints: latency-svc-gm6sw [748.690535ms]
+Oct 31 22:49:37.759: INFO: Created: latency-svc-jp7xv
+Oct 31 22:49:37.802: INFO: Got endpoints: latency-svc-7877t [748.40009ms]
+Oct 31 22:49:37.809: INFO: Created: latency-svc-lv86c
+Oct 31 22:49:37.852: INFO: Got endpoints: latency-svc-8w8lc [749.055065ms]
+Oct 31 22:49:37.860: INFO: Created: latency-svc-7xzz7
+Oct 31 22:49:37.902: INFO: Got endpoints: latency-svc-nfjv8 [748.99259ms]
+Oct 31 22:49:37.912: INFO: Created: latency-svc-w4zng
+Oct 31 22:49:37.952: INFO: Got endpoints: latency-svc-57dlp [750.407302ms]
+Oct 31 22:49:37.960: INFO: Created: latency-svc-sg2bw
+Oct 31 22:49:38.002: INFO: Got endpoints: latency-svc-pbb5x [748.846971ms]
+Oct 31 22:49:38.010: INFO: Created: latency-svc-xxqfm
+Oct 31 22:49:38.052: INFO: Got endpoints: latency-svc-jfbqj [749.762218ms]
+Oct 31 22:49:38.060: INFO: Created: latency-svc-m6j6x
+Oct 31 22:49:38.102: INFO: Got endpoints: latency-svc-7hbbb [749.437151ms]
+Oct 31 22:49:38.109: INFO: Created: latency-svc-jrk5g
+Oct 31 22:49:38.153: INFO: Got endpoints: latency-svc-bhpql [747.588175ms]
+Oct 31 22:49:38.160: INFO: Created: latency-svc-h8pjb
+Oct 31 22:49:38.201: INFO: Got endpoints: latency-svc-7jfn2 [749.551625ms]
+Oct 31 22:49:38.209: INFO: Created: latency-svc-jnv28
+Oct 31 22:49:38.252: INFO: Got endpoints: latency-svc-98xc5 [750.33722ms]
+Oct 31 22:49:38.261: INFO: Created: latency-svc-hwsvt
+Oct 31 22:49:38.302: INFO: Got endpoints: latency-svc-lmj9r [749.790563ms]
+Oct 31 22:49:38.310: INFO: Created: latency-svc-fpkd5
+Oct 31 22:49:38.351: INFO: Got endpoints: latency-svc-ghqx2 [749.577027ms]
+Oct 31 22:49:38.359: INFO: Created: latency-svc-qrbmc
+Oct 31 22:49:38.402: INFO: Got endpoints: latency-svc-tq6rs [750.221691ms]
+Oct 31 22:49:38.408: INFO: Created: latency-svc-mqx4d
+Oct 31 22:49:38.452: INFO: Got endpoints: latency-svc-hm5b4 [749.251444ms]
+Oct 31 22:49:38.460: INFO: Created: latency-svc-9kktw
+Oct 31 22:49:38.502: INFO: Got endpoints: latency-svc-jp7xv [750.121061ms]
+Oct 31 22:49:38.510: INFO: Created: latency-svc-mkn4d
+Oct 31 22:49:38.551: INFO: Got endpoints: latency-svc-lv86c [749.421544ms]
+Oct 31 22:49:38.559: INFO: Created: latency-svc-k4b4g
+Oct 31 22:49:38.603: INFO: Got endpoints: latency-svc-7xzz7 [750.789119ms]
+Oct 31 22:49:38.611: INFO: Created: latency-svc-zcx9n
+Oct 31 22:49:38.654: INFO: Got endpoints: latency-svc-w4zng [752.184535ms]
+Oct 31 22:49:38.661: INFO: Created: latency-svc-rbtcz
+Oct 31 22:49:38.702: INFO: Got endpoints: latency-svc-sg2bw [748.950706ms]
+Oct 31 22:49:38.709: INFO: Created: latency-svc-f7v57
+Oct 31 22:49:38.751: INFO: Got endpoints: latency-svc-xxqfm [749.334157ms]
+Oct 31 22:49:38.760: INFO: Created: latency-svc-kf7vk
+Oct 31 22:49:38.802: INFO: Got endpoints: latency-svc-m6j6x [749.832079ms]
+Oct 31 22:49:38.809: INFO: Created: latency-svc-mkhpg
+Oct 31 22:49:38.853: INFO: Got endpoints: latency-svc-jrk5g [751.132102ms]
+Oct 31 22:49:38.863: INFO: Created: latency-svc-rf4s6
+Oct 31 22:49:38.903: INFO: Got endpoints: latency-svc-h8pjb [749.703172ms]
+Oct 31 22:49:38.911: INFO: Created: latency-svc-hkfxm
+Oct 31 22:49:38.954: INFO: Got endpoints: latency-svc-jnv28 [752.655699ms]
+Oct 31 22:49:38.970: INFO: Created: latency-svc-9sxcp
+Oct 31 22:49:39.002: INFO: Got endpoints: latency-svc-hwsvt [750.153036ms]
+Oct 31 22:49:39.010: INFO: Created: latency-svc-6hrmt
+Oct 31 22:49:39.053: INFO: Got endpoints: latency-svc-fpkd5 [750.772576ms]
+Oct 31 22:49:39.060: INFO: Created: latency-svc-2dxdn
+Oct 31 22:49:39.102: INFO: Got endpoints: latency-svc-qrbmc [750.614914ms]
+Oct 31 22:49:39.110: INFO: Created: latency-svc-72pvc
+Oct 31 22:49:39.153: INFO: Got endpoints: latency-svc-mqx4d [750.805802ms]
+Oct 31 22:49:39.159: INFO: Created: latency-svc-n67f2
+Oct 31 22:49:39.202: INFO: Got endpoints: latency-svc-9kktw [750.26601ms]
+Oct 31 22:49:39.253: INFO: Got endpoints: latency-svc-mkn4d [750.761787ms]
+Oct 31 22:49:39.302: INFO: Got endpoints: latency-svc-k4b4g [750.705702ms]
+Oct 31 22:49:39.352: INFO: Got endpoints: latency-svc-zcx9n [749.582222ms]
+Oct 31 22:49:39.403: INFO: Got endpoints: latency-svc-rbtcz [748.637011ms]
+Oct 31 22:49:39.452: INFO: Got endpoints: latency-svc-f7v57 [750.186868ms]
+Oct 31 22:49:39.503: INFO: Got endpoints: latency-svc-kf7vk [751.695172ms]
+Oct 31 22:49:39.553: INFO: Got endpoints: latency-svc-mkhpg [750.822516ms]
+Oct 31 22:49:39.602: INFO: Got endpoints: latency-svc-rf4s6 [748.444924ms]
+Oct 31 22:49:39.653: INFO: Got endpoints: latency-svc-hkfxm [749.720579ms]
+Oct 31 22:49:39.703: INFO: Got endpoints: latency-svc-9sxcp [748.60183ms]
+Oct 31 22:49:39.752: INFO: Got endpoints: latency-svc-6hrmt [750.364294ms]
+Oct 31 22:49:39.803: INFO: Got endpoints: latency-svc-2dxdn [749.994315ms]
+Oct 31 22:49:39.852: INFO: Got endpoints: latency-svc-72pvc [750.218674ms]
+Oct 31 22:49:39.902: INFO: Got endpoints: latency-svc-n67f2 [749.0379ms]
+Oct 31 22:49:39.902: INFO: Latencies: [16.714439ms 25.480599ms 29.951368ms 32.89487ms 42.03627ms 47.558602ms 55.039312ms 57.033999ms 64.278445ms 72.801681ms 81.107718ms 83.335245ms 94.299921ms 105.069541ms 110.847571ms 111.869958ms 136.52192ms 138.259097ms 140.222301ms 141.79449ms 141.882766ms 147.397341ms 180.193222ms 183.959403ms 189.18602ms 189.476879ms 209.178948ms 212.034539ms 214.354527ms 237.567077ms 249.743872ms 256.256222ms 256.380812ms 260.386609ms 262.227756ms 271.148489ms 278.637865ms 283.114596ms 283.665631ms 283.786997ms 287.202782ms 290.317387ms 293.860804ms 302.131747ms 343.478703ms 386.971098ms 424.72487ms 469.706713ms 514.605443ms 557.062687ms 602.995487ms 644.504709ms 645.421603ms 692.01928ms 693.753167ms 735.858954ms 736.49499ms 741.261316ms 743.327783ms 745.330851ms 747.588175ms 747.644375ms 747.947487ms 747.984141ms 747.988951ms 748.234345ms 748.396008ms 748.40009ms 748.444924ms 748.534465ms 748.555843ms 748.57633ms 748.60183ms 748.611481ms 748.637011ms 748.690535ms 748.748407ms 748.762934ms 748.846774ms 748.846971ms 748.851027ms 748.863328ms 748.878207ms 748.935142ms 748.940496ms 748.947417ms 748.950706ms 748.964439ms 748.99259ms 749.036982ms 749.0379ms 749.055065ms 749.165454ms 749.239956ms 749.251444ms 749.293669ms 749.319558ms 749.334157ms 749.421544ms 749.437151ms 749.45199ms 749.462851ms 749.476101ms 749.551625ms 749.554336ms 749.574933ms 749.577027ms 749.582222ms 749.619543ms 749.637503ms 749.703172ms 749.713832ms 749.719405ms 749.720579ms 749.749192ms 749.762218ms 749.77652ms 749.790563ms 749.798087ms 749.813408ms 749.817234ms 749.823788ms 749.825989ms 749.832079ms 749.842327ms 749.853759ms 749.867067ms 749.919359ms 749.936933ms 749.941903ms 749.942646ms 749.946024ms 749.958719ms 749.965904ms 749.978048ms 749.984252ms 749.994315ms 750.017365ms 750.020818ms 750.044653ms 750.119705ms 750.121061ms 750.135351ms 750.153036ms 750.164966ms 750.167858ms 750.186868ms 750.197331ms 750.214166ms 750.218674ms 750.221691ms 750.26601ms 750.267808ms 750.281352ms 750.31906ms 750.33722ms 750.364294ms 750.407302ms 750.49695ms 750.552891ms 750.614914ms 750.661981ms 750.678328ms 750.686399ms 750.705702ms 750.761787ms 750.772576ms 750.782689ms 750.789119ms 750.801966ms 750.805802ms 750.822516ms 750.867597ms 750.884638ms 750.89702ms 750.908223ms 750.980371ms 751.015848ms 751.025314ms 751.041542ms 751.04285ms 751.088519ms 751.132102ms 751.217168ms 751.341934ms 751.387886ms 751.394564ms 751.471278ms 751.50123ms 751.528455ms 751.695172ms 752.184535ms 752.655699ms 753.302581ms 754.493836ms 756.199836ms 759.084003ms 761.997965ms 809.859235ms 855.418723ms]
+Oct 31 22:49:39.902: INFO: 50 %ile: 749.45199ms
+Oct 31 22:49:39.902: INFO: 90 %ile: 751.04285ms
+Oct 31 22:49:39.902: INFO: 99 %ile: 809.859235ms
+Oct 31 22:49:39.902: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:49:39.902: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-46l94" for this suite.
+Oct 31 22:50:00.020: INFO: namespace: e2e-tests-svc-latency-46l94, resource: bindings, ignored listing per whitelist
+Oct 31 22:50:00.020: INFO: namespace e2e-tests-svc-latency-46l94 deletion completed in 20.115500277s
+
+• [SLOW TEST:29.757 seconds]
+[sig-network] Service endpoints latency
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service_latency.go:117
+------------------------------
+S
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:59
+[BeforeEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:50:00.020: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:59
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-dnc6x
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Oct 31 22:50:00.046: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Oct 31 22:50:26.169: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 10.64.3.12 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-dnc6x PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 22:50:26.169: INFO: >>> kubeConfig: 
+Oct 31 22:50:27.266: INFO: Found all expected endpoints: [netserver-0]
+Oct 31 22:50:27.268: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 10.64.1.6 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-dnc6x PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 22:50:27.268: INFO: >>> kubeConfig: 
+Oct 31 22:50:28.334: INFO: Found all expected endpoints: [netserver-1]
+Oct 31 22:50:28.337: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 10.64.2.8 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-dnc6x PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 22:50:28.337: INFO: >>> kubeConfig: 
+Oct 31 22:50:29.405: INFO: Found all expected endpoints: [netserver-2]
+[AfterEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:50:29.405: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-dnc6x" for this suite.
+Oct 31 22:50:51.471: INFO: namespace: e2e-tests-pod-network-test-dnc6x, resource: bindings, ignored listing per whitelist
+Oct 31 22:50:51.525: INFO: namespace e2e-tests-pod-network-test-dnc6x deletion completed in 22.116594694s
+
+• [SLOW TEST:51.505 seconds]
+[sig-network] Networking
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:61
+  Granular Checks: Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:60
+    should function for node-pod communication: udp [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:59
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:197
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:50:51.525: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:197
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 22:50:51.556: INFO: Waiting up to 5m0s for pod "downwardapi-volume-f1dc0299-be8d-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-x2z2z" to be "success or failure"
+Oct 31 22:50:51.558: INFO: Pod "downwardapi-volume-f1dc0299-be8d-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 1.963436ms
+Oct 31 22:50:53.561: INFO: Pod "downwardapi-volume-f1dc0299-be8d-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004676435s
+STEP: Saw pod success
+Oct 31 22:50:53.561: INFO: Pod "downwardapi-volume-f1dc0299-be8d-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:50:53.562: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-f1dc0299-be8d-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 22:50:53.578: INFO: Waiting for pod downwardapi-volume-f1dc0299-be8d-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:50:53.581: INFO: Pod downwardapi-volume-f1dc0299-be8d-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:50:53.581: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-x2z2z" for this suite.
+Oct 31 22:50:59.616: INFO: namespace: e2e-tests-downward-api-x2z2z, resource: bindings, ignored listing per whitelist
+Oct 31 22:50:59.669: INFO: namespace e2e-tests-downward-api-x2z2z deletion completed in 6.085342628s
+
+• [SLOW TEST:8.144 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:197
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Downward API 
+  should provide pod name and namespace as env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:63
+[BeforeEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:50:59.669: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name and namespace as env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:63
+STEP: Creating a pod to test downward api env vars
+Oct 31 22:50:59.698: INFO: Waiting up to 5m0s for pod "downward-api-f6b68eb0-be8d-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-lnfzb" to be "success or failure"
+Oct 31 22:50:59.705: INFO: Pod "downward-api-f6b68eb0-be8d-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 6.386618ms
+Oct 31 22:51:01.707: INFO: Pod "downward-api-f6b68eb0-be8d-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008917337s
+STEP: Saw pod success
+Oct 31 22:51:01.707: INFO: Pod "downward-api-f6b68eb0-be8d-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:51:01.709: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downward-api-f6b68eb0-be8d-11e7-82e0-0a580a400306 container dapi-container: <nil>
+STEP: delete the pod
+Oct 31 22:51:01.727: INFO: Waiting for pod downward-api-f6b68eb0-be8d-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:51:01.729: INFO: Pod downward-api-f6b68eb0-be8d-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:51:01.729: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-lnfzb" for this suite.
+Oct 31 22:51:07.850: INFO: namespace: e2e-tests-downward-api-lnfzb, resource: bindings, ignored listing per whitelist
+Oct 31 22:51:07.854: INFO: namespace e2e-tests-downward-api-lnfzb deletion completed in 6.122577423s
+
+• [SLOW TEST:8.185 seconds]
+[k8s.io] Downward API
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide pod name and namespace as env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:63
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:65
+[BeforeEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:51:07.854: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:65
+Oct 31 22:51:07.899: INFO: (0) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 20.024303ms)
+Oct 31 22:51:07.902: INFO: (1) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.056368ms)
+Oct 31 22:51:07.905: INFO: (2) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.855313ms)
+Oct 31 22:51:07.909: INFO: (3) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.21304ms)
+Oct 31 22:51:07.911: INFO: (4) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.757855ms)
+Oct 31 22:51:07.914: INFO: (5) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.665351ms)
+Oct 31 22:51:07.917: INFO: (6) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.124863ms)
+Oct 31 22:51:07.923: INFO: (7) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 5.249304ms)
+Oct 31 22:51:07.927: INFO: (8) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 4.536203ms)
+Oct 31 22:51:07.930: INFO: (9) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.932872ms)
+Oct 31 22:51:07.933: INFO: (10) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.965184ms)
+Oct 31 22:51:07.936: INFO: (11) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.028226ms)
+Oct 31 22:51:07.940: INFO: (12) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.980778ms)
+Oct 31 22:51:07.944: INFO: (13) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.522318ms)
+Oct 31 22:51:07.947: INFO: (14) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.050359ms)
+Oct 31 22:51:07.950: INFO: (15) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.468906ms)
+Oct 31 22:51:07.954: INFO: (16) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.647281ms)
+Oct 31 22:51:07.957: INFO: (17) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.677127ms)
+Oct 31 22:51:07.959: INFO: (18) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.516718ms)
+Oct 31 22:51:07.962: INFO: (19) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.762891ms)
+[AfterEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:51:07.962: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-n4lmp" for this suite.
+Oct 31 22:51:14.044: INFO: namespace: e2e-tests-proxy-n4lmp, resource: bindings, ignored listing per whitelist
+Oct 31 22:51:14.058: INFO: namespace e2e-tests-proxy-n4lmp deletion completed in 6.092818787s
+
+• [SLOW TEST:6.203 seconds]
+[sig-network] Proxy
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:278
+    should proxy logs on node with explicit kubelet port [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:65
+------------------------------
+[k8s.io] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:204
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:51:14.058: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:204
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 22:51:14.088: INFO: Waiting up to 5m0s for pod "downwardapi-volume-ff4a7c92-be8d-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-ldr2w" to be "success or failure"
+Oct 31 22:51:14.092: INFO: Pod "downwardapi-volume-ff4a7c92-be8d-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 4.013164ms
+Oct 31 22:51:16.095: INFO: Pod "downwardapi-volume-ff4a7c92-be8d-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007350653s
+STEP: Saw pod success
+Oct 31 22:51:16.095: INFO: Pod "downwardapi-volume-ff4a7c92-be8d-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:51:16.097: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-ff4a7c92-be8d-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 22:51:16.114: INFO: Waiting for pod downwardapi-volume-ff4a7c92-be8d-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:51:16.116: INFO: Pod downwardapi-volume-ff4a7c92-be8d-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:51:16.116: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-ldr2w" for this suite.
+Oct 31 22:51:22.181: INFO: namespace: e2e-tests-downward-api-ldr2w, resource: bindings, ignored listing per whitelist
+Oct 31 22:51:22.211: INFO: namespace e2e-tests-downward-api-ldr2w deletion completed in 6.092152588s
+
+• [SLOW TEST:8.153 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:204
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:38
+[BeforeEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:51:22.211: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:38
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-dc2v8
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Oct 31 22:51:22.247: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Oct 31 22:51:40.318: INFO: ExecWithOptions {Command:[/bin/sh -c curl -q -s 'http://10.64.1.9:8080/dial?request=hostName&protocol=http&host=10.64.3.19&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-dc2v8 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 22:51:40.318: INFO: >>> kubeConfig: 
+Oct 31 22:51:40.423: INFO: Waiting for endpoints: map[]
+Oct 31 22:51:40.426: INFO: ExecWithOptions {Command:[/bin/sh -c curl -q -s 'http://10.64.1.9:8080/dial?request=hostName&protocol=http&host=10.64.2.9&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-dc2v8 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 22:51:40.426: INFO: >>> kubeConfig: 
+Oct 31 22:51:40.528: INFO: Waiting for endpoints: map[]
+Oct 31 22:51:40.533: INFO: ExecWithOptions {Command:[/bin/sh -c curl -q -s 'http://10.64.1.9:8080/dial?request=hostName&protocol=http&host=10.64.1.8&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-dc2v8 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 22:51:40.533: INFO: >>> kubeConfig: 
+Oct 31 22:51:40.630: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:51:40.630: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-dc2v8" for this suite.
+Oct 31 22:52:02.695: INFO: namespace: e2e-tests-pod-network-test-dc2v8, resource: bindings, ignored listing per whitelist
+Oct 31 22:52:02.726: INFO: namespace e2e-tests-pod-network-test-dc2v8 deletion completed in 22.091630734s
+
+• [SLOW TEST:40.515 seconds]
+[sig-network] Networking
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:61
+  Granular Checks: Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:60
+    should function for intra-pod communication: http [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:38
+------------------------------
+SS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (non-root,0644,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:117
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:52:02.726: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:117
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Oct 31 22:52:02.757: INFO: Waiting up to 5m0s for pod "pod-1c4ca93c-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-qbg5v" to be "success or failure"
+Oct 31 22:52:02.764: INFO: Pod "pod-1c4ca93c-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 6.094725ms
+Oct 31 22:52:04.766: INFO: Pod "pod-1c4ca93c-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008944586s
+STEP: Saw pod success
+Oct 31 22:52:04.766: INFO: Pod "pod-1c4ca93c-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:52:04.768: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-1c4ca93c-be8e-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 22:52:04.784: INFO: Waiting for pod pod-1c4ca93c-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:52:04.787: INFO: Pod pod-1c4ca93c-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:52:04.787: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-qbg5v" for this suite.
+Oct 31 22:52:10.901: INFO: namespace: e2e-tests-emptydir-qbg5v, resource: bindings, ignored listing per whitelist
+Oct 31 22:52:10.922: INFO: namespace e2e-tests-emptydir-qbg5v deletion completed in 6.132847872s
+
+• [SLOW TEST:8.196 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should support (non-root,0644,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:117
+------------------------------
+SSS
+------------------------------
+[k8s.io] Downward API volume 
+  should update annotations on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:154
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:52:10.922: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should update annotations on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:154
+STEP: Creating the pod
+Oct 31 22:52:13.484: INFO: Successfully updated pod "annotationupdate212f4a0f-be8e-11e7-82e0-0a580a400306"
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:52:17.506: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-4pvzz" for this suite.
+Oct 31 22:52:39.564: INFO: namespace: e2e-tests-downward-api-4pvzz, resource: bindings, ignored listing per whitelist
+Oct 31 22:52:39.598: INFO: namespace e2e-tests-downward-api-4pvzz deletion completed in 22.088724629s
+
+• [SLOW TEST:28.676 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should update annotations on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:154
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Downward API volume 
+  should provide container's memory limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:172
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:52:39.598: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide container's memory limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:172
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 22:52:39.628: INFO: Waiting up to 5m0s for pod "downwardapi-volume-3246a6cb-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-gbrzv" to be "success or failure"
+Oct 31 22:52:39.635: INFO: Pod "downwardapi-volume-3246a6cb-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 6.76219ms
+Oct 31 22:52:41.637: INFO: Pod "downwardapi-volume-3246a6cb-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009662925s
+STEP: Saw pod success
+Oct 31 22:52:41.638: INFO: Pod "downwardapi-volume-3246a6cb-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:52:41.639: INFO: Trying to get logs from node kubernetes-minion-group-rv1l pod downwardapi-volume-3246a6cb-be8e-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 22:52:41.670: INFO: Waiting for pod downwardapi-volume-3246a6cb-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:52:41.673: INFO: Pod downwardapi-volume-3246a6cb-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:52:41.673: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-gbrzv" for this suite.
+Oct 31 22:52:47.748: INFO: namespace: e2e-tests-downward-api-gbrzv, resource: bindings, ignored listing per whitelist
+Oct 31 22:52:47.782: INFO: namespace e2e-tests-downward-api-gbrzv deletion completed in 6.107028198s
+
+• [SLOW TEST:8.185 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide container's memory limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:172
+------------------------------
+SSS
+------------------------------
+[k8s.io] Secrets 
+  should be consumable via the environment [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:409
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:52:47.783: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:409
+STEP: creating secret e2e-tests-secrets-c6zpr/secret-test-37286c63-be8e-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 22:52:47.819: INFO: Waiting up to 5m0s for pod "pod-configmaps-3728c631-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-secrets-c6zpr" to be "success or failure"
+Oct 31 22:52:47.824: INFO: Pod "pod-configmaps-3728c631-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 4.140519ms
+Oct 31 22:52:49.826: INFO: Pod "pod-configmaps-3728c631-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006863281s
+STEP: Saw pod success
+Oct 31 22:52:49.826: INFO: Pod "pod-configmaps-3728c631-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:52:49.828: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-configmaps-3728c631-be8e-11e7-82e0-0a580a400306 container env-test: <nil>
+STEP: delete the pod
+Oct 31 22:52:49.842: INFO: Waiting for pod pod-configmaps-3728c631-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:52:49.844: INFO: Pod pod-configmaps-3728c631-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:52:49.844: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-c6zpr" for this suite.
+Oct 31 22:52:55.925: INFO: namespace: e2e-tests-secrets-c6zpr, resource: bindings, ignored listing per whitelist
+Oct 31 22:52:55.937: INFO: namespace e2e-tests-secrets-c6zpr deletion completed in 6.090184651s
+
+• [SLOW TEST:8.154 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable via the environment [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:409
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (root,0666,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:81
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:52:55.937: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:81
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Oct 31 22:52:55.969: INFO: Waiting up to 5m0s for pod "pod-3c042414-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-h4s79" to be "success or failure"
+Oct 31 22:52:55.975: INFO: Pod "pod-3c042414-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.389227ms
+Oct 31 22:52:57.979: INFO: Pod "pod-3c042414-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009651794s
+STEP: Saw pod success
+Oct 31 22:52:57.979: INFO: Pod "pod-3c042414-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:52:57.987: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-3c042414-be8e-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 22:52:58.028: INFO: Waiting for pod pod-3c042414-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:52:58.035: INFO: Pod pod-3c042414-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:52:58.035: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-h4s79" for this suite.
+Oct 31 22:53:04.136: INFO: namespace: e2e-tests-emptydir-h4s79, resource: bindings, ignored listing per whitelist
+Oct 31 22:53:04.148: INFO: namespace e2e-tests-emptydir-h4s79 deletion completed in 6.092760554s
+
+• [SLOW TEST:8.211 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should support (root,0666,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:81
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:36
+[BeforeEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:53:04.148: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:36
+STEP: Creating a pod to test use defaults
+Oct 31 22:53:04.176: INFO: Waiting up to 5m0s for pod "client-containers-40e8a0b2-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-containers-xd7r8" to be "success or failure"
+Oct 31 22:53:04.182: INFO: Pod "client-containers-40e8a0b2-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.174879ms
+Oct 31 22:53:06.184: INFO: Pod "client-containers-40e8a0b2-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007974099s
+STEP: Saw pod success
+Oct 31 22:53:06.184: INFO: Pod "client-containers-40e8a0b2-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:53:06.186: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod client-containers-40e8a0b2-be8e-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 22:53:06.201: INFO: Waiting for pod client-containers-40e8a0b2-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:53:06.204: INFO: Pod client-containers-40e8a0b2-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:53:06.204: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-xd7r8" for this suite.
+Oct 31 22:53:12.288: INFO: namespace: e2e-tests-containers-xd7r8, resource: bindings, ignored listing per whitelist
+Oct 31 22:53:12.329: INFO: namespace e2e-tests-containers-xd7r8 deletion completed in 6.122759128s
+
+• [SLOW TEST:8.181 seconds]
+[k8s.io] Docker Containers
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should use the image defaults if command and args are blank [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:36
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (root,0666,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:109
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:53:12.329: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:109
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Oct 31 22:53:12.363: INFO: Waiting up to 5m0s for pod "pod-45c9ae35-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-k7h6v" to be "success or failure"
+Oct 31 22:53:12.369: INFO: Pod "pod-45c9ae35-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.974762ms
+Oct 31 22:53:14.371: INFO: Pod "pod-45c9ae35-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008700279s
+STEP: Saw pod success
+Oct 31 22:53:14.371: INFO: Pod "pod-45c9ae35-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:53:14.373: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-45c9ae35-be8e-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 22:53:14.393: INFO: Waiting for pod pod-45c9ae35-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:53:14.395: INFO: Pod pod-45c9ae35-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:53:14.395: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-k7h6v" for this suite.
+Oct 31 22:53:20.433: INFO: namespace: e2e-tests-emptydir-k7h6v, resource: bindings, ignored listing per whitelist
+Oct 31 22:53:20.493: INFO: namespace e2e-tests-emptydir-k7h6v deletion completed in 6.095315365s
+
+• [SLOW TEST:8.164 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should support (root,0666,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:109
+------------------------------
+SSSS
+------------------------------
+[k8s.io] PreStop 
+  should call prestop when killing a pod [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pre_stop.go:180
+[BeforeEach] [k8s.io] PreStop
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:53:20.493: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pre_stop.go:180
+STEP: Creating server pod server in namespace e2e-tests-prestop-pmnwt
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-pmnwt
+STEP: Deleting pre-stop pod
+Oct 31 22:53:31.552: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] PreStop
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:53:31.558: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-pmnwt" for this suite.
+Oct 31 22:54:07.687: INFO: namespace: e2e-tests-prestop-pmnwt, resource: bindings, ignored listing per whitelist
+Oct 31 22:54:07.687: INFO: namespace e2e-tests-prestop-pmnwt deletion completed in 36.125318021s
+
+• [SLOW TEST:47.194 seconds]
+[k8s.io] PreStop
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should call prestop when killing a pod [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pre_stop.go:180
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:302
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:54:07.687: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:114
+Oct 31 22:54:07.724: INFO: Waiting up to 1m0s for all nodes to be ready
+Oct 31 22:55:07.742: INFO: Waiting for terminating namespaces to be deleted...
+Oct 31 22:55:07.745: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Oct 31 22:55:07.756: INFO: 25 / 25 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Oct 31 22:55:07.756: INFO: expected 9 pod replicas in namespace 'kube-system', 9 are Running and Ready.
+Oct 31 22:55:07.761: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Oct 31 22:55:07.761: INFO: 
+Logging pods the kubelet thinks is on node kubernetes-minion-group-k1nq before test
+Oct 31 22:55:07.774: INFO: fluentd-gcp-v2.0.9-fcr5p from kube-system started at 2017-10-31 22:44:18 +0000 UTC (1 container statuses recorded)
+Oct 31 22:55:07.774: INFO: 	Container fluentd-gcp ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: l7-default-backend-6497bcdb4d-6xxq2 from kube-system started at 2017-10-31 22:44:37 +0000 UTC (1 container statuses recorded)
+Oct 31 22:55:07.774: INFO: 	Container default-http-backend ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: monitoring-influxdb-grafana-v4-sqc8m from kube-system started at 2017-10-31 22:44:37 +0000 UTC (2 container statuses recorded)
+Oct 31 22:55:07.774: INFO: 	Container grafana ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: 	Container influxdb ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: kube-dns-autoscaler-7db47cb9b7-v4drk from kube-system started at 2017-10-31 22:44:39 +0000 UTC (1 container statuses recorded)
+Oct 31 22:55:07.774: INFO: 	Container autoscaler ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: kube-proxy-kubernetes-minion-group-k1nq from kube-system started at <nil> (0 container statuses recorded)
+Oct 31 22:55:07.774: INFO: event-exporter-v0.1.7-6fc6965d54-z4zms from kube-system started at 2017-10-31 22:44:37 +0000 UTC (1 container statuses recorded)
+Oct 31 22:55:07.774: INFO: 	Container event-exporter ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: kube-dns-778977457c-kx87r from kube-system started at 2017-10-31 22:44:46 +0000 UTC (3 container statuses recorded)
+Oct 31 22:55:07.774: INFO: 	Container dnsmasq ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: 	Container kubedns ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: 	Container sidecar ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: heapster-v1.4.3-6b6447897-s8q24 from kube-system started at 2017-10-31 22:45:09 +0000 UTC (4 container statuses recorded)
+Oct 31 22:55:07.774: INFO: 	Container eventer ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: 	Container eventer-nanny ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: 	Container heapster ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: 	Container heapster-nanny ready: true, restart count 0
+Oct 31 22:55:07.774: INFO: 
+Logging pods the kubelet thinks is on node kubernetes-minion-group-rv1l before test
+Oct 31 22:55:07.790: INFO: kube-proxy-kubernetes-minion-group-rv1l from kube-system started at <nil> (0 container statuses recorded)
+Oct 31 22:55:07.790: INFO: fluentd-gcp-v2.0.9-rvltc from kube-system started at 2017-10-31 22:44:14 +0000 UTC (1 container statuses recorded)
+Oct 31 22:55:07.790: INFO: 	Container fluentd-gcp ready: true, restart count 0
+Oct 31 22:55:07.790: INFO: kubernetes-dashboard-76c679977c-mzb6r from kube-system started at 2017-10-31 22:44:37 +0000 UTC (1 container statuses recorded)
+Oct 31 22:55:07.790: INFO: 	Container kubernetes-dashboard ready: true, restart count 0
+Oct 31 22:55:07.790: INFO: kube-dns-778977457c-74n8h from kube-system started at 2017-10-31 22:44:37 +0000 UTC (3 container statuses recorded)
+Oct 31 22:55:07.790: INFO: 	Container dnsmasq ready: true, restart count 0
+Oct 31 22:55:07.790: INFO: 	Container kubedns ready: true, restart count 0
+Oct 31 22:55:07.790: INFO: 	Container sidecar ready: true, restart count 0
+Oct 31 22:55:07.790: INFO: 
+Logging pods the kubelet thinks is on node kubernetes-minion-group-vbpt before test
+Oct 31 22:55:07.807: INFO: kube-proxy-kubernetes-minion-group-vbpt from kube-system started at <nil> (0 container statuses recorded)
+Oct 31 22:55:07.807: INFO: fluentd-gcp-v2.0.9-qldfv from kube-system started at 2017-10-31 22:44:20 +0000 UTC (1 container statuses recorded)
+Oct 31 22:55:07.807: INFO: 	Container fluentd-gcp ready: true, restart count 0
+Oct 31 22:55:07.807: INFO: sonobuoy from sonobuoy started at 2017-10-31 22:48:43 +0000 UTC (1 container statuses recorded)
+Oct 31 22:55:07.807: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Oct 31 22:55:07.807: INFO: metrics-server-v0.2.0-56fddcccfc-m8hw8 from kube-system started at 2017-10-31 22:44:37 +0000 UTC (1 container statuses recorded)
+Oct 31 22:55:07.807: INFO: 	Container metrics-server ready: true, restart count 0
+Oct 31 22:55:07.807: INFO: sonobuoy-e2e-job-9fcd792ab6e447a0 from sonobuoy started at 2017-10-31 22:48:55 +0000 UTC (2 container statuses recorded)
+Oct 31 22:55:07.807: INFO: 	Container e2e ready: true, restart count 0
+Oct 31 22:55:07.807: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:302
+Oct 31 22:55:07.819: INFO: Pod event-exporter-v0.1.7-6fc6965d54-z4zms requesting resource cpu=0m on Node kubernetes-minion-group-k1nq
+Oct 31 22:55:07.819: INFO: Pod fluentd-gcp-v2.0.9-fcr5p requesting resource cpu=100m on Node kubernetes-minion-group-k1nq
+Oct 31 22:55:07.819: INFO: Pod fluentd-gcp-v2.0.9-qldfv requesting resource cpu=100m on Node kubernetes-minion-group-vbpt
+Oct 31 22:55:07.819: INFO: Pod fluentd-gcp-v2.0.9-rvltc requesting resource cpu=100m on Node kubernetes-minion-group-rv1l
+Oct 31 22:55:07.819: INFO: Pod heapster-v1.4.3-6b6447897-s8q24 requesting resource cpu=288m on Node kubernetes-minion-group-k1nq
+Oct 31 22:55:07.819: INFO: Pod kube-dns-778977457c-74n8h requesting resource cpu=260m on Node kubernetes-minion-group-rv1l
+Oct 31 22:55:07.819: INFO: Pod kube-dns-778977457c-kx87r requesting resource cpu=260m on Node kubernetes-minion-group-k1nq
+Oct 31 22:55:07.819: INFO: Pod kube-dns-autoscaler-7db47cb9b7-v4drk requesting resource cpu=20m on Node kubernetes-minion-group-k1nq
+Oct 31 22:55:07.819: INFO: Pod kube-proxy-kubernetes-minion-group-k1nq requesting resource cpu=100m on Node kubernetes-minion-group-k1nq
+Oct 31 22:55:07.819: INFO: Pod kube-proxy-kubernetes-minion-group-rv1l requesting resource cpu=100m on Node kubernetes-minion-group-rv1l
+Oct 31 22:55:07.819: INFO: Pod kube-proxy-kubernetes-minion-group-vbpt requesting resource cpu=100m on Node kubernetes-minion-group-vbpt
+Oct 31 22:55:07.819: INFO: Pod kubernetes-dashboard-76c679977c-mzb6r requesting resource cpu=100m on Node kubernetes-minion-group-rv1l
+Oct 31 22:55:07.819: INFO: Pod l7-default-backend-6497bcdb4d-6xxq2 requesting resource cpu=10m on Node kubernetes-minion-group-k1nq
+Oct 31 22:55:07.819: INFO: Pod metrics-server-v0.2.0-56fddcccfc-m8hw8 requesting resource cpu=0m on Node kubernetes-minion-group-vbpt
+Oct 31 22:55:07.819: INFO: Pod monitoring-influxdb-grafana-v4-sqc8m requesting resource cpu=200m on Node kubernetes-minion-group-k1nq
+Oct 31 22:55:07.819: INFO: Pod sonobuoy requesting resource cpu=0m on Node kubernetes-minion-group-vbpt
+Oct 31 22:55:07.819: INFO: Pod sonobuoy-e2e-job-9fcd792ab6e447a0 requesting resource cpu=0m on Node kubernetes-minion-group-vbpt
+Oct 31 22:55:07.819: INFO: Using pod capacity: 500m
+Oct 31 22:55:07.819: INFO: Node: kubernetes-minion-group-rv1l has cpu allocatable: 1440m
+Oct 31 22:55:07.819: INFO: Node: kubernetes-minion-group-vbpt has cpu allocatable: 1800m
+Oct 31 22:55:07.819: INFO: Node: kubernetes-minion-group-k1nq has cpu allocatable: 1022m
+STEP: Starting additional 7 Pods to fully saturate the cluster CPU and trying to start another one
+Oct 31 22:55:07.894: INFO: Waiting for running...
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-0.14f2c99e87659d00], Reason = [Scheduled], Message = [Successfully assigned overcommit-0 to kubernetes-minion-group-vbpt]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-0.14f2c99e901bfcbf], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-ct2dn" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-0.14f2c99eac35158b], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-0.14f2c99eaef8483f], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-0.14f2c99eb7cb6ed2], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-1.14f2c99e87a846a9], Reason = [Scheduled], Message = [Successfully assigned overcommit-1 to kubernetes-minion-group-rv1l]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-1.14f2c99e9295b019], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-ct2dn" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-1.14f2c99eaf15d1dc], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-1.14f2c99eb14468be], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-1.14f2c99eb78b5acb], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-2.14f2c99e88985643], Reason = [Scheduled], Message = [Successfully assigned overcommit-2 to kubernetes-minion-group-k1nq]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-2.14f2c99e972585d0], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-ct2dn" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-2.14f2c99eb2194698], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-2.14f2c99eb4992c4e], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-2.14f2c99ebfcc6549], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-3.14f2c99e893621e0], Reason = [Scheduled], Message = [Successfully assigned overcommit-3 to kubernetes-minion-group-rv1l]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-3.14f2c99e92be338e], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-ct2dn" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-3.14f2c99eaf0e5e37], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-3.14f2c99eb1ab7bad], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-3.14f2c99eb56340f4], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-4.14f2c99e89fae4c9], Reason = [Scheduled], Message = [Successfully assigned overcommit-4 to kubernetes-minion-group-vbpt]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-4.14f2c99e96be882e], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-ct2dn" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-4.14f2c99eb8c75589], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-4.14f2c99ebc868d43], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-4.14f2c99ec2576fa6], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-5.14f2c99e8afc4810], Reason = [Scheduled], Message = [Successfully assigned overcommit-5 to kubernetes-minion-group-k1nq]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-5.14f2c99e970fc820], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-ct2dn" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-5.14f2c99eb2206495], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-5.14f2c99eb5744a33], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-5.14f2c99ec03e14f4], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-6.14f2c99e8c08d4c4], Reason = [Scheduled], Message = [Successfully assigned overcommit-6 to kubernetes-minion-group-vbpt]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-6.14f2c99e9630f22a], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-ct2dn" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-6.14f2c99eb8dee22b], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-6.14f2c99ebcdb4076], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-6.14f2c99ec1ed7942], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.14f2c99fb5a98e49], Reason = [FailedScheduling], Message = [No nodes are available that match all of the predicates: Insufficient cpu (4), NodeUnschedulable (1).]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:55:13.915: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-65fck" for this suite.
+Oct 31 22:55:35.992: INFO: namespace: e2e-tests-sched-pred-65fck, resource: bindings, ignored listing per whitelist
+Oct 31 22:55:36.018: INFO: namespace e2e-tests-sched-pred-65fck deletion completed in 22.095063214s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:78
+
+• [SLOW TEST:88.330 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:302
+------------------------------
+S
+------------------------------
+[k8s.io] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:59
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:55:36.018: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:59
+STEP: Creating secret with name secret-test-map-9b6ec7a9-be8e-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 22:55:36.054: INFO: Waiting up to 5m0s for pod "pod-secrets-9b6f329e-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-secrets-stknw" to be "success or failure"
+Oct 31 22:55:36.057: INFO: Pod "pod-secrets-9b6f329e-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 2.983345ms
+Oct 31 22:55:38.060: INFO: Pod "pod-secrets-9b6f329e-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005626694s
+STEP: Saw pod success
+Oct 31 22:55:38.060: INFO: Pod "pod-secrets-9b6f329e-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:55:38.062: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-secrets-9b6f329e-be8e-11e7-82e0-0a580a400306 container secret-volume-test: <nil>
+STEP: delete the pod
+Oct 31 22:55:38.078: INFO: Waiting for pod pod-secrets-9b6f329e-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:55:38.081: INFO: Pod pod-secrets-9b6f329e-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:55:38.081: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-stknw" for this suite.
+Oct 31 22:55:44.145: INFO: namespace: e2e-tests-secrets-stknw, resource: bindings, ignored listing per whitelist
+Oct 31 22:55:44.173: INFO: namespace e2e-tests-secrets-stknw deletion completed in 6.089311662s
+
+• [SLOW TEST:8.155 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:59
+------------------------------
+[k8s.io] Secrets 
+  should be consumable from pods in env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:369
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:55:44.174: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:369
+STEP: Creating secret with name secret-test-a052be7b-be8e-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 22:55:44.259: INFO: Waiting up to 5m0s for pod "pod-secrets-a0533935-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-secrets-pt5rn" to be "success or failure"
+Oct 31 22:55:44.265: INFO: Pod "pod-secrets-a0533935-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.762477ms
+Oct 31 22:55:46.267: INFO: Pod "pod-secrets-a0533935-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008593022s
+STEP: Saw pod success
+Oct 31 22:55:46.267: INFO: Pod "pod-secrets-a0533935-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:55:46.269: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-secrets-a0533935-be8e-11e7-82e0-0a580a400306 container secret-env-test: <nil>
+STEP: delete the pod
+Oct 31 22:55:46.284: INFO: Waiting for pod pod-secrets-a0533935-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:55:46.287: INFO: Pod pod-secrets-a0533935-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:55:46.287: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-pt5rn" for this suite.
+Oct 31 22:55:52.336: INFO: namespace: e2e-tests-secrets-pt5rn, resource: bindings, ignored listing per whitelist
+Oct 31 22:55:52.379: INFO: namespace e2e-tests-secrets-pt5rn deletion completed in 6.089449199s
+
+• [SLOW TEST:8.205 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:369
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Downward API volume 
+  should set mode on item file [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:69
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:55:52.379: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should set mode on item file [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:69
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 22:55:52.408: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a52ead5a-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-28rgv" to be "success or failure"
+Oct 31 22:55:52.412: INFO: Pod "downwardapi-volume-a52ead5a-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 3.779135ms
+Oct 31 22:55:54.415: INFO: Pod "downwardapi-volume-a52ead5a-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006677592s
+STEP: Saw pod success
+Oct 31 22:55:54.415: INFO: Pod "downwardapi-volume-a52ead5a-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:55:54.417: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-a52ead5a-be8e-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 22:55:54.433: INFO: Waiting for pod downwardapi-volume-a52ead5a-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:55:54.436: INFO: Pod downwardapi-volume-a52ead5a-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:55:54.436: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-28rgv" for this suite.
+Oct 31 22:56:00.498: INFO: namespace: e2e-tests-downward-api-28rgv, resource: bindings, ignored listing per whitelist
+Oct 31 22:56:00.522: INFO: namespace e2e-tests-downward-api-28rgv deletion completed in 6.084351228s
+
+• [SLOW TEST:8.144 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should set mode on item file [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:69
+------------------------------
+[k8s.io] Pods 
+  should get a host IP [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:146
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:56:00.522: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:129
+[It] should get a host IP [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:146
+STEP: creating pod
+Oct 31 22:56:02.565: INFO: Pod pod-hostip-aa093799-be8e-11e7-82e0-0a580a400306 has hostIP: 10.240.0.5
+[AfterEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:56:02.565: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-p5v55" for this suite.
+Oct 31 22:56:24.650: INFO: namespace: e2e-tests-pods-p5v55, resource: bindings, ignored listing per whitelist
+Oct 31 22:56:24.660: INFO: namespace e2e-tests-pods-p5v55 deletion completed in 22.093169041s
+
+• [SLOW TEST:24.138 seconds]
+[k8s.io] Pods
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should get a host IP [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:146
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:394
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:56:24.660: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:394
+STEP: Creating configMap with name projected-configmap-test-volume-map-b86e2ad8-be8e-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 22:56:24.704: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-b86e8c75-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-rc24d" to be "success or failure"
+Oct 31 22:56:24.707: INFO: Pod "pod-projected-configmaps-b86e8c75-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 2.585478ms
+Oct 31 22:56:26.709: INFO: Pod "pod-projected-configmaps-b86e8c75-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005153545s
+STEP: Saw pod success
+Oct 31 22:56:26.709: INFO: Pod "pod-projected-configmaps-b86e8c75-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:56:26.711: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-configmaps-b86e8c75-be8e-11e7-82e0-0a580a400306 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 22:56:26.725: INFO: Waiting for pod pod-projected-configmaps-b86e8c75-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:56:26.728: INFO: Pod pod-projected-configmaps-b86e8c75-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:56:26.728: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rc24d" for this suite.
+Oct 31 22:56:32.769: INFO: namespace: e2e-tests-projected-rc24d, resource: bindings, ignored listing per whitelist
+Oct 31 22:56:32.821: INFO: namespace e2e-tests-projected-rc24d deletion completed in 6.089628216s
+
+• [SLOW TEST:8.161 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:394
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Projected 
+  should set DefaultMode on files [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:798
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:56:32.821: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should set DefaultMode on files [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:798
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 22:56:32.852: INFO: Waiting up to 5m0s for pod "downwardapi-volume-bd49e3b9-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-7894l" to be "success or failure"
+Oct 31 22:56:32.858: INFO: Pod "downwardapi-volume-bd49e3b9-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.313573ms
+Oct 31 22:56:34.860: INFO: Pod "downwardapi-volume-bd49e3b9-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008024906s
+STEP: Saw pod success
+Oct 31 22:56:34.860: INFO: Pod "downwardapi-volume-bd49e3b9-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:56:34.862: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-bd49e3b9-be8e-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 22:56:34.877: INFO: Waiting for pod downwardapi-volume-bd49e3b9-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:56:34.880: INFO: Pod downwardapi-volume-bd49e3b9-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:56:34.880: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-7894l" for this suite.
+Oct 31 22:56:40.919: INFO: namespace: e2e-tests-projected-7894l, resource: bindings, ignored listing per whitelist
+Oct 31 22:56:40.969: INFO: namespace e2e-tests-projected-7894l deletion completed in 6.086308953s
+
+• [SLOW TEST:8.147 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should set DefaultMode on files [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:798
+------------------------------
+S
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable via the environment [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:411
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:56:40.969: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:411
+STEP: Creating configMap e2e-tests-configmap-cvwxw/configmap-test-c224c098-be8e-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 22:56:40.999: INFO: Waiting up to 5m0s for pod "pod-configmaps-c22518a6-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-configmap-cvwxw" to be "success or failure"
+Oct 31 22:56:41.005: INFO: Pod "pod-configmaps-c22518a6-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.629295ms
+Oct 31 22:56:43.007: INFO: Pod "pod-configmaps-c22518a6-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00826474s
+STEP: Saw pod success
+Oct 31 22:56:43.007: INFO: Pod "pod-configmaps-c22518a6-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:56:43.009: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-configmaps-c22518a6-be8e-11e7-82e0-0a580a400306 container env-test: <nil>
+STEP: delete the pod
+Oct 31 22:56:43.036: INFO: Waiting for pod pod-configmaps-c22518a6-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:56:43.039: INFO: Pod pod-configmaps-c22518a6-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:56:43.039: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-cvwxw" for this suite.
+Oct 31 22:56:49.122: INFO: namespace: e2e-tests-configmap-cvwxw, resource: bindings, ignored listing per whitelist
+Oct 31 22:56:49.133: INFO: namespace e2e-tests-configmap-cvwxw deletion completed in 6.090952473s
+
+• [SLOW TEST:8.164 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable via the environment [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:411
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:59
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:56:49.133: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:59
+STEP: Creating configMap with name configmap-test-volume-map-c70ac746-be8e-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 22:56:49.223: INFO: Waiting up to 5m0s for pod "pod-configmaps-c70bf083-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-configmap-556cn" to be "success or failure"
+Oct 31 22:56:49.227: INFO: Pod "pod-configmaps-c70bf083-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 3.749491ms
+Oct 31 22:56:51.230: INFO: Pod "pod-configmaps-c70bf083-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00646999s
+STEP: Saw pod success
+Oct 31 22:56:51.230: INFO: Pod "pod-configmaps-c70bf083-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:56:51.232: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-configmaps-c70bf083-be8e-11e7-82e0-0a580a400306 container configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 22:56:51.257: INFO: Waiting for pod pod-configmaps-c70bf083-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:56:51.260: INFO: Pod pod-configmaps-c70bf083-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:56:51.260: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-556cn" for this suite.
+Oct 31 22:56:57.317: INFO: namespace: e2e-tests-configmap-556cn, resource: bindings, ignored listing per whitelist
+Oct 31 22:56:57.352: INFO: namespace e2e-tests-configmap-556cn deletion completed in 6.08922429s
+
+• [SLOW TEST:8.219 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:59
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (non-root,0777,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:125
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:56:57.352: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:125
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Oct 31 22:56:57.382: INFO: Waiting up to 5m0s for pod "pod-cbe8f3d6-be8e-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-hb795" to be "success or failure"
+Oct 31 22:56:57.386: INFO: Pod "pod-cbe8f3d6-be8e-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 3.50643ms
+Oct 31 22:56:59.389: INFO: Pod "pod-cbe8f3d6-be8e-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006529174s
+STEP: Saw pod success
+Oct 31 22:56:59.389: INFO: Pod "pod-cbe8f3d6-be8e-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:56:59.391: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-cbe8f3d6-be8e-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 22:56:59.405: INFO: Waiting for pod pod-cbe8f3d6-be8e-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:56:59.407: INFO: Pod pod-cbe8f3d6-be8e-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:56:59.407: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-hb795" for this suite.
+Oct 31 22:57:05.510: INFO: namespace: e2e-tests-emptydir-hb795, resource: bindings, ignored listing per whitelist
+Oct 31 22:57:05.510: INFO: namespace e2e-tests-emptydir-hb795 deletion completed in 6.100105385s
+
+• [SLOW TEST:8.158 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should support (non-root,0777,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:125
+------------------------------
+S
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:322
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:57:05.511: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:114
+Oct 31 22:57:05.534: INFO: Waiting up to 1m0s for all nodes to be ready
+Oct 31 22:58:05.553: INFO: Waiting for terminating namespaces to be deleted...
+Oct 31 22:58:05.557: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Oct 31 22:58:05.569: INFO: 25 / 25 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Oct 31 22:58:05.569: INFO: expected 9 pod replicas in namespace 'kube-system', 9 are Running and Ready.
+Oct 31 22:58:05.573: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Oct 31 22:58:05.573: INFO: 
+Logging pods the kubelet thinks is on node kubernetes-minion-group-k1nq before test
+Oct 31 22:58:05.587: INFO: kube-dns-778977457c-kx87r from kube-system started at 2017-10-31 22:44:46 +0000 UTC (3 container statuses recorded)
+Oct 31 22:58:05.587: INFO: 	Container dnsmasq ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: 	Container kubedns ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: 	Container sidecar ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: heapster-v1.4.3-6b6447897-s8q24 from kube-system started at 2017-10-31 22:45:09 +0000 UTC (4 container statuses recorded)
+Oct 31 22:58:05.587: INFO: 	Container eventer ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: 	Container eventer-nanny ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: 	Container heapster ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: 	Container heapster-nanny ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: kube-proxy-kubernetes-minion-group-k1nq from kube-system started at <nil> (0 container statuses recorded)
+Oct 31 22:58:05.587: INFO: event-exporter-v0.1.7-6fc6965d54-z4zms from kube-system started at 2017-10-31 22:44:37 +0000 UTC (1 container statuses recorded)
+Oct 31 22:58:05.587: INFO: 	Container event-exporter ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: monitoring-influxdb-grafana-v4-sqc8m from kube-system started at 2017-10-31 22:44:37 +0000 UTC (2 container statuses recorded)
+Oct 31 22:58:05.587: INFO: 	Container grafana ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: 	Container influxdb ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: kube-dns-autoscaler-7db47cb9b7-v4drk from kube-system started at 2017-10-31 22:44:39 +0000 UTC (1 container statuses recorded)
+Oct 31 22:58:05.587: INFO: 	Container autoscaler ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: fluentd-gcp-v2.0.9-fcr5p from kube-system started at 2017-10-31 22:44:18 +0000 UTC (1 container statuses recorded)
+Oct 31 22:58:05.587: INFO: 	Container fluentd-gcp ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: l7-default-backend-6497bcdb4d-6xxq2 from kube-system started at 2017-10-31 22:44:37 +0000 UTC (1 container statuses recorded)
+Oct 31 22:58:05.587: INFO: 	Container default-http-backend ready: true, restart count 0
+Oct 31 22:58:05.587: INFO: 
+Logging pods the kubelet thinks is on node kubernetes-minion-group-rv1l before test
+Oct 31 22:58:05.596: INFO: kubernetes-dashboard-76c679977c-mzb6r from kube-system started at 2017-10-31 22:44:37 +0000 UTC (1 container statuses recorded)
+Oct 31 22:58:05.596: INFO: 	Container kubernetes-dashboard ready: true, restart count 0
+Oct 31 22:58:05.596: INFO: kube-dns-778977457c-74n8h from kube-system started at 2017-10-31 22:44:37 +0000 UTC (3 container statuses recorded)
+Oct 31 22:58:05.596: INFO: 	Container dnsmasq ready: true, restart count 0
+Oct 31 22:58:05.596: INFO: 	Container kubedns ready: true, restart count 0
+Oct 31 22:58:05.596: INFO: 	Container sidecar ready: true, restart count 0
+Oct 31 22:58:05.596: INFO: kube-proxy-kubernetes-minion-group-rv1l from kube-system started at <nil> (0 container statuses recorded)
+Oct 31 22:58:05.596: INFO: fluentd-gcp-v2.0.9-rvltc from kube-system started at 2017-10-31 22:44:14 +0000 UTC (1 container statuses recorded)
+Oct 31 22:58:05.596: INFO: 	Container fluentd-gcp ready: true, restart count 0
+Oct 31 22:58:05.596: INFO: 
+Logging pods the kubelet thinks is on node kubernetes-minion-group-vbpt before test
+Oct 31 22:58:05.605: INFO: kube-proxy-kubernetes-minion-group-vbpt from kube-system started at <nil> (0 container statuses recorded)
+Oct 31 22:58:05.605: INFO: fluentd-gcp-v2.0.9-qldfv from kube-system started at 2017-10-31 22:44:20 +0000 UTC (1 container statuses recorded)
+Oct 31 22:58:05.605: INFO: 	Container fluentd-gcp ready: true, restart count 0
+Oct 31 22:58:05.605: INFO: sonobuoy from sonobuoy started at 2017-10-31 22:48:43 +0000 UTC (1 container statuses recorded)
+Oct 31 22:58:05.605: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Oct 31 22:58:05.605: INFO: metrics-server-v0.2.0-56fddcccfc-m8hw8 from kube-system started at 2017-10-31 22:44:37 +0000 UTC (1 container statuses recorded)
+Oct 31 22:58:05.605: INFO: 	Container metrics-server ready: true, restart count 0
+Oct 31 22:58:05.605: INFO: sonobuoy-e2e-job-9fcd792ab6e447a0 from sonobuoy started at 2017-10-31 22:48:55 +0000 UTC (2 container statuses recorded)
+Oct 31 22:58:05.605: INFO: 	Container e2e ready: true, restart count 0
+Oct 31 22:58:05.605: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:322
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.14f2c9c7ed96d732], Reason = [FailedScheduling], Message = [No nodes are available that match all of the predicates: MatchNodeSelector (4), NodeUnschedulable (1).]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:58:06.771: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-s9b9z" for this suite.
+Oct 31 22:58:28.834: INFO: namespace: e2e-tests-sched-pred-s9b9z, resource: bindings, ignored listing per whitelist
+Oct 31 22:58:28.877: INFO: namespace e2e-tests-sched-pred-s9b9z deletion completed in 22.098602868s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:78
+
+• [SLOW TEST:83.367 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:322
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:443
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:58:28.878: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:129
+[It] should contain environment variables for services [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:443
+Oct 31 22:58:30.934: INFO: Waiting up to 5m0s for pod "client-envvars-03abec42-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-pods-v9p4b" to be "success or failure"
+Oct 31 22:58:30.938: INFO: Pod "client-envvars-03abec42-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 4.317992ms
+Oct 31 22:58:32.941: INFO: Pod "client-envvars-03abec42-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007003085s
+STEP: Saw pod success
+Oct 31 22:58:32.941: INFO: Pod "client-envvars-03abec42-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 22:58:32.942: INFO: Trying to get logs from node kubernetes-minion-group-rv1l pod client-envvars-03abec42-be8f-11e7-82e0-0a580a400306 container env3cont: <nil>
+STEP: delete the pod
+Oct 31 22:58:32.957: INFO: Waiting for pod client-envvars-03abec42-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 22:58:32.960: INFO: Pod client-envvars-03abec42-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:58:32.960: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-v9p4b" for this suite.
+Oct 31 22:58:57.055: INFO: namespace: e2e-tests-pods-v9p4b, resource: bindings, ignored listing per whitelist
+Oct 31 22:58:57.057: INFO: namespace e2e-tests-pods-v9p4b deletion completed in 24.094639596s
+
+• [SLOW TEST:28.179 seconds]
+[k8s.io] Pods
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should contain environment variables for services [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:443
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dns.go:365
+[BeforeEach] [sig-network] DNS
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:58:57.057: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dns.go:365
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-9hjdd A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-9hjdd;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-9hjdd A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-9hjdd;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-9hjdd.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-9hjdd.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-9hjdd.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-9hjdd.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-9hjdd.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-9hjdd.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-9hjdd.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-9hjdd.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-9hjdd.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-9hjdd.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-9hjdd.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-9hjdd.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-9hjdd.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 165.79.0.10.in-addr.arpa. PTR)" && echo OK > /results/10.0.79.165_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 165.79.0.10.in-addr.arpa. PTR)" && echo OK > /results/10.0.79.165_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-9hjdd A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-9hjdd;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-9hjdd A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-9hjdd;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-9hjdd.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-9hjdd.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-9hjdd.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-9hjdd.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-9hjdd.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-9hjdd.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-9hjdd.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-9hjdd.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-9hjdd.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-9hjdd.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-9hjdd.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-9hjdd.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-9hjdd.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 165.79.0.10.in-addr.arpa. PTR)" && echo OK > /results/10.0.79.165_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 165.79.0.10.in-addr.arpa. PTR)" && echo OK > /results/10.0.79.165_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Oct 31 22:59:17.211: INFO: DNS probes using dns-test-13455d89-be8f-11e7-82e0-0a580a400306 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 22:59:17.255: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-9hjdd" for this suite.
+Oct 31 22:59:23.338: INFO: namespace: e2e-tests-dns-9hjdd, resource: bindings, ignored listing per whitelist
+Oct 31 22:59:23.352: INFO: namespace e2e-tests-dns-9hjdd deletion completed in 6.094084268s
+
+• [SLOW TEST:26.295 seconds]
+[sig-network] DNS
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dns.go:365
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:151
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 22:59:23.352: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:151
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-7qjdm
+Oct 31 22:59:25.391: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-7qjdm
+STEP: checking the pod's current state and verifying that restartCount is present
+Oct 31 22:59:25.393: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:01:25.600: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-7qjdm" for this suite.
+Oct 31 23:01:31.669: INFO: namespace: e2e-tests-container-probe-7qjdm, resource: bindings, ignored listing per whitelist
+Oct 31 23:01:31.694: INFO: namespace e2e-tests-container-probe-7qjdm deletion completed in 6.090731308s
+
+• [SLOW TEST:128.342 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:151
+------------------------------
+S
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:93
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:01:31.694: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:93
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Oct 31 23:01:31.724: INFO: Waiting up to 5m0s for pod "pod-6f6e32d2-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-fwzpm" to be "success or failure"
+Oct 31 23:01:31.728: INFO: Pod "pod-6f6e32d2-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 4.264634ms
+Oct 31 23:01:33.731: INFO: Pod "pod-6f6e32d2-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00700295s
+STEP: Saw pod success
+Oct 31 23:01:33.731: INFO: Pod "pod-6f6e32d2-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:01:33.732: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-6f6e32d2-be8f-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:01:33.751: INFO: Waiting for pod pod-6f6e32d2-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:01:33.753: INFO: Pod pod-6f6e32d2-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:01:33.753: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-fwzpm" for this suite.
+Oct 31 23:01:39.791: INFO: namespace: e2e-tests-emptydir-fwzpm, resource: bindings, ignored listing per whitelist
+Oct 31 23:01:39.842: INFO: namespace e2e-tests-emptydir-fwzpm deletion completed in 6.086784487s
+
+• [SLOW TEST:8.148 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should support (non-root,0666,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:93
+------------------------------
+SS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:70
+[BeforeEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:01:39.842: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:70
+Oct 31 23:01:39.923: INFO: (0) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 5.000453ms)
+Oct 31 23:01:39.927: INFO: (1) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.377198ms)
+Oct 31 23:01:39.931: INFO: (2) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.996494ms)
+Oct 31 23:01:39.937: INFO: (3) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 6.484502ms)
+Oct 31 23:01:39.946: INFO: (4) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 5.983189ms)
+Oct 31 23:01:39.951: INFO: (5) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 4.990943ms)
+Oct 31 23:01:39.953: INFO: (6) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.922966ms)
+Oct 31 23:01:39.956: INFO: (7) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.498614ms)
+Oct 31 23:01:39.959: INFO: (8) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.579278ms)
+Oct 31 23:01:39.961: INFO: (9) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.606566ms)
+Oct 31 23:01:39.964: INFO: (10) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.81459ms)
+Oct 31 23:01:39.967: INFO: (11) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.517068ms)
+Oct 31 23:01:39.969: INFO: (12) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.594179ms)
+Oct 31 23:01:39.973: INFO: (13) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.648596ms)
+Oct 31 23:01:39.976: INFO: (14) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.975941ms)
+Oct 31 23:01:39.979: INFO: (15) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.878931ms)
+Oct 31 23:01:39.982: INFO: (16) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.682984ms)
+Oct 31 23:01:39.984: INFO: (17) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.600282ms)
+Oct 31 23:01:39.986: INFO: (18) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.260516ms)
+Oct 31 23:01:39.989: INFO: (19) /api/v1/nodes/kubernetes-minion-group-k1nq/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.484219ms)
+[AfterEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:01:39.989: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-sg585" for this suite.
+Oct 31 23:01:46.041: INFO: namespace: e2e-tests-proxy-sg585, resource: bindings, ignored listing per whitelist
+Oct 31 23:01:46.080: INFO: namespace e2e-tests-proxy-sg585 deletion completed in 6.088917612s
+
+• [SLOW TEST:6.238 seconds]
+[sig-network] Proxy
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:278
+    should proxy logs on node using proxy subresource [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:70
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] Projected 
+  should provide container's cpu request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:920
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:01:46.081: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide container's cpu request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:920
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 23:01:46.111: INFO: Waiting up to 5m0s for pod "downwardapi-volume-78016e75-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-hnqqk" to be "success or failure"
+Oct 31 23:01:46.114: INFO: Pod "downwardapi-volume-78016e75-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 3.065567ms
+Oct 31 23:01:48.117: INFO: Pod "downwardapi-volume-78016e75-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006087804s
+STEP: Saw pod success
+Oct 31 23:01:48.117: INFO: Pod "downwardapi-volume-78016e75-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:01:48.120: INFO: Trying to get logs from node kubernetes-minion-group-rv1l pod downwardapi-volume-78016e75-be8f-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 23:01:48.138: INFO: Waiting for pod downwardapi-volume-78016e75-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:01:48.141: INFO: Pod downwardapi-volume-78016e75-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:01:48.141: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hnqqk" for this suite.
+Oct 31 23:01:54.210: INFO: namespace: e2e-tests-projected-hnqqk, resource: bindings, ignored listing per whitelist
+Oct 31 23:01:54.232: INFO: namespace e2e-tests-projected-hnqqk deletion completed in 6.088062462s
+
+• [SLOW TEST:8.151 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide container's cpu request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:920
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:124
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:01:54.232: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:124
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-rs7f7
+Oct 31 23:01:56.268: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-rs7f7
+STEP: checking the pod's current state and verifying that restartCount is present
+Oct 31 23:01:56.270: INFO: Initial restart count of pod liveness-exec is 0
+Oct 31 23:02:48.357: INFO: Restart count of pod e2e-tests-container-probe-rs7f7/liveness-exec is now 1 (52.087244974s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:02:48.375: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-rs7f7" for this suite.
+Oct 31 23:02:54.438: INFO: namespace: e2e-tests-container-probe-rs7f7, resource: bindings, ignored listing per whitelist
+Oct 31 23:02:54.486: INFO: namespace e2e-tests-container-probe-rs7f7 deletion completed in 6.107457205s
+
+• [SLOW TEST:60.254 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:124
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable from pods in volume as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:51
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:02:54.487: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:51
+STEP: Creating configMap with name configmap-test-volume-a0c77331-be8f-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:02:54.519: INFO: Waiting up to 5m0s for pod "pod-configmaps-a0c7e1aa-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-configmap-wzq6g" to be "success or failure"
+Oct 31 23:02:54.522: INFO: Pod "pod-configmaps-a0c7e1aa-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 2.560482ms
+Oct 31 23:02:56.525: INFO: Pod "pod-configmaps-a0c7e1aa-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005489504s
+STEP: Saw pod success
+Oct 31 23:02:56.525: INFO: Pod "pod-configmaps-a0c7e1aa-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:02:56.527: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-configmaps-a0c7e1aa-be8f-11e7-82e0-0a580a400306 container configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:02:56.546: INFO: Waiting for pod pod-configmaps-a0c7e1aa-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:02:56.548: INFO: Pod pod-configmaps-a0c7e1aa-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:02:56.548: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-wzq6g" for this suite.
+Oct 31 23:03:02.593: INFO: namespace: e2e-tests-configmap-wzq6g, resource: bindings, ignored listing per whitelist
+Oct 31 23:03:02.646: INFO: namespace e2e-tests-configmap-wzq6g deletion completed in 6.096064365s
+
+• [SLOW TEST:8.160 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:51
+------------------------------
+SSS
+------------------------------
+[k8s.io] Projected 
+  should provide container's memory request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:929
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:03:02.646: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide container's memory request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:929
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 23:03:02.727: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a5ac0aef-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-lnrjj" to be "success or failure"
+Oct 31 23:03:02.733: INFO: Pod "downwardapi-volume-a5ac0aef-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.658428ms
+Oct 31 23:03:04.736: INFO: Pod "downwardapi-volume-a5ac0aef-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008637286s
+STEP: Saw pod success
+Oct 31 23:03:04.736: INFO: Pod "downwardapi-volume-a5ac0aef-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:03:04.738: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-a5ac0aef-be8f-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 23:03:04.754: INFO: Waiting for pod downwardapi-volume-a5ac0aef-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:03:04.756: INFO: Pod downwardapi-volume-a5ac0aef-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:03:04.756: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lnrjj" for this suite.
+Oct 31 23:03:10.828: INFO: namespace: e2e-tests-projected-lnrjj, resource: bindings, ignored listing per whitelist
+Oct 31 23:03:10.868: INFO: namespace e2e-tests-projected-lnrjj deletion completed in 6.109778577s
+
+• [SLOW TEST:8.222 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide container's memory request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:929
+------------------------------
+SSS
+------------------------------
+[k8s.io] Projected 
+  should provide container's memory limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:911
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:03:10.869: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide container's memory limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:911
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 23:03:10.902: INFO: Waiting up to 5m0s for pod "downwardapi-volume-aa8b2e3e-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-4gn4g" to be "success or failure"
+Oct 31 23:03:10.905: INFO: Pod "downwardapi-volume-aa8b2e3e-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 3.098988ms
+Oct 31 23:03:12.907: INFO: Pod "downwardapi-volume-aa8b2e3e-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005851047s
+STEP: Saw pod success
+Oct 31 23:03:12.907: INFO: Pod "downwardapi-volume-aa8b2e3e-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:03:12.909: INFO: Trying to get logs from node kubernetes-minion-group-rv1l pod downwardapi-volume-aa8b2e3e-be8f-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 23:03:12.925: INFO: Waiting for pod downwardapi-volume-aa8b2e3e-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:03:12.927: INFO: Pod downwardapi-volume-aa8b2e3e-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:03:12.927: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4gn4g" for this suite.
+Oct 31 23:03:18.983: INFO: namespace: e2e-tests-projected-4gn4g, resource: bindings, ignored listing per whitelist
+Oct 31 23:03:19.051: INFO: namespace e2e-tests-projected-4gn4g deletion completed in 6.121831234s
+
+• [SLOW TEST:8.183 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide container's memory limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:911
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (root,0644,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:77
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:03:19.051: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:77
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Oct 31 23:03:19.082: INFO: Waiting up to 5m0s for pod "pod-af6b6f75-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-msmbm" to be "success or failure"
+Oct 31 23:03:19.089: INFO: Pod "pod-af6b6f75-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 7.29174ms
+Oct 31 23:03:21.092: INFO: Pod "pod-af6b6f75-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010444649s
+STEP: Saw pod success
+Oct 31 23:03:21.092: INFO: Pod "pod-af6b6f75-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:03:21.094: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-af6b6f75-be8f-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:03:21.114: INFO: Waiting for pod pod-af6b6f75-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:03:21.116: INFO: Pod pod-af6b6f75-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:03:21.116: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-msmbm" for this suite.
+Oct 31 23:03:27.204: INFO: namespace: e2e-tests-emptydir-msmbm, resource: bindings, ignored listing per whitelist
+Oct 31 23:03:27.220: INFO: namespace e2e-tests-emptydir-msmbm deletion completed in 6.100444454s
+
+• [SLOW TEST:8.169 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should support (root,0644,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:77
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (root,0777,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:85
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:03:27.220: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:85
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Oct 31 23:03:27.248: INFO: Waiting up to 5m0s for pod "pod-b449da27-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-tsgx7" to be "success or failure"
+Oct 31 23:03:27.255: INFO: Pod "pod-b449da27-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 6.898326ms
+Oct 31 23:03:29.258: INFO: Pod "pod-b449da27-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009747929s
+STEP: Saw pod success
+Oct 31 23:03:29.258: INFO: Pod "pod-b449da27-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:03:29.261: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-b449da27-be8f-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:03:29.278: INFO: Waiting for pod pod-b449da27-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:03:29.279: INFO: Pod pod-b449da27-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:03:29.280: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-tsgx7" for this suite.
+Oct 31 23:03:35.347: INFO: namespace: e2e-tests-emptydir-tsgx7, resource: bindings, ignored listing per whitelist
+Oct 31 23:03:35.379: INFO: namespace e2e-tests-emptydir-tsgx7 deletion completed in 6.097313555s
+
+• [SLOW TEST:8.159 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should support (root,0777,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:85
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Secrets 
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:325
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:03:35.380: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:325
+STEP: Creating secret with name s-test-opt-del-b9279c35-be8f-11e7-82e0-0a580a400306
+STEP: Creating secret with name s-test-opt-upd-b9279cb1-be8f-11e7-82e0-0a580a400306
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-b9279c35-be8f-11e7-82e0-0a580a400306
+STEP: Updating secret s-test-opt-upd-b9279cb1-be8f-11e7-82e0-0a580a400306
+STEP: Creating secret with name s-test-opt-create-b9279df8-be8f-11e7-82e0-0a580a400306
+STEP: waiting to observe update in volume
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:03:39.886: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-2d7sv" for this suite.
+Oct 31 23:04:02.218: INFO: namespace: e2e-tests-secrets-2d7sv, resource: bindings, ignored listing per whitelist
+Oct 31 23:04:02.218: INFO: namespace e2e-tests-secrets-2d7sv deletion completed in 22.250708934s
+
+• [SLOW TEST:26.839 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:325
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/events.go:129
+[BeforeEach] [k8s.io] Events
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:04:02.219: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/events.go:129
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-c92689e9-be8f-11e7-82e0-0a580a400306,GenerateName:,Namespace:e2e-tests-events-2tt6f,SelfLink:/api/v1/namespaces/e2e-tests-events-2tt6f/pods/send-events-c92689e9-be8f-11e7-82e0-0a580a400306,UID:c926cfce-be8f-11e7-862c-42010af00002,ResourceVersion:4380,Generation:0,CreationTimestamp:2017-10-31 23:04:02 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 243639166,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-vwdh8 {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-vwdh8,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-vwdh8 true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:kubernetes-minion-group-vbpt,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.alpha.kubernetes.io/notReady Exists  NoExecute 0xc421039840} {node.alpha.kubernetes.io/unreachable Exists  NoExecute 0xc421039860}],HostAliases:[],PriorityClassName:,Priority:nil,},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2017-10-31 23:04:02 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2017-10-31 23:04:02 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2017-10-31 23:04:02 +0000 UTC  }],Message:,Reason:,HostIP:10.240.0.5,PodIP:10.64.3.61,StartTime:2017-10-31 23:04:02 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2017-10-31 23:04:02 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://edcc59f7a651b531c8149520a049a6325f50bc04f031fc328f8527df21b92229}],QOSClass:BestEffort,InitContainerStatuses:[],},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] Events
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:04:08.279: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-2tt6f" for this suite.
+Oct 31 23:04:14.317: INFO: namespace: e2e-tests-events-2tt6f, resource: bindings, ignored listing per whitelist
+Oct 31 23:04:14.381: INFO: namespace e2e-tests-events-2tt6f deletion completed in 6.097349124s
+
+• [SLOW TEST:12.162 seconds]
+[k8s.io] Events
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be sent by kubelets and the scheduler about pods scheduling and running [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/events.go:129
+------------------------------
+SSS
+------------------------------
+[k8s.io] Downward API volume 
+  should provide podname only [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:49
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:04:14.381: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide podname only [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:49
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 23:04:14.411: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d06649fd-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-tztc7" to be "success or failure"
+Oct 31 23:04:14.417: INFO: Pod "downwardapi-volume-d06649fd-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.972478ms
+Oct 31 23:04:16.420: INFO: Pod "downwardapi-volume-d06649fd-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008950743s
+STEP: Saw pod success
+Oct 31 23:04:16.420: INFO: Pod "downwardapi-volume-d06649fd-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:04:16.422: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-d06649fd-be8f-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 23:04:16.437: INFO: Waiting for pod downwardapi-volume-d06649fd-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:04:16.440: INFO: Pod downwardapi-volume-d06649fd-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:04:16.440: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-tztc7" for this suite.
+Oct 31 23:04:22.479: INFO: namespace: e2e-tests-downward-api-tztc7, resource: bindings, ignored listing per whitelist
+Oct 31 23:04:22.533: INFO: namespace e2e-tests-downward-api-tztc7 deletion completed in 6.090626071s
+
+• [SLOW TEST:8.152 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide podname only [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:49
+------------------------------
+[k8s.io] Downward API volume 
+  should set DefaultMode on files [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:59
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:04:22.533: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should set DefaultMode on files [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:59
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 23:04:22.613: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d549bcfb-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-wfl9p" to be "success or failure"
+Oct 31 23:04:22.620: INFO: Pod "downwardapi-volume-d549bcfb-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 6.596965ms
+Oct 31 23:04:24.623: INFO: Pod "downwardapi-volume-d549bcfb-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009368324s
+STEP: Saw pod success
+Oct 31 23:04:24.623: INFO: Pod "downwardapi-volume-d549bcfb-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:04:24.624: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-d549bcfb-be8f-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 23:04:24.639: INFO: Waiting for pod downwardapi-volume-d549bcfb-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:04:24.641: INFO: Pod downwardapi-volume-d549bcfb-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:04:24.641: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-wfl9p" for this suite.
+Oct 31 23:04:30.726: INFO: namespace: e2e-tests-downward-api-wfl9p, resource: bindings, ignored listing per whitelist
+Oct 31 23:04:30.735: INFO: namespace e2e-tests-downward-api-wfl9p deletion completed in 6.09148097s
+
+• [SLOW TEST:8.202 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should set DefaultMode on files [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:59
+------------------------------
+S
+------------------------------
+[k8s.io] ConfigMap 
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:328
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:04:30.735: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:328
+STEP: Creating configMap with name cm-test-opt-del-da25f1bb-be8f-11e7-82e0-0a580a400306
+STEP: Creating configMap with name cm-test-opt-upd-da25f200-be8f-11e7-82e0-0a580a400306
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-da25f1bb-be8f-11e7-82e0-0a580a400306
+STEP: Updating configmap cm-test-opt-upd-da25f200-be8f-11e7-82e0-0a580a400306
+STEP: Creating configMap with name cm-test-opt-create-da25f214-be8f-11e7-82e0-0a580a400306
+STEP: waiting to observe update in volume
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:04:34.836: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-kdtjj" for this suite.
+Oct 31 23:04:56.904: INFO: namespace: e2e-tests-configmap-kdtjj, resource: bindings, ignored listing per whitelist
+Oct 31 23:04:56.935: INFO: namespace e2e-tests-configmap-kdtjj deletion completed in 22.096668666s
+
+• [SLOW TEST:26.200 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:328
+------------------------------
+SSS
+------------------------------
+[k8s.io] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:140
+[BeforeEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:04:56.936: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:140
+STEP: Creating a pod to test downward api env vars
+Oct 31 23:04:56.984: INFO: Waiting up to 5m0s for pod "downward-api-e9c64f55-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-b6zzt" to be "success or failure"
+Oct 31 23:04:56.992: INFO: Pod "downward-api-e9c64f55-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 7.513409ms
+Oct 31 23:04:58.995: INFO: Pod "downward-api-e9c64f55-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010860193s
+STEP: Saw pod success
+Oct 31 23:04:58.995: INFO: Pod "downward-api-e9c64f55-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:04:58.997: INFO: Trying to get logs from node kubernetes-minion-group-rv1l pod downward-api-e9c64f55-be8f-11e7-82e0-0a580a400306 container dapi-container: <nil>
+STEP: delete the pod
+Oct 31 23:04:59.021: INFO: Waiting for pod downward-api-e9c64f55-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:04:59.024: INFO: Pod downward-api-e9c64f55-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:04:59.025: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-b6zzt" for this suite.
+Oct 31 23:05:05.115: INFO: namespace: e2e-tests-downward-api-b6zzt, resource: bindings, ignored listing per whitelist
+Oct 31 23:05:05.132: INFO: namespace e2e-tests-downward-api-b6zzt deletion completed in 6.105592713s
+
+• [SLOW TEST:8.197 seconds]
+[k8s.io] Downward API
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:140
+------------------------------
+SS
+------------------------------
+[k8s.io] Downward API volume 
+  should provide container's memory request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:190
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:05:05.133: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide container's memory request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:190
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 23:05:05.183: INFO: Waiting up to 5m0s for pod "downwardapi-volume-eea85de6-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-7dhkt" to be "success or failure"
+Oct 31 23:05:05.196: INFO: Pod "downwardapi-volume-eea85de6-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 13.595283ms
+Oct 31 23:05:07.199: INFO: Pod "downwardapi-volume-eea85de6-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.016514202s
+STEP: Saw pod success
+Oct 31 23:05:07.199: INFO: Pod "downwardapi-volume-eea85de6-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:05:07.201: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-eea85de6-be8f-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 23:05:07.217: INFO: Waiting for pod downwardapi-volume-eea85de6-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:05:07.225: INFO: Pod downwardapi-volume-eea85de6-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:05:07.226: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-7dhkt" for this suite.
+Oct 31 23:05:13.302: INFO: namespace: e2e-tests-downward-api-7dhkt, resource: bindings, ignored listing per whitelist
+Oct 31 23:05:13.365: INFO: namespace e2e-tests-downward-api-7dhkt deletion completed in 6.136579125s
+
+• [SLOW TEST:8.232 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide container's memory request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:190
+------------------------------
+SS
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:357
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:05:13.365: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:129
+[It] should allow activeDeadlineSeconds to be updated [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:357
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Oct 31 23:05:19.928: INFO: Successfully updated pod "pod-update-activedeadlineseconds-f38f7a41-be8f-11e7-82e0-0a580a400306"
+Oct 31 23:05:19.928: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-f38f7a41-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-pods-6gpg2" to be "terminated due to deadline exceeded"
+Oct 31 23:05:19.929: INFO: Pod "pod-update-activedeadlineseconds-f38f7a41-be8f-11e7-82e0-0a580a400306": Phase="Running", Reason="", readiness=true. Elapsed: 1.765996ms
+Oct 31 23:05:21.932: INFO: Pod "pod-update-activedeadlineseconds-f38f7a41-be8f-11e7-82e0-0a580a400306": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 2.004384263s
+Oct 31 23:05:21.932: INFO: Pod "pod-update-activedeadlineseconds-f38f7a41-be8f-11e7-82e0-0a580a400306" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:05:21.932: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-6gpg2" for this suite.
+Oct 31 23:05:28.030: INFO: namespace: e2e-tests-pods-6gpg2, resource: bindings, ignored listing per whitelist
+Oct 31 23:05:28.035: INFO: namespace e2e-tests-pods-6gpg2 deletion completed in 6.096845134s
+
+• [SLOW TEST:14.670 seconds]
+[k8s.io] Pods
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should allow activeDeadlineSeconds to be updated [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:357
+------------------------------
+SSS
+------------------------------
+[k8s.io] Projected 
+  should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:771
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:05:28.035: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:771
+STEP: Creating configMap with name projected-configmap-test-volume-fc4ced39-be8f-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:05:28.067: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-fc4d5899-be8f-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-lmx2m" to be "success or failure"
+Oct 31 23:05:28.072: INFO: Pod "pod-projected-configmaps-fc4d5899-be8f-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.05898ms
+Oct 31 23:05:30.076: INFO: Pod "pod-projected-configmaps-fc4d5899-be8f-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00844651s
+STEP: Saw pod success
+Oct 31 23:05:30.076: INFO: Pod "pod-projected-configmaps-fc4d5899-be8f-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:05:30.077: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-configmaps-fc4d5899-be8f-11e7-82e0-0a580a400306 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:05:30.093: INFO: Waiting for pod pod-projected-configmaps-fc4d5899-be8f-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:05:30.096: INFO: Pod pod-projected-configmaps-fc4d5899-be8f-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:05:30.096: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lmx2m" for this suite.
+Oct 31 23:05:36.136: INFO: namespace: e2e-tests-projected-lmx2m, resource: bindings, ignored listing per whitelist
+Oct 31 23:05:36.191: INFO: namespace e2e-tests-projected-lmx2m deletion completed in 6.092855206s
+
+• [SLOW TEST:8.156 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:771
+------------------------------
+SSS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:267
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:05:36.191: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:129
+[It] should be submitted and removed [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:267
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Oct 31 23:05:38.288: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-0130cc36-be90-11e7-82e0-0a580a400306", GenerateName:"", Namespace:"e2e-tests-pods-d5wvq", SelfLink:"/api/v1/namespaces/e2e-tests-pods-d5wvq/pods/pod-submit-remove-0130cc36-be90-11e7-82e0-0a580a400306", UID:"013175f7-be90-11e7-862c-42010af00002", ResourceVersion:"4657", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{sec:63645087936, nsec:0, loc:(*time.Location)(0x5c6b200)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"263281672"}, Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-dqx5b", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc420f57e00), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"gcr.io/google-containers/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-dqx5b", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc4207d6fa8), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"kubernetes-minion-group-vbpt", HostNetwork:false, HostPID:false, HostIPC:false, SecurityContext:(*v1.PodSecurityContext)(0xc420f57f00), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.alpha.kubernetes.io/notReady", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc4207d7030)}, v1.Toleration{Key:"node.alpha.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc4207d7060)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{sec:0, nsec:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{sec:63645087936, nsec:0, loc:(*time.Location)(0x5c6b200)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{sec:0, nsec:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{sec:63645087937, nsec:0, loc:(*time.Location)(0x5c6b200)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{sec:0, nsec:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{sec:63645087936, nsec:0, loc:(*time.Location)(0x5c6b200)}}, Reason:"", Message:""}}, Message:"", Reason:"", HostIP:"10.240.0.5", PodIP:"10.64.3.70", StartTime:(*v1.Time)(0xc420d146e0), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc420d14820), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"gcr.io/google-containers/nginx-slim-amd64:0.20", ImageID:"docker-pullable://gcr.io/google-containers/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://363d05b30d46335661f3af3177dfef79d608209d234a037c417467e30b5e0914"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:05:45.221: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-d5wvq" for this suite.
+Oct 31 23:05:51.286: INFO: namespace: e2e-tests-pods-d5wvq, resource: bindings, ignored listing per whitelist
+Oct 31 23:05:51.316: INFO: namespace e2e-tests-pods-d5wvq deletion completed in 6.09251343s
+
+• [SLOW TEST:15.124 seconds]
+[k8s.io] Pods
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be submitted and removed [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:267
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:237
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:05:51.316: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] should *not* be restarted with a /healthz http liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:237
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-xtxxw
+Oct 31 23:05:53.354: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-xtxxw
+STEP: checking the pod's current state and verifying that restartCount is present
+Oct 31 23:05:53.356: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:07:53.541: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-xtxxw" for this suite.
+Oct 31 23:07:59.588: INFO: namespace: e2e-tests-container-probe-xtxxw, resource: bindings, ignored listing per whitelist
+Oct 31 23:07:59.635: INFO: namespace e2e-tests-container-probe-xtxxw deletion completed in 6.09088226s
+
+• [SLOW TEST:128.319 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should *not* be restarted with a /healthz http liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:237
+------------------------------
+SS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:403
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:07:59.635: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:403
+STEP: Creating configMap with name projected-configmap-test-volume-map-56a979a4-be90-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:07:59.669: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-56a9e133-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-q9cf4" to be "success or failure"
+Oct 31 23:07:59.672: INFO: Pod "pod-projected-configmaps-56a9e133-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 3.192434ms
+Oct 31 23:08:01.675: INFO: Pod "pod-projected-configmaps-56a9e133-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006068883s
+STEP: Saw pod success
+Oct 31 23:08:01.675: INFO: Pod "pod-projected-configmaps-56a9e133-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:08:01.676: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-configmaps-56a9e133-be90-11e7-82e0-0a580a400306 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:08:01.692: INFO: Waiting for pod pod-projected-configmaps-56a9e133-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:08:01.697: INFO: Pod pod-projected-configmaps-56a9e133-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:08:01.697: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-q9cf4" for this suite.
+Oct 31 23:08:07.788: INFO: namespace: e2e-tests-projected-q9cf4, resource: bindings, ignored listing per whitelist
+Oct 31 23:08:07.788: INFO: namespace e2e-tests-projected-q9cf4 deletion completed in 6.088706084s
+
+• [SLOW TEST:8.154 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:403
+------------------------------
+[k8s.io] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:936
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:08:07.788: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:936
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 23:08:07.819: INFO: Waiting up to 5m0s for pod "downwardapi-volume-5b854a02-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-jzrkq" to be "success or failure"
+Oct 31 23:08:07.823: INFO: Pod "downwardapi-volume-5b854a02-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 3.340324ms
+Oct 31 23:08:09.825: INFO: Pod "downwardapi-volume-5b854a02-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006255746s
+STEP: Saw pod success
+Oct 31 23:08:09.825: INFO: Pod "downwardapi-volume-5b854a02-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:08:09.828: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-5b854a02-be90-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 23:08:09.846: INFO: Waiting for pod downwardapi-volume-5b854a02-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:08:09.849: INFO: Pod downwardapi-volume-5b854a02-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:08:09.849: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jzrkq" for this suite.
+Oct 31 23:08:15.911: INFO: namespace: e2e-tests-projected-jzrkq, resource: bindings, ignored listing per whitelist
+Oct 31 23:08:15.963: INFO: namespace e2e-tests-projected-jzrkq deletion completed in 6.11080011s
+
+• [SLOW TEST:8.174 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:936
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:66
+[BeforeEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:08:15.963: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:66
+STEP: Creating a pod to test override all
+Oct 31 23:08:15.993: INFO: Waiting up to 5m0s for pod "client-containers-6064986e-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-containers-wkdlf" to be "success or failure"
+Oct 31 23:08:16.001: INFO: Pod "client-containers-6064986e-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 7.855012ms
+Oct 31 23:08:18.005: INFO: Pod "client-containers-6064986e-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.0121372s
+STEP: Saw pod success
+Oct 31 23:08:18.005: INFO: Pod "client-containers-6064986e-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:08:18.007: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod client-containers-6064986e-be90-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:08:18.025: INFO: Waiting for pod client-containers-6064986e-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:08:18.027: INFO: Pod client-containers-6064986e-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:08:18.027: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-wkdlf" for this suite.
+Oct 31 23:08:24.138: INFO: namespace: e2e-tests-containers-wkdlf, resource: bindings, ignored listing per whitelist
+Oct 31 23:08:24.149: INFO: namespace e2e-tests-containers-wkdlf deletion completed in 6.118803397s
+
+• [SLOW TEST:8.186 seconds]
+[k8s.io] Docker Containers
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be able to override the image's default command and arguments [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:66
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (root,0644,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:105
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:08:24.149: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:105
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Oct 31 23:08:24.177: INFO: Waiting up to 5m0s for pod "pod-654578ed-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-9mgjp" to be "success or failure"
+Oct 31 23:08:24.184: INFO: Pod "pod-654578ed-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 7.408549ms
+Oct 31 23:08:26.187: INFO: Pod "pod-654578ed-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010265413s
+STEP: Saw pod success
+Oct 31 23:08:26.187: INFO: Pod "pod-654578ed-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:08:26.189: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-654578ed-be90-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:08:26.205: INFO: Waiting for pod pod-654578ed-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:08:26.207: INFO: Pod pod-654578ed-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:08:26.207: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-9mgjp" for this suite.
+Oct 31 23:08:32.256: INFO: namespace: e2e-tests-emptydir-9mgjp, resource: bindings, ignored listing per whitelist
+Oct 31 23:08:32.298: INFO: namespace e2e-tests-emptydir-9mgjp deletion completed in 6.087974556s
+
+• [SLOW TEST:8.149 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should support (root,0644,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:105
+------------------------------
+SS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:277
+[BeforeEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:08:32.298: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:277
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-dsdsc in namespace e2e-tests-proxy-sxlp7
+Oct 31 23:08:39.407: INFO: setup took 7.08641113s, starting test cases
+STEP: running 34 cases, 20 attempts per case, 680 total attempts
+Oct 31 23:08:39.565: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 157.161434ms)
+Oct 31 23:08:39.566: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 158.151954ms)
+Oct 31 23:08:39.566: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 158.603859ms)
+Oct 31 23:08:39.567: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 160.010796ms)
+Oct 31 23:08:39.568: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 160.653084ms)
+Oct 31 23:08:39.568: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 160.89327ms)
+Oct 31 23:08:39.568: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 161.228117ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 160.554856ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 161.473997ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 161.713055ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 161.833767ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 161.077206ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 162.283856ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 162.015065ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 161.58312ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 161.229145ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 161.399821ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 161.476478ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 161.573706ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 161.689306ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 161.414866ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 161.500372ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 161.674208ms)
+Oct 31 23:08:39.569: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 162.047311ms)
+Oct 31 23:08:39.570: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 162.378047ms)
+Oct 31 23:08:39.570: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 162.90833ms)
+Oct 31 23:08:39.570: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 162.631335ms)
+Oct 31 23:08:39.570: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 162.613789ms)
+Oct 31 23:08:39.582: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 173.691388ms)
+Oct 31 23:08:39.603: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 196.419407ms)
+Oct 31 23:08:39.604: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 196.345887ms)
+Oct 31 23:08:39.604: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 195.679846ms)
+Oct 31 23:08:39.622: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 214.365105ms)
+Oct 31 23:08:39.622: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 213.721683ms)
+Oct 31 23:08:39.800: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 178.018048ms)
+Oct 31 23:08:39.804: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 181.743336ms)
+Oct 31 23:08:39.810: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 187.953247ms)
+Oct 31 23:08:39.810: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 187.965228ms)
+Oct 31 23:08:39.811: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 188.662128ms)
+Oct 31 23:08:39.811: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 188.605524ms)
+Oct 31 23:08:39.811: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 188.291667ms)
+Oct 31 23:08:39.811: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 188.516803ms)
+Oct 31 23:08:39.812: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 189.793274ms)
+Oct 31 23:08:39.812: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 189.229623ms)
+Oct 31 23:08:39.812: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 189.777273ms)
+Oct 31 23:08:39.812: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 190.094504ms)
+Oct 31 23:08:39.812: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 189.107114ms)
+Oct 31 23:08:39.812: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 189.012204ms)
+Oct 31 23:08:39.869: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 245.835659ms)
+Oct 31 23:08:39.869: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 246.406716ms)
+Oct 31 23:08:39.869: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 246.330712ms)
+Oct 31 23:08:39.869: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 246.56621ms)
+Oct 31 23:08:39.869: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 247.050112ms)
+Oct 31 23:08:39.869: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 246.954194ms)
+Oct 31 23:08:39.869: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 247.275885ms)
+Oct 31 23:08:39.870: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 247.579892ms)
+Oct 31 23:08:39.870: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 246.569055ms)
+Oct 31 23:08:39.915: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 292.839551ms)
+Oct 31 23:08:39.915: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 291.832602ms)
+Oct 31 23:08:39.917: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 294.585071ms)
+Oct 31 23:08:39.917: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 294.955773ms)
+Oct 31 23:08:39.918: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 295.264091ms)
+Oct 31 23:08:39.918: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 295.253916ms)
+Oct 31 23:08:39.918: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 294.856265ms)
+Oct 31 23:08:39.918: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 295.127855ms)
+Oct 31 23:08:39.918: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 295.045919ms)
+Oct 31 23:08:39.918: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 295.740885ms)
+Oct 31 23:08:39.918: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 295.131417ms)
+Oct 31 23:08:40.021: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 101.743572ms)
+Oct 31 23:08:40.023: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 102.933572ms)
+Oct 31 23:08:40.023: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 103.385851ms)
+Oct 31 23:08:40.023: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 103.447748ms)
+Oct 31 23:08:40.024: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 105.00868ms)
+Oct 31 23:08:40.024: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 104.939794ms)
+Oct 31 23:08:40.024: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 104.665058ms)
+Oct 31 23:08:40.024: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 105.169145ms)
+Oct 31 23:08:40.024: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 105.396464ms)
+Oct 31 23:08:40.024: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 104.764306ms)
+Oct 31 23:08:40.024: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 104.910615ms)
+Oct 31 23:08:40.024: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 105.319985ms)
+Oct 31 23:08:40.024: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 105.652174ms)
+Oct 31 23:08:40.025: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 104.904589ms)
+Oct 31 23:08:40.049: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 128.749547ms)
+Oct 31 23:08:40.049: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 129.952405ms)
+Oct 31 23:08:40.051: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 132.040296ms)
+Oct 31 23:08:40.051: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 132.029012ms)
+Oct 31 23:08:40.051: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 131.887806ms)
+Oct 31 23:08:40.051: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 131.63994ms)
+Oct 31 23:08:40.051: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 132.093594ms)
+Oct 31 23:08:40.052: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 133.248648ms)
+Oct 31 23:08:40.052: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 132.213868ms)
+Oct 31 23:08:40.052: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 132.359907ms)
+Oct 31 23:08:40.052: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 132.237595ms)
+Oct 31 23:08:40.052: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 131.936921ms)
+Oct 31 23:08:40.052: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 132.151737ms)
+Oct 31 23:08:40.052: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 132.027322ms)
+Oct 31 23:08:40.052: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 133.091743ms)
+Oct 31 23:08:40.052: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 133.215195ms)
+Oct 31 23:08:40.052: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 133.502315ms)
+Oct 31 23:08:40.052: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 133.011131ms)
+Oct 31 23:08:40.053: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 133.935128ms)
+Oct 31 23:08:40.053: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 132.862815ms)
+Oct 31 23:08:40.082: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 27.736401ms)
+Oct 31 23:08:40.082: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 27.437422ms)
+Oct 31 23:08:40.082: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 28.186002ms)
+Oct 31 23:08:40.082: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 28.626582ms)
+Oct 31 23:08:40.084: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 30.819887ms)
+Oct 31 23:08:40.084: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 30.924752ms)
+Oct 31 23:08:40.085: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 30.111047ms)
+Oct 31 23:08:40.085: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 30.371904ms)
+Oct 31 23:08:40.085: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 30.970965ms)
+Oct 31 23:08:40.085: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 31.419632ms)
+Oct 31 23:08:40.085: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 30.462606ms)
+Oct 31 23:08:40.085: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 32.146001ms)
+Oct 31 23:08:40.085: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 32.074657ms)
+Oct 31 23:08:40.085: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 32.230739ms)
+Oct 31 23:08:40.085: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 31.869403ms)
+Oct 31 23:08:40.085: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 32.005062ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 34.308711ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 34.2738ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 35.010254ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 35.873164ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 34.398486ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 35.561533ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 35.391119ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 35.359327ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 34.653647ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 34.478301ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 35.822758ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 35.019891ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 34.440686ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 35.25312ms)
+Oct 31 23:08:40.089: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 35.135075ms)
+Oct 31 23:08:40.090: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 36.235713ms)
+Oct 31 23:08:40.090: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 35.388648ms)
+Oct 31 23:08:40.090: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 35.634457ms)
+Oct 31 23:08:40.110: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 20.243788ms)
+Oct 31 23:08:40.110: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 20.362368ms)
+Oct 31 23:08:40.110: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 20.380384ms)
+Oct 31 23:08:40.115: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 24.149347ms)
+Oct 31 23:08:40.115: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 24.408052ms)
+Oct 31 23:08:40.115: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 24.983812ms)
+Oct 31 23:08:40.116: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 24.907921ms)
+Oct 31 23:08:40.117: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 26.027185ms)
+Oct 31 23:08:40.117: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 26.607153ms)
+Oct 31 23:08:40.118: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 25.231378ms)
+Oct 31 23:08:40.118: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 26.771018ms)
+Oct 31 23:08:40.118: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 27.403751ms)
+Oct 31 23:08:40.118: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 27.651169ms)
+Oct 31 23:08:40.118: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 26.336995ms)
+Oct 31 23:08:40.119: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 28.97674ms)
+Oct 31 23:08:40.121: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 30.128212ms)
+Oct 31 23:08:40.121: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 30.823511ms)
+Oct 31 23:08:40.122: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 30.485245ms)
+Oct 31 23:08:40.122: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 30.451732ms)
+Oct 31 23:08:40.122: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 30.225741ms)
+Oct 31 23:08:40.122: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 31.24818ms)
+Oct 31 23:08:40.122: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 31.570626ms)
+Oct 31 23:08:40.122: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 31.299337ms)
+Oct 31 23:08:40.122: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 31.455973ms)
+Oct 31 23:08:40.122: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 31.410038ms)
+Oct 31 23:08:40.122: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 31.425785ms)
+Oct 31 23:08:40.122: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 31.60991ms)
+Oct 31 23:08:40.122: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 31.972216ms)
+Oct 31 23:08:40.122: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 31.463197ms)
+Oct 31 23:08:40.123: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 30.011257ms)
+Oct 31 23:08:40.123: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 30.427557ms)
+Oct 31 23:08:40.124: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 33.3461ms)
+Oct 31 23:08:40.123: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 33.30656ms)
+Oct 31 23:08:40.124: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 33.224148ms)
+Oct 31 23:08:40.144: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 19.717041ms)
+Oct 31 23:08:40.147: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 22.129084ms)
+Oct 31 23:08:40.147: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 22.816048ms)
+Oct 31 23:08:40.147: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 22.696602ms)
+Oct 31 23:08:40.147: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 23.682484ms)
+Oct 31 23:08:40.148: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 23.908343ms)
+Oct 31 23:08:40.149: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 24.271156ms)
+Oct 31 23:08:40.149: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 24.654993ms)
+Oct 31 23:08:40.149: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 25.025329ms)
+Oct 31 23:08:40.149: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 25.114394ms)
+Oct 31 23:08:40.149: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 24.73241ms)
+Oct 31 23:08:40.149: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 25.06175ms)
+Oct 31 23:08:40.149: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 24.91365ms)
+Oct 31 23:08:40.149: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 25.577958ms)
+Oct 31 23:08:40.152: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 27.410002ms)
+Oct 31 23:08:40.152: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 27.186349ms)
+Oct 31 23:08:40.152: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 27.741729ms)
+Oct 31 23:08:40.152: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 27.705574ms)
+Oct 31 23:08:40.152: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 27.582782ms)
+Oct 31 23:08:40.152: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 28.318179ms)
+Oct 31 23:08:40.152: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 27.817039ms)
+Oct 31 23:08:40.152: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 27.902026ms)
+Oct 31 23:08:40.152: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 28.13497ms)
+Oct 31 23:08:40.155: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 30.118059ms)
+Oct 31 23:08:40.155: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 30.769953ms)
+Oct 31 23:08:40.155: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 30.747103ms)
+Oct 31 23:08:40.155: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 30.363606ms)
+Oct 31 23:08:40.155: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 30.57868ms)
+Oct 31 23:08:40.155: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 30.440089ms)
+Oct 31 23:08:40.155: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 30.683689ms)
+Oct 31 23:08:40.155: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 31.237816ms)
+Oct 31 23:08:40.155: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 30.695977ms)
+Oct 31 23:08:40.155: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 31.015931ms)
+Oct 31 23:08:40.155: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 31.271141ms)
+Oct 31 23:08:40.174: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 18.516546ms)
+Oct 31 23:08:40.175: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 18.140983ms)
+Oct 31 23:08:40.175: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 18.451244ms)
+Oct 31 23:08:40.178: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 22.557751ms)
+Oct 31 23:08:40.179: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 22.871759ms)
+Oct 31 23:08:40.179: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 22.384348ms)
+Oct 31 23:08:40.181: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 24.449609ms)
+Oct 31 23:08:40.182: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 26.204916ms)
+Oct 31 23:08:40.182: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 24.196202ms)
+Oct 31 23:08:40.182: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 25.295038ms)
+Oct 31 23:08:40.183: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 24.722748ms)
+Oct 31 23:08:40.183: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 25.036874ms)
+Oct 31 23:08:40.183: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 25.770268ms)
+Oct 31 23:08:40.183: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 25.405853ms)
+Oct 31 23:08:40.183: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 24.890835ms)
+Oct 31 23:08:40.183: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 25.69353ms)
+Oct 31 23:08:40.183: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 26.840373ms)
+Oct 31 23:08:40.183: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 26.723783ms)
+Oct 31 23:08:40.184: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 24.872401ms)
+Oct 31 23:08:40.184: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 26.171647ms)
+Oct 31 23:08:40.184: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 26.889391ms)
+Oct 31 23:08:40.187: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 28.426008ms)
+Oct 31 23:08:40.187: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 30.100748ms)
+Oct 31 23:08:40.187: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 29.642915ms)
+Oct 31 23:08:40.187: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 30.289712ms)
+Oct 31 23:08:40.187: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 29.256122ms)
+Oct 31 23:08:40.187: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 31.212699ms)
+Oct 31 23:08:40.187: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 31.182208ms)
+Oct 31 23:08:40.187: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 28.686079ms)
+Oct 31 23:08:40.188: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 28.617462ms)
+Oct 31 23:08:40.188: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 30.177169ms)
+Oct 31 23:08:40.188: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 29.025353ms)
+Oct 31 23:08:40.188: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 28.808727ms)
+Oct 31 23:08:40.188: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 30.255604ms)
+Oct 31 23:08:40.210: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 21.295224ms)
+Oct 31 23:08:40.210: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 20.990476ms)
+Oct 31 23:08:40.210: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 21.679801ms)
+Oct 31 23:08:40.210: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 21.823086ms)
+Oct 31 23:08:40.215: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 25.956109ms)
+Oct 31 23:08:40.215: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 26.226789ms)
+Oct 31 23:08:40.215: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 26.359304ms)
+Oct 31 23:08:40.215: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 26.633421ms)
+Oct 31 23:08:40.215: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 26.691546ms)
+Oct 31 23:08:40.215: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 26.806722ms)
+Oct 31 23:08:40.215: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 27.209154ms)
+Oct 31 23:08:40.215: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 26.980985ms)
+Oct 31 23:08:40.216: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 26.987189ms)
+Oct 31 23:08:40.216: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 27.200858ms)
+Oct 31 23:08:40.216: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 27.094601ms)
+Oct 31 23:08:40.216: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 27.197191ms)
+Oct 31 23:08:40.214: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 25.788705ms)
+Oct 31 23:08:40.217: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 28.27005ms)
+Oct 31 23:08:40.219: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 30.120947ms)
+Oct 31 23:08:40.219: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 30.424712ms)
+Oct 31 23:08:40.219: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 30.345185ms)
+Oct 31 23:08:40.219: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 30.578777ms)
+Oct 31 23:08:40.219: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 30.62727ms)
+Oct 31 23:08:40.219: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 30.749256ms)
+Oct 31 23:08:40.219: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 30.607739ms)
+Oct 31 23:08:40.219: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 31.435917ms)
+Oct 31 23:08:40.220: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 30.893876ms)
+Oct 31 23:08:40.220: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 31.11826ms)
+Oct 31 23:08:40.220: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 31.35185ms)
+Oct 31 23:08:40.220: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 31.6531ms)
+Oct 31 23:08:40.220: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 32.190672ms)
+Oct 31 23:08:40.220: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 32.0633ms)
+Oct 31 23:08:40.221: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 31.914904ms)
+Oct 31 23:08:40.221: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 31.952444ms)
+Oct 31 23:08:40.241: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 19.245293ms)
+Oct 31 23:08:40.241: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 19.216657ms)
+Oct 31 23:08:40.242: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 21.371535ms)
+Oct 31 23:08:40.242: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 20.705777ms)
+Oct 31 23:08:40.242: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 21.284254ms)
+Oct 31 23:08:40.243: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 21.542895ms)
+Oct 31 23:08:40.245: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 23.394583ms)
+Oct 31 23:08:40.245: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 23.357224ms)
+Oct 31 23:08:40.245: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 23.73941ms)
+Oct 31 23:08:40.246: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 24.841774ms)
+Oct 31 23:08:40.247: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 25.237182ms)
+Oct 31 23:08:40.247: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 24.784279ms)
+Oct 31 23:08:40.247: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 25.151224ms)
+Oct 31 23:08:40.247: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 26.134132ms)
+Oct 31 23:08:40.248: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 25.400983ms)
+Oct 31 23:08:40.248: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 26.034778ms)
+Oct 31 23:08:40.248: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 25.717321ms)
+Oct 31 23:08:40.248: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 26.142655ms)
+Oct 31 23:08:40.248: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 26.408924ms)
+Oct 31 23:08:40.249: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 27.415268ms)
+Oct 31 23:08:40.251: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 29.588496ms)
+Oct 31 23:08:40.251: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 29.041393ms)
+Oct 31 23:08:40.251: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 28.813983ms)
+Oct 31 23:08:40.251: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 29.385372ms)
+Oct 31 23:08:40.251: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 29.48764ms)
+Oct 31 23:08:40.251: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 29.189277ms)
+Oct 31 23:08:40.251: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 29.6333ms)
+Oct 31 23:08:40.252: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 29.866605ms)
+Oct 31 23:08:40.252: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 29.654753ms)
+Oct 31 23:08:40.252: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 29.77635ms)
+Oct 31 23:08:40.252: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 29.809816ms)
+Oct 31 23:08:40.252: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 29.773714ms)
+Oct 31 23:08:40.252: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 30.081199ms)
+Oct 31 23:08:40.252: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 29.758914ms)
+Oct 31 23:08:40.266: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 13.758756ms)
+Oct 31 23:08:40.271: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 18.484267ms)
+Oct 31 23:08:40.273: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 19.94561ms)
+Oct 31 23:08:40.273: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 20.403662ms)
+Oct 31 23:08:40.273: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 20.69299ms)
+Oct 31 23:08:40.273: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 20.486036ms)
+Oct 31 23:08:40.274: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 21.940862ms)
+Oct 31 23:08:40.275: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 21.59593ms)
+Oct 31 23:08:40.275: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 21.895425ms)
+Oct 31 23:08:40.275: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 22.034629ms)
+Oct 31 23:08:40.275: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 22.237078ms)
+Oct 31 23:08:40.275: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 22.436021ms)
+Oct 31 23:08:40.275: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 22.445634ms)
+Oct 31 23:08:40.275: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 22.096328ms)
+Oct 31 23:08:40.279: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 26.737683ms)
+Oct 31 23:08:40.279: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 26.272662ms)
+Oct 31 23:08:40.279: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 26.428692ms)
+Oct 31 23:08:40.279: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 26.873769ms)
+Oct 31 23:08:40.279: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 26.656176ms)
+Oct 31 23:08:40.280: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 26.15454ms)
+Oct 31 23:08:40.280: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 26.234123ms)
+Oct 31 23:08:40.280: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 26.627969ms)
+Oct 31 23:08:40.280: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 27.083015ms)
+Oct 31 23:08:40.280: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 27.140111ms)
+Oct 31 23:08:40.282: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 29.075114ms)
+Oct 31 23:08:40.283: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 29.157339ms)
+Oct 31 23:08:40.283: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 29.518893ms)
+Oct 31 23:08:40.283: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 29.597788ms)
+Oct 31 23:08:40.283: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 29.809777ms)
+Oct 31 23:08:40.283: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 29.697179ms)
+Oct 31 23:08:40.283: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 30.087489ms)
+Oct 31 23:08:40.283: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 29.955006ms)
+Oct 31 23:08:40.283: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 30.087898ms)
+Oct 31 23:08:40.283: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 30.207926ms)
+Oct 31 23:08:40.308: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 23.920128ms)
+Oct 31 23:08:40.308: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 23.605164ms)
+Oct 31 23:08:40.308: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 23.81259ms)
+Oct 31 23:08:40.308: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 24.453697ms)
+Oct 31 23:08:40.309: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 25.791448ms)
+Oct 31 23:08:40.309: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 25.369193ms)
+Oct 31 23:08:40.311: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 27.171257ms)
+Oct 31 23:08:40.311: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 27.281128ms)
+Oct 31 23:08:40.311: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 26.891501ms)
+Oct 31 23:08:40.311: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 27.181231ms)
+Oct 31 23:08:40.311: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 27.746221ms)
+Oct 31 23:08:40.311: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 27.713974ms)
+Oct 31 23:08:40.311: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 26.817221ms)
+Oct 31 23:08:40.311: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 26.881046ms)
+Oct 31 23:08:40.312: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 27.145255ms)
+Oct 31 23:08:40.312: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 28.081181ms)
+Oct 31 23:08:40.314: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 30.393773ms)
+Oct 31 23:08:40.315: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 30.165776ms)
+Oct 31 23:08:40.316: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 32.615252ms)
+Oct 31 23:08:40.316: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 32.103462ms)
+Oct 31 23:08:40.316: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 31.972789ms)
+Oct 31 23:08:40.316: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 32.472297ms)
+Oct 31 23:08:40.317: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 32.813526ms)
+Oct 31 23:08:40.317: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 32.54058ms)
+Oct 31 23:08:40.317: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 32.495632ms)
+Oct 31 23:08:40.317: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 32.662012ms)
+Oct 31 23:08:40.317: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 33.112619ms)
+Oct 31 23:08:40.317: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 33.011442ms)
+Oct 31 23:08:40.317: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 33.381748ms)
+Oct 31 23:08:40.317: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 32.893905ms)
+Oct 31 23:08:40.317: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 32.654ms)
+Oct 31 23:08:40.317: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 32.716265ms)
+Oct 31 23:08:40.317: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 32.682368ms)
+Oct 31 23:08:40.317: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 33.546372ms)
+Oct 31 23:08:40.341: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 22.679137ms)
+Oct 31 23:08:40.341: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 23.067909ms)
+Oct 31 23:08:40.342: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 23.919491ms)
+Oct 31 23:08:40.342: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 24.147105ms)
+Oct 31 23:08:40.343: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 25.634884ms)
+Oct 31 23:08:40.344: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 25.429717ms)
+Oct 31 23:08:40.344: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 26.347018ms)
+Oct 31 23:08:40.344: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 26.030698ms)
+Oct 31 23:08:40.344: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 25.987393ms)
+Oct 31 23:08:40.344: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 26.333302ms)
+Oct 31 23:08:40.344: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 26.286086ms)
+Oct 31 23:08:40.344: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 25.865436ms)
+Oct 31 23:08:40.344: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 25.656665ms)
+Oct 31 23:08:40.344: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 26.38518ms)
+Oct 31 23:08:40.346: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 27.801308ms)
+Oct 31 23:08:40.348: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 30.893561ms)
+Oct 31 23:08:40.349: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 30.310432ms)
+Oct 31 23:08:40.349: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 31.243168ms)
+Oct 31 23:08:40.349: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 30.713841ms)
+Oct 31 23:08:40.349: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 31.018406ms)
+Oct 31 23:08:40.349: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 31.531973ms)
+Oct 31 23:08:40.349: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 31.121131ms)
+Oct 31 23:08:40.349: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 31.53794ms)
+Oct 31 23:08:40.349: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 31.818895ms)
+Oct 31 23:08:40.349: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 31.465069ms)
+Oct 31 23:08:40.350: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 31.761078ms)
+Oct 31 23:08:40.350: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 31.879503ms)
+Oct 31 23:08:40.350: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 31.509815ms)
+Oct 31 23:08:40.350: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 31.962148ms)
+Oct 31 23:08:40.350: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 31.909496ms)
+Oct 31 23:08:40.350: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 31.90473ms)
+Oct 31 23:08:40.350: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 31.906599ms)
+Oct 31 23:08:40.350: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 32.476839ms)
+Oct 31 23:08:40.351: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 32.549659ms)
+Oct 31 23:08:40.367: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 16.364061ms)
+Oct 31 23:08:40.371: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 20.570248ms)
+Oct 31 23:08:40.372: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 20.774842ms)
+Oct 31 23:08:40.372: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 19.782571ms)
+Oct 31 23:08:40.376: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 24.0205ms)
+Oct 31 23:08:40.376: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 23.922932ms)
+Oct 31 23:08:40.376: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 24.464377ms)
+Oct 31 23:08:40.377: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 26.04949ms)
+Oct 31 23:08:40.378: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 26.056465ms)
+Oct 31 23:08:40.378: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 25.952597ms)
+Oct 31 23:08:40.378: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 25.789054ms)
+Oct 31 23:08:40.378: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 26.683608ms)
+Oct 31 23:08:40.378: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 26.113646ms)
+Oct 31 23:08:40.378: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 26.260521ms)
+Oct 31 23:08:40.378: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 26.309582ms)
+Oct 31 23:08:40.378: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 27.034297ms)
+Oct 31 23:08:40.378: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 26.522298ms)
+Oct 31 23:08:40.379: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 26.761934ms)
+Oct 31 23:08:40.381: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 28.865766ms)
+Oct 31 23:08:40.381: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 29.340769ms)
+Oct 31 23:08:40.381: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 29.277544ms)
+Oct 31 23:08:40.381: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 29.31175ms)
+Oct 31 23:08:40.381: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 29.893584ms)
+Oct 31 23:08:40.381: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 29.747655ms)
+Oct 31 23:08:40.381: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 29.551101ms)
+Oct 31 23:08:40.381: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 29.634691ms)
+Oct 31 23:08:40.381: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 29.733536ms)
+Oct 31 23:08:40.382: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 29.747996ms)
+Oct 31 23:08:40.382: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 29.672942ms)
+Oct 31 23:08:40.382: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 30.177798ms)
+Oct 31 23:08:40.383: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 31.30077ms)
+Oct 31 23:08:40.383: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 31.018478ms)
+Oct 31 23:08:40.383: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 31.285004ms)
+Oct 31 23:08:40.383: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 31.120771ms)
+Oct 31 23:08:40.402: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 18.118563ms)
+Oct 31 23:08:40.402: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 18.559351ms)
+Oct 31 23:08:40.402: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 18.525239ms)
+Oct 31 23:08:40.403: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 19.754107ms)
+Oct 31 23:08:40.407: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 23.143768ms)
+Oct 31 23:08:40.407: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 23.044915ms)
+Oct 31 23:08:40.407: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 23.59439ms)
+Oct 31 23:08:40.407: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 23.441692ms)
+Oct 31 23:08:40.409: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 24.857751ms)
+Oct 31 23:08:40.409: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 24.184667ms)
+Oct 31 23:08:40.409: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 24.751717ms)
+Oct 31 23:08:40.410: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 25.182232ms)
+Oct 31 23:08:40.411: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 27.360124ms)
+Oct 31 23:08:40.411: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 26.870727ms)
+Oct 31 23:08:40.412: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 26.78692ms)
+Oct 31 23:08:40.412: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 27.515914ms)
+Oct 31 23:08:40.412: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 26.881082ms)
+Oct 31 23:08:40.412: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 28.599526ms)
+Oct 31 23:08:40.412: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 27.102069ms)
+Oct 31 23:08:40.412: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 27.596919ms)
+Oct 31 23:08:40.412: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 28.760991ms)
+Oct 31 23:08:40.412: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 26.841933ms)
+Oct 31 23:08:40.412: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 27.238254ms)
+Oct 31 23:08:40.412: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 27.194824ms)
+Oct 31 23:08:40.412: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 27.404778ms)
+Oct 31 23:08:40.414: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 30.435448ms)
+Oct 31 23:08:40.414: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 30.695508ms)
+Oct 31 23:08:40.414: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 29.477442ms)
+Oct 31 23:08:40.415: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 30.809071ms)
+Oct 31 23:08:40.415: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 30.251558ms)
+Oct 31 23:08:40.415: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 30.357141ms)
+Oct 31 23:08:40.415: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 30.713878ms)
+Oct 31 23:08:40.415: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 30.299507ms)
+Oct 31 23:08:40.415: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 31.329441ms)
+Oct 31 23:08:40.435: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 19.629158ms)
+Oct 31 23:08:40.435: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 20.16845ms)
+Oct 31 23:08:40.438: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 22.906627ms)
+Oct 31 23:08:40.439: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 22.959436ms)
+Oct 31 23:08:40.439: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 22.87865ms)
+Oct 31 23:08:40.440: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 24.743049ms)
+Oct 31 23:08:40.440: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 25.270819ms)
+Oct 31 23:08:40.441: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 24.704431ms)
+Oct 31 23:08:40.441: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 25.727141ms)
+Oct 31 23:08:40.441: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 25.475653ms)
+Oct 31 23:08:40.441: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 25.84127ms)
+Oct 31 23:08:40.441: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 25.80841ms)
+Oct 31 23:08:40.441: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 25.540517ms)
+Oct 31 23:08:40.441: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 25.807004ms)
+Oct 31 23:08:40.441: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 25.90851ms)
+Oct 31 23:08:40.441: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 25.996181ms)
+Oct 31 23:08:40.441: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 25.981866ms)
+Oct 31 23:08:40.444: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 29.018446ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 28.986155ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 29.078926ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 28.904363ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 29.424102ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 29.081834ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 29.898731ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 29.437478ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 29.24312ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 29.672525ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 29.978364ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 29.440668ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 29.580328ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 29.408985ms)
+Oct 31 23:08:40.445: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 29.694716ms)
+Oct 31 23:08:40.446: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 30.136536ms)
+Oct 31 23:08:40.446: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 30.522666ms)
+Oct 31 23:08:40.475: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 28.308706ms)
+Oct 31 23:08:40.475: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 28.250965ms)
+Oct 31 23:08:40.476: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 30.006862ms)
+Oct 31 23:08:40.476: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 30.113721ms)
+Oct 31 23:08:40.476: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 29.764685ms)
+Oct 31 23:08:40.477: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 30.47713ms)
+Oct 31 23:08:40.478: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 31.482459ms)
+Oct 31 23:08:40.478: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 31.488863ms)
+Oct 31 23:08:40.478: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 31.588426ms)
+Oct 31 23:08:40.478: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 31.891288ms)
+Oct 31 23:08:40.478: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 31.577105ms)
+Oct 31 23:08:40.478: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 32.063742ms)
+Oct 31 23:08:40.478: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 31.999495ms)
+Oct 31 23:08:40.478: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 31.767242ms)
+Oct 31 23:08:40.480: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 32.391921ms)
+Oct 31 23:08:40.480: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 33.312797ms)
+Oct 31 23:08:40.482: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 35.294481ms)
+Oct 31 23:08:40.482: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 35.486872ms)
+Oct 31 23:08:40.483: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 35.680075ms)
+Oct 31 23:08:40.483: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 35.635393ms)
+Oct 31 23:08:40.483: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 36.115435ms)
+Oct 31 23:08:40.483: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 35.763006ms)
+Oct 31 23:08:40.483: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 35.951942ms)
+Oct 31 23:08:40.483: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 35.889321ms)
+Oct 31 23:08:40.483: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 35.77463ms)
+Oct 31 23:08:40.483: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 37.020692ms)
+Oct 31 23:08:40.483: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 37.166808ms)
+Oct 31 23:08:40.484: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 36.669336ms)
+Oct 31 23:08:40.484: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 37.251978ms)
+Oct 31 23:08:40.484: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 37.602461ms)
+Oct 31 23:08:40.484: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 36.463369ms)
+Oct 31 23:08:40.484: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 37.892394ms)
+Oct 31 23:08:40.484: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 37.757189ms)
+Oct 31 23:08:40.484: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 37.388807ms)
+Oct 31 23:08:40.500: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 15.906535ms)
+Oct 31 23:08:40.503: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 18.359988ms)
+Oct 31 23:08:40.503: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 18.538124ms)
+Oct 31 23:08:40.507: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 22.580538ms)
+Oct 31 23:08:40.510: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 23.804456ms)
+Oct 31 23:08:40.510: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 24.894372ms)
+Oct 31 23:08:40.510: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 24.709313ms)
+Oct 31 23:08:40.510: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 24.014478ms)
+Oct 31 23:08:40.510: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 24.363603ms)
+Oct 31 23:08:40.510: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 24.929743ms)
+Oct 31 23:08:40.512: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 26.64812ms)
+Oct 31 23:08:40.512: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 25.420391ms)
+Oct 31 23:08:40.512: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 25.694185ms)
+Oct 31 23:08:40.512: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 26.719245ms)
+Oct 31 23:08:40.512: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 26.021894ms)
+Oct 31 23:08:40.512: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 26.523494ms)
+Oct 31 23:08:40.515: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 29.156098ms)
+Oct 31 23:08:40.515: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 30.462704ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 29.335305ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 29.455046ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 30.506468ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 29.663139ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 29.776536ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 29.65019ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 29.600106ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 30.116406ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 30.203618ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 29.87149ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 30.173965ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 29.823592ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 30.802766ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 31.10798ms)
+Oct 31 23:08:40.516: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 30.500062ms)
+Oct 31 23:08:40.517: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 30.818184ms)
+Oct 31 23:08:40.538: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 20.253013ms)
+Oct 31 23:08:40.539: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 20.774046ms)
+Oct 31 23:08:40.539: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 20.494571ms)
+Oct 31 23:08:40.539: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 21.738235ms)
+Oct 31 23:08:40.541: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 24.235193ms)
+Oct 31 23:08:40.541: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 24.496973ms)
+Oct 31 23:08:40.541: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 23.847289ms)
+Oct 31 23:08:40.542: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 23.79196ms)
+Oct 31 23:08:40.542: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 24.273941ms)
+Oct 31 23:08:40.542: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 24.366179ms)
+Oct 31 23:08:40.542: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 24.548031ms)
+Oct 31 23:08:40.542: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 23.472365ms)
+Oct 31 23:08:40.542: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 24.135643ms)
+Oct 31 23:08:40.542: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 19.186266ms)
+Oct 31 23:08:40.544: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 25.190932ms)
+Oct 31 23:08:40.544: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 26.20082ms)
+Oct 31 23:08:40.547: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 28.193692ms)
+Oct 31 23:08:40.547: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 27.701422ms)
+Oct 31 23:08:40.547: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 28.012244ms)
+Oct 31 23:08:40.547: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 29.427591ms)
+Oct 31 23:08:40.547: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 28.572531ms)
+Oct 31 23:08:40.547: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 29.701304ms)
+Oct 31 23:08:40.547: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 28.531319ms)
+Oct 31 23:08:40.547: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 28.296708ms)
+Oct 31 23:08:40.548: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 24.550602ms)
+Oct 31 23:08:40.549: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 25.199903ms)
+Oct 31 23:08:40.549: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 30.253724ms)
+Oct 31 23:08:40.549: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 26.060281ms)
+Oct 31 23:08:40.549: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 25.514879ms)
+Oct 31 23:08:40.549: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 25.930568ms)
+Oct 31 23:08:40.549: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 26.066895ms)
+Oct 31 23:08:40.549: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 25.836987ms)
+Oct 31 23:08:40.549: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 31.539046ms)
+Oct 31 23:08:40.550: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 26.998638ms)
+Oct 31 23:08:40.570: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 20.124602ms)
+Oct 31 23:08:40.571: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 20.405418ms)
+Oct 31 23:08:40.571: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 20.897824ms)
+Oct 31 23:08:40.571: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 20.348326ms)
+Oct 31 23:08:40.571: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 20.700687ms)
+Oct 31 23:08:40.571: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 21.017828ms)
+Oct 31 23:08:40.573: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 21.223826ms)
+Oct 31 23:08:40.574: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 22.606636ms)
+Oct 31 23:08:40.574: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 22.182046ms)
+Oct 31 23:08:40.574: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 22.785864ms)
+Oct 31 23:08:40.575: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 23.824254ms)
+Oct 31 23:08:40.575: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 22.947593ms)
+Oct 31 23:08:40.575: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 23.941319ms)
+Oct 31 23:08:40.575: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 24.633589ms)
+Oct 31 23:08:40.576: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 25.182335ms)
+Oct 31 23:08:40.576: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 22.898719ms)
+Oct 31 23:08:40.576: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 23.129379ms)
+Oct 31 23:08:40.576: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 24.304421ms)
+Oct 31 23:08:40.577: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 26.155857ms)
+Oct 31 23:08:40.577: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 25.057824ms)
+Oct 31 23:08:40.579: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 28.891847ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 26.862938ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 27.764101ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 28.435927ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 27.470948ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 28.041742ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 28.809856ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 27.989119ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 28.19309ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 28.377662ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 28.96343ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 28.071897ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 29.611836ms)
+Oct 31 23:08:40.580: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 27.89696ms)
+Oct 31 23:08:40.601: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/rewri... (200; 20.625551ms)
+Oct 31 23:08:40.601: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/: foo (200; 20.797777ms)
+Oct 31 23:08:40.601: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname1/proxy/: foo (200; 20.950111ms)
+Oct 31 23:08:40.601: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/proxy/: bar (200; 21.041615ms)
+Oct 31 23:08:40.605: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:1080/proxy/rewri... (200; 24.100498ms)
+Oct 31 23:08:40.605: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q/proxy/rewriteme"... (200; 24.395556ms)
+Oct 31 23:08:40.605: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/proxy/... (200; 24.657233ms)
+Oct 31 23:08:40.606: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:462/proxy/: tls qux (200; 25.313992ms)
+Oct 31 23:08:40.607: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:460/proxy/: tls baz (200; 26.284133ms)
+Oct 31 23:08:40.608: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/https:proxy-service-dsdsc-8mw8q:443/proxy/... (200; 27.497065ms)
+Oct 31 23:08:40.608: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:80/: foo (200; 27.871268ms)
+Oct 31 23:08:40.608: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/: bar (200; 27.701847ms)
+Oct 31 23:08:40.608: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/proxy/: tls qux (200; 27.830942ms)
+Oct 31 23:08:40.608: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname2/: tls qux (200; 27.247131ms)
+Oct 31 23:08:40.608: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/proxy/: foo (200; 27.791097ms)
+Oct 31 23:08:40.609: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 28.368936ms)
+Oct 31 23:08:40.609: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/: bar (200; 27.95854ms)
+Oct 31 23:08:40.609: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/proxy/: tls baz (200; 27.501923ms)
+Oct 31 23:08:40.609: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:443/: tls baz (200; 28.442618ms)
+Oct 31 23:08:40.609: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:tlsportname1/: tls baz (200; 27.626291ms)
+Oct 31 23:08:40.609: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:81/: bar (200; 28.294154ms)
+Oct 31 23:08:40.611: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:1080/... (200; 29.970456ms)
+Oct 31 23:08:40.612: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/https:proxy-service-dsdsc:444/: tls qux (200; 31.12982ms)
+Oct 31 23:08:40.612: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:80/: foo (200; 31.948778ms)
+Oct 31 23:08:40.612: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:81/: bar (200; 31.65262ms)
+Oct 31 23:08:40.613: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 32.009589ms)
+Oct 31 23:08:40.613: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname2/proxy/: bar (200; 31.703983ms)
+Oct 31 23:08:40.613: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/proxy-service-dsdsc:portname1/: foo (200; 31.662173ms)
+Oct 31 23:08:40.613: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/services/http:proxy-service-dsdsc:portname2/: bar (200; 31.872009ms)
+Oct 31 23:08:40.613: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/proxy/: foo (200; 32.143627ms)
+Oct 31 23:08:40.613: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:162/proxy/: bar (200; 31.878875ms)
+Oct 31 23:08:40.613: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:160/: foo (200; 31.624447ms)
+Oct 31 23:08:40.613: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/http:proxy-service-dsdsc-8mw8q:160/: foo (200; 32.074849ms)
+Oct 31 23:08:40.613: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-sxlp7/pods/proxy-service-dsdsc-8mw8q:162/: bar (200; 32.294668ms)
+STEP: deleting { ReplicationController} proxy-service-dsdsc in namespace e2e-tests-proxy-sxlp7
+Oct 31 23:08:40.748: INFO: Deleting { ReplicationController} proxy-service-dsdsc took: 33.057457ms
+Oct 31 23:08:40.748: INFO: Terminating { ReplicationController} proxy-service-dsdsc pods took: 39.51µs
+Oct 31 23:08:42.048: INFO: Garbage collecting { ReplicationController} proxy-service-dsdsc pods took: 1.333214216s
+[AfterEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:08:42.049: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-sxlp7" for this suite.
+Oct 31 23:08:48.131: INFO: namespace: e2e-tests-proxy-sxlp7, resource: bindings, ignored listing per whitelist
+Oct 31 23:08:48.148: INFO: namespace e2e-tests-proxy-sxlp7 deletion completed in 6.095138028s
+
+• [SLOW TEST:15.850 seconds]
+[sig-network] Proxy
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:278
+    should proxy through a service and a pod [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:277
+------------------------------
+SSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:89
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:08:48.148: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:89
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Oct 31 23:08:48.176: INFO: Waiting up to 5m0s for pod "pod-73938fb5-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-z6g5w" to be "success or failure"
+Oct 31 23:08:48.181: INFO: Pod "pod-73938fb5-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.2215ms
+Oct 31 23:08:50.192: INFO: Pod "pod-73938fb5-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.015564839s
+STEP: Saw pod success
+Oct 31 23:08:50.192: INFO: Pod "pod-73938fb5-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:08:50.193: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-73938fb5-be90-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:08:50.210: INFO: Waiting for pod pod-73938fb5-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:08:50.213: INFO: Pod pod-73938fb5-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:08:50.213: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-z6g5w" for this suite.
+Oct 31 23:08:56.268: INFO: namespace: e2e-tests-emptydir-z6g5w, resource: bindings, ignored listing per whitelist
+Oct 31 23:08:56.303: INFO: namespace e2e-tests-emptydir-z6g5w deletion completed in 6.088259873s
+
+• [SLOW TEST:8.155 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should support (non-root,0644,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:89
+------------------------------
+[k8s.io] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:50
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:08:56.303: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:50
+STEP: Creating secret with name secret-test-7877d9ba-be90-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 23:08:56.388: INFO: Waiting up to 5m0s for pod "pod-secrets-78787a36-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-secrets-4hlz8" to be "success or failure"
+Oct 31 23:08:56.394: INFO: Pod "pod-secrets-78787a36-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.484122ms
+Oct 31 23:08:58.397: INFO: Pod "pod-secrets-78787a36-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008267065s
+STEP: Saw pod success
+Oct 31 23:08:58.397: INFO: Pod "pod-secrets-78787a36-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:08:58.398: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-secrets-78787a36-be90-11e7-82e0-0a580a400306 container secret-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:08:58.413: INFO: Waiting for pod pod-secrets-78787a36-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:08:58.415: INFO: Pod pod-secrets-78787a36-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:08:58.415: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-4hlz8" for this suite.
+Oct 31 23:09:04.499: INFO: namespace: e2e-tests-secrets-4hlz8, resource: bindings, ignored listing per whitelist
+Oct 31 23:09:04.510: INFO: namespace e2e-tests-secrets-4hlz8 deletion completed in 6.092090374s
+
+• [SLOW TEST:8.207 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:50
+------------------------------
+SSS
+------------------------------
+[k8s.io] Downward API volume 
+  should provide container's cpu limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:163
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:09:04.510: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide container's cpu limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:163
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 23:09:04.544: INFO: Waiting up to 5m0s for pod "downwardapi-volume-7d551b44-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-gtjc5" to be "success or failure"
+Oct 31 23:09:04.551: INFO: Pod "downwardapi-volume-7d551b44-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 6.409549ms
+Oct 31 23:09:06.784: INFO: Pod "downwardapi-volume-7d551b44-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.240156062s
+STEP: Saw pod success
+Oct 31 23:09:06.784: INFO: Pod "downwardapi-volume-7d551b44-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:09:06.800: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-7d551b44-be90-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 23:09:07.065: INFO: Waiting for pod downwardapi-volume-7d551b44-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:09:07.075: INFO: Pod downwardapi-volume-7d551b44-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:09:07.075: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-gtjc5" for this suite.
+Oct 31 23:09:13.138: INFO: namespace: e2e-tests-downward-api-gtjc5, resource: bindings, ignored listing per whitelist
+Oct 31 23:09:13.187: INFO: namespace e2e-tests-downward-api-gtjc5 deletion completed in 6.108508788s
+
+• [SLOW TEST:8.678 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide container's cpu limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:163
+------------------------------
+SSSSSS
+------------------------------
+[sig-network] Services 
+  should provide secure master service [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:71
+[BeforeEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:09:13.188: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:52
+[It] should provide secure master service [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:71
+[AfterEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:09:13.229: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-9m2bl" for this suite.
+Oct 31 23:09:19.307: INFO: namespace: e2e-tests-services-9m2bl, resource: bindings, ignored listing per whitelist
+Oct 31 23:09:19.325: INFO: namespace e2e-tests-services-9m2bl deletion completed in 6.094147816s
+[AfterEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:64
+
+• [SLOW TEST:6.138 seconds]
+[sig-network] Services
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:71
+------------------------------
+SSSSSSS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/rc.go:43
+[BeforeEach] [sig-apps] ReplicationController
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:09:19.326: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/rc.go:43
+STEP: Creating replication controller my-hostname-basic-8628d808-be90-11e7-82e0-0a580a400306
+Oct 31 23:09:19.355: INFO: Pod name my-hostname-basic-8628d808-be90-11e7-82e0-0a580a400306: Found 0 pods out of 1
+Oct 31 23:09:24.358: INFO: Pod name my-hostname-basic-8628d808-be90-11e7-82e0-0a580a400306: Found 1 pods out of 1
+Oct 31 23:09:24.358: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-8628d808-be90-11e7-82e0-0a580a400306" are running
+Oct 31 23:09:24.359: INFO: Pod "my-hostname-basic-8628d808-be90-11e7-82e0-0a580a400306-2tb5g" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-10-31 23:09:19 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-10-31 23:09:20 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-10-31 23:09:19 +0000 UTC Reason: Message:}])
+Oct 31 23:09:24.359: INFO: Trying to dial the pod
+Oct 31 23:09:29.369: INFO: Controller my-hostname-basic-8628d808-be90-11e7-82e0-0a580a400306: Got expected result from replica 1 [my-hostname-basic-8628d808-be90-11e7-82e0-0a580a400306-2tb5g]: "my-hostname-basic-8628d808-be90-11e7-82e0-0a580a400306-2tb5g", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:09:29.369: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-f45vv" for this suite.
+Oct 31 23:09:35.448: INFO: namespace: e2e-tests-replication-controller-f45vv, resource: bindings, ignored listing per whitelist
+Oct 31 23:09:35.470: INFO: namespace e2e-tests-replication-controller-f45vv deletion completed in 6.09772688s
+
+• [SLOW TEST:16.144 seconds]
+[sig-apps] ReplicationController
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/rc.go:43
+------------------------------
+SSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd) [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:45
+[BeforeEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:09:35.470: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd) [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:45
+STEP: Creating a pod to test override arguments
+Oct 31 23:09:35.499: INFO: Waiting up to 5m0s for pod "client-containers-8fc87968-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-containers-mn57d" to be "success or failure"
+Oct 31 23:09:35.505: INFO: Pod "client-containers-8fc87968-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.524765ms
+Oct 31 23:09:37.507: INFO: Pod "client-containers-8fc87968-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00819409s
+STEP: Saw pod success
+Oct 31 23:09:37.507: INFO: Pod "client-containers-8fc87968-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:09:37.509: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod client-containers-8fc87968-be90-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:09:37.522: INFO: Waiting for pod client-containers-8fc87968-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:09:37.525: INFO: Pod client-containers-8fc87968-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:09:37.525: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-mn57d" for this suite.
+Oct 31 23:09:43.585: INFO: namespace: e2e-tests-containers-mn57d, resource: bindings, ignored listing per whitelist
+Oct 31 23:09:43.627: INFO: namespace e2e-tests-containers-mn57d deletion completed in 6.099229701s
+
+• [SLOW TEST:8.156 seconds]
+[k8s.io] Docker Containers
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be able to override the image's default arguments (docker cmd) [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:45
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Secrets 
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:54
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:09:43.627: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:54
+STEP: Creating secret with name secret-test-map-94aca9fa-be90-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 23:09:43.708: INFO: Waiting up to 5m0s for pod "pod-secrets-94ad1625-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-secrets-n8qsr" to be "success or failure"
+Oct 31 23:09:43.718: INFO: Pod "pod-secrets-94ad1625-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 10.20092ms
+Oct 31 23:09:45.721: INFO: Pod "pod-secrets-94ad1625-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.013150212s
+STEP: Saw pod success
+Oct 31 23:09:45.722: INFO: Pod "pod-secrets-94ad1625-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:09:45.724: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-secrets-94ad1625-be90-11e7-82e0-0a580a400306 container secret-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:09:45.740: INFO: Waiting for pod pod-secrets-94ad1625-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:09:45.754: INFO: Pod pod-secrets-94ad1625-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:09:45.755: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-n8qsr" for this suite.
+Oct 31 23:09:51.816: INFO: namespace: e2e-tests-secrets-n8qsr, resource: bindings, ignored listing per whitelist
+Oct 31 23:09:51.860: INFO: namespace e2e-tests-secrets-n8qsr deletion completed in 6.098669492s
+
+• [SLOW TEST:8.233 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:54
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Downward API volume 
+  should provide container's cpu request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:181
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:09:51.860: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide container's cpu request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:181
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 23:09:51.890: INFO: Waiting up to 5m0s for pod "downwardapi-volume-998d6203-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-downward-api-r7pkl" to be "success or failure"
+Oct 31 23:09:51.894: INFO: Pod "downwardapi-volume-998d6203-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 4.163433ms
+Oct 31 23:09:53.897: INFO: Pod "downwardapi-volume-998d6203-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007092061s
+STEP: Saw pod success
+Oct 31 23:09:53.897: INFO: Pod "downwardapi-volume-998d6203-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:09:53.899: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-998d6203-be90-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 23:09:53.914: INFO: Waiting for pod downwardapi-volume-998d6203-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:09:53.917: INFO: Pod downwardapi-volume-998d6203-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:09:53.917: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-r7pkl" for this suite.
+Oct 31 23:09:59.957: INFO: namespace: e2e-tests-downward-api-r7pkl, resource: bindings, ignored listing per whitelist
+Oct 31 23:10:00.005: INFO: namespace e2e-tests-downward-api-r7pkl deletion completed in 6.086154436s
+
+• [SLOW TEST:8.145 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide container's cpu request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:181
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:97
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:10:00.006: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] with readiness probe that fails should never be ready and never restart [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:97
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:11:00.035: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-m6dmw" for this suite.
+Oct 31 23:11:22.079: INFO: namespace: e2e-tests-container-probe-m6dmw, resource: bindings, ignored listing per whitelist
+Oct 31 23:11:22.131: INFO: namespace e2e-tests-container-probe-m6dmw deletion completed in 22.093692107s
+
+• [SLOW TEST:82.125 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  with readiness probe that fails should never be ready and never restart [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:97
+------------------------------
+SSSS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable via environment variable [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:371
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:11:22.131: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:371
+STEP: Creating configMap e2e-tests-configmap-4jvt8/configmap-test-cf5bd716-be90-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:11:22.165: INFO: Waiting up to 5m0s for pod "pod-configmaps-cf5c2d48-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-configmap-4jvt8" to be "success or failure"
+Oct 31 23:11:22.173: INFO: Pod "pod-configmaps-cf5c2d48-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 8.23305ms
+Oct 31 23:11:24.176: INFO: Pod "pod-configmaps-cf5c2d48-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011246229s
+STEP: Saw pod success
+Oct 31 23:11:24.176: INFO: Pod "pod-configmaps-cf5c2d48-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:11:24.179: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-configmaps-cf5c2d48-be90-11e7-82e0-0a580a400306 container env-test: <nil>
+STEP: delete the pod
+Oct 31 23:11:24.196: INFO: Waiting for pod pod-configmaps-cf5c2d48-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:11:24.201: INFO: Pod pod-configmaps-cf5c2d48-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:11:24.201: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-4jvt8" for this suite.
+Oct 31 23:11:30.266: INFO: namespace: e2e-tests-configmap-4jvt8, resource: bindings, ignored listing per whitelist
+Oct 31 23:11:30.305: INFO: namespace e2e-tests-configmap-4jvt8 deletion completed in 6.100452401s
+
+• [SLOW TEST:8.174 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable via environment variable [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:371
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:73
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:11:30.305: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:73
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Oct 31 23:11:30.332: INFO: Waiting up to 5m0s for pod "pod-d43aa614-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-ppwt4" to be "success or failure"
+Oct 31 23:11:30.335: INFO: Pod "pod-d43aa614-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 3.088073ms
+Oct 31 23:11:32.337: INFO: Pod "pod-d43aa614-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005780142s
+STEP: Saw pod success
+Oct 31 23:11:32.337: INFO: Pod "pod-d43aa614-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:11:32.339: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-d43aa614-be90-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:11:32.355: INFO: Waiting for pod pod-d43aa614-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:11:32.357: INFO: Pod pod-d43aa614-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:11:32.357: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-ppwt4" for this suite.
+Oct 31 23:11:38.435: INFO: namespace: e2e-tests-emptydir-ppwt4, resource: bindings, ignored listing per whitelist
+Oct 31 23:11:38.447: INFO: namespace e2e-tests-emptydir-ppwt4 deletion completed in 6.087675408s
+
+• [SLOW TEST:8.142 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  volume on tmpfs should have the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:73
+------------------------------
+SS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:77
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:11:38.447: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] with readiness probe should not be ready before initial delay and never restart [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:77
+Oct 31 23:12:02.485: INFO: Container started at 2017-10-31 23:11:39 +0000 UTC, pod became ready at 2017-10-31 23:12:00 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:12:02.485: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-gqd5r" for this suite.
+Oct 31 23:12:24.559: INFO: namespace: e2e-tests-container-probe-gqd5r, resource: bindings, ignored listing per whitelist
+Oct 31 23:12:24.577: INFO: namespace e2e-tests-container-probe-gqd5r deletion completed in 22.089970332s
+
+• [SLOW TEST:46.130 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  with readiness probe should not be ready before initial delay and never restart [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:77
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Secrets 
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:38
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:12:24.578: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:38
+STEP: Creating secret with name secret-test-f494537b-be90-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 23:12:24.608: INFO: Waiting up to 5m0s for pod "pod-secrets-f494a9cb-be90-11e7-82e0-0a580a400306" in namespace "e2e-tests-secrets-pq77f" to be "success or failure"
+Oct 31 23:12:24.611: INFO: Pod "pod-secrets-f494a9cb-be90-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 2.783738ms
+Oct 31 23:12:26.614: INFO: Pod "pod-secrets-f494a9cb-be90-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005221708s
+STEP: Saw pod success
+Oct 31 23:12:26.614: INFO: Pod "pod-secrets-f494a9cb-be90-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:12:26.617: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-secrets-f494a9cb-be90-11e7-82e0-0a580a400306 container secret-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:12:26.636: INFO: Waiting for pod pod-secrets-f494a9cb-be90-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:12:26.638: INFO: Pod pod-secrets-f494a9cb-be90-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:12:26.638: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-pq77f" for this suite.
+Oct 31 23:12:32.721: INFO: namespace: e2e-tests-secrets-pq77f, resource: bindings, ignored listing per whitelist
+Oct 31 23:12:32.727: INFO: namespace e2e-tests-secrets-pq77f deletion completed in 6.08712355s
+
+• [SLOW TEST:8.149 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:38
+------------------------------
+S
+------------------------------
+[k8s.io] Projected 
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:367
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:12:32.727: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:367
+STEP: Creating secret with name s-test-opt-del-f977ace1-be90-11e7-82e0-0a580a400306
+STEP: Creating secret with name s-test-opt-upd-f977ad3b-be90-11e7-82e0-0a580a400306
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-f977ace1-be90-11e7-82e0-0a580a400306
+STEP: Updating secret s-test-opt-upd-f977ad3b-be90-11e7-82e0-0a580a400306
+STEP: Creating secret with name s-test-opt-create-f977ad63-be90-11e7-82e0-0a580a400306
+STEP: waiting to observe update in volume
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:12:39.069: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-ns445" for this suite.
+Oct 31 23:13:01.136: INFO: namespace: e2e-tests-projected-ns445, resource: bindings, ignored listing per whitelist
+Oct 31 23:13:01.162: INFO: namespace e2e-tests-projected-ns445 deletion completed in 22.090940615s
+
+• [SLOW TEST:28.435 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:367
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] ConfigMap 
+  updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:150
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:13:01.163: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:150
+STEP: Creating configMap with name configmap-test-upd-0a64428e-be91-11e7-82e0-0a580a400306
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-0a64428e-be91-11e7-82e0-0a580a400306
+STEP: waiting to observe update in volume
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:13:05.237: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-sm7sn" for this suite.
+Oct 31 23:13:27.316: INFO: namespace: e2e-tests-configmap-sm7sn, resource: bindings, ignored listing per whitelist
+Oct 31 23:13:27.330: INFO: namespace e2e-tests-configmap-sm7sn deletion completed in 22.08979245s
+
+• [SLOW TEST:26.168 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:150
+------------------------------
+SSS
+------------------------------
+[k8s.io] Projected 
+  updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:490
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:13:27.330: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:490
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-19fbf8eb-be91-11e7-82e0-0a580a400306
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-19fbf8eb-be91-11e7-82e0-0a580a400306
+STEP: waiting to observe update in volume
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:13:31.396: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lr6qz" for this suite.
+Oct 31 23:13:53.476: INFO: namespace: e2e-tests-projected-lr6qz, resource: bindings, ignored listing per whitelist
+Oct 31 23:13:53.489: INFO: namespace e2e-tests-projected-lr6qz deletion completed in 22.089874798s
+
+• [SLOW TEST:26.158 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:490
+------------------------------
+SS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:68
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:13:53.489: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:68
+STEP: Creating configMap with name configmap-test-volume-map-299308f7-be91-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:13:53.519: INFO: Waiting up to 5m0s for pod "pod-configmaps-299368ea-be91-11e7-82e0-0a580a400306" in namespace "e2e-tests-configmap-969mr" to be "success or failure"
+Oct 31 23:13:53.525: INFO: Pod "pod-configmaps-299368ea-be91-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.710181ms
+Oct 31 23:13:55.528: INFO: Pod "pod-configmaps-299368ea-be91-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008323357s
+STEP: Saw pod success
+Oct 31 23:13:55.528: INFO: Pod "pod-configmaps-299368ea-be91-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:13:55.530: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-configmaps-299368ea-be91-11e7-82e0-0a580a400306 container configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:13:55.545: INFO: Waiting for pod pod-configmaps-299368ea-be91-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:13:55.548: INFO: Pod pod-configmaps-299368ea-be91-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:13:55.548: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-969mr" for this suite.
+Oct 31 23:14:01.590: INFO: namespace: e2e-tests-configmap-969mr, resource: bindings, ignored listing per whitelist
+Oct 31 23:14:01.639: INFO: namespace e2e-tests-configmap-969mr deletion completed in 6.087853942s
+
+• [SLOW TEST:8.150 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:68
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Pods 
+  should be updated [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:316
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:14:01.639: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:129
+[It] should be updated [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:316
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Oct 31 23:14:04.235: INFO: Successfully updated pod "pod-update-2e76128b-be91-11e7-82e0-0a580a400306"
+STEP: verifying the updated pod is in kubernetes
+Oct 31 23:14:04.240: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:14:04.240: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-6jwvh" for this suite.
+Oct 31 23:14:26.326: INFO: namespace: e2e-tests-pods-6jwvh, resource: bindings, ignored listing per whitelist
+Oct 31 23:14:26.344: INFO: namespace e2e-tests-pods-6jwvh deletion completed in 22.100602692s
+
+• [SLOW TEST:24.705 seconds]
+[k8s.io] Pods
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be updated [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:316
+------------------------------
+SSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:69
+[BeforeEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:14:26.344: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:69
+Oct 31 23:14:26.376: INFO: (0) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 6.298724ms)
+Oct 31 23:14:26.378: INFO: (1) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.551865ms)
+Oct 31 23:14:26.382: INFO: (2) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.179556ms)
+Oct 31 23:14:26.385: INFO: (3) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.977948ms)
+Oct 31 23:14:26.387: INFO: (4) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.898049ms)
+Oct 31 23:14:26.392: INFO: (5) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 4.671487ms)
+Oct 31 23:14:26.395: INFO: (6) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.663712ms)
+Oct 31 23:14:26.398: INFO: (7) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.797414ms)
+Oct 31 23:14:26.400: INFO: (8) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.692098ms)
+Oct 31 23:14:26.404: INFO: (9) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.837298ms)
+Oct 31 23:14:26.407: INFO: (10) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.771104ms)
+Oct 31 23:14:26.410: INFO: (11) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.042779ms)
+Oct 31 23:14:26.413: INFO: (12) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.662264ms)
+Oct 31 23:14:26.416: INFO: (13) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.888212ms)
+Oct 31 23:14:26.419: INFO: (14) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.993786ms)
+Oct 31 23:14:26.421: INFO: (15) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.718886ms)
+Oct 31 23:14:26.424: INFO: (16) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.805955ms)
+Oct 31 23:14:26.427: INFO: (17) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.639156ms)
+Oct 31 23:14:26.430: INFO: (18) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.821207ms)
+Oct 31 23:14:26.433: INFO: (19) /api/v1/nodes/kubernetes-minion-group-k1nq:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.962037ms)
+[AfterEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:14:26.433: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-g4vtl" for this suite.
+Oct 31 23:14:32.528: INFO: namespace: e2e-tests-proxy-g4vtl, resource: bindings, ignored listing per whitelist
+Oct 31 23:14:32.531: INFO: namespace e2e-tests-proxy-g4vtl deletion completed in 6.094934295s
+
+• [SLOW TEST:6.186 seconds]
+[sig-network] Proxy
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:278
+    should proxy logs on node with explicit kubelet port using proxy subresource [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:69
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:372
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:14:32.531: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:372
+STEP: Creating configMap with name projected-configmap-test-volume-40d88661-be91-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:14:32.564: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-40d8dede-be91-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-vt87s" to be "success or failure"
+Oct 31 23:14:32.570: INFO: Pod "pod-projected-configmaps-40d8dede-be91-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.965303ms
+Oct 31 23:14:34.573: INFO: Pod "pod-projected-configmaps-40d8dede-be91-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009308025s
+STEP: Saw pod success
+Oct 31 23:14:34.573: INFO: Pod "pod-projected-configmaps-40d8dede-be91-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:14:34.575: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-configmaps-40d8dede-be91-11e7-82e0-0a580a400306 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:14:34.594: INFO: Waiting for pod pod-projected-configmaps-40d8dede-be91-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:14:34.596: INFO: Pod pod-projected-configmaps-40d8dede-be91-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:14:34.596: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-vt87s" for this suite.
+Oct 31 23:14:40.665: INFO: namespace: e2e-tests-projected-vt87s, resource: bindings, ignored listing per whitelist
+Oct 31 23:14:40.723: INFO: namespace e2e-tests-projected-vt87s deletion completed in 6.120252805s
+
+• [SLOW TEST:8.192 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:372
+------------------------------
+[k8s.io] Projected 
+  should provide container's cpu limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:902
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:14:40.723: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide container's cpu limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:902
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 23:14:40.755: INFO: Waiting up to 5m0s for pod "downwardapi-volume-45baa933-be91-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-g2pwf" to be "success or failure"
+Oct 31 23:14:40.760: INFO: Pod "downwardapi-volume-45baa933-be91-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.564251ms
+Oct 31 23:14:42.763: INFO: Pod "downwardapi-volume-45baa933-be91-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008423022s
+STEP: Saw pod success
+Oct 31 23:14:42.763: INFO: Pod "downwardapi-volume-45baa933-be91-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:14:42.765: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-45baa933-be91-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 23:14:42.781: INFO: Waiting for pod downwardapi-volume-45baa933-be91-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:14:42.785: INFO: Pod downwardapi-volume-45baa933-be91-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:14:42.785: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-g2pwf" for this suite.
+Oct 31 23:14:48.840: INFO: namespace: e2e-tests-projected-g2pwf, resource: bindings, ignored listing per whitelist
+Oct 31 23:14:48.883: INFO: namespace e2e-tests-projected-g2pwf deletion completed in 6.095152414s
+
+• [SLOW TEST:8.159 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide container's cpu limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:902
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Projected 
+  should update labels on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:864
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:14:48.883: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should update labels on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:864
+STEP: Creating the pod
+Oct 31 23:14:51.434: INFO: Successfully updated pod "labelsupdate4a977c0b-be91-11e7-82e0-0a580a400306"
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:16:01.734: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4vts6" for this suite.
+Oct 31 23:16:23.846: INFO: namespace: e2e-tests-projected-4vts6, resource: bindings, ignored listing per whitelist
+Oct 31 23:16:23.849: INFO: namespace e2e-tests-projected-4vts6 deletion completed in 22.112430456s
+
+• [SLOW TEST:94.966 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should update labels on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:864
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/kubelet_etc_hosts.go:57
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:16:23.851: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/kubelet_etc_hosts.go:57
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Oct 31 23:16:27.921: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-pj2r7 PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 23:16:27.921: INFO: >>> kubeConfig: 
+Oct 31 23:16:28.011: INFO: Exec stderr: ""
+Oct 31 23:16:28.011: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-pj2r7 PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 23:16:28.011: INFO: >>> kubeConfig: 
+Oct 31 23:16:28.092: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Oct 31 23:16:28.092: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-pj2r7 PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 23:16:28.092: INFO: >>> kubeConfig: 
+Oct 31 23:16:28.176: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Oct 31 23:16:28.176: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-pj2r7 PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 23:16:28.176: INFO: >>> kubeConfig: 
+Oct 31 23:16:28.262: INFO: Exec stderr: ""
+Oct 31 23:16:28.262: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-pj2r7 PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 23:16:28.262: INFO: >>> kubeConfig: 
+Oct 31 23:16:28.351: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:16:28.352: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-pj2r7" for this suite.
+Oct 31 23:17:14.471: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-pj2r7, resource: bindings, ignored listing per whitelist
+Oct 31 23:17:14.475: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-pj2r7 deletion completed in 46.11923254s
+
+• [SLOW TEST:50.624 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should test kubelet managed /etc/hosts file [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/kubelet_etc_hosts.go:57
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  volume on default medium should have the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:101
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:17:14.475: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:101
+STEP: Creating a pod to test emptydir volume type on node default medium
+Oct 31 23:17:14.505: INFO: Waiting up to 5m0s for pod "pod-a15f3097-be91-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-ssx6r" to be "success or failure"
+Oct 31 23:17:14.508: INFO: Pod "pod-a15f3097-be91-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 2.81804ms
+Oct 31 23:17:16.511: INFO: Pod "pod-a15f3097-be91-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005603552s
+STEP: Saw pod success
+Oct 31 23:17:16.511: INFO: Pod "pod-a15f3097-be91-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:17:16.513: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-a15f3097-be91-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:17:16.537: INFO: Waiting for pod pod-a15f3097-be91-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:17:16.540: INFO: Pod pod-a15f3097-be91-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:17:16.540: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-ssx6r" for this suite.
+Oct 31 23:17:22.645: INFO: namespace: e2e-tests-emptydir-ssx6r, resource: bindings, ignored listing per whitelist
+Oct 31 23:17:22.647: INFO: namespace e2e-tests-emptydir-ssx6r deletion completed in 6.104534885s
+
+• [SLOW TEST:8.172 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  volume on default medium should have the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:101
+------------------------------
+SS
+------------------------------
+[k8s.io] Projected 
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:686
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:17:22.647: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:686
+STEP: Creating configMap with name cm-test-opt-del-a6461774-be91-11e7-82e0-0a580a400306
+STEP: Creating configMap with name cm-test-opt-upd-a64617ba-be91-11e7-82e0-0a580a400306
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-a6461774-be91-11e7-82e0-0a580a400306
+STEP: Updating configmap cm-test-opt-upd-a64617ba-be91-11e7-82e0-0a580a400306
+STEP: Creating configMap with name cm-test-opt-create-a64617ce-be91-11e7-82e0-0a580a400306
+STEP: waiting to observe update in volume
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:17:26.797: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-mp9dp" for this suite.
+Oct 31 23:17:48.865: INFO: namespace: e2e-tests-projected-mp9dp, resource: bindings, ignored listing per whitelist
+Oct 31 23:17:48.886: INFO: namespace e2e-tests-projected-mp9dp deletion completed in 22.086798573s
+
+• [SLOW TEST:26.239 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:686
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:131
+[BeforeEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:17:48.886: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:52
+[It] should serve a basic endpoint from pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:131
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-pbrnf
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-pbrnf to expose endpoints map[]
+Oct 31 23:17:48.925: INFO: Get endpoints failed (2.437098ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Oct 31 23:17:49.927: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-pbrnf exposes endpoints map[] (1.004890403s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-pbrnf
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-pbrnf to expose endpoints map[pod1:[80]]
+Oct 31 23:17:50.946: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-pbrnf exposes endpoints map[pod1:[80]] (1.011282397s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-pbrnf
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-pbrnf to expose endpoints map[pod1:[80] pod2:[80]]
+Oct 31 23:17:51.968: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-pbrnf exposes endpoints map[pod1:[80] pod2:[80]] (1.015895578s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-pbrnf
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-pbrnf to expose endpoints map[pod2:[80]]
+Oct 31 23:17:53.986: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-pbrnf exposes endpoints map[pod2:[80]] (2.012979097s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-pbrnf
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-pbrnf to expose endpoints map[]
+Oct 31 23:17:54.996: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-pbrnf exposes endpoints map[] (1.004558183s elapsed)
+[AfterEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:17:55.008: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-pbrnf" for this suite.
+Oct 31 23:18:17.091: INFO: namespace: e2e-tests-services-pbrnf, resource: bindings, ignored listing per whitelist
+Oct 31 23:18:17.099: INFO: namespace e2e-tests-services-pbrnf deletion completed in 22.087160153s
+[AfterEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:64
+
+• [SLOW TEST:28.212 seconds]
+[sig-network] Services
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:131
+------------------------------
+SS
+------------------------------
+[k8s.io] Secrets 
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:43
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:18:17.099: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:43
+STEP: Creating secret with name secret-test-c6b28d37-be91-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 23:18:17.129: INFO: Waiting up to 5m0s for pod "pod-secrets-c6b2f4f3-be91-11e7-82e0-0a580a400306" in namespace "e2e-tests-secrets-tfmfw" to be "success or failure"
+Oct 31 23:18:17.136: INFO: Pod "pod-secrets-c6b2f4f3-be91-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 6.649886ms
+Oct 31 23:18:19.139: INFO: Pod "pod-secrets-c6b2f4f3-be91-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009626005s
+STEP: Saw pod success
+Oct 31 23:18:19.139: INFO: Pod "pod-secrets-c6b2f4f3-be91-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:18:19.140: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-secrets-c6b2f4f3-be91-11e7-82e0-0a580a400306 container secret-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:18:19.160: INFO: Waiting for pod pod-secrets-c6b2f4f3-be91-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:18:19.162: INFO: Pod pod-secrets-c6b2f4f3-be91-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:18:19.162: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-tfmfw" for this suite.
+Oct 31 23:18:25.270: INFO: namespace: e2e-tests-secrets-tfmfw, resource: bindings, ignored listing per whitelist
+Oct 31 23:18:25.270: INFO: namespace e2e-tests-secrets-tfmfw deletion completed in 6.105374676s
+
+• [SLOW TEST:8.171 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:43
+------------------------------
+SSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (root,0777,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:113
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:18:25.271: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:113
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Oct 31 23:18:25.300: INFO: Waiting up to 5m0s for pod "pod-cb917bde-be91-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-gxgjh" to be "success or failure"
+Oct 31 23:18:25.305: INFO: Pod "pod-cb917bde-be91-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.860526ms
+Oct 31 23:18:27.308: INFO: Pod "pod-cb917bde-be91-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008591831s
+STEP: Saw pod success
+Oct 31 23:18:27.308: INFO: Pod "pod-cb917bde-be91-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:18:27.310: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-cb917bde-be91-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:18:27.325: INFO: Waiting for pod pod-cb917bde-be91-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:18:27.327: INFO: Pod pod-cb917bde-be91-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:18:27.327: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-gxgjh" for this suite.
+Oct 31 23:18:33.412: INFO: namespace: e2e-tests-emptydir-gxgjh, resource: bindings, ignored listing per whitelist
+Oct 31 23:18:33.418: INFO: namespace e2e-tests-emptydir-gxgjh deletion completed in 6.088884559s
+
+• [SLOW TEST:8.148 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should support (root,0777,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:113
+------------------------------
+SS
+------------------------------
+[k8s.io] HostPath 
+  should give a volume the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:56
+[BeforeEach] [k8s.io] HostPath
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:18:33.418: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] HostPath
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:41
+[It] should give a volume the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:56
+STEP: Creating a pod to test hostPath mode
+Oct 31 23:18:33.447: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-7gmb9" to be "success or failure"
+Oct 31 23:18:33.450: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 2.784099ms
+Oct 31 23:18:35.453: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005945557s
+STEP: Saw pod success
+Oct 31 23:18:35.453: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Oct 31 23:18:35.455: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Oct 31 23:18:35.472: INFO: Waiting for pod pod-host-path-test to disappear
+Oct 31 23:18:35.474: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [k8s.io] HostPath
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:18:35.474: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-7gmb9" for this suite.
+Oct 31 23:18:41.539: INFO: namespace: e2e-tests-hostpath-7gmb9, resource: bindings, ignored listing per whitelist
+Oct 31 23:18:41.570: INFO: namespace e2e-tests-hostpath-7gmb9 deletion completed in 6.093064036s
+
+• [SLOW TEST:8.151 seconds]
+[k8s.io] HostPath
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should give a volume the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:56
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (non-root,0666,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:121
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:18:41.570: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:121
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Oct 31 23:18:41.599: INFO: Waiting up to 5m0s for pod "pod-d54895ed-be91-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-rrll8" to be "success or failure"
+Oct 31 23:18:41.610: INFO: Pod "pod-d54895ed-be91-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 11.831267ms
+Oct 31 23:18:43.613: INFO: Pod "pod-d54895ed-be91-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.014623514s
+STEP: Saw pod success
+Oct 31 23:18:43.613: INFO: Pod "pod-d54895ed-be91-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:18:43.615: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-d54895ed-be91-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:18:43.628: INFO: Waiting for pod pod-d54895ed-be91-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:18:43.632: INFO: Pod pod-d54895ed-be91-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:18:43.632: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-rrll8" for this suite.
+Oct 31 23:18:49.693: INFO: namespace: e2e-tests-emptydir-rrll8, resource: bindings, ignored listing per whitelist
+Oct 31 23:18:49.726: INFO: namespace e2e-tests-emptydir-rrll8 deletion completed in 6.092133923s
+
+• [SLOW TEST:8.157 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should support (non-root,0666,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:121
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:132
+[BeforeEach] [k8s.io] Variable Expansion
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:18:49.727: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:132
+STEP: Creating a pod to test substitution in container's args
+Oct 31 23:18:49.757: INFO: Waiting up to 5m0s for pod "var-expansion-da2598a6-be91-11e7-82e0-0a580a400306" in namespace "e2e-tests-var-expansion-mp5qp" to be "success or failure"
+Oct 31 23:18:49.760: INFO: Pod "var-expansion-da2598a6-be91-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 3.36521ms
+Oct 31 23:18:51.762: INFO: Pod "var-expansion-da2598a6-be91-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005399863s
+STEP: Saw pod success
+Oct 31 23:18:51.762: INFO: Pod "var-expansion-da2598a6-be91-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:18:51.764: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod var-expansion-da2598a6-be91-11e7-82e0-0a580a400306 container dapi-container: <nil>
+STEP: delete the pod
+Oct 31 23:18:51.779: INFO: Waiting for pod var-expansion-da2598a6-be91-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:18:51.781: INFO: Pod var-expansion-da2598a6-be91-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:18:51.781: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-mp5qp" for this suite.
+Oct 31 23:18:57.834: INFO: namespace: e2e-tests-var-expansion-mp5qp, resource: bindings, ignored listing per whitelist
+Oct 31 23:18:57.871: INFO: namespace e2e-tests-var-expansion-mp5qp deletion completed in 6.08766533s
+
+• [SLOW TEST:8.145 seconds]
+[k8s.io] Variable Expansion
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should allow substituting values in a container's args [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:132
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:97
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:18:57.872: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:97
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Oct 31 23:18:57.969: INFO: Waiting up to 5m0s for pod "pod-df07ebef-be91-11e7-82e0-0a580a400306" in namespace "e2e-tests-emptydir-pwgjd" to be "success or failure"
+Oct 31 23:18:57.982: INFO: Pod "pod-df07ebef-be91-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 13.317042ms
+Oct 31 23:18:59.985: INFO: Pod "pod-df07ebef-be91-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.016704724s
+STEP: Saw pod success
+Oct 31 23:18:59.985: INFO: Pod "pod-df07ebef-be91-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:18:59.987: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-df07ebef-be91-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:19:00.001: INFO: Waiting for pod pod-df07ebef-be91-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:19:00.004: INFO: Pod pod-df07ebef-be91-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:19:00.004: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-pwgjd" for this suite.
+Oct 31 23:19:06.090: INFO: namespace: e2e-tests-emptydir-pwgjd, resource: bindings, ignored listing per whitelist
+Oct 31 23:19:06.103: INFO: namespace e2e-tests-emptydir-pwgjd deletion completed in 6.09592373s
+
+• [SLOW TEST:8.231 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should support (non-root,0777,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:97
+------------------------------
+SSSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/service_accounts.go:387
+[BeforeEach] [sig-auth] ServiceAccounts
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:19:06.103: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/service_accounts.go:387
+STEP: getting the auto-created API token
+Oct 31 23:19:06.647: INFO: created pod pod-service-account-defaultsa
+Oct 31 23:19:06.647: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Oct 31 23:19:06.654: INFO: created pod pod-service-account-mountsa
+Oct 31 23:19:06.654: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Oct 31 23:19:06.661: INFO: created pod pod-service-account-nomountsa
+Oct 31 23:19:06.661: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Oct 31 23:19:06.673: INFO: created pod pod-service-account-defaultsa-mountspec
+Oct 31 23:19:06.673: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Oct 31 23:19:06.686: INFO: created pod pod-service-account-mountsa-mountspec
+Oct 31 23:19:06.686: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Oct 31 23:19:06.695: INFO: created pod pod-service-account-nomountsa-mountspec
+Oct 31 23:19:06.695: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Oct 31 23:19:06.749: INFO: created pod pod-service-account-defaultsa-nomountspec
+Oct 31 23:19:06.749: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Oct 31 23:19:06.755: INFO: created pod pod-service-account-mountsa-nomountspec
+Oct 31 23:19:06.755: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Oct 31 23:19:06.761: INFO: created pod pod-service-account-nomountsa-nomountspec
+Oct 31 23:19:06.761: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:19:06.761: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-gdt29" for this suite.
+Oct 31 23:19:12.855: INFO: namespace: e2e-tests-svcaccounts-gdt29, resource: bindings, ignored listing per whitelist
+Oct 31 23:19:12.892: INFO: namespace e2e-tests-svcaccounts-gdt29 deletion completed in 6.124022071s
+
+• [SLOW TEST:6.789 seconds]
+[sig-auth] ServiceAccounts
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/service_accounts.go:387
+------------------------------
+S
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dns.go:317
+[BeforeEach] [sig-network] DNS
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:19:12.892: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dns.go:317
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-9klgv.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-9klgv.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-9klgv.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-9klgv.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-9klgv.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-9klgv.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Oct 31 23:19:32.973: INFO: DNS probes using dns-test-e7f42be9-be91-11e7-82e0-0a580a400306 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:19:32.982: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-9klgv" for this suite.
+Oct 31 23:19:39.107: INFO: namespace: e2e-tests-dns-9klgv, resource: bindings, ignored listing per whitelist
+Oct 31 23:19:39.113: INFO: namespace e2e-tests-dns-9klgv deletion completed in 6.125542974s
+
+• [SLOW TEST:26.220 seconds]
+[sig-network] DNS
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dns.go:317
+------------------------------
+SSS
+------------------------------
+[k8s.io] Secrets 
+  should be consumable in multiple volumes in a pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:153
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:19:39.113: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:153
+STEP: Creating secret with name secret-test-f7954c08-be91-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 23:19:39.147: INFO: Waiting up to 5m0s for pod "pod-secrets-f795b99b-be91-11e7-82e0-0a580a400306" in namespace "e2e-tests-secrets-bmsvn" to be "success or failure"
+Oct 31 23:19:39.152: INFO: Pod "pod-secrets-f795b99b-be91-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.407497ms
+Oct 31 23:19:41.155: INFO: Pod "pod-secrets-f795b99b-be91-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008035024s
+STEP: Saw pod success
+Oct 31 23:19:41.155: INFO: Pod "pod-secrets-f795b99b-be91-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:19:41.156: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-secrets-f795b99b-be91-11e7-82e0-0a580a400306 container secret-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:19:41.171: INFO: Waiting for pod pod-secrets-f795b99b-be91-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:19:41.173: INFO: Pod pod-secrets-f795b99b-be91-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:19:41.173: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-bmsvn" for this suite.
+Oct 31 23:19:47.266: INFO: namespace: e2e-tests-secrets-bmsvn, resource: bindings, ignored listing per whitelist
+Oct 31 23:19:47.279: INFO: namespace e2e-tests-secrets-bmsvn deletion completed in 6.100658551s
+
+• [SLOW TEST:8.166 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable in multiple volumes in a pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:153
+------------------------------
+[k8s.io] Downward API volume 
+  should update labels on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:125
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:19:47.279: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should update labels on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:125
+STEP: Creating the pod
+Oct 31 23:19:49.849: INFO: Successfully updated pod "labelsupdatefc752b42-be91-11e7-82e0-0a580a400306"
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:21:02.156: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-wjxxr" for this suite.
+Oct 31 23:21:24.216: INFO: namespace: e2e-tests-downward-api-wjxxr, resource: bindings, ignored listing per whitelist
+Oct 31 23:21:24.256: INFO: namespace e2e-tests-downward-api-wjxxr deletion completed in 22.096590299s
+
+• [SLOW TEST:96.977 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should update labels on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:125
+------------------------------
+SSS
+------------------------------
+[k8s.io] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:943
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:21:24.256: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:943
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 23:21:24.299: INFO: Waiting up to 5m0s for pod "downwardapi-volume-3642b6d6-be92-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-s764r" to be "success or failure"
+Oct 31 23:21:24.306: INFO: Pod "downwardapi-volume-3642b6d6-be92-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 7.382418ms
+Oct 31 23:21:26.309: INFO: Pod "downwardapi-volume-3642b6d6-be92-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009958441s
+STEP: Saw pod success
+Oct 31 23:21:26.309: INFO: Pod "downwardapi-volume-3642b6d6-be92-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:21:26.310: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-3642b6d6-be92-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 23:21:26.324: INFO: Waiting for pod downwardapi-volume-3642b6d6-be92-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:21:26.326: INFO: Pod downwardapi-volume-3642b6d6-be92-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:21:26.326: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-s764r" for this suite.
+Oct 31 23:21:32.407: INFO: namespace: e2e-tests-projected-s764r, resource: bindings, ignored listing per whitelist
+Oct 31 23:21:32.417: INFO: namespace e2e-tests-projected-s764r deletion completed in 6.088822168s
+
+• [SLOW TEST:8.161 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:943
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:179
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:21:32.418: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] should be restarted with a /healthz http liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:179
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-6dpgx
+Oct 31 23:21:34.505: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-6dpgx
+STEP: checking the pod's current state and verifying that restartCount is present
+Oct 31 23:21:34.507: INFO: Initial restart count of pod liveness-http is 0
+Oct 31 23:21:56.766: INFO: Restart count of pod e2e-tests-container-probe-6dpgx/liveness-http is now 1 (22.259200353s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:21:56.773: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-6dpgx" for this suite.
+Oct 31 23:22:02.838: INFO: namespace: e2e-tests-container-probe-6dpgx, resource: bindings, ignored listing per whitelist
+Oct 31 23:22:02.862: INFO: namespace e2e-tests-container-probe-6dpgx deletion completed in 6.085776568s
+
+• [SLOW TEST:30.445 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be restarted with a /healthz http liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:179
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:61
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:22:02.863: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:61
+STEP: Creating projection with secret that has name projected-secret-test-map-4d43518c-be92-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 23:22:02.892: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-4d43b5b6-be92-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-qzplp" to be "success or failure"
+Oct 31 23:22:02.895: INFO: Pod "pod-projected-secrets-4d43b5b6-be92-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 2.69063ms
+Oct 31 23:22:04.898: INFO: Pod "pod-projected-secrets-4d43b5b6-be92-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005739774s
+STEP: Saw pod success
+Oct 31 23:22:04.898: INFO: Pod "pod-projected-secrets-4d43b5b6-be92-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:22:04.899: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-secrets-4d43b5b6-be92-11e7-82e0-0a580a400306 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:22:04.914: INFO: Waiting for pod pod-projected-secrets-4d43b5b6-be92-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:22:04.917: INFO: Pod pod-projected-secrets-4d43b5b6-be92-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:22:04.917: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qzplp" for this suite.
+Oct 31 23:22:11.009: INFO: namespace: e2e-tests-projected-qzplp, resource: bindings, ignored listing per whitelist
+Oct 31 23:22:11.038: INFO: namespace e2e-tests-projected-qzplp deletion completed in 6.118729442s
+
+• [SLOW TEST:8.176 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:61
+------------------------------
+S
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:42
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:22:11.038: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:42
+STEP: Creating configMap with name configmap-test-volume-52232982-be92-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:22:11.070: INFO: Waiting up to 5m0s for pod "pod-configmaps-52239102-be92-11e7-82e0-0a580a400306" in namespace "e2e-tests-configmap-v7wc4" to be "success or failure"
+Oct 31 23:22:11.075: INFO: Pod "pod-configmaps-52239102-be92-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.161279ms
+Oct 31 23:22:13.078: INFO: Pod "pod-configmaps-52239102-be92-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007527718s
+STEP: Saw pod success
+Oct 31 23:22:13.078: INFO: Pod "pod-configmaps-52239102-be92-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:22:13.080: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-configmaps-52239102-be92-11e7-82e0-0a580a400306 container configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:22:13.100: INFO: Waiting for pod pod-configmaps-52239102-be92-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:22:13.103: INFO: Pod pod-configmaps-52239102-be92-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:22:13.103: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-v7wc4" for this suite.
+Oct 31 23:22:19.150: INFO: namespace: e2e-tests-configmap-v7wc4, resource: bindings, ignored listing per whitelist
+Oct 31 23:22:19.240: INFO: namespace e2e-tests-configmap-v7wc4 deletion completed in 6.135094698s
+
+• [SLOW TEST:8.202 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:42
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:66
+[BeforeEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:22:19.241: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:66
+Oct 31 23:22:19.272: INFO: (0) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 5.661022ms)
+Oct 31 23:22:19.275: INFO: (1) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.926226ms)
+Oct 31 23:22:19.278: INFO: (2) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.850435ms)
+Oct 31 23:22:19.281: INFO: (3) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.412054ms)
+Oct 31 23:22:19.284: INFO: (4) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.495023ms)
+Oct 31 23:22:19.287: INFO: (5) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.815637ms)
+Oct 31 23:22:19.289: INFO: (6) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.401995ms)
+Oct 31 23:22:19.292: INFO: (7) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.720589ms)
+Oct 31 23:22:19.295: INFO: (8) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.850315ms)
+Oct 31 23:22:19.298: INFO: (9) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.761111ms)
+Oct 31 23:22:19.300: INFO: (10) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.592918ms)
+Oct 31 23:22:19.303: INFO: (11) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.460068ms)
+Oct 31 23:22:19.305: INFO: (12) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.365054ms)
+Oct 31 23:22:19.308: INFO: (13) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.37084ms)
+Oct 31 23:22:19.310: INFO: (14) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.392195ms)
+Oct 31 23:22:19.313: INFO: (15) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.48743ms)
+Oct 31 23:22:19.316: INFO: (16) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.458921ms)
+Oct 31 23:22:19.320: INFO: (17) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 3.947434ms)
+Oct 31 23:22:19.323: INFO: (18) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 2.674304ms)
+Oct 31 23:22:19.331: INFO: (19) /api/v1/proxy/nodes/kubernetes-minion-group-k1nq/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="cloud-init.log">cloud-init.log</a>
+<a href="containers/">c... (200; 7.899122ms)
+[AfterEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:22:19.331: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-892gj" for this suite.
+Oct 31 23:22:25.425: INFO: namespace: e2e-tests-proxy-892gj, resource: bindings, ignored listing per whitelist
+Oct 31 23:22:25.427: INFO: namespace e2e-tests-proxy-892gj deletion completed in 6.092147113s
+
+• [SLOW TEST:6.186 seconds]
+[sig-network] Proxy
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:278
+    should proxy logs on node [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:66
+------------------------------
+S
+------------------------------
+[sig-network] Networking 
+  should provide Internet connection for containers [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/networking.go:52
+[BeforeEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:22:25.427: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/networking.go:46
+STEP: Executing a successful http request from the external internet
+[It] should provide Internet connection for containers [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/networking.go:52
+STEP: Running container which tries to ping 8.8.8.8
+Oct 31 23:22:25.545: INFO: Waiting up to 5m0s for pod "ping-test" in namespace "e2e-tests-nettest-znjhg" to be "success or failure"
+Oct 31 23:22:25.551: INFO: Pod "ping-test": Phase="Pending", Reason="", readiness=false. Elapsed: 6.406776ms
+Oct 31 23:22:27.554: INFO: Pod "ping-test": Phase="Running", Reason="", readiness=true. Elapsed: 2.009135107s
+Oct 31 23:22:29.557: INFO: Pod "ping-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012231412s
+STEP: Saw pod success
+Oct 31 23:22:29.557: INFO: Pod "ping-test" satisfied condition "success or failure"
+[AfterEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:22:29.557: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-nettest-znjhg" for this suite.
+Oct 31 23:22:35.636: INFO: namespace: e2e-tests-nettest-znjhg, resource: bindings, ignored listing per whitelist
+Oct 31 23:22:35.648: INFO: namespace e2e-tests-nettest-znjhg deletion completed in 6.088103361s
+
+• [SLOW TEST:10.221 seconds]
+[sig-network] Networking
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide Internet connection for containers [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/networking.go:52
+------------------------------
+SSS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:37
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:22:35.648: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:37
+STEP: Creating configMap with name configmap-test-volume-60ce3bd6-be92-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:22:35.681: INFO: Waiting up to 5m0s for pod "pod-configmaps-60cea4fe-be92-11e7-82e0-0a580a400306" in namespace "e2e-tests-configmap-lh7ln" to be "success or failure"
+Oct 31 23:22:35.690: INFO: Pod "pod-configmaps-60cea4fe-be92-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 9.37924ms
+Oct 31 23:22:37.693: INFO: Pod "pod-configmaps-60cea4fe-be92-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012176487s
+STEP: Saw pod success
+Oct 31 23:22:37.693: INFO: Pod "pod-configmaps-60cea4fe-be92-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:22:37.695: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-configmaps-60cea4fe-be92-11e7-82e0-0a580a400306 container configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:22:37.709: INFO: Waiting for pod pod-configmaps-60cea4fe-be92-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:22:37.713: INFO: Pod pod-configmaps-60cea4fe-be92-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:22:37.713: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-lh7ln" for this suite.
+Oct 31 23:22:43.754: INFO: namespace: e2e-tests-configmap-lh7ln, resource: bindings, ignored listing per whitelist
+Oct 31 23:22:43.822: INFO: namespace e2e-tests-configmap-lh7ln deletion completed in 6.106070769s
+
+• [SLOW TEST:8.174 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:37
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:483
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:22:43.822: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:483
+STEP: Creating configMap with name configmap-test-volume-65b536be-be92-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:22:43.906: INFO: Waiting up to 5m0s for pod "pod-configmaps-65b59a15-be92-11e7-82e0-0a580a400306" in namespace "e2e-tests-configmap-76bpv" to be "success or failure"
+Oct 31 23:22:43.908: INFO: Pod "pod-configmaps-65b59a15-be92-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 2.488523ms
+Oct 31 23:22:45.911: INFO: Pod "pod-configmaps-65b59a15-be92-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005405931s
+STEP: Saw pod success
+Oct 31 23:22:45.911: INFO: Pod "pod-configmaps-65b59a15-be92-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:22:45.913: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-configmaps-65b59a15-be92-11e7-82e0-0a580a400306 container configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:22:45.929: INFO: Waiting for pod pod-configmaps-65b59a15-be92-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:22:45.931: INFO: Pod pod-configmaps-65b59a15-be92-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:22:45.931: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-76bpv" for this suite.
+Oct 31 23:22:51.992: INFO: namespace: e2e-tests-configmap-76bpv, resource: bindings, ignored listing per whitelist
+Oct 31 23:22:52.030: INFO: namespace e2e-tests-configmap-76bpv deletion completed in 6.09389066s
+
+• [SLOW TEST:8.208 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:483
+------------------------------
+S
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:40
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:22:52.030: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:40
+STEP: Creating projection with secret that has name projected-secret-test-6a923011-be92-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 23:22:52.065: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-6a929e1d-be92-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-rrsvj" to be "success or failure"
+Oct 31 23:22:52.071: INFO: Pod "pod-projected-secrets-6a929e1d-be92-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.533496ms
+Oct 31 23:22:54.074: INFO: Pod "pod-projected-secrets-6a929e1d-be92-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008621411s
+STEP: Saw pod success
+Oct 31 23:22:54.074: INFO: Pod "pod-projected-secrets-6a929e1d-be92-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:22:54.076: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-secrets-6a929e1d-be92-11e7-82e0-0a580a400306 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:22:54.093: INFO: Waiting for pod pod-projected-secrets-6a929e1d-be92-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:22:54.096: INFO: Pod pod-projected-secrets-6a929e1d-be92-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:22:54.096: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rrsvj" for this suite.
+Oct 31 23:23:00.158: INFO: namespace: e2e-tests-projected-rrsvj, resource: bindings, ignored listing per whitelist
+Oct 31 23:23:00.185: INFO: namespace e2e-tests-projected-rrsvj deletion completed in 6.086194749s
+
+• [SLOW TEST:8.155 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:40
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:64
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:23:00.185: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:64
+Oct 31 23:23:00.260: INFO: >>> kubeConfig: 
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:23:00.803: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-qhldh" for this suite.
+Oct 31 23:23:07.091: INFO: namespace: e2e-tests-custom-resource-definition-qhldh, resource: bindings, ignored listing per whitelist
+Oct 31 23:23:07.126: INFO: namespace e2e-tests-custom-resource-definition-qhldh deletion completed in 6.319958609s
+
+• [SLOW TEST:6.941 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:65
+    creating/deleting custom resource definition objects works [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:64
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:101
+[BeforeEach] [k8s.io] Variable Expansion
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:23:07.126: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:101
+STEP: Creating a pod to test substitution in container's command
+Oct 31 23:23:07.156: INFO: Waiting up to 5m0s for pod "var-expansion-7391700e-be92-11e7-82e0-0a580a400306" in namespace "e2e-tests-var-expansion-cjpxd" to be "success or failure"
+Oct 31 23:23:07.160: INFO: Pod "var-expansion-7391700e-be92-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 4.017611ms
+Oct 31 23:23:09.163: INFO: Pod "var-expansion-7391700e-be92-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007231854s
+STEP: Saw pod success
+Oct 31 23:23:09.163: INFO: Pod "var-expansion-7391700e-be92-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:23:09.165: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod var-expansion-7391700e-be92-11e7-82e0-0a580a400306 container dapi-container: <nil>
+STEP: delete the pod
+Oct 31 23:23:09.196: INFO: Waiting for pod var-expansion-7391700e-be92-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:23:09.200: INFO: Pod var-expansion-7391700e-be92-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:23:09.200: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-cjpxd" for this suite.
+Oct 31 23:23:15.292: INFO: namespace: e2e-tests-var-expansion-cjpxd, resource: bindings, ignored listing per whitelist
+Oct 31 23:23:15.305: INFO: namespace e2e-tests-var-expansion-cjpxd deletion completed in 6.102391679s
+
+• [SLOW TEST:8.179 seconds]
+[k8s.io] Variable Expansion
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should allow substituting values in a container's command [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:101
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:45
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:23:15.305: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:45
+STEP: Creating projection with secret that has name projected-secret-test-78794c4a-be92-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 23:23:15.390: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-7879ad2d-be92-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-wxrjb" to be "success or failure"
+Oct 31 23:23:15.395: INFO: Pod "pod-projected-secrets-7879ad2d-be92-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.436404ms
+Oct 31 23:23:17.398: INFO: Pod "pod-projected-secrets-7879ad2d-be92-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008221771s
+STEP: Saw pod success
+Oct 31 23:23:17.398: INFO: Pod "pod-projected-secrets-7879ad2d-be92-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:23:17.401: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-secrets-7879ad2d-be92-11e7-82e0-0a580a400306 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:23:17.427: INFO: Waiting for pod pod-projected-secrets-7879ad2d-be92-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:23:17.430: INFO: Pod pod-projected-secrets-7879ad2d-be92-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:23:17.430: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wxrjb" for this suite.
+Oct 31 23:23:23.532: INFO: namespace: e2e-tests-projected-wxrjb, resource: bindings, ignored listing per whitelist
+Oct 31 23:23:23.532: INFO: namespace e2e-tests-projected-wxrjb deletion completed in 6.09979237s
+
+• [SLOW TEST:8.227 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:45
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Projected 
+  should be consumable in multiple volumes in a pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:171
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:23:23.533: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable in multiple volumes in a pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:171
+STEP: Creating secret with name projected-secret-test-7d592858-be92-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 23:23:23.567: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-7d5995c0-be92-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-hfsfk" to be "success or failure"
+Oct 31 23:23:23.572: INFO: Pod "pod-projected-secrets-7d5995c0-be92-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.793689ms
+Oct 31 23:23:25.575: INFO: Pod "pod-projected-secrets-7d5995c0-be92-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008518668s
+STEP: Saw pod success
+Oct 31 23:23:25.575: INFO: Pod "pod-projected-secrets-7d5995c0-be92-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:23:25.577: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-secrets-7d5995c0-be92-11e7-82e0-0a580a400306 container secret-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:23:25.593: INFO: Waiting for pod pod-projected-secrets-7d5995c0-be92-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:23:25.596: INFO: Pod pod-projected-secrets-7d5995c0-be92-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:23:25.596: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hfsfk" for this suite.
+Oct 31 23:23:31.652: INFO: namespace: e2e-tests-projected-hfsfk, resource: bindings, ignored listing per whitelist
+Oct 31 23:23:31.686: INFO: namespace e2e-tests-projected-hfsfk deletion completed in 6.086749465s
+
+• [SLOW TEST:8.153 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable in multiple volumes in a pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:171
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:386
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:23:31.686: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:386
+STEP: Creating configMap with name projected-configmap-test-volume-8234bc2c-be92-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:23:31.717: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-8235176d-be92-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-qndbc" to be "success or failure"
+Oct 31 23:23:31.720: INFO: Pod "pod-projected-configmaps-8235176d-be92-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 2.618398ms
+Oct 31 23:23:33.723: INFO: Pod "pod-projected-configmaps-8235176d-be92-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005720305s
+STEP: Saw pod success
+Oct 31 23:23:33.723: INFO: Pod "pod-projected-configmaps-8235176d-be92-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:23:33.725: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-configmaps-8235176d-be92-11e7-82e0-0a580a400306 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:23:33.748: INFO: Waiting for pod pod-projected-configmaps-8235176d-be92-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:23:33.750: INFO: Pod pod-projected-configmaps-8235176d-be92-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:23:33.751: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qndbc" for this suite.
+Oct 31 23:23:43.872: INFO: namespace: e2e-tests-projected-qndbc, resource: bindings, ignored listing per whitelist
+Oct 31 23:23:43.886: INFO: namespace e2e-tests-projected-qndbc deletion completed in 10.13315732s
+
+• [SLOW TEST:12.201 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:386
+------------------------------
+SS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:375
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:23:43.886: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:114
+Oct 31 23:23:43.916: INFO: Waiting up to 1m0s for all nodes to be ready
+Oct 31 23:24:43.935: INFO: Waiting for terminating namespaces to be deleted...
+Oct 31 23:24:43.939: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Oct 31 23:24:43.949: INFO: 25 / 25 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Oct 31 23:24:43.949: INFO: expected 9 pod replicas in namespace 'kube-system', 9 are Running and Ready.
+Oct 31 23:24:43.953: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Oct 31 23:24:43.953: INFO: 
+Logging pods the kubelet thinks is on node kubernetes-minion-group-k1nq before test
+Oct 31 23:24:43.965: INFO: fluentd-gcp-v2.0.9-fcr5p from kube-system started at 2017-10-31 22:44:18 +0000 UTC (1 container statuses recorded)
+Oct 31 23:24:43.965: INFO: 	Container fluentd-gcp ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: l7-default-backend-6497bcdb4d-6xxq2 from kube-system started at 2017-10-31 22:44:37 +0000 UTC (1 container statuses recorded)
+Oct 31 23:24:43.965: INFO: 	Container default-http-backend ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: monitoring-influxdb-grafana-v4-sqc8m from kube-system started at 2017-10-31 22:44:37 +0000 UTC (2 container statuses recorded)
+Oct 31 23:24:43.965: INFO: 	Container grafana ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: 	Container influxdb ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: kube-dns-autoscaler-7db47cb9b7-v4drk from kube-system started at 2017-10-31 22:44:39 +0000 UTC (1 container statuses recorded)
+Oct 31 23:24:43.965: INFO: 	Container autoscaler ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: kube-proxy-kubernetes-minion-group-k1nq from kube-system started at <nil> (0 container statuses recorded)
+Oct 31 23:24:43.965: INFO: event-exporter-v0.1.7-6fc6965d54-z4zms from kube-system started at 2017-10-31 22:44:37 +0000 UTC (1 container statuses recorded)
+Oct 31 23:24:43.965: INFO: 	Container event-exporter ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: kube-dns-778977457c-kx87r from kube-system started at 2017-10-31 22:44:46 +0000 UTC (3 container statuses recorded)
+Oct 31 23:24:43.965: INFO: 	Container dnsmasq ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: 	Container kubedns ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: 	Container sidecar ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: heapster-v1.4.3-6b6447897-s8q24 from kube-system started at 2017-10-31 22:45:09 +0000 UTC (4 container statuses recorded)
+Oct 31 23:24:43.965: INFO: 	Container eventer ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: 	Container eventer-nanny ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: 	Container heapster ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: 	Container heapster-nanny ready: true, restart count 0
+Oct 31 23:24:43.965: INFO: 
+Logging pods the kubelet thinks is on node kubernetes-minion-group-rv1l before test
+Oct 31 23:24:43.973: INFO: kube-proxy-kubernetes-minion-group-rv1l from kube-system started at <nil> (0 container statuses recorded)
+Oct 31 23:24:43.973: INFO: fluentd-gcp-v2.0.9-rvltc from kube-system started at 2017-10-31 22:44:14 +0000 UTC (1 container statuses recorded)
+Oct 31 23:24:43.973: INFO: 	Container fluentd-gcp ready: true, restart count 0
+Oct 31 23:24:43.973: INFO: kubernetes-dashboard-76c679977c-mzb6r from kube-system started at 2017-10-31 22:44:37 +0000 UTC (1 container statuses recorded)
+Oct 31 23:24:43.973: INFO: 	Container kubernetes-dashboard ready: true, restart count 0
+Oct 31 23:24:43.973: INFO: kube-dns-778977457c-74n8h from kube-system started at 2017-10-31 22:44:37 +0000 UTC (3 container statuses recorded)
+Oct 31 23:24:43.973: INFO: 	Container dnsmasq ready: true, restart count 0
+Oct 31 23:24:43.973: INFO: 	Container kubedns ready: true, restart count 0
+Oct 31 23:24:43.973: INFO: 	Container sidecar ready: true, restart count 0
+Oct 31 23:24:43.973: INFO: 
+Logging pods the kubelet thinks is on node kubernetes-minion-group-vbpt before test
+Oct 31 23:24:43.979: INFO: sonobuoy from sonobuoy started at 2017-10-31 22:48:43 +0000 UTC (1 container statuses recorded)
+Oct 31 23:24:43.980: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Oct 31 23:24:43.980: INFO: metrics-server-v0.2.0-56fddcccfc-m8hw8 from kube-system started at 2017-10-31 22:44:37 +0000 UTC (1 container statuses recorded)
+Oct 31 23:24:43.980: INFO: 	Container metrics-server ready: true, restart count 0
+Oct 31 23:24:43.980: INFO: fluentd-gcp-v2.0.9-qldfv from kube-system started at 2017-10-31 22:44:20 +0000 UTC (1 container statuses recorded)
+Oct 31 23:24:43.980: INFO: 	Container fluentd-gcp ready: true, restart count 0
+Oct 31 23:24:43.980: INFO: sonobuoy-e2e-job-9fcd792ab6e447a0 from sonobuoy started at 2017-10-31 22:48:55 +0000 UTC (2 container statuses recorded)
+Oct 31 23:24:43.980: INFO: 	Container e2e ready: true, restart count 0
+Oct 31 23:24:43.980: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Oct 31 23:24:43.980: INFO: kube-proxy-kubernetes-minion-group-vbpt from kube-system started at <nil> (0 container statuses recorded)
+[It] validates that NodeSelector is respected if matching [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:375
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-ae7dd0d5-be92-11e7-82e0-0a580a400306 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-ae7dd0d5-be92-11e7-82e0-0a580a400306 off the node kubernetes-minion-group-vbpt
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-ae7dd0d5-be92-11e7-82e0-0a580a400306
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:24:48.051: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-tm959" for this suite.
+Oct 31 23:25:10.151: INFO: namespace: e2e-tests-sched-pred-tm959, resource: bindings, ignored listing per whitelist
+Oct 31 23:25:10.175: INFO: namespace e2e-tests-sched-pred-tm959 deletion completed in 22.1218091s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:78
+
+• [SLOW TEST:86.289 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:375
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:215
+[BeforeEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:25:10.176: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:52
+[It] should serve multiport endpoints from pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:215
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-7c697
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-7c697 to expose endpoints map[]
+Oct 31 23:25:10.210: INFO: Get endpoints failed (2.967176ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Oct 31 23:25:11.212: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-7c697 exposes endpoints map[] (1.005291971s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-7c697
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-7c697 to expose endpoints map[pod1:[100]]
+Oct 31 23:25:13.238: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-7c697 exposes endpoints map[pod1:[100]] (2.016105494s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-7c697
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-7c697 to expose endpoints map[pod1:[100] pod2:[101]]
+Oct 31 23:25:14.263: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-7c697 exposes endpoints map[pod1:[100] pod2:[101]] (1.020181306s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-7c697
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-7c697 to expose endpoints map[pod2:[101]]
+Oct 31 23:25:16.282: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-7c697 exposes endpoints map[pod2:[101]] (2.013470655s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-7c697
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-7c697 to expose endpoints map[]
+Oct 31 23:25:17.290: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-7c697 exposes endpoints map[] (1.004643423s elapsed)
+[AfterEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:25:17.302: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-7c697" for this suite.
+Oct 31 23:25:39.408: INFO: namespace: e2e-tests-services-7c697, resource: bindings, ignored listing per whitelist
+Oct 31 23:25:39.408: INFO: namespace e2e-tests-services-7c697 deletion completed in 22.10368137s
+[AfterEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:64
+
+• [SLOW TEST:29.233 seconds]
+[sig-network] Services
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:215
+------------------------------
+S
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/service_accounts.go:246
+[BeforeEach] [sig-auth] ServiceAccounts
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:25:39.410: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/service_accounts.go:246
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Oct 31 23:25:39.949: INFO: Waiting up to 5m0s for pod "pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-pz22s" in namespace "e2e-tests-svcaccounts-qwm29" to be "success or failure"
+Oct 31 23:25:39.951: INFO: Pod "pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-pz22s": Phase="Pending", Reason="", readiness=false. Elapsed: 2.311926ms
+Oct 31 23:25:41.954: INFO: Pod "pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-pz22s": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005277833s
+STEP: Saw pod success
+Oct 31 23:25:41.954: INFO: Pod "pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-pz22s" satisfied condition "success or failure"
+Oct 31 23:25:41.956: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-pz22s container token-test: <nil>
+STEP: delete the pod
+Oct 31 23:25:41.972: INFO: Waiting for pod pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-pz22s to disappear
+Oct 31 23:25:41.975: INFO: Pod pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-pz22s no longer exists
+STEP: Creating a pod to test consume service account root CA
+Oct 31 23:25:41.977: INFO: Waiting up to 5m0s for pod "pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-2jz5m" in namespace "e2e-tests-svcaccounts-qwm29" to be "success or failure"
+Oct 31 23:25:41.983: INFO: Pod "pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-2jz5m": Phase="Pending", Reason="", readiness=false. Elapsed: 5.59206ms
+Oct 31 23:25:43.986: INFO: Pod "pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-2jz5m": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008412478s
+STEP: Saw pod success
+Oct 31 23:25:43.986: INFO: Pod "pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-2jz5m" satisfied condition "success or failure"
+Oct 31 23:25:43.988: INFO: Trying to get logs from node kubernetes-minion-group-rv1l pod pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-2jz5m container root-ca-test: <nil>
+STEP: delete the pod
+Oct 31 23:25:44.004: INFO: Waiting for pod pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-2jz5m to disappear
+Oct 31 23:25:44.007: INFO: Pod pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-2jz5m no longer exists
+STEP: Creating a pod to test consume service account namespace
+Oct 31 23:25:44.012: INFO: Waiting up to 5m0s for pod "pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-mpdx2" in namespace "e2e-tests-svcaccounts-qwm29" to be "success or failure"
+Oct 31 23:25:44.015: INFO: Pod "pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-mpdx2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.444008ms
+Oct 31 23:25:46.018: INFO: Pod "pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-mpdx2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006413662s
+STEP: Saw pod success
+Oct 31 23:25:46.018: INFO: Pod "pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-mpdx2" satisfied condition "success or failure"
+Oct 31 23:25:46.020: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-mpdx2 container namespace-test: <nil>
+STEP: delete the pod
+Oct 31 23:25:46.034: INFO: Waiting for pod pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-mpdx2 to disappear
+Oct 31 23:25:46.038: INFO: Pod pod-service-account-cea38aef-be92-11e7-82e0-0a580a400306-mpdx2 no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:25:46.038: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-qwm29" for this suite.
+Oct 31 23:25:52.099: INFO: namespace: e2e-tests-svcaccounts-qwm29, resource: bindings, ignored listing per whitelist
+Oct 31 23:25:52.137: INFO: namespace e2e-tests-svcaccounts-qwm29 deletion completed in 6.094653509s
+
+• [SLOW TEST:12.728 seconds]
+[sig-auth] ServiceAccounts
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/service_accounts.go:246
+------------------------------
+S
+------------------------------
+[k8s.io] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pods.go:239
+[BeforeEach] [k8s.io] Pods Extended
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:25:52.138: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pods.go:201
+[It] should be submitted and removed [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pods.go:239
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] Pods Extended
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:25:52.176: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-w8zd6" for this suite.
+Oct 31 23:26:14.267: INFO: namespace: e2e-tests-pods-w8zd6, resource: bindings, ignored listing per whitelist
+Oct 31 23:26:14.276: INFO: namespace e2e-tests-pods-w8zd6 deletion completed in 22.09618182s
+
+• [SLOW TEST:22.139 seconds]
+[k8s.io] Pods Extended
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  [k8s.io] Pods Set QOS Class
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+    should be submitted and removed [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pods.go:239
+------------------------------
+SSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:45
+[BeforeEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:26:14.276: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:45
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-96kpv
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Oct 31 23:26:14.299: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Oct 31 23:26:36.383: INFO: ExecWithOptions {Command:[/bin/sh -c curl -q -s 'http://10.64.1.35:8080/dial?request=hostName&protocol=udp&host=10.64.1.34&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-96kpv PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 23:26:36.383: INFO: >>> kubeConfig: 
+Oct 31 23:26:36.479: INFO: Waiting for endpoints: map[]
+Oct 31 23:26:36.481: INFO: ExecWithOptions {Command:[/bin/sh -c curl -q -s 'http://10.64.1.35:8080/dial?request=hostName&protocol=udp&host=10.64.3.154&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-96kpv PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 23:26:36.481: INFO: >>> kubeConfig: 
+Oct 31 23:26:36.567: INFO: Waiting for endpoints: map[]
+Oct 31 23:26:36.764: INFO: ExecWithOptions {Command:[/bin/sh -c curl -q -s 'http://10.64.1.35:8080/dial?request=hostName&protocol=udp&host=10.64.2.12&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-96kpv PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 23:26:36.764: INFO: >>> kubeConfig: 
+Oct 31 23:26:37.070: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:26:37.070: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-96kpv" for this suite.
+Oct 31 23:26:59.141: INFO: namespace: e2e-tests-pod-network-test-96kpv, resource: bindings, ignored listing per whitelist
+Oct 31 23:26:59.170: INFO: namespace e2e-tests-pod-network-test-96kpv deletion completed in 22.096385944s
+
+• [SLOW TEST:44.893 seconds]
+[sig-network] Networking
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:61
+  Granular Checks: Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:60
+    should function for intra-pod communication: udp [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:45
+------------------------------
+SS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:64
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:26:59.170: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:64
+STEP: Creating configMap with name configmap-test-volume-map-fde186e7-be92-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:26:59.209: INFO: Waiting up to 5m0s for pod "pod-configmaps-fde1f56b-be92-11e7-82e0-0a580a400306" in namespace "e2e-tests-configmap-k4frn" to be "success or failure"
+Oct 31 23:26:59.215: INFO: Pod "pod-configmaps-fde1f56b-be92-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.867032ms
+Oct 31 23:27:01.217: INFO: Pod "pod-configmaps-fde1f56b-be92-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008699588s
+STEP: Saw pod success
+Oct 31 23:27:01.217: INFO: Pod "pod-configmaps-fde1f56b-be92-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:27:01.219: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-configmaps-fde1f56b-be92-11e7-82e0-0a580a400306 container configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:27:01.233: INFO: Waiting for pod pod-configmaps-fde1f56b-be92-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:27:01.235: INFO: Pod pod-configmaps-fde1f56b-be92-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:27:01.235: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-k4frn" for this suite.
+Oct 31 23:27:07.339: INFO: namespace: e2e-tests-configmap-k4frn, resource: bindings, ignored listing per whitelist
+Oct 31 23:27:07.339: INFO: namespace e2e-tests-configmap-k4frn deletion completed in 6.101125845s
+
+• [SLOW TEST:8.169 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:64
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[k8s.io] Projected 
+  should set mode on item file [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:808
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:27:07.339: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should set mode on item file [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:808
+STEP: Creating a pod to test downward API volume plugin
+Oct 31 23:27:07.367: INFO: Waiting up to 5m0s for pod "downwardapi-volume-02beb870-be93-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-fx8vs" to be "success or failure"
+Oct 31 23:27:07.372: INFO: Pod "downwardapi-volume-02beb870-be93-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 5.030101ms
+Oct 31 23:27:09.375: INFO: Pod "downwardapi-volume-02beb870-be93-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008516413s
+STEP: Saw pod success
+Oct 31 23:27:09.376: INFO: Pod "downwardapi-volume-02beb870-be93-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:27:09.378: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod downwardapi-volume-02beb870-be93-11e7-82e0-0a580a400306 container client-container: <nil>
+STEP: delete the pod
+Oct 31 23:27:09.400: INFO: Waiting for pod downwardapi-volume-02beb870-be93-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:27:09.402: INFO: Pod downwardapi-volume-02beb870-be93-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:27:09.402: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fx8vs" for this suite.
+Oct 31 23:27:15.447: INFO: namespace: e2e-tests-projected-fx8vs, resource: bindings, ignored listing per whitelist
+Oct 31 23:27:15.498: INFO: namespace e2e-tests-projected-fx8vs deletion completed in 6.092202079s
+
+• [SLOW TEST:8.159 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should set mode on item file [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:808
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:56
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:27:15.498: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:56
+STEP: Creating projection with secret that has name projected-secret-test-map-079be6eb-be93-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 23:27:15.529: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-079c3a81-be93-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-r6crj" to be "success or failure"
+Oct 31 23:27:15.532: INFO: Pod "pod-projected-secrets-079c3a81-be93-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 2.816727ms
+Oct 31 23:27:17.535: INFO: Pod "pod-projected-secrets-079c3a81-be93-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005591893s
+STEP: Saw pod success
+Oct 31 23:27:17.535: INFO: Pod "pod-projected-secrets-079c3a81-be93-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:27:17.537: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-secrets-079c3a81-be93-11e7-82e0-0a580a400306 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:27:17.551: INFO: Waiting for pod pod-projected-secrets-079c3a81-be93-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:27:17.554: INFO: Pod pod-projected-secrets-079c3a81-be93-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:27:17.554: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-r6crj" for this suite.
+Oct 31 23:27:23.622: INFO: namespace: e2e-tests-projected-r6crj, resource: bindings, ignored listing per whitelist
+Oct 31 23:27:23.663: INFO: namespace e2e-tests-projected-r6crj deletion completed in 6.106006679s
+
+• [SLOW TEST:8.165 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:56
+------------------------------
+SS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:377
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:27:23.663: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:377
+STEP: Creating configMap with name projected-configmap-test-volume-0c7a7e1b-be93-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:27:23.699: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-0c7af480-be93-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-f99k9" to be "success or failure"
+Oct 31 23:27:23.705: INFO: Pod "pod-projected-configmaps-0c7af480-be93-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 6.203782ms
+Oct 31 23:27:25.708: INFO: Pod "pod-projected-configmaps-0c7af480-be93-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008958949s
+STEP: Saw pod success
+Oct 31 23:27:25.708: INFO: Pod "pod-projected-configmaps-0c7af480-be93-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:27:25.709: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-configmaps-0c7af480-be93-11e7-82e0-0a580a400306 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:27:25.723: INFO: Waiting for pod pod-projected-configmaps-0c7af480-be93-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:27:25.727: INFO: Pod pod-projected-configmaps-0c7af480-be93-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:27:25.727: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-f99k9" for this suite.
+Oct 31 23:27:31.811: INFO: namespace: e2e-tests-projected-f99k9, resource: bindings, ignored listing per whitelist
+Oct 31 23:27:31.823: INFO: namespace e2e-tests-projected-f99k9 deletion completed in 6.093917985s
+
+• [SLOW TEST:8.160 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:377
+------------------------------
+SSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a docker exec liveness probe with timeout [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:267
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:27:31.823: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] should be restarted with a docker exec liveness probe with timeout [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:267
+Oct 31 23:27:31.847: INFO: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:27:31.847: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-4qwqg" for this suite.
+Oct 31 23:27:37.900: INFO: namespace: e2e-tests-container-probe-4qwqg, resource: bindings, ignored listing per whitelist
+Oct 31 23:27:37.946: INFO: namespace e2e-tests-container-probe-4qwqg deletion completed in 6.095945755s
+
+S [SKIPPING] [6.122 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be restarted with a docker exec liveness probe with timeout [Conformance] [It]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:267
+
+  Oct 31 23:27:31.847: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:308
+------------------------------
+S
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/replica_set.go:83
+[BeforeEach] [sig-apps] ReplicaSet
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:27:37.946: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/replica_set.go:83
+Oct 31 23:27:38.018: INFO: Creating ReplicaSet my-hostname-basic-150494e1-be93-11e7-82e0-0a580a400306
+Oct 31 23:27:38.026: INFO: Pod name my-hostname-basic-150494e1-be93-11e7-82e0-0a580a400306: Found 0 pods out of 1
+Oct 31 23:27:43.030: INFO: Pod name my-hostname-basic-150494e1-be93-11e7-82e0-0a580a400306: Found 1 pods out of 1
+Oct 31 23:27:43.030: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-150494e1-be93-11e7-82e0-0a580a400306" is running
+Oct 31 23:27:43.032: INFO: Pod "my-hostname-basic-150494e1-be93-11e7-82e0-0a580a400306-hjlkm" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-10-31 23:27:38 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-10-31 23:27:38 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-10-31 23:27:38 +0000 UTC Reason: Message:}])
+Oct 31 23:27:43.032: INFO: Trying to dial the pod
+Oct 31 23:27:48.042: INFO: Controller my-hostname-basic-150494e1-be93-11e7-82e0-0a580a400306: Got expected result from replica 1 [my-hostname-basic-150494e1-be93-11e7-82e0-0a580a400306-hjlkm]: "my-hostname-basic-150494e1-be93-11e7-82e0-0a580a400306-hjlkm", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:27:48.042: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-4mfgk" for this suite.
+Oct 31 23:27:54.116: INFO: namespace: e2e-tests-replicaset-4mfgk, resource: bindings, ignored listing per whitelist
+Oct 31 23:27:54.140: INFO: namespace e2e-tests-replicaset-4mfgk deletion completed in 6.095490526s
+
+• [SLOW TEST:16.194 seconds]
+[sig-apps] ReplicaSet
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/replica_set.go:83
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Projected 
+  should project all components that make up the projection API [Conformance] [sig-storage] [Projection]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:999
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:27:54.140: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should project all components that make up the projection API [Conformance] [sig-storage] [Projection]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:999
+STEP: Creating configMap with name configmap-projected-all-test-volume-1ea46c98-be93-11e7-82e0-0a580a400306
+STEP: Creating secret with name secret-projected-all-test-volume-1ea46c86-be93-11e7-82e0-0a580a400306
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Oct 31 23:27:54.176: INFO: Waiting up to 5m0s for pod "projected-volume-1ea46c4d-be93-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-m8qfd" to be "success or failure"
+Oct 31 23:27:54.178: INFO: Pod "projected-volume-1ea46c4d-be93-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 1.822925ms
+Oct 31 23:27:56.181: INFO: Pod "projected-volume-1ea46c4d-be93-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005301827s
+STEP: Saw pod success
+Oct 31 23:27:56.181: INFO: Pod "projected-volume-1ea46c4d-be93-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:27:56.183: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod projected-volume-1ea46c4d-be93-11e7-82e0-0a580a400306 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:27:56.214: INFO: Waiting for pod projected-volume-1ea46c4d-be93-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:27:56.216: INFO: Pod projected-volume-1ea46c4d-be93-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:27:56.216: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-m8qfd" for this suite.
+Oct 31 23:28:02.289: INFO: namespace: e2e-tests-projected-m8qfd, resource: bindings, ignored listing per whitelist
+Oct 31 23:28:02.308: INFO: namespace e2e-tests-projected-m8qfd deletion completed in 6.089255767s
+
+• [SLOW TEST:8.168 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should project all components that make up the projection API [Conformance] [sig-storage] [Projection]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:999
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count [Conformance] [Slow]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:208
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:28:02.308: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] should have monotonically increasing restart count [Conformance] [Slow]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:208
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-tshhh
+Oct 31 23:28:04.397: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-tshhh
+STEP: checking the pod's current state and verifying that restartCount is present
+Oct 31 23:28:04.399: INFO: Initial restart count of pod liveness-http is 0
+Oct 31 23:28:22.426: INFO: Restart count of pod e2e-tests-container-probe-tshhh/liveness-http is now 1 (18.027313513s elapsed)
+Oct 31 23:28:42.533: INFO: Restart count of pod e2e-tests-container-probe-tshhh/liveness-http is now 2 (38.133859822s elapsed)
+Oct 31 23:29:02.562: INFO: Restart count of pod e2e-tests-container-probe-tshhh/liveness-http is now 3 (58.163817473s elapsed)
+Oct 31 23:29:22.769: INFO: Restart count of pod e2e-tests-container-probe-tshhh/liveness-http is now 4 (1m18.370042396s elapsed)
+Oct 31 23:30:35.090: INFO: Restart count of pod e2e-tests-container-probe-tshhh/liveness-http is now 5 (2m30.691474603s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:30:35.099: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-tshhh" for this suite.
+Oct 31 23:30:41.172: INFO: namespace: e2e-tests-container-probe-tshhh, resource: bindings, ignored listing per whitelist
+Oct 31 23:30:41.208: INFO: namespace e2e-tests-container-probe-tshhh deletion completed in 6.105025891s
+
+• [SLOW TEST:158.900 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should have monotonically increasing restart count [Conformance] [Slow]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:208
+------------------------------
+S
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:399
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:30:41.209: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:399
+STEP: Creating configMap with name projected-configmap-test-volume-map-823988eb-be93-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume configMaps
+Oct 31 23:30:41.244: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-8239e141-be93-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-xwcnx" to be "success or failure"
+Oct 31 23:30:41.248: INFO: Pod "pod-projected-configmaps-8239e141-be93-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 3.791824ms
+Oct 31 23:30:43.251: INFO: Pod "pod-projected-configmaps-8239e141-be93-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.0064552s
+STEP: Saw pod success
+Oct 31 23:30:43.251: INFO: Pod "pod-projected-configmaps-8239e141-be93-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:30:43.252: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-configmaps-8239e141-be93-11e7-82e0-0a580a400306 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:30:43.271: INFO: Waiting for pod pod-projected-configmaps-8239e141-be93-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:30:43.274: INFO: Pod pod-projected-configmaps-8239e141-be93-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:30:43.274: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xwcnx" for this suite.
+Oct 31 23:30:49.375: INFO: namespace: e2e-tests-projected-xwcnx, resource: bindings, ignored listing per whitelist
+Oct 31 23:30:49.377: INFO: namespace e2e-tests-projected-xwcnx deletion completed in 6.100170374s
+
+• [SLOW TEST:8.168 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:399
+------------------------------
+SS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:52
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:30:49.377: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:52
+STEP: Creating projection with secret that has name projected-secret-test-871eed39-be93-11e7-82e0-0a580a400306
+STEP: Creating a pod to test consume secrets
+Oct 31 23:30:49.461: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-871f6c11-be93-11e7-82e0-0a580a400306" in namespace "e2e-tests-projected-fp4mk" to be "success or failure"
+Oct 31 23:30:49.465: INFO: Pod "pod-projected-secrets-871f6c11-be93-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 3.732615ms
+Oct 31 23:30:51.468: INFO: Pod "pod-projected-secrets-871f6c11-be93-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006567883s
+STEP: Saw pod success
+Oct 31 23:30:51.468: INFO: Pod "pod-projected-secrets-871f6c11-be93-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:30:51.469: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod pod-projected-secrets-871f6c11-be93-11e7-82e0-0a580a400306 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Oct 31 23:30:51.485: INFO: Waiting for pod pod-projected-secrets-871f6c11-be93-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:30:51.488: INFO: Pod pod-projected-secrets-871f6c11-be93-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:30:51.488: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fp4mk" for this suite.
+Oct 31 23:30:57.583: INFO: namespace: e2e-tests-projected-fp4mk, resource: bindings, ignored listing per whitelist
+Oct 31 23:30:57.585: INFO: namespace e2e-tests-projected-fp4mk deletion completed in 6.094644574s
+
+• [SLOW TEST:8.208 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:52
+------------------------------
+SSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:71
+[BeforeEach] [k8s.io] Variable Expansion
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:30:57.585: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:71
+STEP: Creating a pod to test env composition
+Oct 31 23:30:57.614: INFO: Waiting up to 5m0s for pod "var-expansion-8bfbc224-be93-11e7-82e0-0a580a400306" in namespace "e2e-tests-var-expansion-k9kpb" to be "success or failure"
+Oct 31 23:30:57.617: INFO: Pod "var-expansion-8bfbc224-be93-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 3.551317ms
+Oct 31 23:30:59.623: INFO: Pod "var-expansion-8bfbc224-be93-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008942166s
+STEP: Saw pod success
+Oct 31 23:30:59.623: INFO: Pod "var-expansion-8bfbc224-be93-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:30:59.624: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod var-expansion-8bfbc224-be93-11e7-82e0-0a580a400306 container dapi-container: <nil>
+STEP: delete the pod
+Oct 31 23:30:59.639: INFO: Waiting for pod var-expansion-8bfbc224-be93-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:30:59.642: INFO: Pod var-expansion-8bfbc224-be93-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:30:59.642: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-k9kpb" for this suite.
+Oct 31 23:31:05.686: INFO: namespace: e2e-tests-var-expansion-k9kpb, resource: bindings, ignored listing per whitelist
+Oct 31 23:31:05.754: INFO: namespace e2e-tests-var-expansion-k9kpb deletion completed in 6.10590979s
+
+• [SLOW TEST:8.169 seconds]
+[k8s.io] Variable Expansion
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should allow composing env vars into new env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:71
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default commmand (docker entrypoint) [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:56
+[BeforeEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:31:05.754: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default commmand (docker entrypoint) [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:56
+STEP: Creating a pod to test override command
+Oct 31 23:31:05.832: INFO: Waiting up to 5m0s for pod "client-containers-90e1a322-be93-11e7-82e0-0a580a400306" in namespace "e2e-tests-containers-hdnwv" to be "success or failure"
+Oct 31 23:31:05.837: INFO: Pod "client-containers-90e1a322-be93-11e7-82e0-0a580a400306": Phase="Pending", Reason="", readiness=false. Elapsed: 4.774574ms
+Oct 31 23:31:07.839: INFO: Pod "client-containers-90e1a322-be93-11e7-82e0-0a580a400306": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007490037s
+STEP: Saw pod success
+Oct 31 23:31:07.839: INFO: Pod "client-containers-90e1a322-be93-11e7-82e0-0a580a400306" satisfied condition "success or failure"
+Oct 31 23:31:07.841: INFO: Trying to get logs from node kubernetes-minion-group-vbpt pod client-containers-90e1a322-be93-11e7-82e0-0a580a400306 container test-container: <nil>
+STEP: delete the pod
+Oct 31 23:31:07.856: INFO: Waiting for pod client-containers-90e1a322-be93-11e7-82e0-0a580a400306 to disappear
+Oct 31 23:31:07.859: INFO: Pod client-containers-90e1a322-be93-11e7-82e0-0a580a400306 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:31:07.859: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-hdnwv" for this suite.
+Oct 31 23:31:13.932: INFO: namespace: e2e-tests-containers-hdnwv, resource: bindings, ignored listing per whitelist
+Oct 31 23:31:13.950: INFO: namespace e2e-tests-containers-hdnwv deletion completed in 6.088200393s
+
+• [SLOW TEST:8.196 seconds]
+[k8s.io] Docker Containers
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should be able to override the image's default commmand (docker entrypoint) [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:56
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:52
+[BeforeEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:31:13.950: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:52
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-vls69
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Oct 31 23:31:13.975: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Oct 31 23:31:34.056: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -q -s --connect-timeout 1 http://10.64.3.170:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-vls69 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 23:31:34.056: INFO: >>> kubeConfig: 
+Oct 31 23:31:34.129: INFO: Found all expected endpoints: [netserver-0]
+Oct 31 23:31:34.131: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -q -s --connect-timeout 1 http://10.64.1.36:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-vls69 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 23:31:34.131: INFO: >>> kubeConfig: 
+Oct 31 23:31:34.210: INFO: Found all expected endpoints: [netserver-1]
+Oct 31 23:31:34.213: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -q -s --connect-timeout 1 http://10.64.2.13:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-vls69 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Oct 31 23:31:34.213: INFO: >>> kubeConfig: 
+Oct 31 23:31:34.298: INFO: Found all expected endpoints: [netserver-2]
+[AfterEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:31:34.298: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-vls69" for this suite.
+Oct 31 23:31:56.369: INFO: namespace: e2e-tests-pod-network-test-vls69, resource: bindings, ignored listing per whitelist
+Oct 31 23:31:56.393: INFO: namespace e2e-tests-pod-network-test-vls69 deletion completed in 22.091715684s
+
+• [SLOW TEST:42.443 seconds]
+[sig-network] Networking
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:61
+  Granular Checks: Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:60
+    should function for node-pod communication: http [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:52
+------------------------------
+SSS
+------------------------------
+[k8s.io] Projected 
+  should update annotations on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:893
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
+STEP: Creating a kubernetes client
+Oct 31 23:31:56.393: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should update annotations on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:893
+STEP: Creating the pod
+Oct 31 23:31:58.947: INFO: Successfully updated pod "annotationupdateaf09249a-be93-11e7-82e0-0a580a400306"
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+Oct 31 23:32:02.970: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-r4bg9" for this suite.
+Oct 31 23:32:25.038: INFO: namespace: e2e-tests-projected-r4bg9, resource: bindings, ignored listing per whitelist
+Oct 31 23:32:25.065: INFO: namespace e2e-tests-projected-r4bg9 deletion completed in 22.091996447s
+
+• [SLOW TEST:28.672 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:629
+  should update annotations on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:893
+------------------------------
+SSSSSSSSOct 31 23:32:25.065: INFO: Running AfterSuite actions on all node
+Oct 31 23:32:25.065: INFO: Running AfterSuite actions on node 1
+Oct 31 23:32:25.065: INFO: Dumping logs locally to: /tmp/results
+Checking for custom logdump instances, if any
+Sourcing kube-util.sh
+Oct 31 23:32:25.078: INFO: Error running cluster/log-dump/log-dump.sh: exit status 1
+
+Ran 125 of 693 Specs in 2601.408 seconds
+SUCCESS! -- 125 Passed | 0 Failed | 0 Pending | 568 Skipped PASS

--- a/v1.8/kube-up-gce/junit_01.xml
+++ b/v1.8/kube-up-gce/junit_01.xml
@@ -1,0 +1,1832 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="125" failures="0" time="2601.408386591">
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide podname only [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="10.185254007"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ReplicaSet [Feature:Federation] ReplicaSet objects [NoCluster] should be created and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters DNS non-local federated service should be able to discover a non-local federated service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API should provide pod and host IP as an env var [Conformance]" classname="Kubernetes e2e suite" time="8.16573706"></testcase>
+      <testcase name="[sig-storage] Pod Disks should schedule a pod w/ a readonly PD on two hosts, then remove both ungracefully. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API should provide default limits.cpu/memory from node allocatable [Conformance]" classname="Kubernetes e2e suite" time="8.145079122"></testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation jobs [Feature:Federation] Federated Job should not be deleted from underlying clusters when OrphanDependents is true" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high [Conformance]" classname="Kubernetes e2e suite" time="29.756742249"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [Conformance]" classname="Kubernetes e2e suite" time="51.504563075"></testcase>
+      <testcase name="[sig-network] NetworkPolicy should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.143582793"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should have a working scale subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API should provide pod name and namespace as env vars [Conformance]" classname="Kubernetes e2e suite" time="8.185378285"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when using local volume provisioner should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port [Conformance]" classname="Kubernetes e2e suite" time="6.203392815"></testcase>
+      <testcase name="[k8s.io] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.152977574"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [Conformance]" classname="Kubernetes e2e suite" time="40.515126677"></testcase>
+      <testcase name="[k8s.io] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (non-root,0644,default) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.19564384"></testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should update annotations on modification [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="28.67554441"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should rollback without unnecessary restarts" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Federation] Federation API server authentication [NoCluster] should not accept cluster resources when the client has invalid HTTP Basic authentication credentials" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide container&#39;s memory limit [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.184629161"></testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable via the environment [Conformance]" classname="Kubernetes e2e suite" time="8.154165044"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (root,0666,tmpfs) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.211185459"></testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank [Conformance]" classname="Kubernetes e2e suite" time="8.180556207"></testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (root,0666,default) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.163534686"></testcase>
+      <testcase name="[k8s.io] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PreStop should call prestop when killing a pod [Conformance]" classname="Kubernetes e2e suite" time="47.194314592"></testcase>
+      <testcase name="[sig-storage] Pod Disks Should schedule a pod w/ a RW PD, gracefully remove it, then schedule it on another host [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;daemonset&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation events [Feature:Federation] Event objects [NoCluster] should be created and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run [Conformance]" classname="Kubernetes e2e suite" time="88.330314246"></testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] Without Clusters [NoCluster] should succeed when a service is created" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.15502386"></testcase>
+      <testcase name="[k8s.io] Secrets should be consumable from pods in env vars [Conformance]" classname="Kubernetes e2e suite" time="8.205235779"></testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Opaque resources [Feature:OpaqueResources] should schedule pods that initially do not fit after enough opaque integer resources are freed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should set mode on item file [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.143656355"></testcase>
+      <testcase name="[k8s.io] Pods should get a host IP [Conformance]" classname="Kubernetes e2e suite" time="24.137965461"></testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with mappings [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.160597367"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should set DefaultMode on files [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.147444277"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable via the environment [Conformance]" classname="Kubernetes e2e suite" time="8.164218787"></testcase>
+      <testcase name="[k8s.io] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume with mappings [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.218885237"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment lack of progress should be reported in the deployment status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [Slow] should create and update matching ingresses in underlying clusters" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (non-root,0777,default) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.158105964"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching [Conformance]" classname="Kubernetes e2e suite" time="83.366920831"></testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Upgrade [Feature:Upgrade] [k8s.io] Federated clusters upgrade should maintain a functioning federation [Feature:FederatedClustersUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] new files should be created with FSGroup ownership when container is root [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when two pods request one prebound PVC one after other should be able to mount volume, write from pod1, and read from pod2 using one-command containers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services [Conformance]" classname="Kubernetes e2e suite" time="28.179404851"></testcase>
+      <testcase name="[k8s.io] Federated ReplicaSet [Feature:Federation] Features Preferences should create replicasets and rebalance them" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should update pod when spec was updated and update strategy is RollingUpdate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation namespace [Feature:Federation] Namespace objects deletes replicasets in the namespace when the namespace is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services [Conformance]" classname="Kubernetes e2e suite" time="26.294640346"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation apiserver [Feature:Federation] Cluster objects [Serial] should be created and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [Slow] should be deleted from underlying clusters when OrphanDependents is false" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ReplicaSet [Feature:Federation] Features Preferences should create replicasets with min replicas preference" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="128.341791575"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (non-root,0666,tmpfs) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.147928816"></testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0 [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource [Conformance]" classname="Kubernetes e2e suite" time="6.238339364"></testcase>
+      <testcase name="[k8s.io] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain Annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters Federated Service should recreate service shard in underlying clusters when service shard is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount and write to the volume using one-command containers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide container&#39;s cpu request [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.151266549"></testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="60.254238622"></testcase>
+      <testcase name="[k8s.io] Upgrade [Feature:Upgrade] [k8s.io] FCP upgrade followed by federated clusters upgrade should maintain a functioning federation [Feature:FCPUpgradeFollowedByFederatedClustersUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Opaque resources [Feature:OpaqueResources] should account opaque integer resources in pods with multiple containers." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume as non-root [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.159694303"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide container&#39;s memory request [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.222166932"></testcase>
+      <testcase name="[k8s.io] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide container&#39;s memory limit [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.182502609"></testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit [Feature:Audit] should audit API calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount and read from the volume using one-command containers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (root,0644,tmpfs) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.169019852"></testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (root,0777,tmpfs) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.158923765"></testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets optional updates should be reflected in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="26.838676531"></testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide podname as non-root with fsgroup [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Events should be sent by kubelets and the scheduler about pods scheduling and running [Conformance]" classname="Kubernetes e2e suite" time="12.162324655"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;configmap&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide podname as non-root with fsgroup [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide podname only [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.15150467"></testcase>
+      <testcase name="[k8s.io] Downward API volume should set DefaultMode on files [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.202418428"></testcase>
+      <testcase name="[sig-storage] vsphere Volume fstype verify disk format type - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap optional updates should be reflected in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="26.200027697"></testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [NoCluster] should be created and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars [Conformance]" classname="Kubernetes e2e suite" time="8.196955139"></testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation namespace [Feature:Federation] Namespace objects all resources in the namespace should be deleted when namespace is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide container&#39;s memory request [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.231972946"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated [Conformance]" classname="Kubernetes e2e suite" time="14.670224504"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters Federated Service should be deleted from underlying clusters when OrphanDependents is false" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.155823976"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed [Conformance]" classname="Kubernetes e2e suite" time="15.124255875"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe [Conformance]" classname="Kubernetes e2e suite" time="128.318971435"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.153579115"></testcase>
+      <testcase name="[k8s.io] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.17438458"></testcase>
+      <testcase name="[sig-scheduling] [Feature:GPU] run Nvidia GPU tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Opaque resources [Feature:OpaqueResources] should not schedule pods that exceed the available amount of opaque integer resource." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existent secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should label adopted RSs and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments [Conformance]" classname="Kubernetes e2e suite" time="8.185951986"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ReplicaSet [Feature:Federation] Features Preferences should create replicasets with max replicas preference" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (root,0644,default) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.148752496"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod [Conformance]" classname="Kubernetes e2e suite" time="15.849881494"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (non-root,0644,tmpfs) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.155213294"></testcase>
+      <testcase name="[k8s.io] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.206524456"></testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide container&#39;s cpu limit [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.677571176"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service [Conformance]" classname="Kubernetes e2e suite" time="6.137831816"></testcase>
+      <testcase name="[sig-scheduling] Opaque resources [Feature:OpaqueResources] should not break pods that do not consume opaque integer resources." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to detach from a node whose api object was deleted [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image [Conformance]" classname="Kubernetes e2e suite" time="16.144100604"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd) [Conformance]" classname="Kubernetes e2e suite" time="8.156340562"></testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Opaque resources [Feature:OpaqueResources] should schedule pods that do consume opaque integer resources." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] HostPath should support existing single file subPath [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable from pods in volume with mappings [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.233233386"></testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should schedule a pod w/two RW PDs both mounted to one container, write to PD, verify contents, delete pod, recreate pod, verify contents, and repeat in rapid succession [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide container&#39;s cpu request [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.145294288"></testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart [Conformance]" classname="Kubernetes e2e suite" time="82.125345606"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable via environment variable [Conformance]" classname="Kubernetes e2e suite" time="8.174012972"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ReplicaSet [Feature:Federation] Features Preferences should create replicasets with weight preference" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf [Experimental] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] volume on default medium should have the correct mode using FSGroup [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes volume on tmpfs should have the correct mode [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.141866211"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart [Conformance]" classname="Kubernetes e2e suite" time="46.130070342"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable from pods in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.149291541"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected optional updates should be reflected in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="28.435368539"></testcase>
+      <testcase name="[sig-storage] Pod Disks Should schedule a pod w/ a readonly PD on two hosts, then remove both gracefully. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Multi-AZ Clusters should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to detach from a node which was deleted [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap updates should be reflected in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="26.167614405"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected updates should be reflected in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="26.158138245"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.149855356"></testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated [Conformance]" classname="Kubernetes e2e suite" time="24.705414227"></testcase>
+      <testcase name="[k8s.io] Federation jobs [Feature:Federation] Job objects [NoCluster] should be created and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [Slow] Ingress connectivity and DNS should be able to discover a federated ingress service via DNS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed [Conformance] [Flaky]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource [Conformance]" classname="Kubernetes e2e suite" time="6.186229491"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] files with FSGroup ownership should support (root,0644,tmpfs) [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] HostPath should support subPath [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.192487433"></testcase>
+      <testcase name="[k8s.io] Projected should provide container&#39;s cpu limit [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.159409332"></testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should update labels on modification [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="94.966241533"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file [Conformance]" classname="Kubernetes e2e suite" time="50.624108858"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha docker/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation jobs [Feature:Federation] Federated Job should not be deleted from underlying clusters when OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Federation] Federation API server authentication [NoCluster] should not accept cluster resources when the client has invalid token authentication credentials" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Federation] Federation API server authentication [NoCluster] should accept cluster resources when the client has HTTP Basic authentication credentials" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;replicaset&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes volume on default medium should have the correct mode [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.172150006"></testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere volume operations storm should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected optional updates should be reflected in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="26.238745809"></testcase>
+      <testcase name="[k8s.io] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] nonexistent volume subPath should have the correct mode and owner using FSGroup [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods [Conformance]" classname="Kubernetes e2e suite" time="28.212307358"></testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation jobs [Feature:Federation] Federated Job should be deleted from underlying clusters when OrphanDependents is false" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.171305659"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (root,0777,default) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.147738693"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] HostPath should give a volume the correct mode [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.151314375"></testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (non-root,0666,default) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.156600296"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args [Conformance]" classname="Kubernetes e2e suite" time="8.144529548"></testcase>
+      <testcase name="[sig-apps] Deployment overlapping deployment should not fight with each other" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] volume on tmpfs should have the correct mode using FSGroup [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (non-root,0777,tmpfs) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.230992123"></testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;horizontalpodautoscaler&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Federation] Federation API server authentication [NoCluster] should accept cluster resources when the client has token authentication credentials" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount [Conformance]" classname="Kubernetes e2e suite" time="6.789289682"></testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;secret&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster [Conformance]" classname="Kubernetes e2e suite" time="26.220368441"></testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment scaled rollout deployment should not block on annotation check" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable in multiple volumes in a pod [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.166267642"></testcase>
+      <testcase name="[k8s.io] Downward API volume should update labels on modification [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="96.977250271"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.161000588"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe [Conformance]" classname="Kubernetes e2e suite" time="30.444657935"></testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.175816668"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.201983202"></testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation apiserver [Feature:Federation] Admission control [NoCluster] should not be able to create resources if namespace does not exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node [Conformance]" classname="Kubernetes e2e suite" time="6.1863101799999995"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Conformance]" classname="Kubernetes e2e suite" time="10.220837846"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.174020539"></testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [Slow] Ingress connectivity and DNS should be able to connect to a federated ingress via its load balancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.207707433"></testcase>
+      <testcase name="[sig-storage] vsphere Volume fstype verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.154846137"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters Federated Service should not be deleted from underlying clusters when OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation jobs [Feature:Federation] Federated Job should create and update matching jobs in underlying clusters" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works [Conformance]" classname="Kubernetes e2e suite" time="6.940533362"></testcase>
+      <testcase name="[k8s.io] Sysctls should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should adopt existing pods when creating a RollingUpdate DaemonSet regardless of templateGeneration" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command [Conformance]" classname="Kubernetes e2e suite" time="8.178936945"></testcase>
+      <testcase name="[sig-network] NetworkPolicy should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [Slow] should not be deleted from underlying clusters when OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.227198642"></testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters DNS should be able to discover a federated service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [Slow] should not be deleted from underlying clusters when OrphanDependents is true" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable in multiple volumes in a pod [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.153022928"></testcase>
+      <testcase name="[k8s.io] [Feature:Federation] Federation API server authentication [NoCluster] should not accept cluster resources when the client has no authentication credentials" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume as non-root [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="12.200604385"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching [Conformance]" classname="Kubernetes e2e suite" time="86.289045553"></testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters DNS non-local federated service [Slow] missing local service should never find DNS entries for a missing local service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] new files should be created with FSGroup ownership when container is non-root [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods [Conformance]" classname="Kubernetes e2e suite" time="29.232738433"></testcase>
+      <testcase name="[sig-network] NetworkPolicy should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods [Conformance]" classname="Kubernetes e2e suite" time="12.72803698"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed [Conformance]" classname="Kubernetes e2e suite" time="22.138649804"></testcase>
+      <testcase name="[k8s.io] [Feature:Federation] Federation API server authentication [NoCluster] should accept cluster resources when the client has certificate authentication credentials" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [Conformance]" classname="Kubernetes e2e suite" time="44.893368824"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.168747581"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback when there&#39;s replica set with no revision" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor using proxy subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Upgrade [Feature:Upgrade] [k8s.io] Federated clusters upgrade followed by FCP upgrade should maintain a functioning federation [Feature:FederatedClustersUpgradeFollowedByFCPUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should set mode on item file [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.159239684"></testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with mappings [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.164528879"></testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.160409026"></testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters Federated Service should not be deleted from underlying clusters when OrphanDependents is true" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;deployment&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout [Conformance]" classname="Kubernetes e2e suite" time="6.122372211">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image [Conformance]" classname="Kubernetes e2e suite" time="16.194115111"></testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters Federated Service should create and update matching services in underlying clusters" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should schedule a pod w/ a RW PD, ungracefully remove it, then schedule it on another host [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should project all components that make up the projection API [Conformance] [sig-storage] [Projection]" classname="Kubernetes e2e suite" time="8.167902684"></testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count [Conformance] [Slow]" classname="Kubernetes e2e suite" time="158.900147242"></testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.168183801"></testcase>
+      <testcase name="[sig-storage] Volume Disk Format verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.208130192"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] HostPath should support existing directory subPath [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that a pod with an invalid NodeAffinity is rejected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars [Conformance]" classname="Kubernetes e2e suite" time="8.168631325"></testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;namespace&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default commmand (docker entrypoint) [Conformance]" classname="Kubernetes e2e suite" time="8.196038132"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment can avoid hash collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [Conformance]" classname="Kubernetes e2e suite" time="42.443052899"></testcase>
+      <testcase name="[k8s.io] HostPath should support r/w [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should update annotations on modification [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="28.671634999"></testcase>
+      <testcase name="[k8s.io] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should schedule a pod w/ a RW PD shared between multiple containers, write to PD, delete pod, verify contents, and repeat in rapid succession [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Upgrade [Feature:Upgrade] [k8s.io] Federation Control Plane upgrade should maintain a functioning federation [Feature:FCPUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.OrphanDependents is true" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.8/kube-up-gce/version.txt
+++ b/v1.8/kube-up-gce/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.0", GitCommit:"6e937839ac04a38cac63e6a7a306c5d035fe7b0a", GitTreeState:"clean", BuildDate:"2017-09-28T22:57:57Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.1", GitCommit:"f38e43b221d08850172a9a4ea785a86a3ffa3b3a", GitTreeState:"clean", BuildDate:"2017-10-31T22:24:35Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}


### PR DESCRIPTION
Everything is correct here except documentation_url, which I hope to fill in tomorrow.