### PR TITLE
Conformance results for Giant Swarm on AWS

### DIFF
--- a/v1.8/giantswarm-aws/PRODUCT.yaml
+++ b/v1.8/giantswarm-aws/PRODUCT.yaml
@@ -1,0 +1,6 @@
+vendor: Giant Swarm
+name: Managed Kubernetes on AWS
+version: stable-2017-11-17
+website_url: https://giantswarm.io
+documentation_url: https://docs.giantswarm.io
+product_logo_url: https://www.dropbox.com/s/kydb137cjsix7du/giantswarm_ant.png

--- a/v1.8/giantswarm-aws/README.md
+++ b/v1.8/giantswarm-aws/README.md
@@ -1,0 +1,36 @@
+## To Reproduce:
+
+Note: to reproduce you need a Giant Swarm account.
+
+### Create cluster
+
+```
+$ gsctl create cluster --owner=myorg
+```
+
+This will report back a cluster ID that you need for the next step.
+
+
+### Get Credentials
+
+
+```
+$ gsctl create kubeconfig -c <clusterid> --certificate-organizations=system:masters
+```
+
+### Run the tests
+
+Wait a bit for the cluster to come up (depending on the underlying infrastructure this might take a few minutes. Then run:
+
+```
+$ curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+```
+
+Watch Sonobuoy's logs with `kubectl logs -f -n sonobuoy sonobuoy` and wait for the line `no-exit was specified, sonobuoy is now blocking`. At this point, use `kubectl cp` to bring the results to your local machine.
+
+
+### Destroy cluster
+
+```
+$ gsctl delete cluster -c <clusterid>
+```

--- a/v1.8/giantswarm-aws/e2e.log
+++ b/v1.8/giantswarm-aws/e2e.log
@@ -1,0 +1,6438 @@
+Nov 17 10:13:24.898: INFO: Overriding default scale value of zero to 1
+Nov 17 10:13:24.898: INFO: Overriding default milliseconds value of zero to 5000
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1510913604 - Will randomize all specs
+Will run 126 of 697 specs
+
+Nov 17 10:13:25.089: INFO: >>> kubeConfig: 
+Nov 17 10:13:25.091: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
+Nov 17 10:13:25.103: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Nov 17 10:13:25.185: INFO: 22 / 22 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Nov 17 10:13:25.185: INFO: expected 10 pod replicas in namespace 'kube-system', 10 are Running and Ready.
+Nov 17 10:13:25.190: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Nov 17 10:13:25.190: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Nov 17 10:13:25.194: INFO: Client version: v1.8.3
+Nov 17 10:13:25.195: INFO: Server version: v1.8.1+coreos.0
+S
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:40
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:13:25.195: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+Nov 17 10:13:25.232: INFO: Found PodSecurityPolicies; assuming PodSecurityPolicy is enabled.
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-v8gxh
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:40
+STEP: Creating projection with secret that has name projected-secret-test-f2d64a12-cb7f-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:13:25.359: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-f2d6be6f-cb7f-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-v8gxh" to be "success or failure"
+Nov 17 10:13:25.362: INFO: Pod "pod-projected-secrets-f2d6be6f-cb7f-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.723329ms
+Nov 17 10:13:27.371: INFO: Pod "pod-projected-secrets-f2d6be6f-cb7f-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011863919s
+Nov 17 10:13:29.374: INFO: Pod "pod-projected-secrets-f2d6be6f-cb7f-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014552153s
+STEP: Saw pod success
+Nov 17 10:13:29.374: INFO: Pod "pod-projected-secrets-f2d6be6f-cb7f-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:13:29.376: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-secrets-f2d6be6f-cb7f-11e7-b2ab-c6826529d988 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:13:29.401: INFO: Waiting for pod pod-projected-secrets-f2d6be6f-cb7f-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:13:29.405: INFO: Pod pod-projected-secrets-f2d6be6f-cb7f-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:13:29.405: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-v8gxh" for this suite.
+Nov 17 10:13:35.488: INFO: namespace: e2e-tests-projected-v8gxh, resource: bindings, ignored listing per whitelist
+Nov 17 10:13:35.514: INFO: namespace e2e-tests-projected-v8gxh deletion completed in 6.104714387s
+
+• [SLOW TEST:10.319 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:40
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:64
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:13:35.514: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-custom-resource-definition-279mr
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:64
+Nov 17 10:13:35.678: INFO: >>> kubeConfig: 
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:13:36.780: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-279mr" for this suite.
+Nov 17 10:13:42.857: INFO: namespace: e2e-tests-custom-resource-definition-279mr, resource: bindings, ignored listing per whitelist
+Nov 17 10:13:42.872: INFO: namespace e2e-tests-custom-resource-definition-279mr deletion completed in 6.088923949s
+
+• [SLOW TEST:7.358 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:65
+    creating/deleting custom resource definition objects works [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:64
+------------------------------
+SS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:45
+[BeforeEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:13:42.872: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-pod-network-test-hc5c6
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:45
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-hc5c6
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Nov 17 10:13:43.021: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Nov 17 10:14:09.080: INFO: ExecWithOptions {Command:[/bin/sh -c curl -q -s 'http://192.168.185.196:8080/dial?request=hostName&protocol=udp&host=192.168.118.5&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-hc5c6 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:14:09.080: INFO: >>> kubeConfig: 
+Nov 17 10:14:09.149: INFO: Waiting for endpoints: map[]
+Nov 17 10:14:09.151: INFO: ExecWithOptions {Command:[/bin/sh -c curl -q -s 'http://192.168.185.196:8080/dial?request=hostName&protocol=udp&host=192.168.185.195&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-hc5c6 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:14:09.151: INFO: >>> kubeConfig: 
+Nov 17 10:14:09.226: INFO: Waiting for endpoints: map[]
+Nov 17 10:14:09.227: INFO: ExecWithOptions {Command:[/bin/sh -c curl -q -s 'http://192.168.185.196:8080/dial?request=hostName&protocol=udp&host=192.168.118.6&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-hc5c6 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:14:09.228: INFO: >>> kubeConfig: 
+Nov 17 10:14:09.296: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:14:09.296: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-hc5c6" for this suite.
+Nov 17 10:14:31.334: INFO: namespace: e2e-tests-pod-network-test-hc5c6, resource: bindings, ignored listing per whitelist
+Nov 17 10:14:31.377: INFO: namespace e2e-tests-pod-network-test-hc5c6 deletion completed in 22.078315401s
+
+• [SLOW TEST:48.505 seconds]
+[sig-network] Networking
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:61
+  Granular Checks: Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:60
+    should function for intra-pod communication: udp [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:45
+------------------------------
+SSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:375
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:14:31.377: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-sched-pred-7fg7s
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:114
+Nov 17 10:14:31.516: INFO: Waiting up to 1m0s for all nodes to be ready
+Nov 17 10:15:31.532: INFO: Waiting for terminating namespaces to be deleted...
+Nov 17 10:15:31.536: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Nov 17 10:15:31.545: INFO: 22 / 22 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Nov 17 10:15:31.545: INFO: expected 10 pod replicas in namespace 'kube-system', 10 are Running and Ready.
+Nov 17 10:15:31.549: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Nov 17 10:15:31.549: INFO: 
+Logging pods the kubelet thinks is on node ip-10-1-2-110.eu-central-1.compute.internal before test
+Nov 17 10:15:31.565: INFO: kube-proxy-2gr89 from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.565: INFO: 	Container kube-proxy ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: kube-dns-76cfdc459f-8ddhf from kube-system started at 2017-11-17 10:10:32 +0000 UTC (3 container statuses recorded)
+Nov 17 10:15:31.565: INFO: 	Container dnsmasq ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: 	Container kubedns ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: 	Container sidecar ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: calico-kube-controllers-65b85599df-zpk5h from kube-system started at 2017-11-17 10:10:32 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.565: INFO: 	Container calico-kube-controllers ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: nginx-ingress-controller-574f5d4b6b-8ntpt from kube-system started at 2017-11-17 10:10:32 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.565: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: kube-dns-76cfdc459f-s5x4k from kube-system started at 2017-11-17 10:10:32 +0000 UTC (3 container statuses recorded)
+Nov 17 10:15:31.565: INFO: 	Container dnsmasq ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: 	Container kubedns ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: 	Container sidecar ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: kube-dns-76cfdc459f-8nlxq from kube-system started at 2017-11-17 10:10:32 +0000 UTC (3 container statuses recorded)
+Nov 17 10:15:31.565: INFO: 	Container dnsmasq ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: 	Container kubedns ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: 	Container sidecar ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: calico-ipip-pinger-w8xrh from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.565: INFO: 	Container calico-ipip-pinger ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: calico-node-n8drk from kube-system started at 2017-11-17 10:10:01 +0000 UTC (2 container statuses recorded)
+Nov 17 10:15:31.565: INFO: 	Container calico-node ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: 	Container install-cni ready: true, restart count 0
+Nov 17 10:15:31.565: INFO: 
+Logging pods the kubelet thinks is on node ip-10-1-2-35.eu-central-1.compute.internal before test
+Nov 17 10:15:31.573: INFO: default-http-backend-6b6d95dd4f-g7952 from kube-system started at 2017-11-17 10:10:33 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.573: INFO: 	Container default-http-backend ready: true, restart count 0
+Nov 17 10:15:31.573: INFO: default-http-backend-6b6d95dd4f-t6zx7 from kube-system started at 2017-11-17 10:10:33 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.573: INFO: 	Container default-http-backend ready: true, restart count 0
+Nov 17 10:15:31.573: INFO: calico-ipip-pinger-xgz54 from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.573: INFO: 	Container calico-ipip-pinger ready: true, restart count 0
+Nov 17 10:15:31.573: INFO: kube-proxy-7plsv from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.573: INFO: 	Container kube-proxy ready: true, restart count 0
+Nov 17 10:15:31.573: INFO: nginx-ingress-controller-574f5d4b6b-46fqx from kube-system started at 2017-11-17 10:11:04 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.573: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Nov 17 10:15:31.573: INFO: calico-node-bn69r from kube-system started at 2017-11-17 10:10:01 +0000 UTC (2 container statuses recorded)
+Nov 17 10:15:31.573: INFO: 	Container calico-node ready: true, restart count 0
+Nov 17 10:15:31.573: INFO: 	Container install-cni ready: true, restart count 0
+Nov 17 10:15:31.573: INFO: 
+Logging pods the kubelet thinks is on node ip-10-1-2-91.eu-central-1.compute.internal before test
+Nov 17 10:15:31.581: INFO: kube-proxy-snpzn from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.582: INFO: 	Container kube-proxy ready: true, restart count 0
+Nov 17 10:15:31.582: INFO: nginx-ingress-controller-574f5d4b6b-4f94m from kube-system started at 2017-11-17 10:11:04 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.582: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Nov 17 10:15:31.582: INFO: sonobuoy from sonobuoy started at 2017-11-17 10:12:46 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.582: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Nov 17 10:15:31.582: INFO: calico-node-4btfm from kube-system started at 2017-11-17 10:10:01 +0000 UTC (2 container statuses recorded)
+Nov 17 10:15:31.582: INFO: 	Container calico-node ready: true, restart count 0
+Nov 17 10:15:31.582: INFO: 	Container install-cni ready: true, restart count 0
+Nov 17 10:15:31.582: INFO: calico-ipip-pinger-jl5jh from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:15:31.582: INFO: 	Container calico-ipip-pinger ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:375
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-3f47cb65-cb80-11e7-b2ab-c6826529d988 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-3f47cb65-cb80-11e7-b2ab-c6826529d988 off the node ip-10-1-2-35.eu-central-1.compute.internal
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-3f47cb65-cb80-11e7-b2ab-c6826529d988
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:15:35.637: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-7fg7s" for this suite.
+Nov 17 10:15:57.695: INFO: namespace: e2e-tests-sched-pred-7fg7s, resource: bindings, ignored listing per whitelist
+Nov 17 10:15:57.724: INFO: namespace e2e-tests-sched-pred-7fg7s deletion completed in 22.084429115s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:78
+
+• [SLOW TEST:86.347 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:375
+------------------------------
+[k8s.io] Downward API volume 
+  should provide container's memory limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:172
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:15:57.724: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-t2qk2
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide container's memory limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:172
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:15:57.865: INFO: Waiting up to 5m0s for pod "downwardapi-volume-4dbd7f8e-cb80-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-t2qk2" to be "success or failure"
+Nov 17 10:15:57.868: INFO: Pod "downwardapi-volume-4dbd7f8e-cb80-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.639556ms
+Nov 17 10:15:59.870: INFO: Pod "downwardapi-volume-4dbd7f8e-cb80-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004897904s
+Nov 17 10:16:01.872: INFO: Pod "downwardapi-volume-4dbd7f8e-cb80-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.007402753s
+STEP: Saw pod success
+Nov 17 10:16:01.872: INFO: Pod "downwardapi-volume-4dbd7f8e-cb80-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:16:01.874: INFO: Trying to get logs from node ip-10-1-2-91.eu-central-1.compute.internal pod downwardapi-volume-4dbd7f8e-cb80-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:16:01.890: INFO: Waiting for pod downwardapi-volume-4dbd7f8e-cb80-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:16:01.892: INFO: Pod downwardapi-volume-4dbd7f8e-cb80-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:16:01.892: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-t2qk2" for this suite.
+Nov 17 10:16:07.943: INFO: namespace: e2e-tests-downward-api-t2qk2, resource: bindings, ignored listing per whitelist
+Nov 17 10:16:07.970: INFO: namespace e2e-tests-downward-api-t2qk2 deletion completed in 6.07515123s
+
+• [SLOW TEST:10.245 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide container's memory limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:172
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:61
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:16:07.970: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-5ggb2
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:61
+STEP: Creating projection with secret that has name projected-secret-test-map-53d91cbf-cb80-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:16:08.116: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-53d989b0-cb80-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-5ggb2" to be "success or failure"
+Nov 17 10:16:08.119: INFO: Pod "pod-projected-secrets-53d989b0-cb80-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.947176ms
+Nov 17 10:16:10.122: INFO: Pod "pod-projected-secrets-53d989b0-cb80-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005480074s
+STEP: Saw pod success
+Nov 17 10:16:10.122: INFO: Pod "pod-projected-secrets-53d989b0-cb80-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:16:10.123: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-secrets-53d989b0-cb80-11e7-b2ab-c6826529d988 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:16:10.135: INFO: Waiting for pod pod-projected-secrets-53d989b0-cb80-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:16:10.138: INFO: Pod pod-projected-secrets-53d989b0-cb80-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:16:10.138: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5ggb2" for this suite.
+Nov 17 10:16:16.194: INFO: namespace: e2e-tests-projected-5ggb2, resource: bindings, ignored listing per whitelist
+Nov 17 10:16:16.218: INFO: namespace e2e-tests-projected-5ggb2 deletion completed in 6.077357655s
+
+• [SLOW TEST:8.248 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:61
+------------------------------
+[k8s.io] Pods 
+  should be updated [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:316
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:16:16.218: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-pods-nbs2l
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:129
+[It] should be updated [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:316
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Nov 17 10:16:24.886: INFO: Successfully updated pod "pod-update-58c56ef9-cb80-11e7-b2ab-c6826529d988"
+STEP: verifying the updated pod is in kubernetes
+Nov 17 10:16:24.891: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:16:24.891: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-nbs2l" for this suite.
+Nov 17 10:16:46.956: INFO: namespace: e2e-tests-pods-nbs2l, resource: bindings, ignored listing per whitelist
+Nov 17 10:16:46.971: INFO: namespace e2e-tests-pods-nbs2l deletion completed in 22.074209238s
+
+• [SLOW TEST:30.753 seconds]
+[k8s.io] Pods
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be updated [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:316
+------------------------------
+[k8s.io] Downward API volume 
+  should provide container's memory request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:190
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:16:46.971: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-k5wwl
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide container's memory request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:190
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:16:47.111: INFO: Waiting up to 5m0s for pod "downwardapi-volume-6b17d3d0-cb80-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-k5wwl" to be "success or failure"
+Nov 17 10:16:47.114: INFO: Pod "downwardapi-volume-6b17d3d0-cb80-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.758746ms
+Nov 17 10:16:49.116: INFO: Pod "downwardapi-volume-6b17d3d0-cb80-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005421131s
+STEP: Saw pod success
+Nov 17 10:16:49.116: INFO: Pod "downwardapi-volume-6b17d3d0-cb80-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:16:49.118: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downwardapi-volume-6b17d3d0-cb80-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:16:49.131: INFO: Waiting for pod downwardapi-volume-6b17d3d0-cb80-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:16:49.134: INFO: Pod downwardapi-volume-6b17d3d0-cb80-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:16:49.134: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-k5wwl" for this suite.
+Nov 17 10:16:55.169: INFO: namespace: e2e-tests-downward-api-k5wwl, resource: bindings, ignored listing per whitelist
+Nov 17 10:16:55.220: INFO: namespace e2e-tests-downward-api-k5wwl deletion completed in 6.081526944s
+
+• [SLOW TEST:8.249 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide container's memory request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:190
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:483
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:16:55.220: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-configmap-txdcx
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:483
+STEP: Creating configMap with name configmap-test-volume-7002e87a-cb80-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:16:55.366: INFO: Waiting up to 5m0s for pod "pod-configmaps-7003701b-cb80-11e7-b2ab-c6826529d988" in namespace "e2e-tests-configmap-txdcx" to be "success or failure"
+Nov 17 10:16:55.368: INFO: Pod "pod-configmaps-7003701b-cb80-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 1.898056ms
+Nov 17 10:16:57.370: INFO: Pod "pod-configmaps-7003701b-cb80-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004202777s
+STEP: Saw pod success
+Nov 17 10:16:57.370: INFO: Pod "pod-configmaps-7003701b-cb80-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:16:57.372: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-configmaps-7003701b-cb80-11e7-b2ab-c6826529d988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:16:57.386: INFO: Waiting for pod pod-configmaps-7003701b-cb80-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:16:57.387: INFO: Pod pod-configmaps-7003701b-cb80-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:16:57.387: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-txdcx" for this suite.
+Nov 17 10:17:03.447: INFO: namespace: e2e-tests-configmap-txdcx, resource: bindings, ignored listing per whitelist
+Nov 17 10:17:03.480: INFO: namespace e2e-tests-configmap-txdcx deletion completed in 6.090762021s
+
+• [SLOW TEST:8.260 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:483
+------------------------------
+SS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable from pods in volume as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:51
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:17:03.481: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-configmap-8klmw
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:51
+STEP: Creating configMap with name configmap-test-volume-74f17ff3-cb80-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:17:03.640: INFO: Waiting up to 5m0s for pod "pod-configmaps-74f1fe14-cb80-11e7-b2ab-c6826529d988" in namespace "e2e-tests-configmap-8klmw" to be "success or failure"
+Nov 17 10:17:03.643: INFO: Pod "pod-configmaps-74f1fe14-cb80-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.487022ms
+Nov 17 10:17:05.645: INFO: Pod "pod-configmaps-74f1fe14-cb80-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004467491s
+STEP: Saw pod success
+Nov 17 10:17:05.645: INFO: Pod "pod-configmaps-74f1fe14-cb80-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:17:05.646: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-configmaps-74f1fe14-cb80-11e7-b2ab-c6826529d988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:17:05.659: INFO: Waiting for pod pod-configmaps-74f1fe14-cb80-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:17:05.661: INFO: Pod pod-configmaps-74f1fe14-cb80-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:17:05.661: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-8klmw" for this suite.
+Nov 17 10:17:11.706: INFO: namespace: e2e-tests-configmap-8klmw, resource: bindings, ignored listing per whitelist
+Nov 17 10:17:11.755: INFO: namespace e2e-tests-configmap-8klmw deletion completed in 6.090797369s
+
+• [SLOW TEST:8.274 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:51
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] ConfigMap 
+  updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:150
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:17:11.755: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-configmap-6lj8k
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:150
+STEP: Creating configMap with name configmap-test-upd-79de5d51-cb80-11e7-b2ab-c6826529d988
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-79de5d51-cb80-11e7-b2ab-c6826529d988
+STEP: waiting to observe update in volume
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:17:15.932: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-6lj8k" for this suite.
+Nov 17 10:17:37.980: INFO: namespace: e2e-tests-configmap-6lj8k, resource: bindings, ignored listing per whitelist
+Nov 17 10:17:38.010: INFO: namespace e2e-tests-configmap-6lj8k deletion completed in 22.075505928s
+
+• [SLOW TEST:26.255 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:150
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:443
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:17:38.010: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-pods-2mjk8
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:129
+[It] should contain environment variables for services [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:443
+Nov 17 10:17:42.182: INFO: Waiting up to 5m0s for pod "client-envvars-8be91af9-cb80-11e7-b2ab-c6826529d988" in namespace "e2e-tests-pods-2mjk8" to be "success or failure"
+Nov 17 10:17:42.193: INFO: Pod "client-envvars-8be91af9-cb80-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 11.281506ms
+Nov 17 10:17:44.196: INFO: Pod "client-envvars-8be91af9-cb80-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013528335s
+Nov 17 10:17:46.198: INFO: Pod "client-envvars-8be91af9-cb80-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015684667s
+STEP: Saw pod success
+Nov 17 10:17:46.198: INFO: Pod "client-envvars-8be91af9-cb80-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:17:46.200: INFO: Trying to get logs from node ip-10-1-2-91.eu-central-1.compute.internal pod client-envvars-8be91af9-cb80-11e7-b2ab-c6826529d988 container env3cont: <nil>
+STEP: delete the pod
+Nov 17 10:17:46.214: INFO: Waiting for pod client-envvars-8be91af9-cb80-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:17:46.216: INFO: Pod client-envvars-8be91af9-cb80-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:17:46.216: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-2mjk8" for this suite.
+Nov 17 10:18:08.276: INFO: namespace: e2e-tests-pods-2mjk8, resource: bindings, ignored listing per whitelist
+Nov 17 10:18:08.302: INFO: namespace e2e-tests-pods-2mjk8 deletion completed in 22.083450439s
+
+• [SLOW TEST:30.292 seconds]
+[k8s.io] Pods
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should contain environment variables for services [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:443
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Pods 
+  should get a host IP [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:146
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:18:08.302: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-pods-ss6nc
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:129
+[It] should get a host IP [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:146
+STEP: creating pod
+Nov 17 10:18:10.451: INFO: Pod pod-hostip-9b9216fa-cb80-11e7-b2ab-c6826529d988 has hostIP: 10.1.2.35
+[AfterEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:18:10.451: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-ss6nc" for this suite.
+Nov 17 10:18:32.528: INFO: namespace: e2e-tests-pods-ss6nc, resource: bindings, ignored listing per whitelist
+Nov 17 10:18:32.528: INFO: namespace e2e-tests-pods-ss6nc deletion completed in 22.074386117s
+
+• [SLOW TEST:24.225 seconds]
+[k8s.io] Pods
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should get a host IP [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:146
+------------------------------
+S
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:302
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:18:32.528: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-sched-pred-nm44j
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:114
+Nov 17 10:18:32.667: INFO: Waiting up to 1m0s for all nodes to be ready
+Nov 17 10:19:32.687: INFO: Waiting for terminating namespaces to be deleted...
+Nov 17 10:19:32.691: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Nov 17 10:19:32.703: INFO: 22 / 22 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Nov 17 10:19:32.703: INFO: expected 10 pod replicas in namespace 'kube-system', 10 are Running and Ready.
+Nov 17 10:19:32.707: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Nov 17 10:19:32.707: INFO: 
+Logging pods the kubelet thinks is on node ip-10-1-2-110.eu-central-1.compute.internal before test
+Nov 17 10:19:32.714: INFO: calico-kube-controllers-65b85599df-zpk5h from kube-system started at 2017-11-17 10:10:32 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.714: INFO: 	Container calico-kube-controllers ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: nginx-ingress-controller-574f5d4b6b-8ntpt from kube-system started at 2017-11-17 10:10:32 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.714: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: kube-dns-76cfdc459f-s5x4k from kube-system started at 2017-11-17 10:10:32 +0000 UTC (3 container statuses recorded)
+Nov 17 10:19:32.714: INFO: 	Container dnsmasq ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: 	Container kubedns ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: 	Container sidecar ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: kube-dns-76cfdc459f-8nlxq from kube-system started at 2017-11-17 10:10:32 +0000 UTC (3 container statuses recorded)
+Nov 17 10:19:32.714: INFO: 	Container dnsmasq ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: 	Container kubedns ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: 	Container sidecar ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: calico-ipip-pinger-w8xrh from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.714: INFO: 	Container calico-ipip-pinger ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: calico-node-n8drk from kube-system started at 2017-11-17 10:10:01 +0000 UTC (2 container statuses recorded)
+Nov 17 10:19:32.714: INFO: 	Container calico-node ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: 	Container install-cni ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: kube-proxy-2gr89 from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.714: INFO: 	Container kube-proxy ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: kube-dns-76cfdc459f-8ddhf from kube-system started at 2017-11-17 10:10:32 +0000 UTC (3 container statuses recorded)
+Nov 17 10:19:32.714: INFO: 	Container dnsmasq ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: 	Container kubedns ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: 	Container sidecar ready: true, restart count 0
+Nov 17 10:19:32.714: INFO: 
+Logging pods the kubelet thinks is on node ip-10-1-2-35.eu-central-1.compute.internal before test
+Nov 17 10:19:32.719: INFO: calico-node-bn69r from kube-system started at 2017-11-17 10:10:01 +0000 UTC (2 container statuses recorded)
+Nov 17 10:19:32.719: INFO: 	Container calico-node ready: true, restart count 0
+Nov 17 10:19:32.719: INFO: 	Container install-cni ready: true, restart count 0
+Nov 17 10:19:32.719: INFO: calico-ipip-pinger-xgz54 from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.719: INFO: 	Container calico-ipip-pinger ready: true, restart count 0
+Nov 17 10:19:32.719: INFO: kube-proxy-7plsv from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.719: INFO: 	Container kube-proxy ready: true, restart count 0
+Nov 17 10:19:32.719: INFO: nginx-ingress-controller-574f5d4b6b-46fqx from kube-system started at 2017-11-17 10:11:04 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.719: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Nov 17 10:19:32.719: INFO: default-http-backend-6b6d95dd4f-t6zx7 from kube-system started at 2017-11-17 10:10:33 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.719: INFO: 	Container default-http-backend ready: true, restart count 0
+Nov 17 10:19:32.719: INFO: default-http-backend-6b6d95dd4f-g7952 from kube-system started at 2017-11-17 10:10:33 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.720: INFO: 	Container default-http-backend ready: true, restart count 0
+Nov 17 10:19:32.720: INFO: 
+Logging pods the kubelet thinks is on node ip-10-1-2-91.eu-central-1.compute.internal before test
+Nov 17 10:19:32.730: INFO: kube-proxy-snpzn from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.730: INFO: 	Container kube-proxy ready: true, restart count 0
+Nov 17 10:19:32.730: INFO: nginx-ingress-controller-574f5d4b6b-4f94m from kube-system started at 2017-11-17 10:11:04 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.730: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Nov 17 10:19:32.730: INFO: sonobuoy from sonobuoy started at 2017-11-17 10:12:46 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.730: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Nov 17 10:19:32.730: INFO: calico-node-4btfm from kube-system started at 2017-11-17 10:10:01 +0000 UTC (2 container statuses recorded)
+Nov 17 10:19:32.730: INFO: 	Container calico-node ready: true, restart count 0
+Nov 17 10:19:32.730: INFO: 	Container install-cni ready: true, restart count 0
+Nov 17 10:19:32.730: INFO: calico-ipip-pinger-jl5jh from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:19:32.730: INFO: 	Container calico-ipip-pinger ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:302
+Nov 17 10:19:32.741: INFO: Pod calico-ipip-pinger-jl5jh requesting resource cpu=0m on Node ip-10-1-2-91.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod calico-ipip-pinger-w8xrh requesting resource cpu=0m on Node ip-10-1-2-110.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod calico-ipip-pinger-xgz54 requesting resource cpu=0m on Node ip-10-1-2-35.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod calico-kube-controllers-65b85599df-zpk5h requesting resource cpu=0m on Node ip-10-1-2-110.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod calico-node-4btfm requesting resource cpu=250m on Node ip-10-1-2-91.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod calico-node-bn69r requesting resource cpu=250m on Node ip-10-1-2-35.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod calico-node-n8drk requesting resource cpu=250m on Node ip-10-1-2-110.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod default-http-backend-6b6d95dd4f-g7952 requesting resource cpu=10m on Node ip-10-1-2-35.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod default-http-backend-6b6d95dd4f-t6zx7 requesting resource cpu=10m on Node ip-10-1-2-35.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod kube-dns-76cfdc459f-8ddhf requesting resource cpu=260m on Node ip-10-1-2-110.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod kube-dns-76cfdc459f-8nlxq requesting resource cpu=260m on Node ip-10-1-2-110.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod kube-dns-76cfdc459f-s5x4k requesting resource cpu=260m on Node ip-10-1-2-110.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod kube-proxy-2gr89 requesting resource cpu=0m on Node ip-10-1-2-110.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod kube-proxy-7plsv requesting resource cpu=0m on Node ip-10-1-2-35.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod kube-proxy-snpzn requesting resource cpu=0m on Node ip-10-1-2-91.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod nginx-ingress-controller-574f5d4b6b-46fqx requesting resource cpu=0m on Node ip-10-1-2-35.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod nginx-ingress-controller-574f5d4b6b-4f94m requesting resource cpu=0m on Node ip-10-1-2-91.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod nginx-ingress-controller-574f5d4b6b-8ntpt requesting resource cpu=0m on Node ip-10-1-2-110.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Pod sonobuoy requesting resource cpu=0m on Node ip-10-1-2-91.eu-central-1.compute.internal
+Nov 17 10:19:32.741: INFO: Using pod capacity: 500m
+Nov 17 10:19:32.741: INFO: Node: ip-10-1-2-110.eu-central-1.compute.internal has cpu allocatable: 970m
+Nov 17 10:19:32.741: INFO: Node: ip-10-1-2-35.eu-central-1.compute.internal has cpu allocatable: 1730m
+Nov 17 10:19:32.741: INFO: Node: ip-10-1-2-91.eu-central-1.compute.internal has cpu allocatable: 1750m
+STEP: Starting additional 7 Pods to fully saturate the cluster CPU and trying to start another one
+Nov 17 10:19:32.799: INFO: Waiting for running...
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-0.14f7d840c81f5dea], Reason = [Scheduled], Message = [Successfully assigned overcommit-0 to ip-10-1-2-35.eu-central-1.compute.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-0.14f7d840cffb8fa7], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-v9b8z" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-0.14f7d8411448e1ad], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-0.14f7d84116877a7a], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-0.14f7d841228a98cb], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-1.14f7d840c8cb8ec8], Reason = [Scheduled], Message = [Successfully assigned overcommit-1 to ip-10-1-2-91.eu-central-1.compute.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-1.14f7d840da1e3d95], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-v9b8z" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-1.14f7d841123d3bcf], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-1.14f7d84114a5357f], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-1.14f7d8411c1b7e85], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-2.14f7d840c90fcf22], Reason = [Scheduled], Message = [Successfully assigned overcommit-2 to ip-10-1-2-91.eu-central-1.compute.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-2.14f7d840d98df906], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-v9b8z" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-2.14f7d84119b98143], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-2.14f7d8411dab63b7], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-2.14f7d84125c5ca89], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-3.14f7d840c9b88b04], Reason = [Scheduled], Message = [Successfully assigned overcommit-3 to ip-10-1-2-35.eu-central-1.compute.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-3.14f7d840d65c1289], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-v9b8z" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-3.14f7d841210e3d19], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-3.14f7d841259d5c39], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-3.14f7d8412dc6a175], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-4.14f7d840c9f54692], Reason = [Scheduled], Message = [Successfully assigned overcommit-4 to ip-10-1-2-35.eu-central-1.compute.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-4.14f7d840d75f8072], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-v9b8z" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-4.14f7d8411f13d7bb], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-4.14f7d84124361e53], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-4.14f7d8412d4d5062], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-5.14f7d840cae4368d], Reason = [Scheduled], Message = [Successfully assigned overcommit-5 to ip-10-1-2-110.eu-central-1.compute.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-5.14f7d840d3d82986], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-v9b8z" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-5.14f7d840fd55e0c0], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-5.14f7d840ff0858ce], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-5.14f7d841051bcf90], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-6.14f7d840cbb38095], Reason = [Scheduled], Message = [Successfully assigned overcommit-6 to ip-10-1-2-91.eu-central-1.compute.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-6.14f7d840e00cfa77], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-v9b8z" ]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-6.14f7d84129770605], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-6.14f7d8412b032623], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [overcommit-6.14f7d84131bfaa3a], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.14f7d841f59a80ba], Reason = [FailedScheduling], Message = [No nodes are available that match all of the predicates: Insufficient cpu (3), PodToleratesNodeTaints (1).]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:19:38.813: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-nm44j" for this suite.
+Nov 17 10:20:00.894: INFO: namespace: e2e-tests-sched-pred-nm44j, resource: bindings, ignored listing per whitelist
+Nov 17 10:20:00.896: INFO: namespace e2e-tests-sched-pred-nm44j deletion completed in 22.079009593s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:78
+
+• [SLOW TEST:88.368 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:302
+------------------------------
+S
+------------------------------
+[k8s.io] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:59
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:20:00.896: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-secrets-knlrf
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:59
+STEP: Creating secret with name secret-test-map-deaee691-cb80-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:20:01.042: INFO: Waiting up to 5m0s for pod "pod-secrets-deaf6089-cb80-11e7-b2ab-c6826529d988" in namespace "e2e-tests-secrets-knlrf" to be "success or failure"
+Nov 17 10:20:01.044: INFO: Pod "pod-secrets-deaf6089-cb80-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.525719ms
+Nov 17 10:20:03.046: INFO: Pod "pod-secrets-deaf6089-cb80-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004651836s
+STEP: Saw pod success
+Nov 17 10:20:03.047: INFO: Pod "pod-secrets-deaf6089-cb80-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:20:03.048: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-secrets-deaf6089-cb80-11e7-b2ab-c6826529d988 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:20:03.063: INFO: Waiting for pod pod-secrets-deaf6089-cb80-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:20:03.065: INFO: Pod pod-secrets-deaf6089-cb80-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:20:03.065: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-knlrf" for this suite.
+Nov 17 10:20:09.126: INFO: namespace: e2e-tests-secrets-knlrf, resource: bindings, ignored listing per whitelist
+Nov 17 10:20:09.144: INFO: namespace e2e-tests-secrets-knlrf deletion completed in 6.076520087s
+
+• [SLOW TEST:8.248 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:59
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Downward API volume 
+  should provide container's cpu limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:163
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:20:09.144: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-ljf8j
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide container's cpu limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:163
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:20:09.287: INFO: Waiting up to 5m0s for pod "downwardapi-volume-e399613a-cb80-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-ljf8j" to be "success or failure"
+Nov 17 10:20:09.290: INFO: Pod "downwardapi-volume-e399613a-cb80-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.267277ms
+Nov 17 10:20:11.293: INFO: Pod "downwardapi-volume-e399613a-cb80-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005591704s
+STEP: Saw pod success
+Nov 17 10:20:11.293: INFO: Pod "downwardapi-volume-e399613a-cb80-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:20:11.295: INFO: Trying to get logs from node ip-10-1-2-91.eu-central-1.compute.internal pod downwardapi-volume-e399613a-cb80-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:20:11.350: INFO: Waiting for pod downwardapi-volume-e399613a-cb80-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:20:11.352: INFO: Pod downwardapi-volume-e399613a-cb80-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:20:11.352: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-ljf8j" for this suite.
+Nov 17 10:20:17.397: INFO: namespace: e2e-tests-downward-api-ljf8j, resource: bindings, ignored listing per whitelist
+Nov 17 10:20:17.436: INFO: namespace e2e-tests-downward-api-ljf8j deletion completed in 6.081309115s
+
+• [SLOW TEST:8.292 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide container's cpu limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:163
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Secrets 
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:54
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:20:17.436: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-secrets-pjdb7
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:54
+STEP: Creating secret with name secret-test-map-e88a9793-cb80-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:20:17.582: INFO: Waiting up to 5m0s for pod "pod-secrets-e88b1402-cb80-11e7-b2ab-c6826529d988" in namespace "e2e-tests-secrets-pjdb7" to be "success or failure"
+Nov 17 10:20:17.584: INFO: Pod "pod-secrets-e88b1402-cb80-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.039454ms
+Nov 17 10:20:19.586: INFO: Pod "pod-secrets-e88b1402-cb80-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00401244s
+STEP: Saw pod success
+Nov 17 10:20:19.586: INFO: Pod "pod-secrets-e88b1402-cb80-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:20:19.588: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-secrets-e88b1402-cb80-11e7-b2ab-c6826529d988 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:20:19.601: INFO: Waiting for pod pod-secrets-e88b1402-cb80-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:20:19.603: INFO: Pod pod-secrets-e88b1402-cb80-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:20:19.603: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-pjdb7" for this suite.
+Nov 17 10:20:25.682: INFO: namespace: e2e-tests-secrets-pjdb7, resource: bindings, ignored listing per whitelist
+Nov 17 10:20:25.682: INFO: namespace e2e-tests-secrets-pjdb7 deletion completed in 6.074680235s
+
+• [SLOW TEST:8.245 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:54
+------------------------------
+SS
+------------------------------
+[k8s.io] Projected 
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:367
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:20:25.682: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-gqv9g
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:367
+STEP: Creating secret with name s-test-opt-del-ed74fb98-cb80-11e7-b2ab-c6826529d988
+STEP: Creating secret with name s-test-opt-upd-ed74fbe8-cb80-11e7-b2ab-c6826529d988
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-ed74fb98-cb80-11e7-b2ab-c6826529d988
+STEP: Updating secret s-test-opt-upd-ed74fbe8-cb80-11e7-b2ab-c6826529d988
+STEP: Creating secret with name s-test-opt-create-ed74fc04-cb80-11e7-b2ab-c6826529d988
+STEP: waiting to observe update in volume
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:20:29.892: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-gqv9g" for this suite.
+Nov 17 10:20:51.949: INFO: namespace: e2e-tests-projected-gqv9g, resource: bindings, ignored listing per whitelist
+Nov 17 10:20:51.971: INFO: namespace e2e-tests-projected-gqv9g deletion completed in 22.075993588s
+
+• [SLOW TEST:26.289 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:367
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:64
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:20:51.971: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-configmap-mvz2w
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:64
+STEP: Creating configMap with name configmap-test-volume-map-fd20216e-cb80-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:20:52.116: INFO: Waiting up to 5m0s for pod "pod-configmaps-fd20ab2d-cb80-11e7-b2ab-c6826529d988" in namespace "e2e-tests-configmap-mvz2w" to be "success or failure"
+Nov 17 10:20:52.118: INFO: Pod "pod-configmaps-fd20ab2d-cb80-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.433021ms
+Nov 17 10:20:54.121: INFO: Pod "pod-configmaps-fd20ab2d-cb80-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004701599s
+STEP: Saw pod success
+Nov 17 10:20:54.121: INFO: Pod "pod-configmaps-fd20ab2d-cb80-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:20:54.123: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-configmaps-fd20ab2d-cb80-11e7-b2ab-c6826529d988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:20:54.139: INFO: Waiting for pod pod-configmaps-fd20ab2d-cb80-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:20:54.142: INFO: Pod pod-configmaps-fd20ab2d-cb80-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:20:54.142: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-mvz2w" for this suite.
+Nov 17 10:21:00.219: INFO: namespace: e2e-tests-configmap-mvz2w, resource: bindings, ignored listing per whitelist
+Nov 17 10:21:00.221: INFO: namespace e2e-tests-configmap-mvz2w deletion completed in 6.075856233s
+
+• [SLOW TEST:8.249 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:64
+------------------------------
+SSS
+------------------------------
+[k8s.io] Downward API volume 
+  should set DefaultMode on files [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:59
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:21:00.221: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-h98cb
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should set DefaultMode on files [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:59
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:21:00.361: INFO: Waiting up to 5m0s for pod "downwardapi-volume-020ab6ad-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-h98cb" to be "success or failure"
+Nov 17 10:21:00.364: INFO: Pod "downwardapi-volume-020ab6ad-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.026691ms
+Nov 17 10:21:02.366: INFO: Pod "downwardapi-volume-020ab6ad-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005058046s
+STEP: Saw pod success
+Nov 17 10:21:02.366: INFO: Pod "downwardapi-volume-020ab6ad-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:21:02.368: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downwardapi-volume-020ab6ad-cb81-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:21:02.387: INFO: Waiting for pod downwardapi-volume-020ab6ad-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:21:02.389: INFO: Pod downwardapi-volume-020ab6ad-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:21:02.389: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-h98cb" for this suite.
+Nov 17 10:21:08.457: INFO: namespace: e2e-tests-downward-api-h98cb, resource: bindings, ignored listing per whitelist
+Nov 17 10:21:08.470: INFO: namespace e2e-tests-downward-api-h98cb deletion completed in 6.077774191s
+
+• [SLOW TEST:8.249 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should set DefaultMode on files [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:59
+------------------------------
+S
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:59
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:21:08.470: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-configmap-wqdph
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:59
+STEP: Creating configMap with name configmap-test-volume-map-06f5f1a1-cb81-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:21:08.616: INFO: Waiting up to 5m0s for pod "pod-configmaps-06f66702-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-configmap-wqdph" to be "success or failure"
+Nov 17 10:21:08.619: INFO: Pod "pod-configmaps-06f66702-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.8463ms
+Nov 17 10:21:10.621: INFO: Pod "pod-configmaps-06f66702-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00487133s
+STEP: Saw pod success
+Nov 17 10:21:10.621: INFO: Pod "pod-configmaps-06f66702-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:21:10.625: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-configmaps-06f66702-cb81-11e7-b2ab-c6826529d988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:21:10.637: INFO: Waiting for pod pod-configmaps-06f66702-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:21:10.639: INFO: Pod pod-configmaps-06f66702-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:21:10.639: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-wqdph" for this suite.
+Nov 17 10:21:16.702: INFO: namespace: e2e-tests-configmap-wqdph, resource: bindings, ignored listing per whitelist
+Nov 17 10:21:16.716: INFO: namespace e2e-tests-configmap-wqdph deletion completed in 6.074614594s
+
+• [SLOW TEST:8.246 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:59
+------------------------------
+S
+------------------------------
+[k8s.io] Secrets 
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:43
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:21:16.716: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-secrets-dzs8t
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:43
+STEP: Creating secret with name secret-test-0bdfa11a-cb81-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:21:16.859: INFO: Waiting up to 5m0s for pod "pod-secrets-0be0003b-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-secrets-dzs8t" to be "success or failure"
+Nov 17 10:21:16.862: INFO: Pod "pod-secrets-0be0003b-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.361264ms
+Nov 17 10:21:18.863: INFO: Pod "pod-secrets-0be0003b-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004298149s
+STEP: Saw pod success
+Nov 17 10:21:18.863: INFO: Pod "pod-secrets-0be0003b-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:21:18.865: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-secrets-0be0003b-cb81-11e7-b2ab-c6826529d988 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:21:18.878: INFO: Waiting for pod pod-secrets-0be0003b-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:21:18.880: INFO: Pod pod-secrets-0be0003b-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:21:18.880: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-dzs8t" for this suite.
+Nov 17 10:21:24.924: INFO: namespace: e2e-tests-secrets-dzs8t, resource: bindings, ignored listing per whitelist
+Nov 17 10:21:24.957: INFO: namespace e2e-tests-secrets-dzs8t deletion completed in 6.074789003s
+
+• [SLOW TEST:8.241 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:43
+------------------------------
+[k8s.io] Secrets 
+  should be consumable from pods in env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:369
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:21:24.958: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-secrets-v2btk
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:369
+STEP: Creating secret with name secret-test-10c955f2-cb81-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:21:25.102: INFO: Waiting up to 5m0s for pod "pod-secrets-10c9cc80-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-secrets-v2btk" to be "success or failure"
+Nov 17 10:21:25.104: INFO: Pod "pod-secrets-10c9cc80-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.605316ms
+Nov 17 10:21:27.107: INFO: Pod "pod-secrets-10c9cc80-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004892322s
+Nov 17 10:21:29.109: INFO: Pod "pod-secrets-10c9cc80-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.006810711s
+STEP: Saw pod success
+Nov 17 10:21:29.109: INFO: Pod "pod-secrets-10c9cc80-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:21:29.111: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-secrets-10c9cc80-cb81-11e7-b2ab-c6826529d988 container secret-env-test: <nil>
+STEP: delete the pod
+Nov 17 10:21:29.125: INFO: Waiting for pod pod-secrets-10c9cc80-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:21:29.127: INFO: Pod pod-secrets-10c9cc80-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:21:29.127: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-v2btk" for this suite.
+Nov 17 10:21:35.174: INFO: namespace: e2e-tests-secrets-v2btk, resource: bindings, ignored listing per whitelist
+Nov 17 10:21:35.207: INFO: namespace e2e-tests-secrets-v2btk deletion completed in 6.077009375s
+
+• [SLOW TEST:10.249 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:369
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Projected 
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:686
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:21:35.207: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-2lblk
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:686
+STEP: Creating configMap with name cm-test-opt-del-16e72e56-cb81-11e7-b2ab-c6826529d988
+STEP: Creating configMap with name cm-test-opt-upd-16e72ea7-cb81-11e7-b2ab-c6826529d988
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-16e72e56-cb81-11e7-b2ab-c6826529d988
+STEP: Updating configmap cm-test-opt-upd-16e72ea7-cb81-11e7-b2ab-c6826529d988
+STEP: Creating configMap with name cm-test-opt-create-16e72ec2-cb81-11e7-b2ab-c6826529d988
+STEP: waiting to observe update in volume
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:21:39.540: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2lblk" for this suite.
+Nov 17 10:22:01.612: INFO: namespace: e2e-tests-projected-2lblk, resource: bindings, ignored listing per whitelist
+Nov 17 10:22:01.620: INFO: namespace e2e-tests-projected-2lblk deletion completed in 22.077511972s
+
+• [SLOW TEST:26.413 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:686
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Downward API 
+  should provide default limits.cpu/memory from node allocatable [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:200
+[BeforeEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:22:01.620: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-g4sdm
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:200
+STEP: Creating a pod to test downward api env vars
+Nov 17 10:22:01.774: INFO: Waiting up to 5m0s for pod "downward-api-26a5a76c-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-g4sdm" to be "success or failure"
+Nov 17 10:22:01.778: INFO: Pod "downward-api-26a5a76c-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.947399ms
+Nov 17 10:22:03.781: INFO: Pod "downward-api-26a5a76c-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006575867s
+Nov 17 10:22:05.783: INFO: Pod "downward-api-26a5a76c-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009085809s
+STEP: Saw pod success
+Nov 17 10:22:05.783: INFO: Pod "downward-api-26a5a76c-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:22:05.785: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downward-api-26a5a76c-cb81-11e7-b2ab-c6826529d988 container dapi-container: <nil>
+STEP: delete the pod
+Nov 17 10:22:05.799: INFO: Waiting for pod downward-api-26a5a76c-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:22:05.802: INFO: Pod downward-api-26a5a76c-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:22:05.802: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-g4sdm" for this suite.
+Nov 17 10:22:11.856: INFO: namespace: e2e-tests-downward-api-g4sdm, resource: bindings, ignored listing per whitelist
+Nov 17 10:22:11.879: INFO: namespace e2e-tests-downward-api-g4sdm deletion completed in 6.075343976s
+
+• [SLOW TEST:10.259 seconds]
+[k8s.io] Downward API
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide default limits.cpu/memory from node allocatable [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:200
+------------------------------
+SSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:70
+[BeforeEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:22:11.880: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-proxy-b9vjz
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:70
+Nov 17 10:22:12.028: INFO: (0) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.975584ms)
+Nov 17 10:22:12.030: INFO: (1) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.509725ms)
+Nov 17 10:22:12.033: INFO: (2) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.270255ms)
+Nov 17 10:22:12.035: INFO: (3) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.374599ms)
+Nov 17 10:22:12.038: INFO: (4) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.459424ms)
+Nov 17 10:22:12.040: INFO: (5) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.277707ms)
+Nov 17 10:22:12.042: INFO: (6) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.262307ms)
+Nov 17 10:22:12.044: INFO: (7) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.1381ms)
+Nov 17 10:22:12.047: INFO: (8) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.161214ms)
+Nov 17 10:22:12.049: INFO: (9) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.237653ms)
+Nov 17 10:22:12.051: INFO: (10) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.292663ms)
+Nov 17 10:22:12.053: INFO: (11) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.249967ms)
+Nov 17 10:22:12.056: INFO: (12) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.689901ms)
+Nov 17 10:22:12.059: INFO: (13) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.454638ms)
+Nov 17 10:22:12.061: INFO: (14) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.562347ms)
+Nov 17 10:22:12.064: INFO: (15) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.218908ms)
+Nov 17 10:22:12.066: INFO: (16) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.24343ms)
+Nov 17 10:22:12.068: INFO: (17) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.338444ms)
+Nov 17 10:22:12.071: INFO: (18) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.424209ms)
+Nov 17 10:22:12.074: INFO: (19) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.025945ms)
+[AfterEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:22:12.074: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-b9vjz" for this suite.
+Nov 17 10:22:18.143: INFO: namespace: e2e-tests-proxy-b9vjz, resource: bindings, ignored listing per whitelist
+Nov 17 10:22:18.153: INFO: namespace e2e-tests-proxy-b9vjz deletion completed in 6.077151827s
+
+• [SLOW TEST:6.274 seconds]
+[sig-network] Proxy
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:278
+    should proxy logs on node using proxy subresource [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:70
+------------------------------
+S
+------------------------------
+[k8s.io] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:73
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:22:18.153: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-q2ph6
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:73
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Nov 17 10:22:18.291: INFO: Waiting up to 5m0s for pod "pod-307df703-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-q2ph6" to be "success or failure"
+Nov 17 10:22:18.295: INFO: Pod "pod-307df703-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.923612ms
+Nov 17 10:22:20.297: INFO: Pod "pod-307df703-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00624579s
+STEP: Saw pod success
+Nov 17 10:22:20.297: INFO: Pod "pod-307df703-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:22:20.299: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-307df703-cb81-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:22:20.312: INFO: Waiting for pod pod-307df703-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:22:20.314: INFO: Pod pod-307df703-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:22:20.314: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-q2ph6" for this suite.
+Nov 17 10:22:26.352: INFO: namespace: e2e-tests-emptydir-q2ph6, resource: bindings, ignored listing per whitelist
+Nov 17 10:22:26.394: INFO: namespace e2e-tests-emptydir-q2ph6 deletion completed in 6.077795039s
+
+• [SLOW TEST:8.241 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  volume on tmpfs should have the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:73
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:42
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:22:26.395: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-configmap-4klhr
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:42
+STEP: Creating configMap with name configmap-test-volume-35681379-cb81-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:22:26.539: INFO: Waiting up to 5m0s for pod "pod-configmaps-35687d5c-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-configmap-4klhr" to be "success or failure"
+Nov 17 10:22:26.542: INFO: Pod "pod-configmaps-35687d5c-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.612161ms
+Nov 17 10:22:28.545: INFO: Pod "pod-configmaps-35687d5c-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.0056712s
+STEP: Saw pod success
+Nov 17 10:22:28.545: INFO: Pod "pod-configmaps-35687d5c-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:22:28.547: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-configmaps-35687d5c-cb81-11e7-b2ab-c6826529d988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:22:28.563: INFO: Waiting for pod pod-configmaps-35687d5c-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:22:28.565: INFO: Pod pod-configmaps-35687d5c-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:22:28.565: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-4klhr" for this suite.
+Nov 17 10:22:34.628: INFO: namespace: e2e-tests-configmap-4klhr, resource: bindings, ignored listing per whitelist
+Nov 17 10:22:34.645: INFO: namespace e2e-tests-configmap-4klhr deletion completed in 6.077464267s
+
+• [SLOW TEST:8.250 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:42
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Projected 
+  should project all components that make up the projection API [Conformance] [sig-storage] [Projection]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:999
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:22:34.645: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-m5bvq
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should project all components that make up the projection API [Conformance] [sig-storage] [Projection]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:999
+STEP: Creating configMap with name configmap-projected-all-test-volume-3a5335e3-cb81-11e7-b2ab-c6826529d988
+STEP: Creating secret with name secret-projected-all-test-volume-3a5335bc-cb81-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Nov 17 10:22:34.794: INFO: Waiting up to 5m0s for pod "projected-volume-3a53356e-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-m5bvq" to be "success or failure"
+Nov 17 10:22:34.800: INFO: Pod "projected-volume-3a53356e-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 6.391988ms
+Nov 17 10:22:36.803: INFO: Pod "projected-volume-3a53356e-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009287184s
+Nov 17 10:22:38.805: INFO: Pod "projected-volume-3a53356e-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011760854s
+STEP: Saw pod success
+Nov 17 10:22:38.805: INFO: Pod "projected-volume-3a53356e-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:22:38.807: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod projected-volume-3a53356e-cb81-11e7-b2ab-c6826529d988 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:22:38.820: INFO: Waiting for pod projected-volume-3a53356e-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:22:38.822: INFO: Pod projected-volume-3a53356e-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:22:38.822: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-m5bvq" for this suite.
+Nov 17 10:22:44.900: INFO: namespace: e2e-tests-projected-m5bvq, resource: bindings, ignored listing per whitelist
+Nov 17 10:22:44.908: INFO: namespace e2e-tests-projected-m5bvq deletion completed in 6.08351607s
+
+• [SLOW TEST:10.263 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should project all components that make up the projection API [Conformance] [sig-storage] [Projection]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:999
+------------------------------
+SSSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (root,0666,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:109
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:22:44.909: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-pjpgx
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:109
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Nov 17 10:22:45.054: INFO: Waiting up to 5m0s for pod "pod-40718e2b-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-pjpgx" to be "success or failure"
+Nov 17 10:22:45.058: INFO: Pod "pod-40718e2b-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.902034ms
+Nov 17 10:22:47.060: INFO: Pod "pod-40718e2b-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006324917s
+STEP: Saw pod success
+Nov 17 10:22:47.060: INFO: Pod "pod-40718e2b-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:22:47.062: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-40718e2b-cb81-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:22:47.075: INFO: Waiting for pod pod-40718e2b-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:22:47.078: INFO: Pod pod-40718e2b-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:22:47.078: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-pjpgx" for this suite.
+Nov 17 10:22:53.107: INFO: namespace: e2e-tests-emptydir-pjpgx, resource: bindings, ignored listing per whitelist
+Nov 17 10:22:53.159: INFO: namespace e2e-tests-emptydir-pjpgx deletion completed in 6.078862068s
+
+• [SLOW TEST:8.251 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should support (root,0666,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:109
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Downward API volume 
+  should provide podname only [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:49
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:22:53.159: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-hn4xf
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide podname only [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:49
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:22:53.306: INFO: Waiting up to 5m0s for pod "downwardapi-volume-455cb89b-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-hn4xf" to be "success or failure"
+Nov 17 10:22:53.309: INFO: Pod "downwardapi-volume-455cb89b-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.978935ms
+Nov 17 10:22:55.312: INFO: Pod "downwardapi-volume-455cb89b-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005328579s
+STEP: Saw pod success
+Nov 17 10:22:55.312: INFO: Pod "downwardapi-volume-455cb89b-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:22:55.313: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downwardapi-volume-455cb89b-cb81-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:22:55.327: INFO: Waiting for pod downwardapi-volume-455cb89b-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:22:55.329: INFO: Pod downwardapi-volume-455cb89b-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:22:55.329: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-hn4xf" for this suite.
+Nov 17 10:23:01.394: INFO: namespace: e2e-tests-downward-api-hn4xf, resource: bindings, ignored listing per whitelist
+Nov 17 10:23:01.412: INFO: namespace e2e-tests-downward-api-hn4xf deletion completed in 6.080903589s
+
+• [SLOW TEST:8.253 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide podname only [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:49
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:50
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:23:01.412: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-secrets-fkpfp
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:50
+STEP: Creating secret with name secret-test-4a47c55c-cb81-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:23:01.561: INFO: Waiting up to 5m0s for pod "pod-secrets-4a483b63-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-secrets-fkpfp" to be "success or failure"
+Nov 17 10:23:01.563: INFO: Pod "pod-secrets-4a483b63-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 1.815479ms
+Nov 17 10:23:03.567: INFO: Pod "pod-secrets-4a483b63-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005934524s
+STEP: Saw pod success
+Nov 17 10:23:03.567: INFO: Pod "pod-secrets-4a483b63-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:23:03.569: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-secrets-4a483b63-cb81-11e7-b2ab-c6826529d988 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:23:03.588: INFO: Waiting for pod pod-secrets-4a483b63-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:23:03.591: INFO: Pod pod-secrets-4a483b63-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:23:03.591: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-fkpfp" for this suite.
+Nov 17 10:23:09.731: INFO: namespace: e2e-tests-secrets-fkpfp, resource: bindings, ignored listing per whitelist
+Nov 17 10:23:09.750: INFO: namespace e2e-tests-secrets-fkpfp deletion completed in 6.151325675s
+
+• [SLOW TEST:8.338 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:50
+------------------------------
+S
+------------------------------
+[k8s.io] Projected 
+  should provide container's cpu limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:902
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:23:09.750: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-kzmz9
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide container's cpu limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:902
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:23:09.893: INFO: Waiting up to 5m0s for pod "downwardapi-volume-4f3f9677-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-kzmz9" to be "success or failure"
+Nov 17 10:23:09.896: INFO: Pod "downwardapi-volume-4f3f9677-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.566282ms
+Nov 17 10:23:11.898: INFO: Pod "downwardapi-volume-4f3f9677-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00528825s
+STEP: Saw pod success
+Nov 17 10:23:11.899: INFO: Pod "downwardapi-volume-4f3f9677-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:23:11.900: INFO: Trying to get logs from node ip-10-1-2-91.eu-central-1.compute.internal pod downwardapi-volume-4f3f9677-cb81-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:23:11.916: INFO: Waiting for pod downwardapi-volume-4f3f9677-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:23:11.918: INFO: Pod downwardapi-volume-4f3f9677-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:23:11.918: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-kzmz9" for this suite.
+Nov 17 10:23:17.947: INFO: namespace: e2e-tests-projected-kzmz9, resource: bindings, ignored listing per whitelist
+Nov 17 10:23:17.998: INFO: namespace e2e-tests-projected-kzmz9 deletion completed in 6.076399427s
+
+• [SLOW TEST:8.248 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide container's cpu limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:902
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:151
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:23:17.998: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-container-probe-9zdz6
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:151
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-9zdz6
+Nov 17 10:23:22.146: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-9zdz6
+STEP: checking the pod's current state and verifying that restartCount is present
+Nov 17 10:23:22.148: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:25:22.301: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-9zdz6" for this suite.
+Nov 17 10:25:28.364: INFO: namespace: e2e-tests-container-probe-9zdz6, resource: bindings, ignored listing per whitelist
+Nov 17 10:25:28.379: INFO: namespace e2e-tests-container-probe-9zdz6 deletion completed in 6.075295155s
+
+• [SLOW TEST:130.381 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:151
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:132
+[BeforeEach] [k8s.io] Variable Expansion
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:25:28.379: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-var-expansion-pttl9
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:132
+STEP: Creating a pod to test substitution in container's args
+Nov 17 10:25:28.524: INFO: Waiting up to 5m0s for pod "var-expansion-a1e118f7-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-var-expansion-pttl9" to be "success or failure"
+Nov 17 10:25:28.527: INFO: Pod "var-expansion-a1e118f7-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.972815ms
+Nov 17 10:25:30.529: INFO: Pod "var-expansion-a1e118f7-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005719941s
+Nov 17 10:25:32.532: INFO: Pod "var-expansion-a1e118f7-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.007994895s
+STEP: Saw pod success
+Nov 17 10:25:32.532: INFO: Pod "var-expansion-a1e118f7-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:25:32.533: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod var-expansion-a1e118f7-cb81-11e7-b2ab-c6826529d988 container dapi-container: <nil>
+STEP: delete the pod
+Nov 17 10:25:32.583: INFO: Waiting for pod var-expansion-a1e118f7-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:25:32.585: INFO: Pod var-expansion-a1e118f7-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:25:32.585: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-pttl9" for this suite.
+Nov 17 10:25:38.615: INFO: namespace: e2e-tests-var-expansion-pttl9, resource: bindings, ignored listing per whitelist
+Nov 17 10:25:38.666: INFO: namespace e2e-tests-var-expansion-pttl9 deletion completed in 6.077902789s
+
+• [SLOW TEST:10.287 seconds]
+[k8s.io] Variable Expansion
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should allow substituting values in a container's args [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:132
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:68
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:25:38.666: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-configmap-6qp57
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:68
+STEP: Creating configMap with name configmap-test-volume-map-a80220d2-cb81-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:25:38.809: INFO: Waiting up to 5m0s for pod "pod-configmaps-a8029a5f-cb81-11e7-b2ab-c6826529d988" in namespace "e2e-tests-configmap-6qp57" to be "success or failure"
+Nov 17 10:25:38.812: INFO: Pod "pod-configmaps-a8029a5f-cb81-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.871977ms
+Nov 17 10:25:40.814: INFO: Pod "pod-configmaps-a8029a5f-cb81-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00501864s
+STEP: Saw pod success
+Nov 17 10:25:40.814: INFO: Pod "pod-configmaps-a8029a5f-cb81-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:25:40.816: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-configmaps-a8029a5f-cb81-11e7-b2ab-c6826529d988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:25:40.829: INFO: Waiting for pod pod-configmaps-a8029a5f-cb81-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:25:40.831: INFO: Pod pod-configmaps-a8029a5f-cb81-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:25:40.831: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-6qp57" for this suite.
+Nov 17 10:25:46.897: INFO: namespace: e2e-tests-configmap-6qp57, resource: bindings, ignored listing per whitelist
+Nov 17 10:25:46.911: INFO: namespace e2e-tests-configmap-6qp57 deletion completed in 6.077801301s
+
+• [SLOW TEST:8.245 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:68
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count [Conformance] [Slow]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:208
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:25:46.911: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-container-probe-2kknb
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] should have monotonically increasing restart count [Conformance] [Slow]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:208
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-2kknb
+Nov 17 10:25:51.065: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-2kknb
+STEP: checking the pod's current state and verifying that restartCount is present
+Nov 17 10:25:51.066: INFO: Initial restart count of pod liveness-http is 0
+Nov 17 10:26:07.087: INFO: Restart count of pod e2e-tests-container-probe-2kknb/liveness-http is now 1 (16.020753302s elapsed)
+Nov 17 10:26:27.109: INFO: Restart count of pod e2e-tests-container-probe-2kknb/liveness-http is now 2 (36.042552962s elapsed)
+Nov 17 10:26:47.132: INFO: Restart count of pod e2e-tests-container-probe-2kknb/liveness-http is now 3 (56.065535455s elapsed)
+Nov 17 10:27:07.153: INFO: Restart count of pod e2e-tests-container-probe-2kknb/liveness-http is now 4 (1m16.086971462s elapsed)
+Nov 17 10:28:09.221: INFO: Restart count of pod e2e-tests-container-probe-2kknb/liveness-http is now 5 (2m18.154976047s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:28:09.244: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-2kknb" for this suite.
+Nov 17 10:28:15.274: INFO: namespace: e2e-tests-container-probe-2kknb, resource: bindings, ignored listing per whitelist
+Nov 17 10:28:15.330: INFO: namespace e2e-tests-container-probe-2kknb deletion completed in 6.083174488s
+
+• [SLOW TEST:148.419 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should have monotonically increasing restart count [Conformance] [Slow]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:208
+------------------------------
+[k8s.io] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pods.go:239
+[BeforeEach] [k8s.io] Pods Extended
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:28:15.330: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-pods-m44hz
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pods.go:201
+[It] should be submitted and removed [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pods.go:239
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] Pods Extended
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:28:15.479: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-m44hz" for this suite.
+Nov 17 10:28:37.553: INFO: namespace: e2e-tests-pods-m44hz, resource: bindings, ignored listing per whitelist
+Nov 17 10:28:37.566: INFO: namespace e2e-tests-pods-m44hz deletion completed in 22.079532687s
+
+• [SLOW TEST:22.236 seconds]
+[k8s.io] Pods Extended
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  [k8s.io] Pods Set QOS Class
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+    should be submitted and removed [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pods.go:239
+------------------------------
+SS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:179
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:28:37.566: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-container-probe-p88rf
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] should be restarted with a /healthz http liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:179
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-p88rf
+Nov 17 10:28:39.714: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-p88rf
+STEP: checking the pod's current state and verifying that restartCount is present
+Nov 17 10:28:39.715: INFO: Initial restart count of pod liveness-http is 0
+Nov 17 10:29:03.752: INFO: Restart count of pod e2e-tests-container-probe-p88rf/liveness-http is now 1 (24.036684544s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:29:03.761: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-p88rf" for this suite.
+Nov 17 10:29:09.818: INFO: namespace: e2e-tests-container-probe-p88rf, resource: bindings, ignored listing per whitelist
+Nov 17 10:29:09.849: INFO: namespace e2e-tests-container-probe-p88rf deletion completed in 6.084136744s
+
+• [SLOW TEST:32.284 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be restarted with a /healthz http liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:179
+------------------------------
+S
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:101
+[BeforeEach] [k8s.io] Variable Expansion
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:29:09.854: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-var-expansion-bwmn6
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:101
+STEP: Creating a pod to test substitution in container's command
+Nov 17 10:29:10.034: INFO: Waiting up to 5m0s for pod "var-expansion-25e8cedb-cb82-11e7-b2ab-c6826529d988" in namespace "e2e-tests-var-expansion-bwmn6" to be "success or failure"
+Nov 17 10:29:10.036: INFO: Pod "var-expansion-25e8cedb-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.229343ms
+Nov 17 10:29:12.038: INFO: Pod "var-expansion-25e8cedb-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004725381s
+Nov 17 10:29:14.041: INFO: Pod "var-expansion-25e8cedb-cb82-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.007040322s
+STEP: Saw pod success
+Nov 17 10:29:14.041: INFO: Pod "var-expansion-25e8cedb-cb82-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:29:14.042: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod var-expansion-25e8cedb-cb82-11e7-b2ab-c6826529d988 container dapi-container: <nil>
+STEP: delete the pod
+Nov 17 10:29:14.058: INFO: Waiting for pod var-expansion-25e8cedb-cb82-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:29:14.060: INFO: Pod var-expansion-25e8cedb-cb82-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:29:14.060: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-bwmn6" for this suite.
+Nov 17 10:29:20.089: INFO: namespace: e2e-tests-var-expansion-bwmn6, resource: bindings, ignored listing per whitelist
+Nov 17 10:29:20.139: INFO: namespace e2e-tests-var-expansion-bwmn6 deletion completed in 6.075997312s
+
+• [SLOW TEST:10.285 seconds]
+[k8s.io] Variable Expansion
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should allow substituting values in a container's command [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:101
+------------------------------
+S
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:59
+[BeforeEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:29:20.139: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-pod-network-test-plxqw
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:59
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-plxqw
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Nov 17 10:29:20.280: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Nov 17 10:29:44.344: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.118.44 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-plxqw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:29:44.344: INFO: >>> kubeConfig: 
+Nov 17 10:29:45.403: INFO: Found all expected endpoints: [netserver-0]
+Nov 17 10:29:45.406: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.118.43 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-plxqw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:29:45.406: INFO: >>> kubeConfig: 
+Nov 17 10:29:46.408: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.118.43 8081 | grep -v '^\\s*$'": command terminated with exit code 137, stdout: "", stderr: ""
+Nov 17 10:29:46.408: INFO: Waiting for [netserver-1] endpoints (expected=[netserver-1], actual=[])
+Nov 17 10:29:48.411: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.118.43 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-plxqw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:29:48.411: INFO: >>> kubeConfig: 
+Nov 17 10:29:49.488: INFO: Found all expected endpoints: [netserver-1]
+Nov 17 10:29:49.491: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-plxqw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:29:49.491: INFO: >>> kubeConfig: 
+Nov 17 10:29:50.481: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\\s*$'": command terminated with exit code 137, stdout: "", stderr: ""
+Nov 17 10:29:50.481: INFO: Waiting for [netserver-2] endpoints (expected=[netserver-2], actual=[])
+Nov 17 10:29:52.484: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-plxqw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:29:52.484: INFO: >>> kubeConfig: 
+Nov 17 10:29:52.503: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\\s*$'": unable to upgrade connection: container not found ("hostexec"), stdout: "", stderr: ""
+Nov 17 10:29:52.503: INFO: Waiting for [netserver-2] endpoints (expected=[netserver-2], actual=[])
+Nov 17 10:29:54.505: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-plxqw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:29:54.506: INFO: >>> kubeConfig: 
+Nov 17 10:29:54.525: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\\s*$'": unable to upgrade connection: container not found ("hostexec"), stdout: "", stderr: ""
+Nov 17 10:29:54.525: INFO: Waiting for [netserver-2] endpoints (expected=[netserver-2], actual=[])
+Nov 17 10:29:56.528: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-plxqw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:29:56.528: INFO: >>> kubeConfig: 
+Nov 17 10:29:56.547: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\\s*$'": unable to upgrade connection: container not found ("hostexec"), stdout: "", stderr: ""
+Nov 17 10:29:56.547: INFO: Waiting for [netserver-2] endpoints (expected=[netserver-2], actual=[])
+Nov 17 10:29:58.549: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-plxqw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:29:58.549: INFO: >>> kubeConfig: 
+Nov 17 10:29:58.568: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\\s*$'": unable to upgrade connection: container not found ("hostexec"), stdout: "", stderr: ""
+Nov 17 10:29:58.568: INFO: Waiting for [netserver-2] endpoints (expected=[netserver-2], actual=[])
+Nov 17 10:30:00.571: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-plxqw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:30:00.571: INFO: >>> kubeConfig: 
+Nov 17 10:30:00.591: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\\s*$'": unable to upgrade connection: container not found ("hostexec"), stdout: "", stderr: ""
+Nov 17 10:30:00.591: INFO: Waiting for [netserver-2] endpoints (expected=[netserver-2], actual=[])
+Nov 17 10:30:02.594: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-plxqw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:30:02.594: INFO: >>> kubeConfig: 
+Nov 17 10:30:02.613: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\\s*$'": unable to upgrade connection: container not found ("hostexec"), stdout: "", stderr: ""
+Nov 17 10:30:02.613: INFO: Waiting for [netserver-2] endpoints (expected=[netserver-2], actual=[])
+Nov 17 10:30:04.616: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-plxqw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:30:04.616: INFO: >>> kubeConfig: 
+Nov 17 10:30:04.634: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\\s*$'": unable to upgrade connection: container not found ("hostexec"), stdout: "", stderr: ""
+Nov 17 10:30:04.634: INFO: Waiting for [netserver-2] endpoints (expected=[netserver-2], actual=[])
+Nov 17 10:30:06.637: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 192.168.185.205 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-plxqw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:30:06.637: INFO: >>> kubeConfig: 
+Nov 17 10:30:07.696: INFO: Found all expected endpoints: [netserver-2]
+[AfterEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:30:07.696: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-plxqw" for this suite.
+Nov 17 10:30:29.749: INFO: namespace: e2e-tests-pod-network-test-plxqw, resource: bindings, ignored listing per whitelist
+Nov 17 10:30:29.797: INFO: namespace e2e-tests-pod-network-test-plxqw deletion completed in 22.097607469s
+
+• [SLOW TEST:69.658 seconds]
+[sig-network] Networking
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:61
+  Granular Checks: Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:60
+    should function for node-pod communication: udp [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:59
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:97
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:30:29.797: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-container-probe-brc6g
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] with readiness probe that fails should never be ready and never restart [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:97
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:31:29.945: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-brc6g" for this suite.
+Nov 17 10:31:52.002: INFO: namespace: e2e-tests-container-probe-brc6g, resource: bindings, ignored listing per whitelist
+Nov 17 10:31:52.026: INFO: namespace e2e-tests-container-probe-brc6g deletion completed in 22.078080936s
+
+• [SLOW TEST:82.229 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  with readiness probe that fails should never be ready and never restart [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:97
+------------------------------
+SS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (root,0644,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:77
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:31:52.027: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-sn6wj
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:77
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Nov 17 10:31:52.169: INFO: Waiting up to 5m0s for pod "pod-868cc672-cb82-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-sn6wj" to be "success or failure"
+Nov 17 10:31:52.172: INFO: Pod "pod-868cc672-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.012002ms
+Nov 17 10:31:54.174: INFO: Pod "pod-868cc672-cb82-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005117564s
+STEP: Saw pod success
+Nov 17 10:31:54.174: INFO: Pod "pod-868cc672-cb82-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:31:54.176: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-868cc672-cb82-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:31:54.188: INFO: Waiting for pod pod-868cc672-cb82-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:31:54.190: INFO: Pod pod-868cc672-cb82-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:31:54.190: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-sn6wj" for this suite.
+Nov 17 10:32:00.223: INFO: namespace: e2e-tests-emptydir-sn6wj, resource: bindings, ignored listing per whitelist
+Nov 17 10:32:00.278: INFO: namespace e2e-tests-emptydir-sn6wj deletion completed in 6.085140282s
+
+• [SLOW TEST:8.251 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should support (root,0644,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:77
+------------------------------
+SSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (root,0777,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:85
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:32:00.278: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-6pdgh
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:85
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Nov 17 10:32:00.421: INFO: Waiting up to 5m0s for pod "pod-8b77d0f0-cb82-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-6pdgh" to be "success or failure"
+Nov 17 10:32:00.424: INFO: Pod "pod-8b77d0f0-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.980288ms
+Nov 17 10:32:02.426: INFO: Pod "pod-8b77d0f0-cb82-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00542048s
+STEP: Saw pod success
+Nov 17 10:32:02.426: INFO: Pod "pod-8b77d0f0-cb82-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:32:02.428: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-8b77d0f0-cb82-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:32:02.442: INFO: Waiting for pod pod-8b77d0f0-cb82-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:32:02.445: INFO: Pod pod-8b77d0f0-cb82-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:32:02.445: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-6pdgh" for this suite.
+Nov 17 10:32:08.490: INFO: namespace: e2e-tests-emptydir-6pdgh, resource: bindings, ignored listing per whitelist
+Nov 17 10:32:08.525: INFO: namespace e2e-tests-emptydir-6pdgh deletion completed in 6.077985349s
+
+• [SLOW TEST:8.247 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should support (root,0777,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:85
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:66
+[BeforeEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:32:08.526: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-containers-cfwt2
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:66
+STEP: Creating a pod to test override all
+Nov 17 10:32:08.666: INFO: Waiting up to 5m0s for pod "client-containers-9061ff74-cb82-11e7-b2ab-c6826529d988" in namespace "e2e-tests-containers-cfwt2" to be "success or failure"
+Nov 17 10:32:08.668: INFO: Pod "client-containers-9061ff74-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.260106ms
+Nov 17 10:32:10.670: INFO: Pod "client-containers-9061ff74-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004234488s
+Nov 17 10:32:12.673: INFO: Pod "client-containers-9061ff74-cb82-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.00678776s
+STEP: Saw pod success
+Nov 17 10:32:12.673: INFO: Pod "client-containers-9061ff74-cb82-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:32:12.675: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod client-containers-9061ff74-cb82-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:32:12.689: INFO: Waiting for pod client-containers-9061ff74-cb82-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:32:12.692: INFO: Pod client-containers-9061ff74-cb82-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:32:12.692: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-cfwt2" for this suite.
+Nov 17 10:32:18.743: INFO: namespace: e2e-tests-containers-cfwt2, resource: bindings, ignored listing per whitelist
+Nov 17 10:32:18.772: INFO: namespace e2e-tests-containers-cfwt2 deletion completed in 6.077244597s
+
+• [SLOW TEST:10.246 seconds]
+[k8s.io] Docker Containers
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be able to override the image's default command and arguments [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:66
+------------------------------
+[k8s.io] Projected 
+  should update labels on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:864
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:32:18.772: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-zs7mc
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should update labels on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:864
+STEP: Creating the pod
+Nov 17 10:32:21.434: INFO: Successfully updated pod "labelsupdate967dcef0-cb82-11e7-b2ab-c6826529d988"
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:32:25.453: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-zs7mc" for this suite.
+Nov 17 10:32:47.525: INFO: namespace: e2e-tests-projected-zs7mc, resource: bindings, ignored listing per whitelist
+Nov 17 10:32:47.532: INFO: namespace e2e-tests-projected-zs7mc deletion completed in 22.076627973s
+
+• [SLOW TEST:28.761 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should update labels on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:864
+------------------------------
+SS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:97
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:32:47.533: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-sq2gp
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:97
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Nov 17 10:32:47.676: INFO: Waiting up to 5m0s for pod "pod-a7a28b98-cb82-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-sq2gp" to be "success or failure"
+Nov 17 10:32:47.679: INFO: Pod "pod-a7a28b98-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.804877ms
+Nov 17 10:32:49.681: INFO: Pod "pod-a7a28b98-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004779173s
+Nov 17 10:32:51.683: INFO: Pod "pod-a7a28b98-cb82-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.006862491s
+STEP: Saw pod success
+Nov 17 10:32:51.683: INFO: Pod "pod-a7a28b98-cb82-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:32:51.685: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-a7a28b98-cb82-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:32:51.699: INFO: Waiting for pod pod-a7a28b98-cb82-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:32:51.701: INFO: Pod pod-a7a28b98-cb82-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:32:51.701: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-sq2gp" for this suite.
+Nov 17 10:32:57.740: INFO: namespace: e2e-tests-emptydir-sq2gp, resource: bindings, ignored listing per whitelist
+Nov 17 10:32:57.779: INFO: namespace e2e-tests-emptydir-sq2gp deletion completed in 6.075405059s
+
+• [SLOW TEST:10.246 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should support (non-root,0777,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:97
+------------------------------
+SS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:65
+[BeforeEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:32:57.779: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-proxy-jxg8l
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:65
+Nov 17 10:32:57.938: INFO: (0) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.938537ms)
+Nov 17 10:32:57.940: INFO: (1) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.422132ms)
+Nov 17 10:32:57.942: INFO: (2) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.211648ms)
+Nov 17 10:32:57.945: INFO: (3) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.165887ms)
+Nov 17 10:32:57.947: INFO: (4) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.298527ms)
+Nov 17 10:32:57.949: INFO: (5) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.258542ms)
+Nov 17 10:32:57.952: INFO: (6) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.269955ms)
+Nov 17 10:32:57.954: INFO: (7) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.252175ms)
+Nov 17 10:32:57.956: INFO: (8) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.276355ms)
+Nov 17 10:32:57.959: INFO: (9) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.344084ms)
+Nov 17 10:32:57.961: INFO: (10) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.201211ms)
+Nov 17 10:32:57.963: INFO: (11) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.251478ms)
+Nov 17 10:32:57.965: INFO: (12) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.186413ms)
+Nov 17 10:32:57.968: INFO: (13) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.192623ms)
+Nov 17 10:32:57.970: INFO: (14) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.118101ms)
+Nov 17 10:32:57.972: INFO: (15) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.325207ms)
+Nov 17 10:32:57.974: INFO: (16) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.136785ms)
+Nov 17 10:32:57.976: INFO: (17) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.17574ms)
+Nov 17 10:32:57.979: INFO: (18) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.269292ms)
+Nov 17 10:32:57.981: INFO: (19) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.264703ms)
+[AfterEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:32:57.981: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-jxg8l" for this suite.
+Nov 17 10:33:04.025: INFO: namespace: e2e-tests-proxy-jxg8l, resource: bindings, ignored listing per whitelist
+Nov 17 10:33:04.083: INFO: namespace e2e-tests-proxy-jxg8l deletion completed in 6.09975934s
+
+• [SLOW TEST:6.304 seconds]
+[sig-network] Proxy
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:278
+    should proxy logs on node with explicit kubelet port [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:65
+------------------------------
+SS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:386
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:33:04.083: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-th7bl
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:386
+STEP: Creating configMap with name projected-configmap-test-volume-b17fa43f-cb82-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:33:04.228: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-b1801b64-cb82-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-th7bl" to be "success or failure"
+Nov 17 10:33:04.231: INFO: Pod "pod-projected-configmaps-b1801b64-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.101385ms
+Nov 17 10:33:06.234: INFO: Pod "pod-projected-configmaps-b1801b64-cb82-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005363176s
+STEP: Saw pod success
+Nov 17 10:33:06.234: INFO: Pod "pod-projected-configmaps-b1801b64-cb82-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:33:06.236: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-configmaps-b1801b64-cb82-11e7-b2ab-c6826529d988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:33:06.326: INFO: Waiting for pod pod-projected-configmaps-b1801b64-cb82-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:33:06.329: INFO: Pod pod-projected-configmaps-b1801b64-cb82-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:33:06.329: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-th7bl" for this suite.
+Nov 17 10:33:12.374: INFO: namespace: e2e-tests-projected-th7bl, resource: bindings, ignored listing per whitelist
+Nov 17 10:33:12.425: INFO: namespace e2e-tests-projected-th7bl deletion completed in 6.080291732s
+
+• [SLOW TEST:8.342 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:386
+------------------------------
+SSSS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/rc.go:43
+[BeforeEach] [sig-apps] ReplicationController
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:33:12.425: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-replication-controller-v9g5t
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/rc.go:43
+STEP: Creating replication controller my-hostname-basic-b678870e-cb82-11e7-b2ab-c6826529d988
+Nov 17 10:33:12.570: INFO: Pod name my-hostname-basic-b678870e-cb82-11e7-b2ab-c6826529d988: Found 0 pods out of 1
+Nov 17 10:33:17.572: INFO: Pod name my-hostname-basic-b678870e-cb82-11e7-b2ab-c6826529d988: Found 1 pods out of 1
+Nov 17 10:33:17.572: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-b678870e-cb82-11e7-b2ab-c6826529d988" are running
+Nov 17 10:33:17.574: INFO: Pod "my-hostname-basic-b678870e-cb82-11e7-b2ab-c6826529d988-b6bnn" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-11-17 10:33:12 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-11-17 10:33:14 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-11-17 10:33:12 +0000 UTC Reason: Message:}])
+Nov 17 10:33:17.574: INFO: Trying to dial the pod
+Nov 17 10:33:22.585: INFO: Controller my-hostname-basic-b678870e-cb82-11e7-b2ab-c6826529d988: Got expected result from replica 1 [my-hostname-basic-b678870e-cb82-11e7-b2ab-c6826529d988-b6bnn]: "my-hostname-basic-b678870e-cb82-11e7-b2ab-c6826529d988-b6bnn", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:33:22.585: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-v9g5t" for this suite.
+Nov 17 10:33:28.648: INFO: namespace: e2e-tests-replication-controller-v9g5t, resource: bindings, ignored listing per whitelist
+Nov 17 10:33:28.674: INFO: namespace e2e-tests-replication-controller-v9g5t deletion completed in 6.086421549s
+
+• [SLOW TEST:16.249 seconds]
+[sig-apps] ReplicationController
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/rc.go:43
+------------------------------
+S
+------------------------------
+[k8s.io] Downward API volume 
+  should provide container's cpu request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:181
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:33:28.674: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-c885x
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide container's cpu request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:181
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:33:28.816: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c027c8b1-cb82-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-c885x" to be "success or failure"
+Nov 17 10:33:28.818: INFO: Pod "downwardapi-volume-c027c8b1-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.582975ms
+Nov 17 10:33:30.821: INFO: Pod "downwardapi-volume-c027c8b1-cb82-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004830175s
+STEP: Saw pod success
+Nov 17 10:33:30.821: INFO: Pod "downwardapi-volume-c027c8b1-cb82-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:33:30.823: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downwardapi-volume-c027c8b1-cb82-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:33:30.842: INFO: Waiting for pod downwardapi-volume-c027c8b1-cb82-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:33:30.844: INFO: Pod downwardapi-volume-c027c8b1-cb82-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:33:30.844: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-c885x" for this suite.
+Nov 17 10:33:36.921: INFO: namespace: e2e-tests-downward-api-c885x, resource: bindings, ignored listing per whitelist
+Nov 17 10:33:36.923: INFO: namespace e2e-tests-downward-api-c885x deletion completed in 6.076311708s
+
+• [SLOW TEST:8.249 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide container's cpu request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:181
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Projected 
+  should provide container's memory limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:911
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:33:36.924: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-2mxhk
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide container's memory limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:911
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:33:37.066: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c512a1b2-cb82-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-2mxhk" to be "success or failure"
+Nov 17 10:33:37.069: INFO: Pod "downwardapi-volume-c512a1b2-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.126309ms
+Nov 17 10:33:39.071: INFO: Pod "downwardapi-volume-c512a1b2-cb82-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004476992s
+STEP: Saw pod success
+Nov 17 10:33:39.071: INFO: Pod "downwardapi-volume-c512a1b2-cb82-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:33:39.077: INFO: Trying to get logs from node ip-10-1-2-91.eu-central-1.compute.internal pod downwardapi-volume-c512a1b2-cb82-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:33:39.102: INFO: Waiting for pod downwardapi-volume-c512a1b2-cb82-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:33:39.105: INFO: Pod downwardapi-volume-c512a1b2-cb82-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:33:39.106: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2mxhk" for this suite.
+Nov 17 10:33:45.162: INFO: namespace: e2e-tests-projected-2mxhk, resource: bindings, ignored listing per whitelist
+Nov 17 10:33:45.203: INFO: namespace e2e-tests-projected-2mxhk deletion completed in 6.094989238s
+
+• [SLOW TEST:8.279 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide container's memory limit [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:911
+------------------------------
+S
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (non-root,0644,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:117
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:33:45.203: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-tgwxp
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:117
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Nov 17 10:33:45.344: INFO: Waiting up to 5m0s for pod "pod-ca01d176-cb82-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-tgwxp" to be "success or failure"
+Nov 17 10:33:45.346: INFO: Pod "pod-ca01d176-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.034771ms
+Nov 17 10:33:47.348: INFO: Pod "pod-ca01d176-cb82-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004253445s
+STEP: Saw pod success
+Nov 17 10:33:47.348: INFO: Pod "pod-ca01d176-cb82-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:33:47.350: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-ca01d176-cb82-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:33:47.362: INFO: Waiting for pod pod-ca01d176-cb82-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:33:47.364: INFO: Pod pod-ca01d176-cb82-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:33:47.365: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-tgwxp" for this suite.
+Nov 17 10:33:53.441: INFO: namespace: e2e-tests-emptydir-tgwxp, resource: bindings, ignored listing per whitelist
+Nov 17 10:33:53.443: INFO: namespace e2e-tests-emptydir-tgwxp deletion completed in 6.075757151s
+
+• [SLOW TEST:8.239 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should support (non-root,0644,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:117
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Downward API 
+  should provide host IP as an env var [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:109
+[BeforeEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:33:53.443: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-p9lhx
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:109
+STEP: Creating a pod to test downward api env vars
+Nov 17 10:33:53.583: INFO: Waiting up to 5m0s for pod "downward-api-ceeb02a0-cb82-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-p9lhx" to be "success or failure"
+Nov 17 10:33:53.586: INFO: Pod "downward-api-ceeb02a0-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.212004ms
+Nov 17 10:33:55.589: INFO: Pod "downward-api-ceeb02a0-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005384238s
+Nov 17 10:33:57.591: INFO: Pod "downward-api-ceeb02a0-cb82-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.007677151s
+STEP: Saw pod success
+Nov 17 10:33:57.591: INFO: Pod "downward-api-ceeb02a0-cb82-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:33:57.593: INFO: Trying to get logs from node ip-10-1-2-91.eu-central-1.compute.internal pod downward-api-ceeb02a0-cb82-11e7-b2ab-c6826529d988 container dapi-container: <nil>
+STEP: delete the pod
+Nov 17 10:33:57.606: INFO: Waiting for pod downward-api-ceeb02a0-cb82-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:33:57.608: INFO: Pod downward-api-ceeb02a0-cb82-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:33:57.608: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-p9lhx" for this suite.
+Nov 17 10:34:03.709: INFO: namespace: e2e-tests-downward-api-p9lhx, resource: bindings, ignored listing per whitelist
+Nov 17 10:34:03.724: INFO: namespace e2e-tests-downward-api-p9lhx deletion completed in 6.113249998s
+
+• [SLOW TEST:10.281 seconds]
+[k8s.io] Downward API
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide host IP as an env var [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:109
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:69
+[BeforeEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:34:03.724: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-proxy-vx92f
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:69
+Nov 17 10:34:03.893: INFO: (0) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.002221ms)
+Nov 17 10:34:03.897: INFO: (1) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.629015ms)
+Nov 17 10:34:03.900: INFO: (2) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.065082ms)
+Nov 17 10:34:03.904: INFO: (3) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.776561ms)
+Nov 17 10:34:03.907: INFO: (4) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.187161ms)
+Nov 17 10:34:03.910: INFO: (5) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.323474ms)
+Nov 17 10:34:03.914: INFO: (6) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.405957ms)
+Nov 17 10:34:03.917: INFO: (7) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.274846ms)
+Nov 17 10:34:03.920: INFO: (8) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.247794ms)
+Nov 17 10:34:03.924: INFO: (9) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.253644ms)
+Nov 17 10:34:03.927: INFO: (10) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.153061ms)
+Nov 17 10:34:03.930: INFO: (11) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.313408ms)
+Nov 17 10:34:03.935: INFO: (12) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.301884ms)
+Nov 17 10:34:03.943: INFO: (13) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 8.471533ms)
+Nov 17 10:34:03.950: INFO: (14) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.830757ms)
+Nov 17 10:34:03.959: INFO: (15) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 8.526507ms)
+Nov 17 10:34:03.962: INFO: (16) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.986932ms)
+Nov 17 10:34:03.965: INFO: (17) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.144711ms)
+Nov 17 10:34:03.989: INFO: (18) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 23.778825ms)
+Nov 17 10:34:04.001: INFO: (19) /api/v1/nodes/ip-10-1-2-110.eu-central-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 12.325162ms)
+[AfterEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:34:04.001: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-vx92f" for this suite.
+Nov 17 10:34:10.079: INFO: namespace: e2e-tests-proxy-vx92f, resource: bindings, ignored listing per whitelist
+Nov 17 10:34:10.095: INFO: namespace e2e-tests-proxy-vx92f deletion completed in 6.090331289s
+
+• [SLOW TEST:6.371 seconds]
+[sig-network] Proxy
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:278
+    should proxy logs on node with explicit kubelet port using proxy subresource [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:69
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:204
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:34:10.096: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-z9zjr
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:204
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:34:10.243: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d8d903a2-cb82-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-z9zjr" to be "success or failure"
+Nov 17 10:34:10.247: INFO: Pod "downwardapi-volume-d8d903a2-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.230537ms
+Nov 17 10:34:12.249: INFO: Pod "downwardapi-volume-d8d903a2-cb82-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006884487s
+STEP: Saw pod success
+Nov 17 10:34:12.249: INFO: Pod "downwardapi-volume-d8d903a2-cb82-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:34:12.251: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downwardapi-volume-d8d903a2-cb82-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:34:12.266: INFO: Waiting for pod downwardapi-volume-d8d903a2-cb82-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:34:12.267: INFO: Pod downwardapi-volume-d8d903a2-cb82-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:34:12.267: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-z9zjr" for this suite.
+Nov 17 10:34:18.344: INFO: namespace: e2e-tests-downward-api-z9zjr, resource: bindings, ignored listing per whitelist
+Nov 17 10:34:18.348: INFO: namespace e2e-tests-downward-api-z9zjr deletion completed in 6.077059667s
+
+• [SLOW TEST:8.252 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:204
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] Projected 
+  should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:771
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:34:18.348: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-8m9xn
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:771
+STEP: Creating configMap with name projected-configmap-test-volume-ddc3a5b8-cb82-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:34:18.494: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-ddc42180-cb82-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-8m9xn" to be "success or failure"
+Nov 17 10:34:18.500: INFO: Pod "pod-projected-configmaps-ddc42180-cb82-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 5.670349ms
+Nov 17 10:34:20.503: INFO: Pod "pod-projected-configmaps-ddc42180-cb82-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008355971s
+STEP: Saw pod success
+Nov 17 10:34:20.503: INFO: Pod "pod-projected-configmaps-ddc42180-cb82-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:34:20.506: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-configmaps-ddc42180-cb82-11e7-b2ab-c6826529d988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:34:20.518: INFO: Waiting for pod pod-projected-configmaps-ddc42180-cb82-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:34:20.520: INFO: Pod pod-projected-configmaps-ddc42180-cb82-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:34:20.520: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8m9xn" for this suite.
+Nov 17 10:34:26.581: INFO: namespace: e2e-tests-projected-8m9xn, resource: bindings, ignored listing per whitelist
+Nov 17 10:34:26.601: INFO: namespace e2e-tests-projected-8m9xn deletion completed in 6.078855194s
+
+• [SLOW TEST:8.253 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:771
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:322
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:34:26.602: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-sched-pred-mh494
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:114
+Nov 17 10:34:26.746: INFO: Waiting up to 1m0s for all nodes to be ready
+Nov 17 10:35:26.766: INFO: Waiting for terminating namespaces to be deleted...
+Nov 17 10:35:26.770: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Nov 17 10:35:26.779: INFO: 22 / 22 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Nov 17 10:35:26.779: INFO: expected 10 pod replicas in namespace 'kube-system', 10 are Running and Ready.
+Nov 17 10:35:26.783: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Nov 17 10:35:26.783: INFO: 
+Logging pods the kubelet thinks is on node ip-10-1-2-110.eu-central-1.compute.internal before test
+Nov 17 10:35:26.790: INFO: kube-proxy-2gr89 from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.790: INFO: 	Container kube-proxy ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: calico-kube-controllers-65b85599df-zpk5h from kube-system started at 2017-11-17 10:10:32 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.790: INFO: 	Container calico-kube-controllers ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: nginx-ingress-controller-574f5d4b6b-8ntpt from kube-system started at 2017-11-17 10:10:32 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.790: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: kube-dns-76cfdc459f-s5x4k from kube-system started at 2017-11-17 10:10:32 +0000 UTC (3 container statuses recorded)
+Nov 17 10:35:26.790: INFO: 	Container dnsmasq ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: 	Container kubedns ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: 	Container sidecar ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: kube-dns-76cfdc459f-8nlxq from kube-system started at 2017-11-17 10:10:32 +0000 UTC (3 container statuses recorded)
+Nov 17 10:35:26.790: INFO: 	Container dnsmasq ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: 	Container kubedns ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: 	Container sidecar ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: calico-ipip-pinger-w8xrh from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.790: INFO: 	Container calico-ipip-pinger ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: calico-node-n8drk from kube-system started at 2017-11-17 10:10:01 +0000 UTC (2 container statuses recorded)
+Nov 17 10:35:26.790: INFO: 	Container calico-node ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: 	Container install-cni ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: kube-dns-76cfdc459f-8ddhf from kube-system started at 2017-11-17 10:10:32 +0000 UTC (3 container statuses recorded)
+Nov 17 10:35:26.790: INFO: 	Container dnsmasq ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: 	Container kubedns ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: 	Container sidecar ready: true, restart count 0
+Nov 17 10:35:26.790: INFO: 
+Logging pods the kubelet thinks is on node ip-10-1-2-35.eu-central-1.compute.internal before test
+Nov 17 10:35:26.796: INFO: default-http-backend-6b6d95dd4f-g7952 from kube-system started at 2017-11-17 10:10:33 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.796: INFO: 	Container default-http-backend ready: true, restart count 0
+Nov 17 10:35:26.796: INFO: default-http-backend-6b6d95dd4f-t6zx7 from kube-system started at 2017-11-17 10:10:33 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.796: INFO: 	Container default-http-backend ready: true, restart count 0
+Nov 17 10:35:26.796: INFO: calico-ipip-pinger-xgz54 from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.796: INFO: 	Container calico-ipip-pinger ready: true, restart count 0
+Nov 17 10:35:26.796: INFO: kube-proxy-7plsv from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.796: INFO: 	Container kube-proxy ready: true, restart count 0
+Nov 17 10:35:26.796: INFO: nginx-ingress-controller-574f5d4b6b-46fqx from kube-system started at 2017-11-17 10:11:04 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.796: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Nov 17 10:35:26.796: INFO: calico-node-bn69r from kube-system started at 2017-11-17 10:10:01 +0000 UTC (2 container statuses recorded)
+Nov 17 10:35:26.796: INFO: 	Container calico-node ready: true, restart count 0
+Nov 17 10:35:26.796: INFO: 	Container install-cni ready: true, restart count 0
+Nov 17 10:35:26.796: INFO: 
+Logging pods the kubelet thinks is on node ip-10-1-2-91.eu-central-1.compute.internal before test
+Nov 17 10:35:26.801: INFO: kube-proxy-snpzn from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.801: INFO: 	Container kube-proxy ready: true, restart count 0
+Nov 17 10:35:26.801: INFO: nginx-ingress-controller-574f5d4b6b-4f94m from kube-system started at 2017-11-17 10:11:04 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.801: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Nov 17 10:35:26.801: INFO: sonobuoy from sonobuoy started at 2017-11-17 10:12:46 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.801: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Nov 17 10:35:26.801: INFO: calico-node-4btfm from kube-system started at 2017-11-17 10:10:01 +0000 UTC (2 container statuses recorded)
+Nov 17 10:35:26.801: INFO: 	Container calico-node ready: true, restart count 0
+Nov 17 10:35:26.801: INFO: 	Container install-cni ready: true, restart count 0
+Nov 17 10:35:26.801: INFO: calico-ipip-pinger-jl5jh from kube-system started at 2017-11-17 10:10:01 +0000 UTC (1 container statuses recorded)
+Nov 17 10:35:26.801: INFO: 	Container calico-ipip-pinger ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:322
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.14f7d91eeac18779], Reason = [FailedScheduling], Message = [No nodes are available that match all of the predicates: MatchNodeSelector (4), PodToleratesNodeTaints (1).]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:35:27.819: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-mh494" for this suite.
+Nov 17 10:35:49.884: INFO: namespace: e2e-tests-sched-pred-mh494, resource: bindings, ignored listing per whitelist
+Nov 17 10:35:49.903: INFO: namespace e2e-tests-sched-pred-mh494 deletion completed in 22.078551544s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:78
+
+• [SLOW TEST:83.302 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:322
+------------------------------
+S
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/service_accounts.go:246
+[BeforeEach] [sig-auth] ServiceAccounts
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:35:49.903: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-svcaccounts-fpjk8
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/service_accounts.go:246
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Nov 17 10:35:50.552: INFO: Waiting up to 5m0s for pod "pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-h9cwr" in namespace "e2e-tests-svcaccounts-fpjk8" to be "success or failure"
+Nov 17 10:35:50.558: INFO: Pod "pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-h9cwr": Phase="Pending", Reason="", readiness=false. Elapsed: 5.789836ms
+Nov 17 10:35:52.560: INFO: Pod "pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-h9cwr": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007990637s
+STEP: Saw pod success
+Nov 17 10:35:52.560: INFO: Pod "pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-h9cwr" satisfied condition "success or failure"
+Nov 17 10:35:52.562: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-h9cwr container token-test: <nil>
+STEP: delete the pod
+Nov 17 10:35:52.577: INFO: Waiting for pod pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-h9cwr to disappear
+Nov 17 10:35:52.579: INFO: Pod pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-h9cwr no longer exists
+STEP: Creating a pod to test consume service account root CA
+Nov 17 10:35:52.582: INFO: Waiting up to 5m0s for pod "pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-2pk57" in namespace "e2e-tests-svcaccounts-fpjk8" to be "success or failure"
+Nov 17 10:35:52.585: INFO: Pod "pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-2pk57": Phase="Pending", Reason="", readiness=false. Elapsed: 2.811645ms
+Nov 17 10:35:54.587: INFO: Pod "pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-2pk57": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005281847s
+STEP: Saw pod success
+Nov 17 10:35:54.588: INFO: Pod "pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-2pk57" satisfied condition "success or failure"
+Nov 17 10:35:54.589: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-2pk57 container root-ca-test: <nil>
+STEP: delete the pod
+Nov 17 10:35:54.607: INFO: Waiting for pod pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-2pk57 to disappear
+Nov 17 10:35:54.609: INFO: Pod pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-2pk57 no longer exists
+STEP: Creating a pod to test consume service account namespace
+Nov 17 10:35:54.612: INFO: Waiting up to 5m0s for pod "pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-qk6xd" in namespace "e2e-tests-svcaccounts-fpjk8" to be "success or failure"
+Nov 17 10:35:54.615: INFO: Pod "pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-qk6xd": Phase="Pending", Reason="", readiness=false. Elapsed: 3.319957ms
+Nov 17 10:35:56.618: INFO: Pod "pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-qk6xd": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005744986s
+STEP: Saw pod success
+Nov 17 10:35:56.618: INFO: Pod "pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-qk6xd" satisfied condition "success or failure"
+Nov 17 10:35:56.620: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-qk6xd container namespace-test: <nil>
+STEP: delete the pod
+Nov 17 10:35:56.636: INFO: Waiting for pod pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-qk6xd to disappear
+Nov 17 10:35:56.639: INFO: Pod pod-service-account-14a2c64c-cb83-11e7-b2ab-c6826529d988-qk6xd no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:35:56.639: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-fpjk8" for this suite.
+Nov 17 10:36:02.697: INFO: namespace: e2e-tests-svcaccounts-fpjk8, resource: bindings, ignored listing per whitelist
+Nov 17 10:36:02.717: INFO: namespace e2e-tests-svcaccounts-fpjk8 deletion completed in 6.075394023s
+
+• [SLOW TEST:12.814 seconds]
+[sig-auth] ServiceAccounts
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/service_accounts.go:246
+------------------------------
+SS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/service_accounts.go:387
+[BeforeEach] [sig-auth] ServiceAccounts
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:36:02.717: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-svcaccounts-5cksp
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/service_accounts.go:387
+STEP: getting the auto-created API token
+Nov 17 10:36:03.374: INFO: created pod pod-service-account-defaultsa
+Nov 17 10:36:03.374: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Nov 17 10:36:03.382: INFO: created pod pod-service-account-mountsa
+Nov 17 10:36:03.382: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Nov 17 10:36:03.389: INFO: created pod pod-service-account-nomountsa
+Nov 17 10:36:03.389: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Nov 17 10:36:03.394: INFO: created pod pod-service-account-defaultsa-mountspec
+Nov 17 10:36:03.394: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Nov 17 10:36:03.398: INFO: created pod pod-service-account-mountsa-mountspec
+Nov 17 10:36:03.398: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Nov 17 10:36:03.405: INFO: created pod pod-service-account-nomountsa-mountspec
+Nov 17 10:36:03.405: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Nov 17 10:36:03.411: INFO: created pod pod-service-account-defaultsa-nomountspec
+Nov 17 10:36:03.411: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Nov 17 10:36:03.415: INFO: created pod pod-service-account-mountsa-nomountspec
+Nov 17 10:36:03.415: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Nov 17 10:36:03.434: INFO: created pod pod-service-account-nomountsa-nomountspec
+Nov 17 10:36:03.434: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:36:03.434: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-5cksp" for this suite.
+Nov 17 10:36:09.497: INFO: namespace: e2e-tests-svcaccounts-5cksp, resource: bindings, ignored listing per whitelist
+Nov 17 10:36:09.525: INFO: namespace e2e-tests-svcaccounts-5cksp deletion completed in 6.086404467s
+
+• [SLOW TEST:6.807 seconds]
+[sig-auth] ServiceAccounts
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/service_accounts.go:387
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dns.go:317
+[BeforeEach] [sig-network] DNS
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:36:09.525: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-dns-4wwmr
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dns.go:317
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-4wwmr.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-4wwmr.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-4wwmr.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-4wwmr.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-4wwmr.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-4wwmr.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Nov 17 10:36:33.719: INFO: DNS probes using dns-test-20076b05-cb83-11e7-b2ab-c6826529d988 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:36:33.728: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-4wwmr" for this suite.
+Nov 17 10:36:39.792: INFO: namespace: e2e-tests-dns-4wwmr, resource: bindings, ignored listing per whitelist
+Nov 17 10:36:39.806: INFO: namespace e2e-tests-dns-4wwmr deletion completed in 6.075350776s
+
+• [SLOW TEST:30.281 seconds]
+[sig-network] DNS
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dns.go:317
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (root,0644,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:105
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:36:39.806: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-26n5s
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:105
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Nov 17 10:36:39.953: INFO: Waiting up to 5m0s for pod "pod-321524ed-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-26n5s" to be "success or failure"
+Nov 17 10:36:39.955: INFO: Pod "pod-321524ed-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.168934ms
+Nov 17 10:36:41.958: INFO: Pod "pod-321524ed-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004588879s
+STEP: Saw pod success
+Nov 17 10:36:41.958: INFO: Pod "pod-321524ed-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:36:41.959: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-321524ed-cb83-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:36:41.972: INFO: Waiting for pod pod-321524ed-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:36:41.974: INFO: Pod pod-321524ed-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:36:41.974: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-26n5s" for this suite.
+Nov 17 10:36:48.111: INFO: namespace: e2e-tests-emptydir-26n5s, resource: bindings, ignored listing per whitelist
+Nov 17 10:36:48.121: INFO: namespace e2e-tests-emptydir-26n5s deletion completed in 6.145119393s
+
+• [SLOW TEST:8.315 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should support (root,0644,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:105
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable via environment variable [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:371
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:36:48.122: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-configmap-gv7bs
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:371
+STEP: Creating configMap e2e-tests-configmap-gv7bs/configmap-test-370a2dfd-cb83-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:36:48.273: INFO: Waiting up to 5m0s for pod "pod-configmaps-370aa241-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-configmap-gv7bs" to be "success or failure"
+Nov 17 10:36:48.275: INFO: Pod "pod-configmaps-370aa241-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.36663ms
+Nov 17 10:36:50.278: INFO: Pod "pod-configmaps-370aa241-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004442385s
+Nov 17 10:36:52.280: INFO: Pod "pod-configmaps-370aa241-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.006930036s
+STEP: Saw pod success
+Nov 17 10:36:52.280: INFO: Pod "pod-configmaps-370aa241-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:36:52.282: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-configmaps-370aa241-cb83-11e7-b2ab-c6826529d988 container env-test: <nil>
+STEP: delete the pod
+Nov 17 10:36:52.295: INFO: Waiting for pod pod-configmaps-370aa241-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:36:52.297: INFO: Pod pod-configmaps-370aa241-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:36:52.297: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-gv7bs" for this suite.
+Nov 17 10:36:58.350: INFO: namespace: e2e-tests-configmap-gv7bs, resource: bindings, ignored listing per whitelist
+Nov 17 10:36:58.379: INFO: namespace e2e-tests-configmap-gv7bs deletion completed in 6.079775183s
+
+• [SLOW TEST:10.257 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable via environment variable [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:371
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Projected 
+  should provide container's memory request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:929
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:36:58.379: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-lp6qp
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide container's memory request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:929
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:36:58.522: INFO: Waiting up to 5m0s for pod "downwardapi-volume-3d267857-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-lp6qp" to be "success or failure"
+Nov 17 10:36:58.524: INFO: Pod "downwardapi-volume-3d267857-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.615303ms
+Nov 17 10:37:00.527: INFO: Pod "downwardapi-volume-3d267857-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004879941s
+STEP: Saw pod success
+Nov 17 10:37:00.527: INFO: Pod "downwardapi-volume-3d267857-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:37:00.529: INFO: Trying to get logs from node ip-10-1-2-91.eu-central-1.compute.internal pod downwardapi-volume-3d267857-cb83-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:37:00.542: INFO: Waiting for pod downwardapi-volume-3d267857-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:37:00.544: INFO: Pod downwardapi-volume-3d267857-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:37:00.544: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lp6qp" for this suite.
+Nov 17 10:37:06.597: INFO: namespace: e2e-tests-projected-lp6qp, resource: bindings, ignored listing per whitelist
+Nov 17 10:37:06.624: INFO: namespace e2e-tests-projected-lp6qp deletion completed in 6.077362535s
+
+• [SLOW TEST:8.244 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide container's memory request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:929
+------------------------------
+S
+------------------------------
+[k8s.io] PreStop 
+  should call prestop when killing a pod [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pre_stop.go:180
+[BeforeEach] [k8s.io] PreStop
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:37:06.624: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-prestop-nqd4b
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pre_stop.go:180
+STEP: Creating server pod server in namespace e2e-tests-prestop-nqd4b
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-nqd4b
+STEP: Deleting pre-stop pod
+Nov 17 10:37:19.788: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] PreStop
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:37:19.797: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-nqd4b" for this suite.
+Nov 17 10:37:59.894: INFO: namespace: e2e-tests-prestop-nqd4b, resource: bindings, ignored listing per whitelist
+Nov 17 10:37:59.896: INFO: namespace e2e-tests-prestop-nqd4b deletion completed in 40.089903804s
+
+• [SLOW TEST:53.273 seconds]
+[k8s.io] PreStop
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should call prestop when killing a pod [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/pre_stop.go:180
+------------------------------
+SSS
+------------------------------
+[k8s.io] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:197
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:37:59.897: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-8gtjw
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:197
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:38:00.058: INFO: Waiting up to 5m0s for pod "downwardapi-volume-61d3fe6b-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-8gtjw" to be "success or failure"
+Nov 17 10:38:00.060: INFO: Pod "downwardapi-volume-61d3fe6b-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.481232ms
+Nov 17 10:38:02.063: INFO: Pod "downwardapi-volume-61d3fe6b-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00476353s
+STEP: Saw pod success
+Nov 17 10:38:02.063: INFO: Pod "downwardapi-volume-61d3fe6b-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:38:02.064: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downwardapi-volume-61d3fe6b-cb83-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:38:02.086: INFO: Waiting for pod downwardapi-volume-61d3fe6b-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:38:02.087: INFO: Pod downwardapi-volume-61d3fe6b-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:38:02.087: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-8gtjw" for this suite.
+Nov 17 10:38:08.142: INFO: namespace: e2e-tests-downward-api-8gtjw, resource: bindings, ignored listing per whitelist
+Nov 17 10:38:08.167: INFO: namespace e2e-tests-downward-api-8gtjw deletion completed in 6.076564053s
+
+• [SLOW TEST:8.270 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:197
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Downward API volume 
+  should update annotations on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:154
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:38:08.167: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-pptld
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should update annotations on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:154
+STEP: Creating the pod
+Nov 17 10:38:10.827: INFO: Successfully updated pod "annotationupdate66bead38-cb83-11e7-b2ab-c6826529d988"
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:38:14.851: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-pptld" for this suite.
+Nov 17 10:38:36.939: INFO: namespace: e2e-tests-downward-api-pptld, resource: bindings, ignored listing per whitelist
+Nov 17 10:38:36.941: INFO: namespace e2e-tests-downward-api-pptld deletion completed in 22.08780814s
+
+• [SLOW TEST:28.774 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should update annotations on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:154
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:71
+[BeforeEach] [k8s.io] Variable Expansion
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:38:36.941: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-var-expansion-dvr8w
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:71
+STEP: Creating a pod to test env composition
+Nov 17 10:38:37.087: INFO: Waiting up to 5m0s for pod "var-expansion-77e61303-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-var-expansion-dvr8w" to be "success or failure"
+Nov 17 10:38:37.090: INFO: Pod "var-expansion-77e61303-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.675344ms
+Nov 17 10:38:39.094: INFO: Pod "var-expansion-77e61303-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006946877s
+Nov 17 10:38:41.096: INFO: Pod "var-expansion-77e61303-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009214672s
+STEP: Saw pod success
+Nov 17 10:38:41.096: INFO: Pod "var-expansion-77e61303-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:38:41.098: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod var-expansion-77e61303-cb83-11e7-b2ab-c6826529d988 container dapi-container: <nil>
+STEP: delete the pod
+Nov 17 10:38:41.112: INFO: Waiting for pod var-expansion-77e61303-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:38:41.115: INFO: Pod var-expansion-77e61303-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:38:41.115: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-dvr8w" for this suite.
+Nov 17 10:38:47.186: INFO: namespace: e2e-tests-var-expansion-dvr8w, resource: bindings, ignored listing per whitelist
+Nov 17 10:38:47.194: INFO: namespace e2e-tests-var-expansion-dvr8w deletion completed in 6.076572393s
+
+• [SLOW TEST:10.253 seconds]
+[k8s.io] Variable Expansion
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should allow composing env vars into new env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/expansion.go:71
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:155
+[BeforeEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:38:47.194: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-84bjd
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:155
+STEP: Creating a pod to test downward api env vars
+Nov 17 10:38:47.334: INFO: Waiting up to 5m0s for pod "downward-api-7e0203f9-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-84bjd" to be "success or failure"
+Nov 17 10:38:47.337: INFO: Pod "downward-api-7e0203f9-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.140102ms
+Nov 17 10:38:49.339: INFO: Pod "downward-api-7e0203f9-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00417454s
+Nov 17 10:38:51.341: INFO: Pod "downward-api-7e0203f9-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.006500397s
+STEP: Saw pod success
+Nov 17 10:38:51.341: INFO: Pod "downward-api-7e0203f9-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:38:51.343: INFO: Trying to get logs from node ip-10-1-2-91.eu-central-1.compute.internal pod downward-api-7e0203f9-cb83-11e7-b2ab-c6826529d988 container dapi-container: <nil>
+STEP: delete the pod
+Nov 17 10:38:51.362: INFO: Waiting for pod downward-api-7e0203f9-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:38:51.364: INFO: Pod downward-api-7e0203f9-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:38:51.364: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-84bjd" for this suite.
+Nov 17 10:38:57.435: INFO: namespace: e2e-tests-downward-api-84bjd, resource: bindings, ignored listing per whitelist
+Nov 17 10:38:57.442: INFO: namespace e2e-tests-downward-api-84bjd deletion completed in 6.07635636s
+
+• [SLOW TEST:10.248 seconds]
+[k8s.io] Downward API
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:155
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default commmand (docker entrypoint) [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:56
+[BeforeEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:38:57.442: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-containers-rvf4t
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default commmand (docker entrypoint) [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:56
+STEP: Creating a pod to test override command
+Nov 17 10:38:57.584: INFO: Waiting up to 5m0s for pod "client-containers-841dfbe8-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-containers-rvf4t" to be "success or failure"
+Nov 17 10:38:57.588: INFO: Pod "client-containers-841dfbe8-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.389714ms
+Nov 17 10:38:59.590: INFO: Pod "client-containers-841dfbe8-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005474903s
+STEP: Saw pod success
+Nov 17 10:38:59.590: INFO: Pod "client-containers-841dfbe8-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:38:59.592: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod client-containers-841dfbe8-cb83-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:38:59.605: INFO: Waiting for pod client-containers-841dfbe8-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:38:59.607: INFO: Pod client-containers-841dfbe8-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:38:59.607: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-rvf4t" for this suite.
+Nov 17 10:39:05.682: INFO: namespace: e2e-tests-containers-rvf4t, resource: bindings, ignored listing per whitelist
+Nov 17 10:39:05.685: INFO: namespace e2e-tests-containers-rvf4t deletion completed in 6.075481719s
+
+• [SLOW TEST:8.243 seconds]
+[k8s.io] Docker Containers
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be able to override the image's default commmand (docker entrypoint) [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:56
+------------------------------
+SSS
+------------------------------
+[k8s.io] Downward API 
+  should provide pod IP as an env var [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:87
+[BeforeEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:39:05.686: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-s89x2
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod IP as an env var [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:87
+STEP: Creating a pod to test downward api env vars
+Nov 17 10:39:05.837: INFO: Waiting up to 5m0s for pod "downward-api-890940e8-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-s89x2" to be "success or failure"
+Nov 17 10:39:05.841: INFO: Pod "downward-api-890940e8-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.563733ms
+Nov 17 10:39:07.843: INFO: Pod "downward-api-890940e8-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006057598s
+Nov 17 10:39:09.845: INFO: Pod "downward-api-890940e8-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008162948s
+STEP: Saw pod success
+Nov 17 10:39:09.845: INFO: Pod "downward-api-890940e8-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:39:09.847: INFO: Trying to get logs from node ip-10-1-2-91.eu-central-1.compute.internal pod downward-api-890940e8-cb83-11e7-b2ab-c6826529d988 container dapi-container: <nil>
+STEP: delete the pod
+Nov 17 10:39:09.860: INFO: Waiting for pod downward-api-890940e8-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:39:09.862: INFO: Pod downward-api-890940e8-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:39:09.862: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-s89x2" for this suite.
+Nov 17 10:39:15.951: INFO: namespace: e2e-tests-downward-api-s89x2, resource: bindings, ignored listing per whitelist
+Nov 17 10:39:15.955: INFO: namespace e2e-tests-downward-api-s89x2 deletion completed in 6.090469093s
+
+• [SLOW TEST:10.270 seconds]
+[k8s.io] Downward API
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide pod IP as an env var [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:87
+------------------------------
+SSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:77
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:39:15.956: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-container-probe-49vzh
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] with readiness probe should not be ready before initial delay and never restart [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:77
+Nov 17 10:39:34.108: INFO: Container started at 2017-11-17 10:39:16 +0000 UTC, pod became ready at 2017-11-17 10:39:33 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:39:34.108: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-49vzh" for this suite.
+Nov 17 10:39:56.140: INFO: namespace: e2e-tests-container-probe-49vzh, resource: bindings, ignored listing per whitelist
+Nov 17 10:39:56.187: INFO: namespace e2e-tests-container-probe-49vzh deletion completed in 22.076546675s
+
+• [SLOW TEST:40.231 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  with readiness probe should not be ready before initial delay and never restart [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:77
+------------------------------
+SSSS
+------------------------------
+[k8s.io] HostPath 
+  should give a volume the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:56
+[BeforeEach] [k8s.io] HostPath
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:39:56.188: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-hostpath-hhqnb
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] HostPath
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:41
+[It] should give a volume the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:56
+STEP: Creating a pod to test hostPath mode
+Nov 17 10:39:56.330: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-hhqnb" to be "success or failure"
+Nov 17 10:39:56.333: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 3.316718ms
+Nov 17 10:39:58.336: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005769117s
+STEP: Saw pod success
+Nov 17 10:39:58.336: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Nov 17 10:39:58.338: INFO: Trying to get logs from node ip-10-1-2-91.eu-central-1.compute.internal pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Nov 17 10:39:58.351: INFO: Waiting for pod pod-host-path-test to disappear
+Nov 17 10:39:58.353: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [k8s.io] HostPath
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:39:58.353: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-hhqnb" for this suite.
+Nov 17 10:40:04.403: INFO: namespace: e2e-tests-hostpath-hhqnb, resource: bindings, ignored listing per whitelist
+Nov 17 10:40:04.451: INFO: namespace e2e-tests-hostpath-hhqnb deletion completed in 6.095194021s
+
+• [SLOW TEST:8.263 seconds]
+[k8s.io] HostPath
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should give a volume the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:56
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Secrets 
+  should be consumable in multiple volumes in a pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:153
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:40:04.451: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-secrets-jjbwd
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:153
+STEP: Creating secret with name secret-test-ac122247-cb83-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:40:04.619: INFO: Waiting up to 5m0s for pod "pod-secrets-ac129eb3-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-secrets-jjbwd" to be "success or failure"
+Nov 17 10:40:04.621: INFO: Pod "pod-secrets-ac129eb3-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 1.741878ms
+Nov 17 10:40:06.624: INFO: Pod "pod-secrets-ac129eb3-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004235633s
+STEP: Saw pod success
+Nov 17 10:40:06.624: INFO: Pod "pod-secrets-ac129eb3-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:40:06.625: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-secrets-ac129eb3-cb83-11e7-b2ab-c6826529d988 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:40:06.638: INFO: Waiting for pod pod-secrets-ac129eb3-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:40:06.640: INFO: Pod pod-secrets-ac129eb3-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:40:06.640: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-jjbwd" for this suite.
+Nov 17 10:40:12.681: INFO: namespace: e2e-tests-secrets-jjbwd, resource: bindings, ignored listing per whitelist
+Nov 17 10:40:12.721: INFO: namespace e2e-tests-secrets-jjbwd deletion completed in 6.078072834s
+
+• [SLOW TEST:8.270 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable in multiple volumes in a pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:153
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:38
+[BeforeEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:40:12.721: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-pod-network-test-vqgq6
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:38
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-vqgq6
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Nov 17 10:40:12.859: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Nov 17 10:40:36.915: INFO: ExecWithOptions {Command:[/bin/sh -c curl -q -s 'http://192.168.118.18:8080/dial?request=hostName&protocol=http&host=192.168.118.16&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-vqgq6 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:40:36.915: INFO: >>> kubeConfig: 
+Nov 17 10:40:36.986: INFO: Waiting for endpoints: map[]
+Nov 17 10:40:36.988: INFO: ExecWithOptions {Command:[/bin/sh -c curl -q -s 'http://192.168.118.18:8080/dial?request=hostName&protocol=http&host=192.168.118.17&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-vqgq6 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:40:36.988: INFO: >>> kubeConfig: 
+Nov 17 10:40:37.054: INFO: Waiting for endpoints: map[]
+Nov 17 10:40:37.057: INFO: ExecWithOptions {Command:[/bin/sh -c curl -q -s 'http://192.168.118.18:8080/dial?request=hostName&protocol=http&host=192.168.185.219&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-vqgq6 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:40:37.057: INFO: >>> kubeConfig: 
+Nov 17 10:40:37.137: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:40:37.137: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-vqgq6" for this suite.
+Nov 17 10:40:59.177: INFO: namespace: e2e-tests-pod-network-test-vqgq6, resource: bindings, ignored listing per whitelist
+Nov 17 10:40:59.217: INFO: namespace e2e-tests-pod-network-test-vqgq6 deletion completed in 22.076859891s
+
+• [SLOW TEST:46.496 seconds]
+[sig-network] Networking
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:61
+  Granular Checks: Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:60
+    should function for intra-pod communication: http [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:38
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:372
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:40:59.217: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-lvhkx
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:372
+STEP: Creating configMap with name projected-configmap-test-volume-ccb40574-cb83-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:40:59.367: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-ccb48aa2-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-lvhkx" to be "success or failure"
+Nov 17 10:40:59.370: INFO: Pod "pod-projected-configmaps-ccb48aa2-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.366461ms
+Nov 17 10:41:01.372: INFO: Pod "pod-projected-configmaps-ccb48aa2-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004523655s
+STEP: Saw pod success
+Nov 17 10:41:01.372: INFO: Pod "pod-projected-configmaps-ccb48aa2-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:41:01.374: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-configmaps-ccb48aa2-cb83-11e7-b2ab-c6826529d988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:41:01.386: INFO: Waiting for pod pod-projected-configmaps-ccb48aa2-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:41:01.388: INFO: Pod pod-projected-configmaps-ccb48aa2-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:41:01.388: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lvhkx" for this suite.
+Nov 17 10:41:07.465: INFO: namespace: e2e-tests-projected-lvhkx, resource: bindings, ignored listing per whitelist
+Nov 17 10:41:07.467: INFO: namespace e2e-tests-projected-lvhkx deletion completed in 6.076237864s
+
+• [SLOW TEST:8.250 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:372
+------------------------------
+[k8s.io] EmptyDir volumes 
+  volume on default medium should have the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:101
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:41:07.467: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-nktj7
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:101
+STEP: Creating a pod to test emptydir volume type on node default medium
+Nov 17 10:41:07.608: INFO: Waiting up to 5m0s for pod "pod-d19dd5af-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-nktj7" to be "success or failure"
+Nov 17 10:41:07.611: INFO: Pod "pod-d19dd5af-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.064648ms
+Nov 17 10:41:09.613: INFO: Pod "pod-d19dd5af-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005556739s
+STEP: Saw pod success
+Nov 17 10:41:09.613: INFO: Pod "pod-d19dd5af-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:41:09.615: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-d19dd5af-cb83-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:41:09.628: INFO: Waiting for pod pod-d19dd5af-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:41:09.630: INFO: Pod pod-d19dd5af-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:41:09.631: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-nktj7" for this suite.
+Nov 17 10:41:15.661: INFO: namespace: e2e-tests-emptydir-nktj7, resource: bindings, ignored listing per whitelist
+Nov 17 10:41:15.709: INFO: namespace e2e-tests-emptydir-nktj7 deletion completed in 6.076526066s
+
+• [SLOW TEST:8.243 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  volume on default medium should have the correct mode [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:101
+------------------------------
+[k8s.io] Downward API 
+  should provide pod name and namespace as env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:66
+[BeforeEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:41:15.710: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-7hw5s
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name and namespace as env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:66
+STEP: Creating a pod to test downward api env vars
+Nov 17 10:41:15.851: INFO: Waiting up to 5m0s for pod "downward-api-d687d03c-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-7hw5s" to be "success or failure"
+Nov 17 10:41:15.853: INFO: Pod "downward-api-d687d03c-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.139929ms
+Nov 17 10:41:17.855: INFO: Pod "downward-api-d687d03c-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004400891s
+Nov 17 10:41:19.857: INFO: Pod "downward-api-d687d03c-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.006425672s
+STEP: Saw pod success
+Nov 17 10:41:19.857: INFO: Pod "downward-api-d687d03c-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:41:19.859: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downward-api-d687d03c-cb83-11e7-b2ab-c6826529d988 container dapi-container: <nil>
+STEP: delete the pod
+Nov 17 10:41:19.874: INFO: Waiting for pod downward-api-d687d03c-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:41:19.876: INFO: Pod downward-api-d687d03c-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:41:19.876: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-7hw5s" for this suite.
+Nov 17 10:41:25.943: INFO: namespace: e2e-tests-downward-api-7hw5s, resource: bindings, ignored listing per whitelist
+Nov 17 10:41:25.955: INFO: namespace e2e-tests-downward-api-7hw5s deletion completed in 6.076558895s
+
+• [SLOW TEST:10.246 seconds]
+[k8s.io] Downward API
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide pod name and namespace as env vars [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:66
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:403
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:41:25.955: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-tt8rt
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:403
+STEP: Creating configMap with name projected-configmap-test-volume-map-dca32552-cb83-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:41:26.099: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-dca38989-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-tt8rt" to be "success or failure"
+Nov 17 10:41:26.102: INFO: Pod "pod-projected-configmaps-dca38989-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.890115ms
+Nov 17 10:41:28.105: INFO: Pod "pod-projected-configmaps-dca38989-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005167511s
+STEP: Saw pod success
+Nov 17 10:41:28.105: INFO: Pod "pod-projected-configmaps-dca38989-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:41:28.107: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-configmaps-dca38989-cb83-11e7-b2ab-c6826529d988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:41:28.123: INFO: Waiting for pod pod-projected-configmaps-dca38989-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:41:28.125: INFO: Pod pod-projected-configmaps-dca38989-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:41:28.126: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-tt8rt" for this suite.
+Nov 17 10:41:34.164: INFO: namespace: e2e-tests-projected-tt8rt, resource: bindings, ignored listing per whitelist
+Nov 17 10:41:34.203: INFO: namespace e2e-tests-projected-tt8rt deletion completed in 6.075577674s
+
+• [SLOW TEST:8.248 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:403
+------------------------------
+S
+------------------------------
+[k8s.io] Projected 
+  should provide podname only [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:788
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:41:34.204: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-hr652
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide podname only [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:788
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:41:34.344: INFO: Waiting up to 5m0s for pod "downwardapi-volume-e18da1a3-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-hr652" to be "success or failure"
+Nov 17 10:41:34.346: INFO: Pod "downwardapi-volume-e18da1a3-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.680185ms
+Nov 17 10:41:36.349: INFO: Pod "downwardapi-volume-e18da1a3-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005070539s
+STEP: Saw pod success
+Nov 17 10:41:36.349: INFO: Pod "downwardapi-volume-e18da1a3-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:41:36.351: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downwardapi-volume-e18da1a3-cb83-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:41:36.366: INFO: Waiting for pod downwardapi-volume-e18da1a3-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:41:36.368: INFO: Pod downwardapi-volume-e18da1a3-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:41:36.368: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hr652" for this suite.
+Nov 17 10:41:42.434: INFO: namespace: e2e-tests-projected-hr652, resource: bindings, ignored listing per whitelist
+Nov 17 10:41:42.448: INFO: namespace e2e-tests-projected-hr652 deletion completed in 6.076776106s
+
+• [SLOW TEST:8.244 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide podname only [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:788
+------------------------------
+SSS
+------------------------------
+[k8s.io] Secrets 
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:38
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:41:42.448: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-secrets-s4kjk
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:38
+STEP: Creating secret with name secret-test-e677e0ea-cb83-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:41:42.593: INFO: Waiting up to 5m0s for pod "pod-secrets-e6785fe2-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-secrets-s4kjk" to be "success or failure"
+Nov 17 10:41:42.596: INFO: Pod "pod-secrets-e6785fe2-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.693969ms
+Nov 17 10:41:44.598: INFO: Pod "pod-secrets-e6785fe2-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004764176s
+STEP: Saw pod success
+Nov 17 10:41:44.598: INFO: Pod "pod-secrets-e6785fe2-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:41:44.600: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-secrets-e6785fe2-cb83-11e7-b2ab-c6826529d988 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:41:44.613: INFO: Waiting for pod pod-secrets-e6785fe2-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:41:44.615: INFO: Pod pod-secrets-e6785fe2-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:41:44.615: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-s4kjk" for this suite.
+Nov 17 10:41:50.646: INFO: namespace: e2e-tests-secrets-s4kjk, resource: bindings, ignored listing per whitelist
+Nov 17 10:41:50.711: INFO: namespace e2e-tests-secrets-s4kjk deletion completed in 6.093198794s
+
+• [SLOW TEST:8.263 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:38
+------------------------------
+[k8s.io] Projected 
+  should be consumable in multiple volumes in a pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:171
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:41:50.711: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-v5f2p
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable in multiple volumes in a pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:171
+STEP: Creating secret with name projected-secret-test-eb64bbab-cb83-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:41:50.858: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-eb653dfc-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-v5f2p" to be "success or failure"
+Nov 17 10:41:50.862: INFO: Pod "pod-projected-secrets-eb653dfc-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.814471ms
+Nov 17 10:41:52.864: INFO: Pod "pod-projected-secrets-eb653dfc-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006047638s
+STEP: Saw pod success
+Nov 17 10:41:52.864: INFO: Pod "pod-projected-secrets-eb653dfc-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:41:52.866: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-secrets-eb653dfc-cb83-11e7-b2ab-c6826529d988 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:41:52.879: INFO: Waiting for pod pod-projected-secrets-eb653dfc-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:41:52.881: INFO: Pod pod-projected-secrets-eb653dfc-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:41:52.881: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-v5f2p" for this suite.
+Nov 17 10:41:58.958: INFO: namespace: e2e-tests-projected-v5f2p, resource: bindings, ignored listing per whitelist
+Nov 17 10:41:58.969: INFO: namespace e2e-tests-projected-v5f2p deletion completed in 6.084961067s
+
+• [SLOW TEST:8.258 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable in multiple volumes in a pod [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:171
+------------------------------
+SS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:37
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:41:58.969: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-configmap-6lmdf
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:37
+STEP: Creating configMap with name configmap-test-volume-f051b946-cb83-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:41:59.120: INFO: Waiting up to 5m0s for pod "pod-configmaps-f0521e48-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-configmap-6lmdf" to be "success or failure"
+Nov 17 10:41:59.123: INFO: Pod "pod-configmaps-f0521e48-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.868872ms
+Nov 17 10:42:01.125: INFO: Pod "pod-configmaps-f0521e48-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005061026s
+STEP: Saw pod success
+Nov 17 10:42:01.125: INFO: Pod "pod-configmaps-f0521e48-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:42:01.127: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-configmaps-f0521e48-cb83-11e7-b2ab-c6826529d988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:42:01.140: INFO: Waiting for pod pod-configmaps-f0521e48-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:42:01.142: INFO: Pod pod-configmaps-f0521e48-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:42:01.142: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-6lmdf" for this suite.
+Nov 17 10:42:07.196: INFO: namespace: e2e-tests-configmap-6lmdf, resource: bindings, ignored listing per whitelist
+Nov 17 10:42:07.221: INFO: namespace e2e-tests-configmap-6lmdf deletion completed in 6.076804418s
+
+• [SLOW TEST:8.252 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:37
+------------------------------
+SS
+------------------------------
+[k8s.io] Projected 
+  should set mode on item file [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:808
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:42:07.221: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-7f5jx
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should set mode on item file [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:808
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:42:07.376: INFO: Waiting up to 5m0s for pod "downwardapi-volume-f53de4f1-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-7f5jx" to be "success or failure"
+Nov 17 10:42:07.379: INFO: Pod "downwardapi-volume-f53de4f1-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.782292ms
+Nov 17 10:42:09.382: INFO: Pod "downwardapi-volume-f53de4f1-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005217199s
+STEP: Saw pod success
+Nov 17 10:42:09.382: INFO: Pod "downwardapi-volume-f53de4f1-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:42:09.383: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downwardapi-volume-f53de4f1-cb83-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:42:09.400: INFO: Waiting for pod downwardapi-volume-f53de4f1-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:42:09.403: INFO: Pod downwardapi-volume-f53de4f1-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:42:09.403: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-7f5jx" for this suite.
+Nov 17 10:42:15.469: INFO: namespace: e2e-tests-projected-7f5jx, resource: bindings, ignored listing per whitelist
+Nov 17 10:42:15.479: INFO: namespace e2e-tests-projected-7f5jx deletion completed in 6.073720337s
+
+• [SLOW TEST:8.258 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should set mode on item file [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:808
+------------------------------
+S
+------------------------------
+[k8s.io] Projected 
+  should provide container's cpu request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:920
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:42:15.479: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-9j7bh
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide container's cpu request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:920
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:42:15.621: INFO: Waiting up to 5m0s for pod "downwardapi-volume-fa27f272-cb83-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-9j7bh" to be "success or failure"
+Nov 17 10:42:15.625: INFO: Pod "downwardapi-volume-fa27f272-cb83-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.173135ms
+Nov 17 10:42:17.627: INFO: Pod "downwardapi-volume-fa27f272-cb83-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005429728s
+STEP: Saw pod success
+Nov 17 10:42:17.627: INFO: Pod "downwardapi-volume-fa27f272-cb83-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:42:17.629: INFO: Trying to get logs from node ip-10-1-2-91.eu-central-1.compute.internal pod downwardapi-volume-fa27f272-cb83-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:42:17.642: INFO: Waiting for pod downwardapi-volume-fa27f272-cb83-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:42:17.645: INFO: Pod downwardapi-volume-fa27f272-cb83-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:42:17.645: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-9j7bh" for this suite.
+Nov 17 10:42:23.700: INFO: namespace: e2e-tests-projected-9j7bh, resource: bindings, ignored listing per whitelist
+Nov 17 10:42:23.724: INFO: namespace e2e-tests-projected-9j7bh deletion completed in 6.076487159s
+
+• [SLOW TEST:8.245 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide container's cpu request [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:920
+------------------------------
+SS
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service_latency.go:117
+[BeforeEach] [sig-network] Service endpoints latency
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:42:23.724: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-svc-latency-rj7df
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service_latency.go:117
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-rj7df
+Nov 17 10:42:25.973: INFO: Created: latency-svc-f2nhr
+Nov 17 10:42:25.980: INFO: Got endpoints: latency-svc-f2nhr [15.423048ms]
+Nov 17 10:42:25.993: INFO: Created: latency-svc-999ht
+Nov 17 10:42:26.000: INFO: Got endpoints: latency-svc-999ht [19.123901ms]
+Nov 17 10:42:26.006: INFO: Created: latency-svc-nlndb
+Nov 17 10:42:26.010: INFO: Got endpoints: latency-svc-nlndb [28.68392ms]
+Nov 17 10:42:26.038: INFO: Created: latency-svc-mtmpw
+Nov 17 10:42:26.040: INFO: Created: latency-svc-l7vlf
+Nov 17 10:42:26.042: INFO: Created: latency-svc-wg4g9
+Nov 17 10:42:26.042: INFO: Created: latency-svc-76f87
+Nov 17 10:42:26.042: INFO: Got endpoints: latency-svc-76f87 [60.095327ms]
+Nov 17 10:42:26.042: INFO: Got endpoints: latency-svc-l7vlf [61.295992ms]
+Nov 17 10:42:26.056: INFO: Created: latency-svc-jb2vf
+Nov 17 10:42:26.056: INFO: Got endpoints: latency-svc-mtmpw [71.203512ms]
+Nov 17 10:42:26.056: INFO: Got endpoints: latency-svc-wg4g9 [73.351971ms]
+Nov 17 10:42:26.062: INFO: Created: latency-svc-xcnxn
+Nov 17 10:42:26.064: INFO: Got endpoints: latency-svc-jb2vf [76.909477ms]
+Nov 17 10:42:26.066: INFO: Got endpoints: latency-svc-xcnxn [80.49884ms]
+Nov 17 10:42:26.068: INFO: Created: latency-svc-rpmk2
+Nov 17 10:42:26.084: INFO: Created: latency-svc-l7sjk
+Nov 17 10:42:26.084: INFO: Got endpoints: latency-svc-rpmk2 [97.401962ms]
+Nov 17 10:42:26.084: INFO: Created: latency-svc-4972s
+Nov 17 10:42:26.112: INFO: Got endpoints: latency-svc-l7sjk [111.936143ms]
+Nov 17 10:42:26.122: INFO: Got endpoints: latency-svc-4972s [66.522999ms]
+Nov 17 10:42:26.123: INFO: Created: latency-svc-vvmdd
+Nov 17 10:42:26.123: INFO: Got endpoints: latency-svc-vvmdd [56.901384ms]
+Nov 17 10:42:26.124: INFO: Created: latency-svc-r7nmz
+Nov 17 10:42:26.124: INFO: Created: latency-svc-5gcvv
+Nov 17 10:42:26.128: INFO: Got endpoints: latency-svc-r7nmz [140.541705ms]
+Nov 17 10:42:26.147: INFO: Got endpoints: latency-svc-5gcvv [158.747701ms]
+Nov 17 10:42:26.147: INFO: Created: latency-svc-4d4k6
+Nov 17 10:42:26.148: INFO: Created: latency-svc-pvcxq
+Nov 17 10:42:26.148: INFO: Created: latency-svc-65g65
+Nov 17 10:42:26.157: INFO: Got endpoints: latency-svc-4d4k6 [167.936933ms]
+Nov 17 10:42:26.157: INFO: Got endpoints: latency-svc-pvcxq [168.350853ms]
+Nov 17 10:42:26.252: INFO: Created: latency-svc-2bjbj
+Nov 17 10:42:26.252: INFO: Got endpoints: latency-svc-2bjbj [210.140555ms]
+Nov 17 10:42:26.256: INFO: Got endpoints: latency-svc-65g65 [245.596721ms]
+Nov 17 10:42:26.257: INFO: Created: latency-svc-rjv4c
+Nov 17 10:42:26.257: INFO: Created: latency-svc-b7bxg
+Nov 17 10:42:26.257: INFO: Created: latency-svc-t9j5k
+Nov 17 10:42:26.259: INFO: Created: latency-svc-5fs4w
+Nov 17 10:42:26.260: INFO: Got endpoints: latency-svc-b7bxg [217.670906ms]
+Nov 17 10:42:26.260: INFO: Created: latency-svc-rct6p
+Nov 17 10:42:26.264: INFO: Got endpoints: latency-svc-rct6p [200.32701ms]
+Nov 17 10:42:26.262: INFO: Created: latency-svc-m5vxn
+Nov 17 10:42:26.265: INFO: Got endpoints: latency-svc-m5vxn [277.302582ms]
+Nov 17 10:42:26.262: INFO: Got endpoints: latency-svc-t9j5k [274.687968ms]
+Nov 17 10:42:26.262: INFO: Got endpoints: latency-svc-rjv4c [206.279984ms]
+Nov 17 10:42:26.269: INFO: Created: latency-svc-9zwhv
+Nov 17 10:42:26.269: INFO: Created: latency-svc-p9p7t
+Nov 17 10:42:26.269: INFO: Got endpoints: latency-svc-p9p7t [146.761382ms]
+Nov 17 10:42:26.270: INFO: Created: latency-svc-f8czb
+Nov 17 10:42:26.270: INFO: Got endpoints: latency-svc-f8czb [185.777526ms]
+Nov 17 10:42:26.271: INFO: Created: latency-svc-bkqbs
+Nov 17 10:42:26.271: INFO: Got endpoints: latency-svc-bkqbs [147.807161ms]
+Nov 17 10:42:26.282: INFO: Got endpoints: latency-svc-5fs4w [170.663723ms]
+Nov 17 10:42:26.296: INFO: Created: latency-svc-x2lwh
+Nov 17 10:42:26.297: INFO: Got endpoints: latency-svc-x2lwh [150.034099ms]
+Nov 17 10:42:26.297: INFO: Got endpoints: latency-svc-9zwhv [168.961276ms]
+Nov 17 10:42:26.323: INFO: Created: latency-svc-twg6c
+Nov 17 10:42:26.323: INFO: Created: latency-svc-2mzkh
+Nov 17 10:42:26.332: INFO: Created: latency-svc-q74vv
+Nov 17 10:42:26.340: INFO: Got endpoints: latency-svc-twg6c [182.955701ms]
+Nov 17 10:42:26.340: INFO: Got endpoints: latency-svc-2mzkh [183.316516ms]
+Nov 17 10:42:26.352: INFO: Created: latency-svc-dpxqc
+Nov 17 10:42:26.356: INFO: Created: latency-svc-nkqxt
+Nov 17 10:42:26.360: INFO: Created: latency-svc-c9rrf
+Nov 17 10:42:26.371: INFO: Created: latency-svc-vftsg
+Nov 17 10:42:26.385: INFO: Got endpoints: latency-svc-vftsg [129.277412ms]
+Nov 17 10:42:26.398: INFO: Got endpoints: latency-svc-dpxqc [134.263402ms]
+Nov 17 10:42:26.399: INFO: Got endpoints: latency-svc-c9rrf [134.12993ms]
+Nov 17 10:42:26.399: INFO: Got endpoints: latency-svc-q74vv [146.814785ms]
+Nov 17 10:42:26.406: INFO: Created: latency-svc-v98dc
+Nov 17 10:42:26.407: INFO: Got endpoints: latency-svc-nkqxt [137.205774ms]
+Nov 17 10:42:26.415: INFO: Created: latency-svc-rx59g
+Nov 17 10:42:26.442: INFO: Created: latency-svc-pbrtr
+Nov 17 10:42:26.442: INFO: Created: latency-svc-7289n
+Nov 17 10:42:26.442: INFO: Got endpoints: latency-svc-v98dc [177.165583ms]
+Nov 17 10:42:26.443: INFO: Got endpoints: latency-svc-rx59g [178.105365ms]
+Nov 17 10:42:26.454: INFO: Got endpoints: latency-svc-7289n [68.750143ms]
+Nov 17 10:42:26.455: INFO: Created: latency-svc-tr59k
+Nov 17 10:42:26.460: INFO: Created: latency-svc-c99qd
+Nov 17 10:42:26.463: INFO: Got endpoints: latency-svc-pbrtr [192.92987ms]
+Nov 17 10:42:26.466: INFO: Created: latency-svc-hmwld
+Nov 17 10:42:26.474: INFO: Created: latency-svc-8d4ks
+Nov 17 10:42:26.482: INFO: Created: latency-svc-2sppl
+Nov 17 10:42:26.493: INFO: Created: latency-svc-7zbct
+Nov 17 10:42:26.498: INFO: Created: latency-svc-jp2cr
+Nov 17 10:42:26.510: INFO: Got endpoints: latency-svc-tr59k [227.349192ms]
+Nov 17 10:42:26.518: INFO: Created: latency-svc-7bwpk
+Nov 17 10:42:26.518: INFO: Created: latency-svc-kbhjt
+Nov 17 10:42:26.530: INFO: Created: latency-svc-9d28j
+Nov 17 10:42:26.539: INFO: Created: latency-svc-6b2k2
+Nov 17 10:42:26.545: INFO: Created: latency-svc-pt45k
+Nov 17 10:42:26.553: INFO: Created: latency-svc-d8rqx
+Nov 17 10:42:26.562: INFO: Got endpoints: latency-svc-c99qd [291.114122ms]
+Nov 17 10:42:26.591: INFO: Created: latency-svc-htnvh
+Nov 17 10:42:26.591: INFO: Created: latency-svc-zp7r6
+Nov 17 10:42:26.591: INFO: Created: latency-svc-qfd8v
+Nov 17 10:42:26.592: INFO: Created: latency-svc-4rv22
+Nov 17 10:42:26.609: INFO: Got endpoints: latency-svc-hmwld [311.791416ms]
+Nov 17 10:42:26.626: INFO: Created: latency-svc-55d27
+Nov 17 10:42:26.660: INFO: Got endpoints: latency-svc-8d4ks [362.779638ms]
+Nov 17 10:42:26.675: INFO: Created: latency-svc-m9l7g
+Nov 17 10:42:26.716: INFO: Got endpoints: latency-svc-2sppl [376.264864ms]
+Nov 17 10:42:26.727: INFO: Created: latency-svc-952zm
+Nov 17 10:42:26.758: INFO: Got endpoints: latency-svc-7zbct [417.299349ms]
+Nov 17 10:42:26.768: INFO: Created: latency-svc-vfmfq
+Nov 17 10:42:26.810: INFO: Got endpoints: latency-svc-jp2cr [541.269544ms]
+Nov 17 10:42:26.820: INFO: Created: latency-svc-qbn9n
+Nov 17 10:42:26.859: INFO: Got endpoints: latency-svc-kbhjt [460.412686ms]
+Nov 17 10:42:26.871: INFO: Created: latency-svc-fk94f
+Nov 17 10:42:26.908: INFO: Got endpoints: latency-svc-7bwpk [507.89895ms]
+Nov 17 10:42:26.916: INFO: Created: latency-svc-cgggs
+Nov 17 10:42:26.959: INFO: Got endpoints: latency-svc-9d28j [552.544524ms]
+Nov 17 10:42:26.969: INFO: Created: latency-svc-g5gm7
+Nov 17 10:42:27.008: INFO: Got endpoints: latency-svc-6b2k2 [609.425353ms]
+Nov 17 10:42:27.018: INFO: Created: latency-svc-mfbwx
+Nov 17 10:42:27.065: INFO: Got endpoints: latency-svc-pt45k [622.514286ms]
+Nov 17 10:42:27.090: INFO: Created: latency-svc-bxz7z
+Nov 17 10:42:27.115: INFO: Got endpoints: latency-svc-d8rqx [671.835582ms]
+Nov 17 10:42:27.128: INFO: Created: latency-svc-hwgnz
+Nov 17 10:42:27.160: INFO: Got endpoints: latency-svc-zp7r6 [705.307922ms]
+Nov 17 10:42:27.171: INFO: Created: latency-svc-fljxt
+Nov 17 10:42:27.209: INFO: Got endpoints: latency-svc-qfd8v [745.959005ms]
+Nov 17 10:42:27.221: INFO: Created: latency-svc-ct6fm
+Nov 17 10:42:27.260: INFO: Got endpoints: latency-svc-4rv22 [750.39661ms]
+Nov 17 10:42:27.267: INFO: Created: latency-svc-j7q9q
+Nov 17 10:42:27.309: INFO: Got endpoints: latency-svc-htnvh [742.898121ms]
+Nov 17 10:42:27.319: INFO: Created: latency-svc-vbnf6
+Nov 17 10:42:27.358: INFO: Got endpoints: latency-svc-55d27 [749.089977ms]
+Nov 17 10:42:27.368: INFO: Created: latency-svc-6kfpt
+Nov 17 10:42:27.410: INFO: Got endpoints: latency-svc-m9l7g [749.662518ms]
+Nov 17 10:42:27.421: INFO: Created: latency-svc-27jvr
+Nov 17 10:42:27.459: INFO: Got endpoints: latency-svc-952zm [742.129687ms]
+Nov 17 10:42:27.471: INFO: Created: latency-svc-ggmlr
+Nov 17 10:42:27.512: INFO: Got endpoints: latency-svc-vfmfq [754.066086ms]
+Nov 17 10:42:27.524: INFO: Created: latency-svc-5nwsn
+Nov 17 10:42:27.559: INFO: Got endpoints: latency-svc-qbn9n [749.287056ms]
+Nov 17 10:42:27.570: INFO: Created: latency-svc-2lkkn
+Nov 17 10:42:27.609: INFO: Got endpoints: latency-svc-fk94f [750.409829ms]
+Nov 17 10:42:27.617: INFO: Created: latency-svc-kbjl6
+Nov 17 10:42:27.659: INFO: Got endpoints: latency-svc-cgggs [751.104866ms]
+Nov 17 10:42:27.671: INFO: Created: latency-svc-dwwb2
+Nov 17 10:42:27.711: INFO: Got endpoints: latency-svc-g5gm7 [751.915377ms]
+Nov 17 10:42:27.730: INFO: Created: latency-svc-jqvq7
+Nov 17 10:42:27.759: INFO: Got endpoints: latency-svc-mfbwx [750.571321ms]
+Nov 17 10:42:27.775: INFO: Created: latency-svc-59h2c
+Nov 17 10:42:27.809: INFO: Got endpoints: latency-svc-bxz7z [743.732924ms]
+Nov 17 10:42:27.817: INFO: Created: latency-svc-9qpmb
+Nov 17 10:42:27.859: INFO: Got endpoints: latency-svc-hwgnz [742.632418ms]
+Nov 17 10:42:27.870: INFO: Created: latency-svc-6c46p
+Nov 17 10:42:27.909: INFO: Got endpoints: latency-svc-fljxt [748.997818ms]
+Nov 17 10:42:27.920: INFO: Created: latency-svc-bdvlk
+Nov 17 10:42:27.958: INFO: Got endpoints: latency-svc-ct6fm [749.2503ms]
+Nov 17 10:42:27.968: INFO: Created: latency-svc-8s4jj
+Nov 17 10:42:28.009: INFO: Got endpoints: latency-svc-j7q9q [748.437764ms]
+Nov 17 10:42:28.021: INFO: Created: latency-svc-rb2bv
+Nov 17 10:42:28.060: INFO: Got endpoints: latency-svc-vbnf6 [750.770671ms]
+Nov 17 10:42:28.072: INFO: Created: latency-svc-cdttd
+Nov 17 10:42:28.110: INFO: Got endpoints: latency-svc-6kfpt [751.540709ms]
+Nov 17 10:42:28.119: INFO: Created: latency-svc-krr6j
+Nov 17 10:42:28.159: INFO: Got endpoints: latency-svc-27jvr [748.607548ms]
+Nov 17 10:42:28.170: INFO: Created: latency-svc-k54pf
+Nov 17 10:42:28.209: INFO: Got endpoints: latency-svc-ggmlr [749.996243ms]
+Nov 17 10:42:28.219: INFO: Created: latency-svc-lv4bw
+Nov 17 10:42:28.259: INFO: Got endpoints: latency-svc-5nwsn [747.069803ms]
+Nov 17 10:42:28.271: INFO: Created: latency-svc-zv779
+Nov 17 10:42:28.308: INFO: Got endpoints: latency-svc-2lkkn [748.371056ms]
+Nov 17 10:42:28.315: INFO: Created: latency-svc-k7jrp
+Nov 17 10:42:28.358: INFO: Got endpoints: latency-svc-kbjl6 [748.565973ms]
+Nov 17 10:42:28.367: INFO: Created: latency-svc-h2rlz
+Nov 17 10:42:28.409: INFO: Got endpoints: latency-svc-dwwb2 [750.24723ms]
+Nov 17 10:42:28.418: INFO: Created: latency-svc-7d6ck
+Nov 17 10:42:28.460: INFO: Got endpoints: latency-svc-jqvq7 [748.896175ms]
+Nov 17 10:42:28.471: INFO: Created: latency-svc-5c5q7
+Nov 17 10:42:28.509: INFO: Got endpoints: latency-svc-59h2c [750.586969ms]
+Nov 17 10:42:28.521: INFO: Created: latency-svc-xdck7
+Nov 17 10:42:28.560: INFO: Got endpoints: latency-svc-9qpmb [750.72715ms]
+Nov 17 10:42:28.571: INFO: Created: latency-svc-ttnjh
+Nov 17 10:42:28.612: INFO: Got endpoints: latency-svc-6c46p [751.830369ms]
+Nov 17 10:42:28.642: INFO: Created: latency-svc-dzcng
+Nov 17 10:42:28.659: INFO: Got endpoints: latency-svc-bdvlk [750.553922ms]
+Nov 17 10:42:28.669: INFO: Created: latency-svc-tkrsz
+Nov 17 10:42:28.708: INFO: Got endpoints: latency-svc-8s4jj [749.065713ms]
+Nov 17 10:42:28.718: INFO: Created: latency-svc-xdl77
+Nov 17 10:42:28.763: INFO: Got endpoints: latency-svc-rb2bv [754.031643ms]
+Nov 17 10:42:28.775: INFO: Created: latency-svc-lfkr6
+Nov 17 10:42:28.809: INFO: Got endpoints: latency-svc-cdttd [748.862332ms]
+Nov 17 10:42:28.832: INFO: Created: latency-svc-rj7cw
+Nov 17 10:42:28.861: INFO: Got endpoints: latency-svc-krr6j [751.191091ms]
+Nov 17 10:42:28.872: INFO: Created: latency-svc-q8crg
+Nov 17 10:42:28.909: INFO: Got endpoints: latency-svc-k54pf [750.39307ms]
+Nov 17 10:42:28.921: INFO: Created: latency-svc-ptn7d
+Nov 17 10:42:28.958: INFO: Got endpoints: latency-svc-lv4bw [749.004843ms]
+Nov 17 10:42:28.967: INFO: Created: latency-svc-bzvpv
+Nov 17 10:42:29.009: INFO: Got endpoints: latency-svc-zv779 [749.545992ms]
+Nov 17 10:42:29.020: INFO: Created: latency-svc-rdsvw
+Nov 17 10:42:29.058: INFO: Got endpoints: latency-svc-k7jrp [750.236538ms]
+Nov 17 10:42:29.066: INFO: Created: latency-svc-46dmt
+Nov 17 10:42:29.110: INFO: Got endpoints: latency-svc-h2rlz [751.701629ms]
+Nov 17 10:42:29.121: INFO: Created: latency-svc-fskhh
+Nov 17 10:42:29.157: INFO: Got endpoints: latency-svc-7d6ck [747.851192ms]
+Nov 17 10:42:29.167: INFO: Created: latency-svc-9ngw7
+Nov 17 10:42:29.206: INFO: Got endpoints: latency-svc-5c5q7 [746.171255ms]
+Nov 17 10:42:29.212: INFO: Created: latency-svc-nwtdc
+Nov 17 10:42:29.260: INFO: Got endpoints: latency-svc-xdck7 [750.425907ms]
+Nov 17 10:42:29.269: INFO: Created: latency-svc-6wjn5
+Nov 17 10:42:29.309: INFO: Got endpoints: latency-svc-ttnjh [749.149862ms]
+Nov 17 10:42:29.320: INFO: Created: latency-svc-5zn94
+Nov 17 10:42:29.358: INFO: Got endpoints: latency-svc-dzcng [746.498337ms]
+Nov 17 10:42:29.366: INFO: Created: latency-svc-vmx66
+Nov 17 10:42:29.408: INFO: Got endpoints: latency-svc-tkrsz [748.483427ms]
+Nov 17 10:42:29.418: INFO: Created: latency-svc-gkx2f
+Nov 17 10:42:29.458: INFO: Got endpoints: latency-svc-xdl77 [750.491051ms]
+Nov 17 10:42:29.468: INFO: Created: latency-svc-bvtqk
+Nov 17 10:42:29.511: INFO: Got endpoints: latency-svc-lfkr6 [748.151656ms]
+Nov 17 10:42:29.523: INFO: Created: latency-svc-zt74n
+Nov 17 10:42:29.566: INFO: Got endpoints: latency-svc-rj7cw [753.885258ms]
+Nov 17 10:42:29.593: INFO: Created: latency-svc-rd6jz
+Nov 17 10:42:29.614: INFO: Got endpoints: latency-svc-q8crg [752.590818ms]
+Nov 17 10:42:29.627: INFO: Created: latency-svc-4rfkw
+Nov 17 10:42:29.659: INFO: Got endpoints: latency-svc-ptn7d [749.680164ms]
+Nov 17 10:42:29.670: INFO: Created: latency-svc-49vnm
+Nov 17 10:42:29.714: INFO: Got endpoints: latency-svc-bzvpv [755.277481ms]
+Nov 17 10:42:29.739: INFO: Created: latency-svc-5qqps
+Nov 17 10:42:29.759: INFO: Got endpoints: latency-svc-rdsvw [749.737322ms]
+Nov 17 10:42:29.773: INFO: Created: latency-svc-gn5mw
+Nov 17 10:42:29.813: INFO: Got endpoints: latency-svc-46dmt [755.015522ms]
+Nov 17 10:42:29.836: INFO: Created: latency-svc-s9xgj
+Nov 17 10:42:29.866: INFO: Got endpoints: latency-svc-fskhh [755.808103ms]
+Nov 17 10:42:29.877: INFO: Created: latency-svc-88fck
+Nov 17 10:42:29.911: INFO: Got endpoints: latency-svc-9ngw7 [753.704783ms]
+Nov 17 10:42:29.922: INFO: Created: latency-svc-mx68h
+Nov 17 10:42:29.961: INFO: Got endpoints: latency-svc-nwtdc [755.11188ms]
+Nov 17 10:42:29.972: INFO: Created: latency-svc-45kzw
+Nov 17 10:42:30.010: INFO: Got endpoints: latency-svc-6wjn5 [750.132414ms]
+Nov 17 10:42:30.020: INFO: Created: latency-svc-p6f4p
+Nov 17 10:42:30.060: INFO: Got endpoints: latency-svc-5zn94 [750.581508ms]
+Nov 17 10:42:30.069: INFO: Created: latency-svc-sf4ch
+Nov 17 10:42:30.109: INFO: Got endpoints: latency-svc-vmx66 [750.541147ms]
+Nov 17 10:42:30.120: INFO: Created: latency-svc-gx54j
+Nov 17 10:42:30.162: INFO: Got endpoints: latency-svc-gkx2f [753.810807ms]
+Nov 17 10:42:30.174: INFO: Created: latency-svc-p22hg
+Nov 17 10:42:30.209: INFO: Got endpoints: latency-svc-bvtqk [751.362779ms]
+Nov 17 10:42:30.221: INFO: Created: latency-svc-wkt6z
+Nov 17 10:42:30.258: INFO: Got endpoints: latency-svc-zt74n [745.911624ms]
+Nov 17 10:42:30.270: INFO: Created: latency-svc-8k9lf
+Nov 17 10:42:30.311: INFO: Got endpoints: latency-svc-rd6jz [743.386589ms]
+Nov 17 10:42:30.319: INFO: Created: latency-svc-xgkgf
+Nov 17 10:42:30.359: INFO: Got endpoints: latency-svc-4rfkw [744.830829ms]
+Nov 17 10:42:30.368: INFO: Created: latency-svc-qt5r5
+Nov 17 10:42:30.409: INFO: Got endpoints: latency-svc-49vnm [749.658792ms]
+Nov 17 10:42:30.418: INFO: Created: latency-svc-7n62q
+Nov 17 10:42:30.456: INFO: Got endpoints: latency-svc-5qqps [742.183021ms]
+Nov 17 10:42:30.469: INFO: Created: latency-svc-shmbw
+Nov 17 10:42:30.507: INFO: Got endpoints: latency-svc-gn5mw [746.900351ms]
+Nov 17 10:42:30.515: INFO: Created: latency-svc-n9cvf
+Nov 17 10:42:30.559: INFO: Got endpoints: latency-svc-s9xgj [743.011966ms]
+Nov 17 10:42:30.572: INFO: Created: latency-svc-d44t5
+Nov 17 10:42:30.609: INFO: Got endpoints: latency-svc-88fck [743.097916ms]
+Nov 17 10:42:30.619: INFO: Created: latency-svc-dlkp5
+Nov 17 10:42:30.658: INFO: Got endpoints: latency-svc-mx68h [744.711558ms]
+Nov 17 10:42:30.668: INFO: Created: latency-svc-cgc8m
+Nov 17 10:42:30.711: INFO: Got endpoints: latency-svc-45kzw [749.498468ms]
+Nov 17 10:42:30.722: INFO: Created: latency-svc-nrjbv
+Nov 17 10:42:30.760: INFO: Got endpoints: latency-svc-p6f4p [749.628943ms]
+Nov 17 10:42:30.772: INFO: Created: latency-svc-chf7l
+Nov 17 10:42:30.809: INFO: Got endpoints: latency-svc-sf4ch [749.575775ms]
+Nov 17 10:42:30.823: INFO: Created: latency-svc-8hq6b
+Nov 17 10:42:30.859: INFO: Got endpoints: latency-svc-gx54j [750.393824ms]
+Nov 17 10:42:30.871: INFO: Created: latency-svc-59l7p
+Nov 17 10:42:30.909: INFO: Got endpoints: latency-svc-p22hg [747.30858ms]
+Nov 17 10:42:30.924: INFO: Created: latency-svc-wpzs8
+Nov 17 10:42:30.960: INFO: Got endpoints: latency-svc-wkt6z [749.701726ms]
+Nov 17 10:42:30.969: INFO: Created: latency-svc-qxmxw
+Nov 17 10:42:31.009: INFO: Got endpoints: latency-svc-8k9lf [751.38689ms]
+Nov 17 10:42:31.020: INFO: Created: latency-svc-h8bkl
+Nov 17 10:42:31.059: INFO: Got endpoints: latency-svc-xgkgf [748.655441ms]
+Nov 17 10:42:31.070: INFO: Created: latency-svc-fdpdj
+Nov 17 10:42:31.111: INFO: Got endpoints: latency-svc-qt5r5 [752.255181ms]
+Nov 17 10:42:31.120: INFO: Created: latency-svc-sqfbj
+Nov 17 10:42:31.159: INFO: Got endpoints: latency-svc-7n62q [750.309599ms]
+Nov 17 10:42:31.173: INFO: Created: latency-svc-xzkgz
+Nov 17 10:42:31.209: INFO: Got endpoints: latency-svc-shmbw [753.013508ms]
+Nov 17 10:42:31.220: INFO: Created: latency-svc-wwvp9
+Nov 17 10:42:31.259: INFO: Got endpoints: latency-svc-n9cvf [751.590416ms]
+Nov 17 10:42:31.274: INFO: Created: latency-svc-zqj8k
+Nov 17 10:42:31.311: INFO: Got endpoints: latency-svc-d44t5 [751.919051ms]
+Nov 17 10:42:31.323: INFO: Created: latency-svc-jpnmr
+Nov 17 10:42:31.360: INFO: Got endpoints: latency-svc-dlkp5 [750.297526ms]
+Nov 17 10:42:31.371: INFO: Created: latency-svc-8pjrx
+Nov 17 10:42:31.413: INFO: Got endpoints: latency-svc-cgc8m [754.486299ms]
+Nov 17 10:42:31.424: INFO: Created: latency-svc-dzl4k
+Nov 17 10:42:31.458: INFO: Got endpoints: latency-svc-nrjbv [747.026057ms]
+Nov 17 10:42:31.468: INFO: Created: latency-svc-6ct24
+Nov 17 10:42:31.509: INFO: Got endpoints: latency-svc-chf7l [748.624997ms]
+Nov 17 10:42:31.520: INFO: Created: latency-svc-zfj2k
+Nov 17 10:42:31.558: INFO: Got endpoints: latency-svc-8hq6b [748.51947ms]
+Nov 17 10:42:31.570: INFO: Created: latency-svc-tvkqb
+Nov 17 10:42:31.610: INFO: Got endpoints: latency-svc-59l7p [749.922348ms]
+Nov 17 10:42:31.622: INFO: Created: latency-svc-gwjfp
+Nov 17 10:42:31.660: INFO: Got endpoints: latency-svc-wpzs8 [750.861601ms]
+Nov 17 10:42:31.670: INFO: Created: latency-svc-nxlbj
+Nov 17 10:42:31.708: INFO: Got endpoints: latency-svc-qxmxw [747.677672ms]
+Nov 17 10:42:31.719: INFO: Created: latency-svc-ld68q
+Nov 17 10:42:31.757: INFO: Got endpoints: latency-svc-h8bkl [747.316372ms]
+Nov 17 10:42:31.766: INFO: Created: latency-svc-hdcn9
+Nov 17 10:42:31.808: INFO: Got endpoints: latency-svc-fdpdj [747.96926ms]
+Nov 17 10:42:31.815: INFO: Created: latency-svc-xpgwn
+Nov 17 10:42:31.858: INFO: Got endpoints: latency-svc-sqfbj [747.341001ms]
+Nov 17 10:42:31.867: INFO: Created: latency-svc-5d698
+Nov 17 10:42:31.907: INFO: Got endpoints: latency-svc-xzkgz [747.736728ms]
+Nov 17 10:42:31.915: INFO: Created: latency-svc-hzzz6
+Nov 17 10:42:31.960: INFO: Got endpoints: latency-svc-wwvp9 [750.905008ms]
+Nov 17 10:42:31.971: INFO: Created: latency-svc-qhb8b
+Nov 17 10:42:32.010: INFO: Got endpoints: latency-svc-zqj8k [750.808373ms]
+Nov 17 10:42:32.021: INFO: Created: latency-svc-s8gng
+Nov 17 10:42:32.061: INFO: Got endpoints: latency-svc-jpnmr [750.023219ms]
+Nov 17 10:42:32.074: INFO: Created: latency-svc-5lk89
+Nov 17 10:42:32.106: INFO: Got endpoints: latency-svc-8pjrx [745.79363ms]
+Nov 17 10:42:32.118: INFO: Created: latency-svc-zc2s4
+Nov 17 10:42:32.159: INFO: Got endpoints: latency-svc-dzl4k [746.721799ms]
+Nov 17 10:42:32.170: INFO: Created: latency-svc-xznw4
+Nov 17 10:42:32.209: INFO: Got endpoints: latency-svc-6ct24 [750.134719ms]
+Nov 17 10:42:32.218: INFO: Created: latency-svc-pb2lh
+Nov 17 10:42:32.258: INFO: Got endpoints: latency-svc-zfj2k [749.273895ms]
+Nov 17 10:42:32.268: INFO: Created: latency-svc-lw8hp
+Nov 17 10:42:32.309: INFO: Got endpoints: latency-svc-tvkqb [750.488471ms]
+Nov 17 10:42:32.318: INFO: Created: latency-svc-5dg5j
+Nov 17 10:42:32.358: INFO: Got endpoints: latency-svc-gwjfp [747.672262ms]
+Nov 17 10:42:32.370: INFO: Created: latency-svc-bwcnn
+Nov 17 10:42:32.412: INFO: Got endpoints: latency-svc-nxlbj [752.035426ms]
+Nov 17 10:42:32.430: INFO: Created: latency-svc-cjqnt
+Nov 17 10:42:32.461: INFO: Got endpoints: latency-svc-ld68q [753.284005ms]
+Nov 17 10:42:32.475: INFO: Created: latency-svc-sdkhl
+Nov 17 10:42:32.506: INFO: Got endpoints: latency-svc-hdcn9 [748.945469ms]
+Nov 17 10:42:32.519: INFO: Created: latency-svc-mhzjd
+Nov 17 10:42:32.557: INFO: Got endpoints: latency-svc-xpgwn [749.566572ms]
+Nov 17 10:42:32.568: INFO: Created: latency-svc-jmcqs
+Nov 17 10:42:32.607: INFO: Got endpoints: latency-svc-5d698 [748.832788ms]
+Nov 17 10:42:32.620: INFO: Created: latency-svc-q5rrd
+Nov 17 10:42:32.659: INFO: Got endpoints: latency-svc-hzzz6 [752.397565ms]
+Nov 17 10:42:32.671: INFO: Created: latency-svc-rzvv8
+Nov 17 10:42:32.708: INFO: Got endpoints: latency-svc-qhb8b [747.99839ms]
+Nov 17 10:42:32.718: INFO: Created: latency-svc-cv9bh
+Nov 17 10:42:32.758: INFO: Got endpoints: latency-svc-s8gng [747.615464ms]
+Nov 17 10:42:32.770: INFO: Created: latency-svc-c9996
+Nov 17 10:42:32.809: INFO: Got endpoints: latency-svc-5lk89 [747.10098ms]
+Nov 17 10:42:32.819: INFO: Created: latency-svc-fp5lv
+Nov 17 10:42:32.858: INFO: Got endpoints: latency-svc-zc2s4 [752.337219ms]
+Nov 17 10:42:32.868: INFO: Created: latency-svc-9jlq2
+Nov 17 10:42:32.909: INFO: Got endpoints: latency-svc-xznw4 [749.087315ms]
+Nov 17 10:42:32.919: INFO: Created: latency-svc-2gk86
+Nov 17 10:42:32.958: INFO: Got endpoints: latency-svc-pb2lh [749.17928ms]
+Nov 17 10:42:32.976: INFO: Created: latency-svc-nbmxc
+Nov 17 10:42:33.015: INFO: Got endpoints: latency-svc-lw8hp [757.06615ms]
+Nov 17 10:42:33.042: INFO: Created: latency-svc-zq6f8
+Nov 17 10:42:33.060: INFO: Got endpoints: latency-svc-5dg5j [751.476758ms]
+Nov 17 10:42:33.071: INFO: Created: latency-svc-vdqhh
+Nov 17 10:42:33.111: INFO: Got endpoints: latency-svc-bwcnn [753.040888ms]
+Nov 17 10:42:33.131: INFO: Created: latency-svc-dhpvz
+Nov 17 10:42:33.160: INFO: Got endpoints: latency-svc-cjqnt [747.571446ms]
+Nov 17 10:42:33.184: INFO: Created: latency-svc-2dxg8
+Nov 17 10:42:33.214: INFO: Got endpoints: latency-svc-sdkhl [752.747463ms]
+Nov 17 10:42:33.237: INFO: Created: latency-svc-zznzj
+Nov 17 10:42:33.260: INFO: Got endpoints: latency-svc-mhzjd [753.896349ms]
+Nov 17 10:42:33.277: INFO: Created: latency-svc-222xj
+Nov 17 10:42:33.313: INFO: Got endpoints: latency-svc-jmcqs [755.473087ms]
+Nov 17 10:42:33.327: INFO: Created: latency-svc-s8xvn
+Nov 17 10:42:33.367: INFO: Got endpoints: latency-svc-q5rrd [758.776779ms]
+Nov 17 10:42:33.383: INFO: Created: latency-svc-j6qxf
+Nov 17 10:42:33.408: INFO: Got endpoints: latency-svc-rzvv8 [748.590132ms]
+Nov 17 10:42:33.422: INFO: Created: latency-svc-gp5kj
+Nov 17 10:42:33.462: INFO: Got endpoints: latency-svc-cv9bh [753.873725ms]
+Nov 17 10:42:33.474: INFO: Created: latency-svc-kt9sp
+Nov 17 10:42:33.509: INFO: Got endpoints: latency-svc-c9996 [749.146693ms]
+Nov 17 10:42:33.523: INFO: Created: latency-svc-l9czg
+Nov 17 10:42:33.560: INFO: Got endpoints: latency-svc-fp5lv [751.566554ms]
+Nov 17 10:42:33.573: INFO: Created: latency-svc-28q4v
+Nov 17 10:42:33.609: INFO: Got endpoints: latency-svc-9jlq2 [750.677806ms]
+Nov 17 10:42:33.621: INFO: Created: latency-svc-5l4tx
+Nov 17 10:42:33.659: INFO: Got endpoints: latency-svc-2gk86 [750.007188ms]
+Nov 17 10:42:33.674: INFO: Created: latency-svc-v75q8
+Nov 17 10:42:33.711: INFO: Got endpoints: latency-svc-nbmxc [752.337807ms]
+Nov 17 10:42:33.725: INFO: Created: latency-svc-kgmqg
+Nov 17 10:42:33.761: INFO: Got endpoints: latency-svc-zq6f8 [745.900039ms]
+Nov 17 10:42:33.808: INFO: Got endpoints: latency-svc-vdqhh [747.447943ms]
+Nov 17 10:42:33.864: INFO: Got endpoints: latency-svc-dhpvz [752.355194ms]
+Nov 17 10:42:33.909: INFO: Got endpoints: latency-svc-2dxg8 [748.792758ms]
+Nov 17 10:42:33.959: INFO: Got endpoints: latency-svc-zznzj [744.9253ms]
+Nov 17 10:42:34.011: INFO: Got endpoints: latency-svc-222xj [751.115738ms]
+Nov 17 10:42:34.057: INFO: Got endpoints: latency-svc-s8xvn [743.844969ms]
+Nov 17 10:42:34.110: INFO: Got endpoints: latency-svc-j6qxf [743.159905ms]
+Nov 17 10:42:34.164: INFO: Got endpoints: latency-svc-gp5kj [755.154369ms]
+Nov 17 10:42:34.206: INFO: Got endpoints: latency-svc-kt9sp [743.700613ms]
+Nov 17 10:42:34.259: INFO: Got endpoints: latency-svc-l9czg [749.575899ms]
+Nov 17 10:42:34.308: INFO: Got endpoints: latency-svc-28q4v [747.90397ms]
+Nov 17 10:42:34.359: INFO: Got endpoints: latency-svc-5l4tx [749.465123ms]
+Nov 17 10:42:34.410: INFO: Got endpoints: latency-svc-v75q8 [750.862386ms]
+Nov 17 10:42:34.459: INFO: Got endpoints: latency-svc-kgmqg [747.952956ms]
+Nov 17 10:42:34.459: INFO: Latencies: [19.123901ms 28.68392ms 56.901384ms 60.095327ms 61.295992ms 66.522999ms 68.750143ms 71.203512ms 73.351971ms 76.909477ms 80.49884ms 97.401962ms 111.936143ms 129.277412ms 134.12993ms 134.263402ms 137.205774ms 140.541705ms 146.761382ms 146.814785ms 147.807161ms 150.034099ms 158.747701ms 167.936933ms 168.350853ms 168.961276ms 170.663723ms 177.165583ms 178.105365ms 182.955701ms 183.316516ms 185.777526ms 192.92987ms 200.32701ms 206.279984ms 210.140555ms 217.670906ms 227.349192ms 245.596721ms 274.687968ms 277.302582ms 291.114122ms 311.791416ms 362.779638ms 376.264864ms 417.299349ms 460.412686ms 507.89895ms 541.269544ms 552.544524ms 609.425353ms 622.514286ms 671.835582ms 705.307922ms 742.129687ms 742.183021ms 742.632418ms 742.898121ms 743.011966ms 743.097916ms 743.159905ms 743.386589ms 743.700613ms 743.732924ms 743.844969ms 744.711558ms 744.830829ms 744.9253ms 745.79363ms 745.900039ms 745.911624ms 745.959005ms 746.171255ms 746.498337ms 746.721799ms 746.900351ms 747.026057ms 747.069803ms 747.10098ms 747.30858ms 747.316372ms 747.341001ms 747.447943ms 747.571446ms 747.615464ms 747.672262ms 747.677672ms 747.736728ms 747.851192ms 747.90397ms 747.952956ms 747.96926ms 747.99839ms 748.151656ms 748.371056ms 748.437764ms 748.483427ms 748.51947ms 748.565973ms 748.590132ms 748.607548ms 748.624997ms 748.655441ms 748.792758ms 748.832788ms 748.862332ms 748.896175ms 748.945469ms 748.997818ms 749.004843ms 749.065713ms 749.087315ms 749.089977ms 749.146693ms 749.149862ms 749.17928ms 749.2503ms 749.273895ms 749.287056ms 749.465123ms 749.498468ms 749.545992ms 749.566572ms 749.575775ms 749.575899ms 749.628943ms 749.658792ms 749.662518ms 749.680164ms 749.701726ms 749.737322ms 749.922348ms 749.996243ms 750.007188ms 750.023219ms 750.132414ms 750.134719ms 750.236538ms 750.24723ms 750.297526ms 750.309599ms 750.39307ms 750.393824ms 750.39661ms 750.409829ms 750.425907ms 750.488471ms 750.491051ms 750.541147ms 750.553922ms 750.571321ms 750.581508ms 750.586969ms 750.677806ms 750.72715ms 750.770671ms 750.808373ms 750.861601ms 750.862386ms 750.905008ms 751.104866ms 751.115738ms 751.191091ms 751.362779ms 751.38689ms 751.476758ms 751.540709ms 751.566554ms 751.590416ms 751.701629ms 751.830369ms 751.915377ms 751.919051ms 752.035426ms 752.255181ms 752.337219ms 752.337807ms 752.355194ms 752.397565ms 752.590818ms 752.747463ms 753.013508ms 753.040888ms 753.284005ms 753.704783ms 753.810807ms 753.873725ms 753.885258ms 753.896349ms 754.031643ms 754.066086ms 754.486299ms 755.015522ms 755.11188ms 755.154369ms 755.277481ms 755.473087ms 755.808103ms 757.06615ms 758.776779ms]
+Nov 17 10:42:34.459: INFO: 50 %ile: 748.607548ms
+Nov 17 10:42:34.459: INFO: 90 %ile: 752.747463ms
+Nov 17 10:42:34.460: INFO: 99 %ile: 757.06615ms
+Nov 17 10:42:34.460: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:42:34.460: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-rj7df" for this suite.
+Nov 17 10:42:52.542: INFO: namespace: e2e-tests-svc-latency-rj7df, resource: bindings, ignored listing per whitelist
+Nov 17 10:42:52.542: INFO: namespace e2e-tests-svc-latency-rj7df deletion completed in 18.077641313s
+
+• [SLOW TEST:28.818 seconds]
+[sig-network] Service endpoints latency
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service_latency.go:117
+------------------------------
+S
+------------------------------
+[k8s.io] Downward API volume 
+  should update labels on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:125
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:42:52.542: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-bvghk
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should update labels on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:125
+STEP: Creating the pod
+Nov 17 10:42:55.215: INFO: Successfully updated pod "labelsupdate1040abe1-cb84-11e7-b2ab-c6826529d988"
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:44:21.628: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-bvghk" for this suite.
+Nov 17 10:44:43.669: INFO: namespace: e2e-tests-downward-api-bvghk, resource: bindings, ignored listing per whitelist
+Nov 17 10:44:43.707: INFO: namespace e2e-tests-downward-api-bvghk deletion completed in 22.07722725s
+
+• [SLOW TEST:111.165 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should update labels on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:125
+------------------------------
+SS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:124
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:44:43.708: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-container-probe-79cfw
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:124
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-79cfw
+Nov 17 10:44:47.871: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-79cfw
+STEP: checking the pod's current state and verifying that restartCount is present
+Nov 17 10:44:47.873: INFO: Initial restart count of pod liveness-exec is 0
+Nov 17 10:45:35.928: INFO: Restart count of pod e2e-tests-container-probe-79cfw/liveness-exec is now 1 (48.055639994s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:45:35.936: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-79cfw" for this suite.
+Nov 17 10:45:42.005: INFO: namespace: e2e-tests-container-probe-79cfw, resource: bindings, ignored listing per whitelist
+Nov 17 10:45:42.015: INFO: namespace e2e-tests-container-probe-79cfw deletion completed in 6.076358828s
+
+• [SLOW TEST:58.307 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:124
+------------------------------
+SSS
+------------------------------
+[k8s.io] ConfigMap 
+  should be consumable via the environment [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:411
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:45:42.015: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-configmap-rcjzz
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:411
+STEP: Creating configMap e2e-tests-configmap-rcjzz/configmap-test-7542bf8f-cb84-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:45:42.160: INFO: Waiting up to 5m0s for pod "pod-configmaps-7543416c-cb84-11e7-b2ab-c6826529d988" in namespace "e2e-tests-configmap-rcjzz" to be "success or failure"
+Nov 17 10:45:42.163: INFO: Pod "pod-configmaps-7543416c-cb84-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.053194ms
+Nov 17 10:45:44.165: INFO: Pod "pod-configmaps-7543416c-cb84-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005669122s
+Nov 17 10:45:46.168: INFO: Pod "pod-configmaps-7543416c-cb84-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.00818539s
+STEP: Saw pod success
+Nov 17 10:45:46.168: INFO: Pod "pod-configmaps-7543416c-cb84-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:45:46.170: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-configmaps-7543416c-cb84-11e7-b2ab-c6826529d988 container env-test: <nil>
+STEP: delete the pod
+Nov 17 10:45:46.185: INFO: Waiting for pod pod-configmaps-7543416c-cb84-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:45:46.188: INFO: Pod pod-configmaps-7543416c-cb84-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:45:46.188: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-rcjzz" for this suite.
+Nov 17 10:45:52.233: INFO: namespace: e2e-tests-configmap-rcjzz, resource: bindings, ignored listing per whitelist
+Nov 17 10:45:52.270: INFO: namespace e2e-tests-configmap-rcjzz deletion completed in 6.079176241s
+
+• [SLOW TEST:10.255 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable via the environment [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:411
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:56
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:45:52.270: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-hggxq
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:56
+STEP: Creating projection with secret that has name projected-secret-test-map-7b6039e3-cb84-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:45:52.419: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-7b60a741-cb84-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-hggxq" to be "success or failure"
+Nov 17 10:45:52.422: INFO: Pod "pod-projected-secrets-7b60a741-cb84-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.392546ms
+Nov 17 10:45:54.425: INFO: Pod "pod-projected-secrets-7b60a741-cb84-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006091135s
+STEP: Saw pod success
+Nov 17 10:45:54.425: INFO: Pod "pod-projected-secrets-7b60a741-cb84-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:45:54.427: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-secrets-7b60a741-cb84-11e7-b2ab-c6826529d988 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:45:54.439: INFO: Waiting for pod pod-projected-secrets-7b60a741-cb84-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:45:54.442: INFO: Pod pod-projected-secrets-7b60a741-cb84-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:45:54.442: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hggxq" for this suite.
+Nov 17 10:46:00.508: INFO: namespace: e2e-tests-projected-hggxq, resource: bindings, ignored listing per whitelist
+Nov 17 10:46:00.533: INFO: namespace e2e-tests-projected-hggxq deletion completed in 6.088907578s
+
+• [SLOW TEST:8.263 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:56
+------------------------------
+S
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:52
+[BeforeEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:46:00.533: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-pod-network-test-dp9px
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:52
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-dp9px
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Nov 17 10:46:00.670: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Nov 17 10:46:24.737: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -q -s --connect-timeout 1 http://192.168.118.33:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-dp9px PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:46:24.737: INFO: >>> kubeConfig: 
+Nov 17 10:46:24.816: INFO: Found all expected endpoints: [netserver-0]
+Nov 17 10:46:24.818: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -q -s --connect-timeout 1 http://192.168.118.34:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-dp9px PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:46:24.818: INFO: >>> kubeConfig: 
+Nov 17 10:46:24.884: INFO: Found all expected endpoints: [netserver-1]
+Nov 17 10:46:24.886: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -q -s --connect-timeout 1 http://192.168.185.221:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-dp9px PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:46:24.886: INFO: >>> kubeConfig: 
+Nov 17 10:46:24.954: INFO: Found all expected endpoints: [netserver-2]
+[AfterEach] [sig-network] Networking
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:46:24.954: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-dp9px" for this suite.
+Nov 17 10:46:47.019: INFO: namespace: e2e-tests-pod-network-test-dp9px, resource: bindings, ignored listing per whitelist
+Nov 17 10:46:47.033: INFO: namespace e2e-tests-pod-network-test-dp9px deletion completed in 22.076015528s
+
+• [SLOW TEST:46.499 seconds]
+[sig-network] Networking
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:61
+  Granular Checks: Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:60
+    should function for node-pod communication: http [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:52
+------------------------------
+S
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/replica_set.go:83
+[BeforeEach] [sig-apps] ReplicaSet
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:46:47.033: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-replicaset-gh545
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/replica_set.go:83
+Nov 17 10:46:47.175: INFO: Creating ReplicaSet my-hostname-basic-9c0490e2-cb84-11e7-b2ab-c6826529d988
+Nov 17 10:46:47.181: INFO: Pod name my-hostname-basic-9c0490e2-cb84-11e7-b2ab-c6826529d988: Found 0 pods out of 1
+Nov 17 10:46:52.184: INFO: Pod name my-hostname-basic-9c0490e2-cb84-11e7-b2ab-c6826529d988: Found 1 pods out of 1
+Nov 17 10:46:52.184: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-9c0490e2-cb84-11e7-b2ab-c6826529d988" is running
+Nov 17 10:46:52.185: INFO: Pod "my-hostname-basic-9c0490e2-cb84-11e7-b2ab-c6826529d988-htvs4" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-11-17 10:46:47 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-11-17 10:46:48 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-11-17 10:46:47 +0000 UTC Reason: Message:}])
+Nov 17 10:46:52.185: INFO: Trying to dial the pod
+Nov 17 10:46:57.194: INFO: Controller my-hostname-basic-9c0490e2-cb84-11e7-b2ab-c6826529d988: Got expected result from replica 1 [my-hostname-basic-9c0490e2-cb84-11e7-b2ab-c6826529d988-htvs4]: "my-hostname-basic-9c0490e2-cb84-11e7-b2ab-c6826529d988-htvs4", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:46:57.194: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-gh545" for this suite.
+Nov 17 10:47:03.270: INFO: namespace: e2e-tests-replicaset-gh545, resource: bindings, ignored listing per whitelist
+Nov 17 10:47:03.304: INFO: namespace e2e-tests-replicaset-gh545 deletion completed in 6.107560691s
+
+• [SLOW TEST:16.271 seconds]
+[sig-apps] ReplicaSet
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/replica_set.go:83
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:399
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:47:03.304: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-jfl4k
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:399
+STEP: Creating configMap with name projected-configmap-test-volume-map-a5b6f063-cb84-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:47:03.452: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-a5b75ab2-cb84-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-jfl4k" to be "success or failure"
+Nov 17 10:47:03.455: INFO: Pod "pod-projected-configmaps-a5b75ab2-cb84-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.283592ms
+Nov 17 10:47:05.458: INFO: Pod "pod-projected-configmaps-a5b75ab2-cb84-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005927532s
+STEP: Saw pod success
+Nov 17 10:47:05.458: INFO: Pod "pod-projected-configmaps-a5b75ab2-cb84-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:47:05.459: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-configmaps-a5b75ab2-cb84-11e7-b2ab-c6826529d988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:47:05.476: INFO: Waiting for pod pod-projected-configmaps-a5b75ab2-cb84-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:47:05.479: INFO: Pod pod-projected-configmaps-a5b75ab2-cb84-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:47:05.479: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jfl4k" for this suite.
+Nov 17 10:47:11.531: INFO: namespace: e2e-tests-projected-jfl4k, resource: bindings, ignored listing per whitelist
+Nov 17 10:47:11.564: INFO: namespace e2e-tests-projected-jfl4k deletion completed in 6.082801686s
+
+• [SLOW TEST:8.260 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:399
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[k8s.io] Downward API volume 
+  should set mode on item file [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:69
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:47:11.565: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-downward-api-qqs8g
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:40
+[It] should set mode on item file [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:69
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:47:11.708: INFO: Waiting up to 5m0s for pod "downwardapi-volume-aaa348f8-cb84-11e7-b2ab-c6826529d988" in namespace "e2e-tests-downward-api-qqs8g" to be "success or failure"
+Nov 17 10:47:11.711: INFO: Pod "downwardapi-volume-aaa348f8-cb84-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.602566ms
+Nov 17 10:47:13.713: INFO: Pod "downwardapi-volume-aaa348f8-cb84-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004887907s
+STEP: Saw pod success
+Nov 17 10:47:13.713: INFO: Pod "downwardapi-volume-aaa348f8-cb84-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:47:13.715: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downwardapi-volume-aaa348f8-cb84-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:47:13.728: INFO: Waiting for pod downwardapi-volume-aaa348f8-cb84-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:47:13.730: INFO: Pod downwardapi-volume-aaa348f8-cb84-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Downward API volume
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:47:13.730: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-qqs8g" for this suite.
+Nov 17 10:47:19.773: INFO: namespace: e2e-tests-downward-api-qqs8g, resource: bindings, ignored listing per whitelist
+Nov 17 10:47:19.808: INFO: namespace e2e-tests-downward-api-qqs8g deletion completed in 6.075696718s
+
+• [SLOW TEST:8.244 seconds]
+[k8s.io] Downward API volume
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should set mode on item file [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:69
+------------------------------
+S
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:215
+[BeforeEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:47:19.808: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-services-ptxt8
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:52
+[It] should serve multiport endpoints from pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:215
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-ptxt8
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-ptxt8 to expose endpoints map[]
+Nov 17 10:47:19.968: INFO: Get endpoints failed (11.305701ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Nov 17 10:47:20.970: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-ptxt8 exposes endpoints map[] (1.013139522s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-ptxt8
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-ptxt8 to expose endpoints map[pod1:[100]]
+Nov 17 10:47:22.991: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-ptxt8 exposes endpoints map[pod1:[100]] (2.015278702s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-ptxt8
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-ptxt8 to expose endpoints map[pod1:[100] pod2:[101]]
+Nov 17 10:47:26.022: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-ptxt8 exposes endpoints map[pod1:[100] pod2:[101]] (3.026438544s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-ptxt8
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-ptxt8 to expose endpoints map[pod2:[101]]
+Nov 17 10:47:27.033: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-ptxt8 exposes endpoints map[pod2:[101]] (1.007650345s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-ptxt8
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-ptxt8 to expose endpoints map[]
+Nov 17 10:47:29.043: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-ptxt8 exposes endpoints map[] (2.006548396s elapsed)
+[AfterEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:47:29.061: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-ptxt8" for this suite.
+Nov 17 10:47:35.114: INFO: namespace: e2e-tests-services-ptxt8, resource: bindings, ignored listing per whitelist
+Nov 17 10:47:35.151: INFO: namespace e2e-tests-services-ptxt8 deletion completed in 6.085732464s
+[AfterEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:64
+
+• [SLOW TEST:15.342 seconds]
+[sig-network] Services
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:215
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd) [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:45
+[BeforeEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:47:35.151: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-containers-w7vh9
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd) [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:45
+STEP: Creating a pod to test override arguments
+Nov 17 10:47:35.294: INFO: Waiting up to 5m0s for pod "client-containers-b8b22cf5-cb84-11e7-b2ab-c6826529d988" in namespace "e2e-tests-containers-w7vh9" to be "success or failure"
+Nov 17 10:47:35.297: INFO: Pod "client-containers-b8b22cf5-cb84-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.564778ms
+Nov 17 10:47:37.299: INFO: Pod "client-containers-b8b22cf5-cb84-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004966512s
+STEP: Saw pod success
+Nov 17 10:47:37.299: INFO: Pod "client-containers-b8b22cf5-cb84-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:47:37.302: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod client-containers-b8b22cf5-cb84-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:47:37.321: INFO: Waiting for pod client-containers-b8b22cf5-cb84-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:47:37.323: INFO: Pod client-containers-b8b22cf5-cb84-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:47:37.323: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-w7vh9" for this suite.
+Nov 17 10:47:43.355: INFO: namespace: e2e-tests-containers-w7vh9, resource: bindings, ignored listing per whitelist
+Nov 17 10:47:43.403: INFO: namespace e2e-tests-containers-w7vh9 deletion completed in 6.076902228s
+
+• [SLOW TEST:8.252 seconds]
+[k8s.io] Docker Containers
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be able to override the image's default arguments (docker cmd) [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:45
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:36
+[BeforeEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:47:43.403: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-containers-7x22g
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:36
+STEP: Creating a pod to test use defaults
+Nov 17 10:47:43.549: INFO: Waiting up to 5m0s for pod "client-containers-bd9dc346-cb84-11e7-b2ab-c6826529d988" in namespace "e2e-tests-containers-7x22g" to be "success or failure"
+Nov 17 10:47:43.551: INFO: Pod "client-containers-bd9dc346-cb84-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.410119ms
+Nov 17 10:47:45.554: INFO: Pod "client-containers-bd9dc346-cb84-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004774812s
+STEP: Saw pod success
+Nov 17 10:47:45.554: INFO: Pod "client-containers-bd9dc346-cb84-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:47:45.555: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod client-containers-bd9dc346-cb84-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:47:45.570: INFO: Waiting for pod client-containers-bd9dc346-cb84-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:47:45.572: INFO: Pod client-containers-bd9dc346-cb84-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:47:45.572: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-7x22g" for this suite.
+Nov 17 10:47:51.649: INFO: namespace: e2e-tests-containers-7x22g, resource: bindings, ignored listing per whitelist
+Nov 17 10:47:51.656: INFO: namespace e2e-tests-containers-7x22g deletion completed in 6.081799228s
+
+• [SLOW TEST:8.253 seconds]
+[k8s.io] Docker Containers
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should use the image defaults if command and args are blank [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/docker_containers.go:36
+------------------------------
+S
+------------------------------
+[k8s.io] Secrets 
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:325
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:47:51.657: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-secrets-gzz67
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:325
+STEP: Creating secret with name s-test-opt-del-c288f775-cb84-11e7-b2ab-c6826529d988
+STEP: Creating secret with name s-test-opt-upd-c288f7c2-cb84-11e7-b2ab-c6826529d988
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-c288f775-cb84-11e7-b2ab-c6826529d988
+STEP: Updating secret s-test-opt-upd-c288f7c2-cb84-11e7-b2ab-c6826529d988
+STEP: Creating secret with name s-test-opt-create-c288f7f9-cb84-11e7-b2ab-c6826529d988
+STEP: waiting to observe update in volume
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:49:26.235: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-gzz67" for this suite.
+Nov 17 10:49:48.300: INFO: namespace: e2e-tests-secrets-gzz67, resource: bindings, ignored listing per whitelist
+Nov 17 10:49:48.314: INFO: namespace e2e-tests-secrets-gzz67 deletion completed in 22.07631203s
+
+• [SLOW TEST:116.657 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:325
+------------------------------
+[k8s.io] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:936
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:49:48.314: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-4pcxv
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:936
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:49:48.457: INFO: Waiting up to 5m0s for pod "downwardapi-volume-081139ff-cb85-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-4pcxv" to be "success or failure"
+Nov 17 10:49:48.459: INFO: Pod "downwardapi-volume-081139ff-cb85-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.624204ms
+Nov 17 10:49:50.461: INFO: Pod "downwardapi-volume-081139ff-cb85-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004642471s
+STEP: Saw pod success
+Nov 17 10:49:50.461: INFO: Pod "downwardapi-volume-081139ff-cb85-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:49:50.463: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downwardapi-volume-081139ff-cb85-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:49:50.476: INFO: Waiting for pod downwardapi-volume-081139ff-cb85-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:49:50.478: INFO: Pod downwardapi-volume-081139ff-cb85-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:49:50.479: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4pcxv" for this suite.
+Nov 17 10:49:56.555: INFO: namespace: e2e-tests-projected-4pcxv, resource: bindings, ignored listing per whitelist
+Nov 17 10:49:56.567: INFO: namespace e2e-tests-projected-4pcxv deletion completed in 6.085419989s
+
+• [SLOW TEST:8.253 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:936
+------------------------------
+SS
+------------------------------
+[k8s.io] Projected 
+  updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:490
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:49:56.567: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-gjml9
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:490
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-0cfc4715-cb85-11e7-b2ab-c6826529d988
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-0cfc4715-cb85-11e7-b2ab-c6826529d988
+STEP: waiting to observe update in volume
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:51:25.063: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-gjml9" for this suite.
+Nov 17 10:51:47.091: INFO: namespace: e2e-tests-projected-gjml9, resource: bindings, ignored listing per whitelist
+Nov 17 10:51:47.142: INFO: namespace e2e-tests-projected-gjml9 deletion completed in 22.076639415s
+
+• [SLOW TEST:110.575 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:490
+------------------------------
+S
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:131
+[BeforeEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:51:47.142: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-services-fx5zk
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:52
+[It] should serve a basic endpoint from pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:131
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-fx5zk
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-fx5zk to expose endpoints map[]
+Nov 17 10:51:47.296: INFO: Get endpoints failed (6.788165ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Nov 17 10:51:48.299: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-fx5zk exposes endpoints map[] (1.009267776s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-fx5zk
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-fx5zk to expose endpoints map[pod1:[80]]
+Nov 17 10:51:50.317: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-fx5zk exposes endpoints map[pod1:[80]] (2.011825904s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-fx5zk
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-fx5zk to expose endpoints map[pod1:[80] pod2:[80]]
+Nov 17 10:51:52.338: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-fx5zk exposes endpoints map[pod1:[80] pod2:[80]] (2.017834024s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-fx5zk
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-fx5zk to expose endpoints map[pod2:[80]]
+Nov 17 10:51:54.353: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-fx5zk exposes endpoints map[pod2:[80]] (2.012007995s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-fx5zk
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-fx5zk to expose endpoints map[]
+Nov 17 10:51:55.362: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-fx5zk exposes endpoints map[] (1.003850349s elapsed)
+[AfterEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:51:55.382: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-fx5zk" for this suite.
+Nov 17 10:52:17.447: INFO: namespace: e2e-tests-services-fx5zk, resource: bindings, ignored listing per whitelist
+Nov 17 10:52:17.464: INFO: namespace e2e-tests-services-fx5zk deletion completed in 22.077039069s
+[AfterEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:64
+
+• [SLOW TEST:30.322 seconds]
+[sig-network] Services
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:131
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:267
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:52:17.464: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-pods-vgwrf
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:129
+[It] should be submitted and removed [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:267
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Nov 17 10:52:19.641: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-60fafd57-cb85-11e7-b2ab-c6826529d988", GenerateName:"", Namespace:"e2e-tests-pods-vgwrf", SelfLink:"/api/v1/namespaces/e2e-tests-pods-vgwrf/pods/pod-submit-remove-60fafd57-cb85-11e7-b2ab-c6826529d988", UID:"60fbeb36-cb85-11e7-a607-0283760d9af0", ResourceVersion:"10289", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{sec:63646512737, nsec:0, loc:(*time.Location)(0x5c785e0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"624003090"}, Annotations:map[string]string{"kubernetes.io/psp":"privileged"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-hkjdv", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc4215e3c40), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"gcr.io/google-containers/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-hkjdv", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(0xc4215e3cc0), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc42178ac18), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"ip-10-1-2-35.eu-central-1.compute.internal", HostNetwork:false, HostPID:false, HostIPC:false, SecurityContext:(*v1.PodSecurityContext)(0xc4215e3d00), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration(nil), HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{sec:0, nsec:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{sec:63646512737, nsec:0, loc:(*time.Location)(0x5c785e0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{sec:0, nsec:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{sec:63646512739, nsec:0, loc:(*time.Location)(0x5c785e0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{sec:0, nsec:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{sec:63646512737, nsec:0, loc:(*time.Location)(0x5c785e0)}}, Reason:"", Message:""}}, Message:"", Reason:"", HostIP:"10.1.2.35", PodIP:"192.168.118.46", StartTime:(*v1.Time)(0xc4210caa80), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc4210caaa0), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"gcr.io/google-containers/nginx-slim-amd64:0.20", ImageID:"docker-pullable://gcr.io/google-containers/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://74f59e446d7f7f5d7dab134d7b146368d36e3ace75d662528370bfd1f6d7a130"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:52:32.041: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-vgwrf" for this suite.
+Nov 17 10:52:38.076: INFO: namespace: e2e-tests-pods-vgwrf, resource: bindings, ignored listing per whitelist
+Nov 17 10:52:38.130: INFO: namespace e2e-tests-pods-vgwrf deletion completed in 6.085939867s
+
+• [SLOW TEST:20.665 seconds]
+[k8s.io] Pods
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be submitted and removed [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:267
+------------------------------
+SSSSSSS
+------------------------------
+[sig-network] Services 
+  should provide secure master service [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:71
+[BeforeEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:52:38.130: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-services-f6s2f
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:52
+[It] should provide secure master service [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:71
+[AfterEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:52:38.269: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-f6s2f" for this suite.
+Nov 17 10:52:44.333: INFO: namespace: e2e-tests-services-f6s2f, resource: bindings, ignored listing per whitelist
+Nov 17 10:52:44.349: INFO: namespace e2e-tests-services-f6s2f deletion completed in 6.076764681s
+[AfterEach] [sig-network] Services
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:64
+
+• [SLOW TEST:6.219 seconds]
+[sig-network] Services
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:71
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/kubelet_etc_hosts.go:57
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:52:44.349: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-e2e-kubelet-etc-hosts-8s9hk
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/kubelet_etc_hosts.go:57
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Nov 17 10:52:48.507: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8s9hk PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:52:48.507: INFO: >>> kubeConfig: 
+Nov 17 10:52:48.575: INFO: Exec stderr: ""
+Nov 17 10:52:48.575: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8s9hk PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:52:48.576: INFO: >>> kubeConfig: 
+Nov 17 10:52:48.642: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Nov 17 10:52:48.643: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8s9hk PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:52:48.643: INFO: >>> kubeConfig: 
+Nov 17 10:52:48.709: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Nov 17 10:52:48.709: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8s9hk PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:52:48.709: INFO: >>> kubeConfig: 
+Nov 17 10:52:48.785: INFO: Exec stderr: ""
+Nov 17 10:52:48.785: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8s9hk PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 17 10:52:48.785: INFO: >>> kubeConfig: 
+Nov 17 10:52:48.851: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:52:48.851: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-8s9hk" for this suite.
+Nov 17 10:53:26.925: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-8s9hk, resource: bindings, ignored listing per whitelist
+Nov 17 10:53:26.932: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-8s9hk deletion completed in 38.078297843s
+
+• [SLOW TEST:42.583 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should test kubelet managed /etc/hosts file [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/kubelet_etc_hosts.go:57
+------------------------------
+SS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:45
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:53:26.933: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-9zvnc
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:45
+STEP: Creating projection with secret that has name projected-secret-test-8a61ee5d-cb85-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:53:27.094: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-8a625e8e-cb85-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-9zvnc" to be "success or failure"
+Nov 17 10:53:27.097: INFO: Pod "pod-projected-secrets-8a625e8e-cb85-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.855216ms
+Nov 17 10:53:29.099: INFO: Pod "pod-projected-secrets-8a625e8e-cb85-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005174067s
+STEP: Saw pod success
+Nov 17 10:53:29.099: INFO: Pod "pod-projected-secrets-8a625e8e-cb85-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:53:29.101: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-secrets-8a625e8e-cb85-11e7-b2ab-c6826529d988 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:53:29.118: INFO: Waiting for pod pod-projected-secrets-8a625e8e-cb85-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:53:29.121: INFO: Pod pod-projected-secrets-8a625e8e-cb85-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:53:29.121: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-9zvnc" for this suite.
+Nov 17 10:53:35.179: INFO: namespace: e2e-tests-projected-9zvnc, resource: bindings, ignored listing per whitelist
+Nov 17 10:53:35.206: INFO: namespace e2e-tests-projected-9zvnc deletion completed in 6.082612808s
+
+• [SLOW TEST:8.273 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:45
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a docker exec liveness probe with timeout [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:267
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:53:35.206: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-container-probe-ld5rh
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] should be restarted with a docker exec liveness probe with timeout [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:267
+Nov 17 10:53:35.345: INFO: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:53:35.346: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-ld5rh" for this suite.
+Nov 17 10:53:41.406: INFO: namespace: e2e-tests-container-probe-ld5rh, resource: bindings, ignored listing per whitelist
+Nov 17 10:53:41.429: INFO: namespace e2e-tests-container-probe-ld5rh deletion completed in 6.080308707s
+
+S [SKIPPING] [6.223 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be restarted with a docker exec liveness probe with timeout [Conformance] [It]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:267
+
+  Nov 17 10:53:35.345: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:309
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:277
+[BeforeEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:53:41.429: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-proxy-h566l
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:277
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-5nk7v in namespace e2e-tests-proxy-h566l
+Nov 17 10:53:47.590: INFO: setup took 6.021587765s, starting test cases
+STEP: running 34 cases, 20 attempts per case, 680 total attempts
+Nov 17 10:53:47.604: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 14.122973ms)
+Nov 17 10:53:47.611: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 21.194281ms)
+Nov 17 10:53:47.615: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 22.406985ms)
+Nov 17 10:53:47.616: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 25.436068ms)
+Nov 17 10:53:47.617: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 25.869424ms)
+Nov 17 10:53:47.618: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 22.285132ms)
+Nov 17 10:53:47.618: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 22.544015ms)
+Nov 17 10:53:47.619: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 27.147419ms)
+Nov 17 10:53:47.624: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 28.852186ms)
+Nov 17 10:53:47.625: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 33.913017ms)
+Nov 17 10:53:47.625: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 29.861865ms)
+Nov 17 10:53:47.626: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 35.502509ms)
+Nov 17 10:53:47.626: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 29.982711ms)
+Nov 17 10:53:47.626: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 31.183426ms)
+Nov 17 10:53:47.632: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 36.540993ms)
+Nov 17 10:53:47.633: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 41.775844ms)
+Nov 17 10:53:47.633: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 43.313688ms)
+Nov 17 10:53:47.635: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 44.38831ms)
+Nov 17 10:53:47.636: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 46.447536ms)
+Nov 17 10:53:47.638: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 48.047383ms)
+Nov 17 10:53:47.639: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 46.317318ms)
+Nov 17 10:53:47.639: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 47.109026ms)
+Nov 17 10:53:47.639: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 47.432517ms)
+Nov 17 10:53:47.647: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 56.882176ms)
+Nov 17 10:53:47.648: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 51.820182ms)
+Nov 17 10:53:47.650: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 57.808328ms)
+Nov 17 10:53:47.651: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 58.352607ms)
+Nov 17 10:53:47.652: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 53.577169ms)
+Nov 17 10:53:47.653: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 53.603037ms)
+Nov 17 10:53:47.653: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 54.00408ms)
+Nov 17 10:53:47.654: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 62.989894ms)
+Nov 17 10:53:47.655: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 63.337563ms)
+Nov 17 10:53:47.656: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 64.069333ms)
+Nov 17 10:53:47.656: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 63.598297ms)
+Nov 17 10:53:47.669: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 12.759284ms)
+Nov 17 10:53:47.669: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 12.700119ms)
+Nov 17 10:53:47.680: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 22.214065ms)
+Nov 17 10:53:47.680: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 21.836287ms)
+Nov 17 10:53:47.680: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 24.684732ms)
+Nov 17 10:53:47.681: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 18.716583ms)
+Nov 17 10:53:47.681: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 24.410436ms)
+Nov 17 10:53:47.681: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 23.778089ms)
+Nov 17 10:53:47.681: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 18.758944ms)
+Nov 17 10:53:47.687: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 29.10442ms)
+Nov 17 10:53:47.687: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 29.896876ms)
+Nov 17 10:53:47.687: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 29.829135ms)
+Nov 17 10:53:47.688: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 30.659881ms)
+Nov 17 10:53:47.688: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 31.437659ms)
+Nov 17 10:53:47.688: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 30.214723ms)
+Nov 17 10:53:47.688: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 29.012919ms)
+Nov 17 10:53:47.688: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 29.688496ms)
+Nov 17 10:53:47.688: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 29.216753ms)
+Nov 17 10:53:47.688: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 30.623388ms)
+Nov 17 10:53:47.688: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 30.765705ms)
+Nov 17 10:53:47.688: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 30.062363ms)
+Nov 17 10:53:47.688: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 31.075769ms)
+Nov 17 10:53:47.688: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 31.373369ms)
+Nov 17 10:53:47.688: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 29.880499ms)
+Nov 17 10:53:47.690: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 31.728522ms)
+Nov 17 10:53:47.691: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 34.804876ms)
+Nov 17 10:53:47.692: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 33.023751ms)
+Nov 17 10:53:47.692: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 35.909047ms)
+Nov 17 10:53:47.692: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 35.644481ms)
+Nov 17 10:53:47.692: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 34.488079ms)
+Nov 17 10:53:47.692: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 35.620491ms)
+Nov 17 10:53:47.692: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 35.958312ms)
+Nov 17 10:53:47.692: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 34.292448ms)
+Nov 17 10:53:47.692: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 33.916574ms)
+Nov 17 10:53:47.700: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 7.106288ms)
+Nov 17 10:53:47.708: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 15.658108ms)
+Nov 17 10:53:47.708: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 15.882388ms)
+Nov 17 10:53:47.708: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 15.791044ms)
+Nov 17 10:53:47.709: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 15.021444ms)
+Nov 17 10:53:47.716: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 23.190335ms)
+Nov 17 10:53:47.716: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 22.302807ms)
+Nov 17 10:53:47.716: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 19.817821ms)
+Nov 17 10:53:47.719: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 25.346251ms)
+Nov 17 10:53:47.719: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 24.782288ms)
+Nov 17 10:53:47.719: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 22.733553ms)
+Nov 17 10:53:47.719: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 25.828835ms)
+Nov 17 10:53:47.719: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 22.998603ms)
+Nov 17 10:53:47.719: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 25.734755ms)
+Nov 17 10:53:47.727: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 30.38247ms)
+Nov 17 10:53:47.727: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 30.399752ms)
+Nov 17 10:53:47.727: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 31.145381ms)
+Nov 17 10:53:47.727: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 31.122828ms)
+Nov 17 10:53:47.727: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 30.841199ms)
+Nov 17 10:53:47.727: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 30.572051ms)
+Nov 17 10:53:47.727: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 34.035065ms)
+Nov 17 10:53:47.727: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 30.245952ms)
+Nov 17 10:53:47.727: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 31.275763ms)
+Nov 17 10:53:47.728: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 31.040022ms)
+Nov 17 10:53:47.728: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 31.231395ms)
+Nov 17 10:53:47.728: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 30.668134ms)
+Nov 17 10:53:47.728: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 30.895697ms)
+Nov 17 10:53:47.728: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 34.414301ms)
+Nov 17 10:53:47.728: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 31.071949ms)
+Nov 17 10:53:47.728: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 31.274921ms)
+Nov 17 10:53:47.728: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 31.682791ms)
+Nov 17 10:53:47.728: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 30.98787ms)
+Nov 17 10:53:47.728: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 31.102728ms)
+Nov 17 10:53:47.728: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 31.461391ms)
+Nov 17 10:53:47.742: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 13.591351ms)
+Nov 17 10:53:47.742: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 13.413836ms)
+Nov 17 10:53:47.742: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 13.982644ms)
+Nov 17 10:53:47.742: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 13.770756ms)
+Nov 17 10:53:47.742: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 13.751198ms)
+Nov 17 10:53:47.742: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 14.131569ms)
+Nov 17 10:53:47.746: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 17.666341ms)
+Nov 17 10:53:47.746: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 17.555235ms)
+Nov 17 10:53:47.756: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 24.806003ms)
+Nov 17 10:53:47.759: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 29.621731ms)
+Nov 17 10:53:47.759: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 28.224851ms)
+Nov 17 10:53:47.759: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 28.432314ms)
+Nov 17 10:53:47.759: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 30.608092ms)
+Nov 17 10:53:47.759: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 26.602484ms)
+Nov 17 10:53:47.759: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 28.883103ms)
+Nov 17 10:53:47.759: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 29.896154ms)
+Nov 17 10:53:47.759: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 28.141392ms)
+Nov 17 10:53:47.762: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 30.711259ms)
+Nov 17 10:53:47.762: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 33.005744ms)
+Nov 17 10:53:47.762: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 31.331102ms)
+Nov 17 10:53:47.762: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 29.010864ms)
+Nov 17 10:53:47.762: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 31.090294ms)
+Nov 17 10:53:47.762: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 30.677025ms)
+Nov 17 10:53:47.762: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 29.296662ms)
+Nov 17 10:53:47.762: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 30.5877ms)
+Nov 17 10:53:47.762: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 32.733693ms)
+Nov 17 10:53:47.762: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 30.092069ms)
+Nov 17 10:53:47.762: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 29.120203ms)
+Nov 17 10:53:47.762: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 30.182668ms)
+Nov 17 10:53:47.763: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 31.053125ms)
+Nov 17 10:53:47.764: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 31.843032ms)
+Nov 17 10:53:47.764: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 31.785222ms)
+Nov 17 10:53:47.764: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 34.796847ms)
+Nov 17 10:53:47.764: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 31.694131ms)
+Nov 17 10:53:47.777: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 12.014431ms)
+Nov 17 10:53:47.777: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 12.445786ms)
+Nov 17 10:53:47.777: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 12.24734ms)
+Nov 17 10:53:47.777: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 12.397588ms)
+Nov 17 10:53:47.782: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 17.956297ms)
+Nov 17 10:53:47.782: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 17.429987ms)
+Nov 17 10:53:47.787: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 22.482071ms)
+Nov 17 10:53:47.787: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 22.044745ms)
+Nov 17 10:53:47.787: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 22.31056ms)
+Nov 17 10:53:47.793: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 27.393622ms)
+Nov 17 10:53:47.793: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 28.367969ms)
+Nov 17 10:53:47.794: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 27.602151ms)
+Nov 17 10:53:47.794: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 28.236432ms)
+Nov 17 10:53:47.794: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 27.677692ms)
+Nov 17 10:53:47.794: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 27.502924ms)
+Nov 17 10:53:47.794: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 28.362617ms)
+Nov 17 10:53:47.794: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 27.957035ms)
+Nov 17 10:53:47.794: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 27.232333ms)
+Nov 17 10:53:47.794: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 27.533982ms)
+Nov 17 10:53:47.794: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 29.241571ms)
+Nov 17 10:53:47.794: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 28.376251ms)
+Nov 17 10:53:47.797: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 29.827914ms)
+Nov 17 10:53:47.797: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 30.306638ms)
+Nov 17 10:53:47.797: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 31.105407ms)
+Nov 17 10:53:47.797: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 31.240119ms)
+Nov 17 10:53:47.802: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 35.400962ms)
+Nov 17 10:53:47.802: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 34.839161ms)
+Nov 17 10:53:47.802: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 35.058831ms)
+Nov 17 10:53:47.802: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 35.463705ms)
+Nov 17 10:53:47.802: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 35.631351ms)
+Nov 17 10:53:47.802: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 35.882888ms)
+Nov 17 10:53:47.802: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 35.476189ms)
+Nov 17 10:53:47.802: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 35.545561ms)
+Nov 17 10:53:47.802: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 36.159511ms)
+Nov 17 10:53:47.827: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 24.430856ms)
+Nov 17 10:53:47.827: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 24.682627ms)
+Nov 17 10:53:47.827: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 24.578711ms)
+Nov 17 10:53:47.827: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 24.7077ms)
+Nov 17 10:53:47.827: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 23.316283ms)
+Nov 17 10:53:47.827: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 24.524369ms)
+Nov 17 10:53:47.827: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 23.462909ms)
+Nov 17 10:53:47.827: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 24.306902ms)
+Nov 17 10:53:47.827: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 23.261512ms)
+Nov 17 10:53:47.828: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 23.985934ms)
+Nov 17 10:53:47.828: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 22.408533ms)
+Nov 17 10:53:47.828: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 24.746827ms)
+Nov 17 10:53:47.828: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 24.394796ms)
+Nov 17 10:53:47.831: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 26.457103ms)
+Nov 17 10:53:47.831: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 26.038218ms)
+Nov 17 10:53:47.832: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 26.297159ms)
+Nov 17 10:53:47.832: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 27.743735ms)
+Nov 17 10:53:47.832: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 27.773571ms)
+Nov 17 10:53:47.832: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 27.591372ms)
+Nov 17 10:53:47.832: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 28.953331ms)
+Nov 17 10:53:47.832: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 28.819159ms)
+Nov 17 10:53:47.833: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 29.807969ms)
+Nov 17 10:53:47.833: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 28.515749ms)
+Nov 17 10:53:47.833: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 28.183676ms)
+Nov 17 10:53:47.833: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 27.698276ms)
+Nov 17 10:53:47.838: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 32.779569ms)
+Nov 17 10:53:47.838: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 32.641895ms)
+Nov 17 10:53:47.838: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 32.408409ms)
+Nov 17 10:53:47.839: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 32.091666ms)
+Nov 17 10:53:47.839: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 32.302901ms)
+Nov 17 10:53:47.839: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 33.029034ms)
+Nov 17 10:53:47.840: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 33.372572ms)
+Nov 17 10:53:47.840: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 37.813985ms)
+Nov 17 10:53:47.840: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 34.541819ms)
+Nov 17 10:53:47.865: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 24.215412ms)
+Nov 17 10:53:47.865: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 24.626898ms)
+Nov 17 10:53:47.865: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 23.50042ms)
+Nov 17 10:53:47.865: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 21.918086ms)
+Nov 17 10:53:47.865: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 24.380675ms)
+Nov 17 10:53:47.867: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 23.667471ms)
+Nov 17 10:53:47.867: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 23.940937ms)
+Nov 17 10:53:47.867: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 24.291863ms)
+Nov 17 10:53:47.867: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 25.247474ms)
+Nov 17 10:53:47.867: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 24.269054ms)
+Nov 17 10:53:47.867: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 24.517561ms)
+Nov 17 10:53:47.867: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 25.50043ms)
+Nov 17 10:53:47.874: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 33.45548ms)
+Nov 17 10:53:47.874: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 33.064958ms)
+Nov 17 10:53:47.874: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 32.015359ms)
+Nov 17 10:53:47.874: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 31.450678ms)
+Nov 17 10:53:47.874: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 30.927351ms)
+Nov 17 10:53:47.874: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 30.849189ms)
+Nov 17 10:53:47.874: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 32.860282ms)
+Nov 17 10:53:47.875: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 31.355929ms)
+Nov 17 10:53:47.875: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 33.86617ms)
+Nov 17 10:53:47.875: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 34.012241ms)
+Nov 17 10:53:47.875: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 31.762205ms)
+Nov 17 10:53:47.875: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 32.962232ms)
+Nov 17 10:53:47.875: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 31.507144ms)
+Nov 17 10:53:47.875: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 31.193855ms)
+Nov 17 10:53:47.875: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 31.179737ms)
+Nov 17 10:53:47.875: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 32.821576ms)
+Nov 17 10:53:47.875: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 33.645138ms)
+Nov 17 10:53:47.875: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 31.677545ms)
+Nov 17 10:53:47.876: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 31.303802ms)
+Nov 17 10:53:47.876: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 31.704568ms)
+Nov 17 10:53:47.876: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 34.01911ms)
+Nov 17 10:53:47.876: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 32.597279ms)
+Nov 17 10:53:47.902: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 25.137635ms)
+Nov 17 10:53:47.902: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 25.795526ms)
+Nov 17 10:53:47.902: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 24.994142ms)
+Nov 17 10:53:47.902: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 25.424074ms)
+Nov 17 10:53:47.902: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 24.871306ms)
+Nov 17 10:53:47.902: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 26.512238ms)
+Nov 17 10:53:47.902: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 26.402651ms)
+Nov 17 10:53:47.902: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 25.932566ms)
+Nov 17 10:53:47.908: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 29.583157ms)
+Nov 17 10:53:47.908: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 31.23708ms)
+Nov 17 10:53:47.908: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 32.153594ms)
+Nov 17 10:53:47.908: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 30.171446ms)
+Nov 17 10:53:47.908: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 30.712246ms)
+Nov 17 10:53:47.908: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 29.701576ms)
+Nov 17 10:53:47.908: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 30.904158ms)
+Nov 17 10:53:47.909: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 29.664563ms)
+Nov 17 10:53:47.909: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 30.780006ms)
+Nov 17 10:53:47.909: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 30.561691ms)
+Nov 17 10:53:47.909: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 31.406185ms)
+Nov 17 10:53:47.909: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 30.77271ms)
+Nov 17 10:53:47.910: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 33.113708ms)
+Nov 17 10:53:47.910: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 33.606535ms)
+Nov 17 10:53:47.910: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 31.643018ms)
+Nov 17 10:53:47.911: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 31.493158ms)
+Nov 17 10:53:47.911: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 32.120322ms)
+Nov 17 10:53:47.912: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 33.392583ms)
+Nov 17 10:53:47.912: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 32.500981ms)
+Nov 17 10:53:47.912: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 34.493978ms)
+Nov 17 10:53:47.913: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 33.427059ms)
+Nov 17 10:53:47.913: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 35.593822ms)
+Nov 17 10:53:47.915: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 35.294788ms)
+Nov 17 10:53:47.915: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 35.41479ms)
+Nov 17 10:53:47.915: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 36.476924ms)
+Nov 17 10:53:47.915: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 35.932305ms)
+Nov 17 10:53:47.933: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 17.083915ms)
+Nov 17 10:53:47.934: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 16.670942ms)
+Nov 17 10:53:47.934: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 16.785506ms)
+Nov 17 10:53:47.934: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 17.2794ms)
+Nov 17 10:53:47.935: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 17.610877ms)
+Nov 17 10:53:47.935: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 17.945762ms)
+Nov 17 10:53:47.935: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 17.765114ms)
+Nov 17 10:53:47.935: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 17.409596ms)
+Nov 17 10:53:47.938: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 20.19444ms)
+Nov 17 10:53:47.938: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 20.164372ms)
+Nov 17 10:53:47.938: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 19.706984ms)
+Nov 17 10:53:47.941: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 23.956513ms)
+Nov 17 10:53:47.941: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 23.12508ms)
+Nov 17 10:53:47.941: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 23.048626ms)
+Nov 17 10:53:47.942: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 24.152727ms)
+Nov 17 10:53:47.942: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 24.503114ms)
+Nov 17 10:53:47.942: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 24.286775ms)
+Nov 17 10:53:47.942: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 23.826287ms)
+Nov 17 10:53:47.942: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 26.193124ms)
+Nov 17 10:53:47.942: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 24.006413ms)
+Nov 17 10:53:47.945: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 28.468413ms)
+Nov 17 10:53:47.945: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 26.488929ms)
+Nov 17 10:53:47.948: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 31.600982ms)
+Nov 17 10:53:47.948: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 31.950517ms)
+Nov 17 10:53:47.951: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 34.128878ms)
+Nov 17 10:53:47.951: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 32.646377ms)
+Nov 17 10:53:47.951: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 34.596026ms)
+Nov 17 10:53:47.951: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 34.610911ms)
+Nov 17 10:53:47.951: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 34.920486ms)
+Nov 17 10:53:47.951: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 35.030432ms)
+Nov 17 10:53:47.952: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 35.702609ms)
+Nov 17 10:53:47.952: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 35.323274ms)
+Nov 17 10:53:47.952: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 35.472893ms)
+Nov 17 10:53:47.952: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 36.09725ms)
+Nov 17 10:53:47.976: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 24.339968ms)
+Nov 17 10:53:47.976: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 24.694995ms)
+Nov 17 10:53:47.976: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 24.681095ms)
+Nov 17 10:53:47.977: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 24.277322ms)
+Nov 17 10:53:47.977: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 24.38264ms)
+Nov 17 10:53:47.977: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 24.525422ms)
+Nov 17 10:53:47.977: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 24.801556ms)
+Nov 17 10:53:47.977: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 25.06669ms)
+Nov 17 10:53:47.977: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 24.745384ms)
+Nov 17 10:53:47.981: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 28.378465ms)
+Nov 17 10:53:47.983: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 20.952465ms)
+Nov 17 10:53:47.983: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 30.415932ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 30.406459ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 21.184543ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 20.493772ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 31.11137ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 24.649974ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 31.249122ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 21.291337ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 21.261383ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 21.65785ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 31.107184ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 31.087541ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 24.773216ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 24.669679ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 24.357223ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 31.123667ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 24.57894ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 31.405008ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 22.198773ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 32.590233ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 31.21746ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 21.559954ms)
+Nov 17 10:53:47.984: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 31.671144ms)
+Nov 17 10:53:47.992: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 7.66634ms)
+Nov 17 10:53:48.011: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 23.547564ms)
+Nov 17 10:53:48.011: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 24.490056ms)
+Nov 17 10:53:48.011: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 24.705557ms)
+Nov 17 10:53:48.011: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 24.48513ms)
+Nov 17 10:53:48.011: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 26.064129ms)
+Nov 17 10:53:48.011: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 25.703214ms)
+Nov 17 10:53:48.013: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 28.249417ms)
+Nov 17 10:53:48.014: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 28.52106ms)
+Nov 17 10:53:48.016: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 29.989713ms)
+Nov 17 10:53:48.020: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 34.557205ms)
+Nov 17 10:53:48.020: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 34.411478ms)
+Nov 17 10:53:48.020: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 32.532758ms)
+Nov 17 10:53:48.020: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 33.355084ms)
+Nov 17 10:53:48.020: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 33.728631ms)
+Nov 17 10:53:48.020: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 33.166986ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 32.369724ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 33.469717ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 32.377635ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 32.656664ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 32.995749ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 32.569391ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 32.606067ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 31.776589ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 33.22931ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 32.757168ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 31.573595ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 35.55141ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 31.805123ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 33.134017ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 32.844848ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 33.161111ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 33.712276ms)
+Nov 17 10:53:48.021: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 34.720982ms)
+Nov 17 10:53:48.024: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 2.697356ms)
+Nov 17 10:53:48.039: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 17.181347ms)
+Nov 17 10:53:48.051: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 28.643781ms)
+Nov 17 10:53:48.054: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 31.423814ms)
+Nov 17 10:53:48.054: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 31.504087ms)
+Nov 17 10:53:48.058: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 35.572705ms)
+Nov 17 10:53:48.059: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 36.811333ms)
+Nov 17 10:53:48.059: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 35.655164ms)
+Nov 17 10:53:48.059: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 36.643446ms)
+Nov 17 10:53:48.060: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 37.357835ms)
+Nov 17 10:53:48.060: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 37.920174ms)
+Nov 17 10:53:48.060: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 37.217289ms)
+Nov 17 10:53:48.061: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 37.057707ms)
+Nov 17 10:53:48.061: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 36.657311ms)
+Nov 17 10:53:48.061: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 37.464648ms)
+Nov 17 10:53:48.061: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 37.858102ms)
+Nov 17 10:53:48.061: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 37.781974ms)
+Nov 17 10:53:48.061: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 37.922751ms)
+Nov 17 10:53:48.061: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 37.920779ms)
+Nov 17 10:53:48.061: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 38.169449ms)
+Nov 17 10:53:48.061: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 38.42976ms)
+Nov 17 10:53:48.061: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 38.605934ms)
+Nov 17 10:53:48.061: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 38.444814ms)
+Nov 17 10:53:48.061: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 38.015502ms)
+Nov 17 10:53:48.062: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 38.264048ms)
+Nov 17 10:53:48.062: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 37.806512ms)
+Nov 17 10:53:48.062: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 37.851999ms)
+Nov 17 10:53:48.062: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 39.083102ms)
+Nov 17 10:53:48.062: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 38.692132ms)
+Nov 17 10:53:48.062: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 38.188405ms)
+Nov 17 10:53:48.062: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 38.220799ms)
+Nov 17 10:53:48.062: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 37.978174ms)
+Nov 17 10:53:48.062: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 38.807593ms)
+Nov 17 10:53:48.062: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 38.106725ms)
+Nov 17 10:53:48.072: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 9.705918ms)
+Nov 17 10:53:48.073: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 10.908033ms)
+Nov 17 10:53:48.073: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 10.430278ms)
+Nov 17 10:53:48.073: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 10.285243ms)
+Nov 17 10:53:48.073: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 10.267677ms)
+Nov 17 10:53:48.073: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 10.407407ms)
+Nov 17 10:53:48.073: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 10.507172ms)
+Nov 17 10:53:48.092: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 28.847312ms)
+Nov 17 10:53:48.092: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 28.656931ms)
+Nov 17 10:53:48.092: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 28.841065ms)
+Nov 17 10:53:48.092: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 28.537762ms)
+Nov 17 10:53:48.099: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 34.761085ms)
+Nov 17 10:53:48.099: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 36.087802ms)
+Nov 17 10:53:48.099: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 35.280584ms)
+Nov 17 10:53:48.099: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 35.507403ms)
+Nov 17 10:53:48.099: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 35.597697ms)
+Nov 17 10:53:48.099: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 35.035783ms)
+Nov 17 10:53:48.099: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 35.975277ms)
+Nov 17 10:53:48.099: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 35.658382ms)
+Nov 17 10:53:48.099: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 35.839424ms)
+Nov 17 10:53:48.099: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 35.815947ms)
+Nov 17 10:53:48.100: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 35.764789ms)
+Nov 17 10:53:48.100: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 35.688417ms)
+Nov 17 10:53:48.100: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 36.492615ms)
+Nov 17 10:53:48.100: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 35.945646ms)
+Nov 17 10:53:48.100: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 36.511062ms)
+Nov 17 10:53:48.100: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 35.831022ms)
+Nov 17 10:53:48.100: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 36.553332ms)
+Nov 17 10:53:48.100: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 35.998297ms)
+Nov 17 10:53:48.100: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 36.220939ms)
+Nov 17 10:53:48.100: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 36.609004ms)
+Nov 17 10:53:48.100: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 36.131001ms)
+Nov 17 10:53:48.100: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 37.195616ms)
+Nov 17 10:53:48.101: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 37.529402ms)
+Nov 17 10:53:48.108: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 7.256273ms)
+Nov 17 10:53:48.136: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 35.30027ms)
+Nov 17 10:53:48.136: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 34.851294ms)
+Nov 17 10:53:48.136: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 35.19467ms)
+Nov 17 10:53:48.136: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 35.108163ms)
+Nov 17 10:53:48.137: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 31.787442ms)
+Nov 17 10:53:48.137: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 32.787093ms)
+Nov 17 10:53:48.137: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 32.538196ms)
+Nov 17 10:53:48.137: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 32.495846ms)
+Nov 17 10:53:48.137: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 31.800726ms)
+Nov 17 10:53:48.137: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 33.073807ms)
+Nov 17 10:53:48.137: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 32.004043ms)
+Nov 17 10:53:48.137: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 33.001388ms)
+Nov 17 10:53:48.138: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 32.022759ms)
+Nov 17 10:53:48.138: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 36.989571ms)
+Nov 17 10:53:48.138: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 31.968571ms)
+Nov 17 10:53:48.138: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 32.710468ms)
+Nov 17 10:53:48.138: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 33.138272ms)
+Nov 17 10:53:48.138: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 31.963096ms)
+Nov 17 10:53:48.138: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 30.996137ms)
+Nov 17 10:53:48.138: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 31.793493ms)
+Nov 17 10:53:48.138: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 31.7885ms)
+Nov 17 10:53:48.138: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 31.734937ms)
+Nov 17 10:53:48.138: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 31.922743ms)
+Nov 17 10:53:48.138: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 33.326542ms)
+Nov 17 10:53:48.139: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 32.123329ms)
+Nov 17 10:53:48.139: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 32.663756ms)
+Nov 17 10:53:48.139: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 34.040433ms)
+Nov 17 10:53:48.139: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 32.547941ms)
+Nov 17 10:53:48.139: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 31.704605ms)
+Nov 17 10:53:48.139: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 31.67963ms)
+Nov 17 10:53:48.139: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 32.698005ms)
+Nov 17 10:53:48.139: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 32.501398ms)
+Nov 17 10:53:48.139: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 33.198778ms)
+Nov 17 10:53:48.167: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 25.68958ms)
+Nov 17 10:53:48.172: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 31.894839ms)
+Nov 17 10:53:48.172: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 31.280171ms)
+Nov 17 10:53:48.172: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 31.169714ms)
+Nov 17 10:53:48.172: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 31.710923ms)
+Nov 17 10:53:48.172: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 32.607128ms)
+Nov 17 10:53:48.172: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 30.213792ms)
+Nov 17 10:53:48.172: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 30.678655ms)
+Nov 17 10:53:48.174: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 31.20472ms)
+Nov 17 10:53:48.174: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 33.034925ms)
+Nov 17 10:53:48.174: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 34.340111ms)
+Nov 17 10:53:48.174: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 34.126063ms)
+Nov 17 10:53:48.174: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 32.660929ms)
+Nov 17 10:53:48.174: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 31.990935ms)
+Nov 17 10:53:48.174: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 32.314938ms)
+Nov 17 10:53:48.175: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 34.614873ms)
+Nov 17 10:53:48.175: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 33.039216ms)
+Nov 17 10:53:48.175: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 33.662229ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 31.831023ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 34.89971ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 36.345803ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 34.762151ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 36.736287ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 32.303431ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 33.046625ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 33.410245ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 32.761922ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 33.277335ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 32.748516ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 32.42134ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 32.168103ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 32.904888ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 33.035793ms)
+Nov 17 10:53:48.176: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 31.838672ms)
+Nov 17 10:53:48.187: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 10.000613ms)
+Nov 17 10:53:48.187: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 10.277792ms)
+Nov 17 10:53:48.187: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 9.971237ms)
+Nov 17 10:53:48.193: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 16.261013ms)
+Nov 17 10:53:48.198: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 21.553897ms)
+Nov 17 10:53:48.202: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 23.825035ms)
+Nov 17 10:53:48.202: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 23.496766ms)
+Nov 17 10:53:48.202: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 23.763798ms)
+Nov 17 10:53:48.202: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 24.041961ms)
+Nov 17 10:53:48.202: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 23.478663ms)
+Nov 17 10:53:48.202: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 24.009722ms)
+Nov 17 10:53:48.202: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 23.436807ms)
+Nov 17 10:53:48.202: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 23.820041ms)
+Nov 17 10:53:48.202: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 24.209393ms)
+Nov 17 10:53:48.202: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 23.816558ms)
+Nov 17 10:53:48.202: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 24.082035ms)
+Nov 17 10:53:48.202: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 24.431458ms)
+Nov 17 10:53:48.203: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 23.813339ms)
+Nov 17 10:53:48.207: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 29.076915ms)
+Nov 17 10:53:48.207: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 28.236032ms)
+Nov 17 10:53:48.207: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 26.46472ms)
+Nov 17 10:53:48.207: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 26.891045ms)
+Nov 17 10:53:48.207: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 27.419559ms)
+Nov 17 10:53:48.207: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 27.33635ms)
+Nov 17 10:53:48.208: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 27.251285ms)
+Nov 17 10:53:48.208: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 28.983067ms)
+Nov 17 10:53:48.213: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 32.463978ms)
+Nov 17 10:53:48.213: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 32.626688ms)
+Nov 17 10:53:48.213: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 33.294231ms)
+Nov 17 10:53:48.213: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 34.935119ms)
+Nov 17 10:53:48.213: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 32.919637ms)
+Nov 17 10:53:48.213: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 34.514583ms)
+Nov 17 10:53:48.213: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 35.202547ms)
+Nov 17 10:53:48.213: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 33.087772ms)
+Nov 17 10:53:48.218: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 3.830122ms)
+Nov 17 10:53:48.218: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 4.521077ms)
+Nov 17 10:53:48.227: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 13.207961ms)
+Nov 17 10:53:48.227: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 11.484583ms)
+Nov 17 10:53:48.227: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 11.424186ms)
+Nov 17 10:53:48.235: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 18.87361ms)
+Nov 17 10:53:48.235: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 19.047737ms)
+Nov 17 10:53:48.236: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 18.877302ms)
+Nov 17 10:53:48.236: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 20.089971ms)
+Nov 17 10:53:48.236: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 19.41388ms)
+Nov 17 10:53:48.236: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 19.45878ms)
+Nov 17 10:53:48.236: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 19.672582ms)
+Nov 17 10:53:48.241: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 23.928166ms)
+Nov 17 10:53:48.241: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 24.825542ms)
+Nov 17 10:53:48.241: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 24.708311ms)
+Nov 17 10:53:48.241: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 24.940857ms)
+Nov 17 10:53:48.243: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 27.415693ms)
+Nov 17 10:53:48.243: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 26.683478ms)
+Nov 17 10:53:48.247: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 30.670859ms)
+Nov 17 10:53:48.247: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 21.955796ms)
+Nov 17 10:53:48.247: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 22.370885ms)
+Nov 17 10:53:48.247: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 27.913681ms)
+Nov 17 10:53:48.247: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 22.018946ms)
+Nov 17 10:53:48.248: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 29.434538ms)
+Nov 17 10:53:48.250: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 24.584359ms)
+Nov 17 10:53:48.250: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 24.590226ms)
+Nov 17 10:53:48.250: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 25.38938ms)
+Nov 17 10:53:48.250: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 24.922338ms)
+Nov 17 10:53:48.251: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 25.735315ms)
+Nov 17 10:53:48.251: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 25.922149ms)
+Nov 17 10:53:48.251: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 25.952456ms)
+Nov 17 10:53:48.251: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 26.07295ms)
+Nov 17 10:53:48.251: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 26.060871ms)
+Nov 17 10:53:48.247: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 21.796665ms)
+Nov 17 10:53:48.265: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 13.46289ms)
+Nov 17 10:53:48.265: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 13.086673ms)
+Nov 17 10:53:48.275: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 23.059862ms)
+Nov 17 10:53:48.276: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 23.325465ms)
+Nov 17 10:53:48.276: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 23.056906ms)
+Nov 17 10:53:48.277: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 23.288999ms)
+Nov 17 10:53:48.277: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 25.291509ms)
+Nov 17 10:53:48.277: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 24.175135ms)
+Nov 17 10:53:48.277: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 25.620553ms)
+Nov 17 10:53:48.277: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 22.999302ms)
+Nov 17 10:53:48.278: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 22.176002ms)
+Nov 17 10:53:48.278: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 23.278667ms)
+Nov 17 10:53:48.279: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 23.86607ms)
+Nov 17 10:53:48.280: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 25.744913ms)
+Nov 17 10:53:48.281: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 24.974759ms)
+Nov 17 10:53:48.289: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 35.755891ms)
+Nov 17 10:53:48.289: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 37.077035ms)
+Nov 17 10:53:48.289: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 36.736338ms)
+Nov 17 10:53:48.289: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 36.942669ms)
+Nov 17 10:53:48.289: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 36.861653ms)
+Nov 17 10:53:48.289: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 34.433535ms)
+Nov 17 10:53:48.289: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 36.088828ms)
+Nov 17 10:53:48.290: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 35.120202ms)
+Nov 17 10:53:48.290: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 36.659179ms)
+Nov 17 10:53:48.290: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 33.781985ms)
+Nov 17 10:53:48.290: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 35.002303ms)
+Nov 17 10:53:48.290: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 33.96545ms)
+Nov 17 10:53:48.290: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 36.619628ms)
+Nov 17 10:53:48.290: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 34.493ms)
+Nov 17 10:53:48.290: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 35.035627ms)
+Nov 17 10:53:48.290: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 36.664655ms)
+Nov 17 10:53:48.290: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 36.980036ms)
+Nov 17 10:53:48.290: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 36.908195ms)
+Nov 17 10:53:48.290: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 37.004802ms)
+Nov 17 10:53:48.315: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 24.564019ms)
+Nov 17 10:53:48.315: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 24.549388ms)
+Nov 17 10:53:48.323: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 29.843869ms)
+Nov 17 10:53:48.323: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 32.510311ms)
+Nov 17 10:53:48.323: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 32.622269ms)
+Nov 17 10:53:48.324: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 32.417816ms)
+Nov 17 10:53:48.324: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 33.189165ms)
+Nov 17 10:53:48.324: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 32.41428ms)
+Nov 17 10:53:48.324: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 30.234478ms)
+Nov 17 10:53:48.324: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 31.734367ms)
+Nov 17 10:53:48.324: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 32.44392ms)
+Nov 17 10:53:48.324: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 32.339339ms)
+Nov 17 10:53:48.324: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 32.155311ms)
+Nov 17 10:53:48.324: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 32.1236ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 35.337123ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 38.01757ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 38.1297ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 36.551725ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 38.036647ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 36.471731ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 32.071115ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 38.577395ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 36.161301ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 37.61551ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 37.980931ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 37.196114ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 36.463241ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 38.161076ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 38.366726ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 37.689131ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 32.540523ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 36.325892ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 37.711038ms)
+Nov 17 10:53:48.329: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 36.896862ms)
+Nov 17 10:53:48.353: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx/proxy/rewriteme"... (200; 23.725383ms)
+Nov 17 10:53:48.355: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:460/proxy/: tls baz (200; 25.458393ms)
+Nov 17 10:53:48.357: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:462/proxy/: tls qux (200; 27.09158ms)
+Nov 17 10:53:48.363: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/https:proxy-service-5nk7v-bk6mx:443/proxy/... (200; 32.260486ms)
+Nov 17 10:53:48.363: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 32.012807ms)
+Nov 17 10:53:48.363: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/proxy/rewri... (200; 32.562983ms)
+Nov 17 10:53:48.363: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/... (200; 32.897032ms)
+Nov 17 10:53:48.363: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:160/: foo (200; 32.283787ms)
+Nov 17 10:53:48.363: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/: tls qux (200; 32.014866ms)
+Nov 17 10:53:48.363: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname2/proxy/: tls qux (200; 31.992517ms)
+Nov 17 10:53:48.363: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/: tls baz (200; 32.946187ms)
+Nov 17 10:53:48.363: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/: bar (200; 31.944985ms)
+Nov 17 10:53:48.363: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:80/: foo (200; 31.643284ms)
+Nov 17 10:53:48.365: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/: bar (200; 33.646987ms)
+Nov 17 10:53:48.365: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:444/: tls qux (200; 34.902789ms)
+Nov 17 10:53:48.365: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:81/: bar (200; 33.725347ms)
+Nov 17 10:53:48.367: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:80/: foo (200; 36.399854ms)
+Nov 17 10:53:48.367: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/proxy/: bar (200; 35.732205ms)
+Nov 17 10:53:48.368: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 38.186116ms)
+Nov 17 10:53:48.368: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname2/proxy/: bar (200; 37.320347ms)
+Nov 17 10:53:48.368: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/proxy/: foo (200; 36.37449ms)
+Nov 17 10:53:48.368: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:162/: bar (200; 36.65597ms)
+Nov 17 10:53:48.368: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:162/proxy/: bar (200; 36.743076ms)
+Nov 17 10:53:48.368: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/: foo (200; 38.656831ms)
+Nov 17 10:53:48.369: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-h566l/pods/http:proxy-service-5nk7v-bk6mx:1080/proxy/... (200; 37.964994ms)
+Nov 17 10:53:48.369: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/: foo (200; 37.547581ms)
+Nov 17 10:53:48.369: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname2/: bar (200; 38.226489ms)
+Nov 17 10:53:48.369: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:160/: foo (200; 37.713769ms)
+Nov 17 10:53:48.369: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/services/proxy-service-5nk7v:portname1/proxy/: foo (200; 39.069831ms)
+Nov 17 10:53:48.369: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:portname1/proxy/: foo (200; 37.805826ms)
+Nov 17 10:53:48.370: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-h566l/pods/proxy-service-5nk7v-bk6mx:1080/rewri... (200; 37.888451ms)
+Nov 17 10:53:48.370: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:tlsportname1/proxy/: tls baz (200; 38.132528ms)
+Nov 17 10:53:48.370: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/http:proxy-service-5nk7v:81/: bar (200; 38.786148ms)
+Nov 17 10:53:48.370: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-h566l/services/https:proxy-service-5nk7v:443/: tls baz (200; 38.260961ms)
+STEP: deleting { ReplicationController} proxy-service-5nk7v in namespace e2e-tests-proxy-h566l
+Nov 17 10:53:48.513: INFO: Deleting { ReplicationController} proxy-service-5nk7v took: 41.142916ms
+Nov 17 10:53:48.513: INFO: Terminating { ReplicationController} proxy-service-5nk7v pods took: 36.576µs
+Nov 17 10:53:52.113: INFO: Garbage collecting { ReplicationController} proxy-service-5nk7v pods took: 3.641319272s
+[AfterEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:53:52.113: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-h566l" for this suite.
+Nov 17 10:53:58.143: INFO: namespace: e2e-tests-proxy-h566l, resource: bindings, ignored listing per whitelist
+Nov 17 10:53:58.192: INFO: namespace e2e-tests-proxy-h566l deletion completed in 6.076401319s
+
+• [SLOW TEST:16.763 seconds]
+[sig-network] Proxy
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:278
+    should proxy through a service and a pod [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:277
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:52
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:53:58.193: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-6rj7c
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:52
+STEP: Creating projection with secret that has name projected-secret-test-9d0181fc-cb85-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:53:58.369: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-9d047898-cb85-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-6rj7c" to be "success or failure"
+Nov 17 10:53:58.372: INFO: Pod "pod-projected-secrets-9d047898-cb85-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.722067ms
+Nov 17 10:54:00.374: INFO: Pod "pod-projected-secrets-9d047898-cb85-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005085394s
+STEP: Saw pod success
+Nov 17 10:54:00.374: INFO: Pod "pod-projected-secrets-9d047898-cb85-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:54:00.376: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-secrets-9d047898-cb85-11e7-b2ab-c6826529d988 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:54:00.390: INFO: Waiting for pod pod-projected-secrets-9d047898-cb85-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:54:00.392: INFO: Pod pod-projected-secrets-9d047898-cb85-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:54:00.392: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6rj7c" for this suite.
+Nov 17 10:54:06.424: INFO: namespace: e2e-tests-projected-6rj7c, resource: bindings, ignored listing per whitelist
+Nov 17 10:54:06.475: INFO: namespace e2e-tests-projected-6rj7c deletion completed in 6.080696749s
+
+• [SLOW TEST:8.283 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:52
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:943
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:54:06.476: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-q6qgl
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:943
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:54:06.617: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a1f1322a-cb85-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-q6qgl" to be "success or failure"
+Nov 17 10:54:06.621: INFO: Pod "downwardapi-volume-a1f1322a-cb85-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.454093ms
+Nov 17 10:54:08.623: INFO: Pod "downwardapi-volume-a1f1322a-cb85-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005802945s
+STEP: Saw pod success
+Nov 17 10:54:08.623: INFO: Pod "downwardapi-volume-a1f1322a-cb85-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:54:08.625: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downwardapi-volume-a1f1322a-cb85-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:54:08.638: INFO: Waiting for pod downwardapi-volume-a1f1322a-cb85-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:54:08.640: INFO: Pod downwardapi-volume-a1f1322a-cb85-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:54:08.640: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-q6qgl" for this suite.
+Nov 17 10:54:14.690: INFO: namespace: e2e-tests-projected-q6qgl, resource: bindings, ignored listing per whitelist
+Nov 17 10:54:14.717: INFO: namespace e2e-tests-projected-q6qgl deletion completed in 6.07424501s
+
+• [SLOW TEST:8.241 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:943
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:237
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:54:14.717: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-container-probe-hp2dh
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:50
+[It] should *not* be restarted with a /healthz http liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:237
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-hp2dh
+Nov 17 10:54:16.865: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-hp2dh
+STEP: checking the pod's current state and verifying that restartCount is present
+Nov 17 10:54:16.867: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:56:17.008: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-hp2dh" for this suite.
+Nov 17 10:56:23.042: INFO: namespace: e2e-tests-container-probe-hp2dh, resource: bindings, ignored listing per whitelist
+Nov 17 10:56:23.088: INFO: namespace e2e-tests-container-probe-hp2dh deletion completed in 6.075759195s
+
+• [SLOW TEST:128.370 seconds]
+[k8s.io] Probing container
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should *not* be restarted with a /healthz http liveness probe [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:237
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/events.go:129
+[BeforeEach] [k8s.io] Events
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:56:23.088: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-events-xwg8m
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/events.go:129
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-f35f2d55-cb85-11e7-b2ab-c6826529d988,GenerateName:,Namespace:e2e-tests-events-xwg8m,SelfLink:/api/v1/namespaces/e2e-tests-events-xwg8m/pods/send-events-f35f2d55-cb85-11e7-b2ab-c6826529d988,UID:f35fd6fd-cb85-11e7-a607-0283760d9af0,ResourceVersion:10973,Generation:0,CreationTimestamp:2017-11-17 10:56:23 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 227945632,},Annotations:map[string]string{kubernetes.io/psp: privileged,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-t2l7c {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-t2l7c,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-t2l7c true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] nil nil nil /dev/termination-log File IfNotPresent SecurityContext{Capabilities:nil,Privileged:*false,SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,ReadOnlyRootFilesystem:nil,AllowPrivilegeEscalation:nil,} false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:ip-10-1-2-35.eu-central-1.compute.internal,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[],HostAliases:[],PriorityClassName:,Priority:nil,},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2017-11-17 10:56:23 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2017-11-17 10:56:24 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2017-11-17 10:56:23 +0000 UTC  }],Message:,Reason:,HostIP:10.1.2.35,PodIP:192.168.118.53,StartTime:2017-11-17 10:56:23 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2017-11-17 10:56:24 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://26db8ba7a97dac74011b8208cdfdd7029a910a23f2168622cbb94a65e9e4e306}],QOSClass:BestEffort,InitContainerStatuses:[],},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] Events
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:56:29.256: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-xwg8m" for this suite.
+Nov 17 10:56:35.295: INFO: namespace: e2e-tests-events-xwg8m, resource: bindings, ignored listing per whitelist
+Nov 17 10:56:35.342: INFO: namespace e2e-tests-events-xwg8m deletion completed in 6.083512011s
+
+• [SLOW TEST:12.254 seconds]
+[k8s.io] Events
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be sent by kubelets and the scheduler about pods scheduling and running [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/events.go:129
+------------------------------
+SSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:66
+[BeforeEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:56:35.342: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-proxy-n8xc8
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:66
+Nov 17 10:56:35.486: INFO: (0) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.883164ms)
+Nov 17 10:56:35.488: INFO: (1) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.37939ms)
+Nov 17 10:56:35.490: INFO: (2) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.336166ms)
+Nov 17 10:56:35.493: INFO: (3) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.456329ms)
+Nov 17 10:56:35.495: INFO: (4) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.18997ms)
+Nov 17 10:56:35.498: INFO: (5) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.300304ms)
+Nov 17 10:56:35.501: INFO: (6) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.054649ms)
+Nov 17 10:56:35.503: INFO: (7) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.329868ms)
+Nov 17 10:56:35.505: INFO: (8) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.379185ms)
+Nov 17 10:56:35.508: INFO: (9) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.161669ms)
+Nov 17 10:56:35.510: INFO: (10) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.190992ms)
+Nov 17 10:56:35.512: INFO: (11) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.26943ms)
+Nov 17 10:56:35.514: INFO: (12) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.188882ms)
+Nov 17 10:56:35.517: INFO: (13) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.341399ms)
+Nov 17 10:56:35.519: INFO: (14) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.180725ms)
+Nov 17 10:56:35.521: INFO: (15) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.179293ms)
+Nov 17 10:56:35.523: INFO: (16) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.234892ms)
+Nov 17 10:56:35.526: INFO: (17) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.222388ms)
+Nov 17 10:56:35.528: INFO: (18) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.336421ms)
+Nov 17 10:56:35.530: INFO: (19) /api/v1/proxy/nodes/ip-10-1-2-110.eu-central-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.297924ms)
+[AfterEach] version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:56:35.530: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-n8xc8" for this suite.
+Nov 17 10:56:41.581: INFO: namespace: e2e-tests-proxy-n8xc8, resource: bindings, ignored listing per whitelist
+Nov 17 10:56:41.611: INFO: namespace e2e-tests-proxy-n8xc8 deletion completed in 6.078420746s
+
+• [SLOW TEST:6.269 seconds]
+[sig-network] Proxy
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:278
+    should proxy logs on node [Conformance]
+    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:66
+------------------------------
+SSSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (non-root,0666,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:121
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:56:41.611: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-dpkl9
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:121
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Nov 17 10:56:41.750: INFO: Waiting up to 5m0s for pod "pod-fe68d235-cb85-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-dpkl9" to be "success or failure"
+Nov 17 10:56:41.753: INFO: Pod "pod-fe68d235-cb85-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.642355ms
+Nov 17 10:56:43.755: INFO: Pod "pod-fe68d235-cb85-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004707524s
+STEP: Saw pod success
+Nov 17 10:56:43.755: INFO: Pod "pod-fe68d235-cb85-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:56:43.757: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-fe68d235-cb85-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:56:43.769: INFO: Waiting for pod pod-fe68d235-cb85-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:56:43.771: INFO: Pod pod-fe68d235-cb85-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:56:43.772: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-dpkl9" for this suite.
+Nov 17 10:56:49.808: INFO: namespace: e2e-tests-emptydir-dpkl9, resource: bindings, ignored listing per whitelist
+Nov 17 10:56:49.849: INFO: namespace e2e-tests-emptydir-dpkl9 deletion completed in 6.075313579s
+
+• [SLOW TEST:8.238 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should support (non-root,0666,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:121
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Secrets 
+  should be consumable via the environment [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:409
+[BeforeEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:56:49.849: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-secrets-m2rq8
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:409
+STEP: creating secret e2e-tests-secrets-m2rq8/secret-test-0352713e-cb86-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume secrets
+Nov 17 10:56:49.994: INFO: Waiting up to 5m0s for pod "pod-configmaps-0352d774-cb86-11e7-b2ab-c6826529d988" in namespace "e2e-tests-secrets-m2rq8" to be "success or failure"
+Nov 17 10:56:50.000: INFO: Pod "pod-configmaps-0352d774-cb86-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 5.441942ms
+Nov 17 10:56:52.002: INFO: Pod "pod-configmaps-0352d774-cb86-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00769522s
+Nov 17 10:56:54.004: INFO: Pod "pod-configmaps-0352d774-cb86-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010230233s
+STEP: Saw pod success
+Nov 17 10:56:54.005: INFO: Pod "pod-configmaps-0352d774-cb86-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:56:54.006: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-configmaps-0352d774-cb86-11e7-b2ab-c6826529d988 container env-test: <nil>
+STEP: delete the pod
+Nov 17 10:56:54.021: INFO: Waiting for pod pod-configmaps-0352d774-cb86-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:56:54.023: INFO: Pod pod-configmaps-0352d774-cb86-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Secrets
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:56:54.023: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-m2rq8" for this suite.
+Nov 17 10:57:00.103: INFO: namespace: e2e-tests-secrets-m2rq8, resource: bindings, ignored listing per whitelist
+Nov 17 10:57:00.106: INFO: namespace e2e-tests-secrets-m2rq8 deletion completed in 6.077026444s
+
+• [SLOW TEST:10.257 seconds]
+[k8s.io] Secrets
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable via the environment [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:409
+------------------------------
+SSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:89
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:57:00.106: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-fdbdx
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:89
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Nov 17 10:57:00.274: INFO: Waiting up to 5m0s for pod "pod-0972d0fc-cb86-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-fdbdx" to be "success or failure"
+Nov 17 10:57:00.276: INFO: Pod "pod-0972d0fc-cb86-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.49305ms
+Nov 17 10:57:02.279: INFO: Pod "pod-0972d0fc-cb86-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005584842s
+STEP: Saw pod success
+Nov 17 10:57:02.279: INFO: Pod "pod-0972d0fc-cb86-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:57:02.282: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-0972d0fc-cb86-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:57:02.300: INFO: Waiting for pod pod-0972d0fc-cb86-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:57:02.302: INFO: Pod pod-0972d0fc-cb86-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:57:02.302: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-fdbdx" for this suite.
+Nov 17 10:57:08.351: INFO: namespace: e2e-tests-emptydir-fdbdx, resource: bindings, ignored listing per whitelist
+Nov 17 10:57:08.399: INFO: namespace e2e-tests-emptydir-fdbdx deletion completed in 6.094992865s
+
+• [SLOW TEST:8.293 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should support (non-root,0644,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:89
+------------------------------
+S
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (non-root,0777,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:125
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:57:08.399: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-6l8jd
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:125
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Nov 17 10:57:08.544: INFO: Waiting up to 5m0s for pod "pod-0e614cbb-cb86-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-6l8jd" to be "success or failure"
+Nov 17 10:57:08.548: INFO: Pod "pod-0e614cbb-cb86-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.901265ms
+Nov 17 10:57:10.550: INFO: Pod "pod-0e614cbb-cb86-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005614246s
+STEP: Saw pod success
+Nov 17 10:57:10.550: INFO: Pod "pod-0e614cbb-cb86-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:57:10.552: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-0e614cbb-cb86-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:57:10.570: INFO: Waiting for pod pod-0e614cbb-cb86-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:57:10.572: INFO: Pod pod-0e614cbb-cb86-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:57:10.572: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-6l8jd" for this suite.
+Nov 17 10:57:16.618: INFO: namespace: e2e-tests-emptydir-6l8jd, resource: bindings, ignored listing per whitelist
+Nov 17 10:57:16.662: INFO: namespace e2e-tests-emptydir-6l8jd deletion completed in 6.086606557s
+
+• [SLOW TEST:8.262 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should support (non-root,0777,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:125
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:377
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:57:16.662: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-v9fb7
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:377
+STEP: Creating configMap with name projected-configmap-test-volume-134dbed6-cb86-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:57:16.809: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-134e4a16-cb86-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-v9fb7" to be "success or failure"
+Nov 17 10:57:16.811: INFO: Pod "pod-projected-configmaps-134e4a16-cb86-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 1.718478ms
+Nov 17 10:57:18.813: INFO: Pod "pod-projected-configmaps-134e4a16-cb86-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.003968288s
+STEP: Saw pod success
+Nov 17 10:57:18.813: INFO: Pod "pod-projected-configmaps-134e4a16-cb86-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:57:18.815: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-configmaps-134e4a16-cb86-11e7-b2ab-c6826529d988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:57:18.827: INFO: Waiting for pod pod-projected-configmaps-134e4a16-cb86-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:57:18.830: INFO: Pod pod-projected-configmaps-134e4a16-cb86-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:57:18.830: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-v9fb7" for this suite.
+Nov 17 10:57:24.899: INFO: namespace: e2e-tests-projected-v9fb7, resource: bindings, ignored listing per whitelist
+Nov 17 10:57:24.908: INFO: namespace e2e-tests-projected-v9fb7 deletion completed in 6.075578571s
+
+• [SLOW TEST:8.246 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:377
+------------------------------
+SS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dns.go:365
+[BeforeEach] [sig-network] DNS
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:57:24.908: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-dns-p697w
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dns.go:365
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-p697w A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-p697w;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-p697w A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-p697w;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-p697w.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-p697w.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-p697w.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-p697w.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-p697w.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-p697w.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-p697w.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-p697w.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-p697w.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-p697w.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-p697w.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-p697w.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-p697w.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 213.0.31.172.in-addr.arpa. PTR)" && echo OK > /results/172.31.0.213_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 213.0.31.172.in-addr.arpa. PTR)" && echo OK > /results/172.31.0.213_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-p697w A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-p697w;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-p697w A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-p697w;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-p697w.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-p697w.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-p697w.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-p697w.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-p697w.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-p697w.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-p697w.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-p697w.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-p697w.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-p697w.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-p697w.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-p697w.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-p697w.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 213.0.31.172.in-addr.arpa. PTR)" && echo OK > /results/172.31.0.213_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 213.0.31.172.in-addr.arpa. PTR)" && echo OK > /results/172.31.0.213_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Nov 17 10:57:37.144: INFO: DNS probes using dns-test-1839ce30-cb86-11e7-b2ab-c6826529d988 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:57:37.196: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-p697w" for this suite.
+Nov 17 10:57:43.288: INFO: namespace: e2e-tests-dns-p697w, resource: bindings, ignored listing per whitelist
+Nov 17 10:57:43.292: INFO: namespace e2e-tests-dns-p697w deletion completed in 6.091383041s
+
+• [SLOW TEST:18.384 seconds]
+[sig-network] DNS
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/dns.go:365
+------------------------------
+SS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:93
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:57:43.292: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-zdqlt
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:93
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Nov 17 10:57:43.438: INFO: Waiting up to 5m0s for pod "pod-232d8a29-cb86-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-zdqlt" to be "success or failure"
+Nov 17 10:57:43.441: INFO: Pod "pod-232d8a29-cb86-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.760412ms
+Nov 17 10:57:45.443: INFO: Pod "pod-232d8a29-cb86-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004822837s
+STEP: Saw pod success
+Nov 17 10:57:45.443: INFO: Pod "pod-232d8a29-cb86-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:57:45.445: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-232d8a29-cb86-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:57:45.459: INFO: Waiting for pod pod-232d8a29-cb86-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:57:45.461: INFO: Pod pod-232d8a29-cb86-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:57:45.461: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-zdqlt" for this suite.
+Nov 17 10:57:51.523: INFO: namespace: e2e-tests-emptydir-zdqlt, resource: bindings, ignored listing per whitelist
+Nov 17 10:57:51.538: INFO: namespace e2e-tests-emptydir-zdqlt deletion completed in 6.074807752s
+
+• [SLOW TEST:8.246 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should support (non-root,0666,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:93
+------------------------------
+S
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (root,0777,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:113
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:57:51.538: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-kg7fg
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:113
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Nov 17 10:57:51.683: INFO: Waiting up to 5m0s for pod "pod-2817c327-cb86-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-kg7fg" to be "success or failure"
+Nov 17 10:57:51.685: INFO: Pod "pod-2817c327-cb86-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.502488ms
+Nov 17 10:57:53.688: INFO: Pod "pod-2817c327-cb86-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004853151s
+STEP: Saw pod success
+Nov 17 10:57:53.688: INFO: Pod "pod-2817c327-cb86-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:57:53.689: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-2817c327-cb86-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:57:53.703: INFO: Waiting for pod pod-2817c327-cb86-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:57:53.705: INFO: Pod pod-2817c327-cb86-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:57:53.705: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-kg7fg" for this suite.
+Nov 17 10:57:59.751: INFO: namespace: e2e-tests-emptydir-kg7fg, resource: bindings, ignored listing per whitelist
+Nov 17 10:57:59.787: INFO: namespace e2e-tests-emptydir-kg7fg deletion completed in 6.079039918s
+
+• [SLOW TEST:8.249 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should support (root,0777,default) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:113
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:357
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:57:59.787: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-pods-dp5pc
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:129
+[It] should allow activeDeadlineSeconds to be updated [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:357
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Nov 17 10:58:02.448: INFO: Successfully updated pod "pod-update-activedeadlineseconds-2d01ffd4-cb86-11e7-b2ab-c6826529d988"
+Nov 17 10:58:02.448: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-2d01ffd4-cb86-11e7-b2ab-c6826529d988" in namespace "e2e-tests-pods-dp5pc" to be "terminated due to deadline exceeded"
+Nov 17 10:58:02.451: INFO: Pod "pod-update-activedeadlineseconds-2d01ffd4-cb86-11e7-b2ab-c6826529d988": Phase="Running", Reason="", readiness=true. Elapsed: 2.442953ms
+Nov 17 10:58:04.453: INFO: Pod "pod-update-activedeadlineseconds-2d01ffd4-cb86-11e7-b2ab-c6826529d988": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 2.004446433s
+Nov 17 10:58:04.453: INFO: Pod "pod-update-activedeadlineseconds-2d01ffd4-cb86-11e7-b2ab-c6826529d988" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:58:04.453: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-dp5pc" for this suite.
+Nov 17 10:58:10.491: INFO: namespace: e2e-tests-pods-dp5pc, resource: bindings, ignored listing per whitelist
+Nov 17 10:58:10.535: INFO: namespace e2e-tests-pods-dp5pc deletion completed in 6.08002701s
+
+• [SLOW TEST:10.749 seconds]
+[k8s.io] Pods
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should allow activeDeadlineSeconds to be updated [Conformance]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:357
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Projected 
+  should set DefaultMode on files [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:798
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:58:10.535: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-fjw6z
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should set DefaultMode on files [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:798
+STEP: Creating a pod to test downward API volume plugin
+Nov 17 10:58:10.683: INFO: Waiting up to 5m0s for pod "downwardapi-volume-336abe76-cb86-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-fjw6z" to be "success or failure"
+Nov 17 10:58:10.688: INFO: Pod "downwardapi-volume-336abe76-cb86-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.830001ms
+Nov 17 10:58:12.690: INFO: Pod "downwardapi-volume-336abe76-cb86-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006963018s
+STEP: Saw pod success
+Nov 17 10:58:12.690: INFO: Pod "downwardapi-volume-336abe76-cb86-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:58:12.692: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod downwardapi-volume-336abe76-cb86-11e7-b2ab-c6826529d988 container client-container: <nil>
+STEP: delete the pod
+Nov 17 10:58:12.705: INFO: Waiting for pod downwardapi-volume-336abe76-cb86-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:58:12.708: INFO: Pod downwardapi-volume-336abe76-cb86-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:58:12.708: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fjw6z" for this suite.
+Nov 17 10:58:18.759: INFO: namespace: e2e-tests-projected-fjw6z, resource: bindings, ignored listing per whitelist
+Nov 17 10:58:18.785: INFO: namespace e2e-tests-projected-fjw6z deletion completed in 6.074803553s
+
+• [SLOW TEST:8.249 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should set DefaultMode on files [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:798
+------------------------------
+SSSS
+------------------------------
+[k8s.io] ConfigMap 
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:328
+[BeforeEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:58:18.785: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-configmap-wm6zx
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:328
+STEP: Creating configMap with name cm-test-opt-del-385689e9-cb86-11e7-b2ab-c6826529d988
+STEP: Creating configMap with name cm-test-opt-upd-38568a24-cb86-11e7-b2ab-c6826529d988
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-385689e9-cb86-11e7-b2ab-c6826529d988
+STEP: Updating configmap cm-test-opt-upd-38568a24-cb86-11e7-b2ab-c6826529d988
+STEP: Creating configMap with name cm-test-opt-create-38568a41-cb86-11e7-b2ab-c6826529d988
+STEP: waiting to observe update in volume
+[AfterEach] [k8s.io] ConfigMap
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:58:23.001: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-wm6zx" for this suite.
+Nov 17 10:58:45.058: INFO: namespace: e2e-tests-configmap-wm6zx, resource: bindings, ignored listing per whitelist
+Nov 17 10:58:45.079: INFO: namespace e2e-tests-configmap-wm6zx deletion completed in 22.074951864s
+
+• [SLOW TEST:26.294 seconds]
+[k8s.io] ConfigMap
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  optional updates should be reflected in volume [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:328
+------------------------------
+SSS
+------------------------------
+[k8s.io] Projected 
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:394
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:58:45.079: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-6qnxg
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:394
+STEP: Creating configMap with name projected-configmap-test-volume-map-48010a77-cb86-11e7-b2ab-c6826529d988
+STEP: Creating a pod to test consume configMaps
+Nov 17 10:58:45.226: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-48018c08-cb86-11e7-b2ab-c6826529d988" in namespace "e2e-tests-projected-6qnxg" to be "success or failure"
+Nov 17 10:58:45.228: INFO: Pod "pod-projected-configmaps-48018c08-cb86-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.289134ms
+Nov 17 10:58:47.231: INFO: Pod "pod-projected-configmaps-48018c08-cb86-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004534718s
+STEP: Saw pod success
+Nov 17 10:58:47.231: INFO: Pod "pod-projected-configmaps-48018c08-cb86-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:58:47.232: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-projected-configmaps-48018c08-cb86-11e7-b2ab-c6826529d988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 17 10:58:47.246: INFO: Waiting for pod pod-projected-configmaps-48018c08-cb86-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:58:47.248: INFO: Pod pod-projected-configmaps-48018c08-cb86-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:58:47.248: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6qnxg" for this suite.
+Nov 17 10:58:53.307: INFO: namespace: e2e-tests-projected-6qnxg, resource: bindings, ignored listing per whitelist
+Nov 17 10:58:53.335: INFO: namespace e2e-tests-projected-6qnxg deletion completed in 6.083579888s
+
+• [SLOW TEST:8.257 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should be consumable from pods in volume with mappings [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:394
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Projected 
+  should update annotations on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:893
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:58:53.336: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-projected-rznqb
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:779
+[It] should update annotations on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:893
+STEP: Creating the pod
+Nov 17 10:58:55.996: INFO: Successfully updated pod "annotationupdate4ceca22f-cb86-11e7-b2ab-c6826529d988"
+[AfterEach] [k8s.io] Projected
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:59:00.016: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rznqb" for this suite.
+Nov 17 10:59:22.050: INFO: namespace: e2e-tests-projected-rznqb, resource: bindings, ignored listing per whitelist
+Nov 17 10:59:22.095: INFO: namespace e2e-tests-projected-rznqb deletion completed in 22.076514782s
+
+• [SLOW TEST:28.760 seconds]
+[k8s.io] Projected
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should update annotations on modification [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:893
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] EmptyDir volumes 
+  should support (root,0666,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:81
+[BeforeEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Nov 17 10:59:22.096: INFO: >>> kubeConfig: 
+STEP: Building a namespace api object
+STEP: Binding the e2e-test-privileged-psp PodSecurityPolicy to the default service account in e2e-tests-emptydir-4kjmm
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:81
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Nov 17 10:59:22.241: INFO: Waiting up to 5m0s for pod "pod-5e11a283-cb86-11e7-b2ab-c6826529d988" in namespace "e2e-tests-emptydir-4kjmm" to be "success or failure"
+Nov 17 10:59:22.243: INFO: Pod "pod-5e11a283-cb86-11e7-b2ab-c6826529d988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.76595ms
+Nov 17 10:59:24.246: INFO: Pod "pod-5e11a283-cb86-11e7-b2ab-c6826529d988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004950882s
+STEP: Saw pod success
+Nov 17 10:59:24.246: INFO: Pod "pod-5e11a283-cb86-11e7-b2ab-c6826529d988" satisfied condition "success or failure"
+Nov 17 10:59:24.247: INFO: Trying to get logs from node ip-10-1-2-35.eu-central-1.compute.internal pod pod-5e11a283-cb86-11e7-b2ab-c6826529d988 container test-container: <nil>
+STEP: delete the pod
+Nov 17 10:59:24.262: INFO: Waiting for pod pod-5e11a283-cb86-11e7-b2ab-c6826529d988 to disappear
+Nov 17 10:59:24.274: INFO: Pod pod-5e11a283-cb86-11e7-b2ab-c6826529d988 no longer exists
+[AfterEach] [k8s.io] EmptyDir volumes
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Nov 17 10:59:24.274: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-4kjmm" for this suite.
+Nov 17 10:59:30.338: INFO: namespace: e2e-tests-emptydir-4kjmm, resource: bindings, ignored listing per whitelist
+Nov 17 10:59:30.360: INFO: namespace e2e-tests-emptydir-4kjmm deletion completed in 6.082167536s
+
+• [SLOW TEST:8.264 seconds]
+[k8s.io] EmptyDir volumes
+/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:635
+  should support (root,0666,tmpfs) [Conformance] [sig-storage]
+  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:81
+------------------------------
+SSNov 17 10:59:30.360: INFO: Running AfterSuite actions on all node
+Nov 17 10:59:30.360: INFO: Running AfterSuite actions on node 1
+Nov 17 10:59:30.360: INFO: Dumping logs locally to: /tmp/results
+Checking for custom logdump instances, if any
+Sourcing kube-util.sh
+Nov 17 10:59:30.375: INFO: Error running cluster/log-dump/log-dump.sh: exit status 1
+
+Ran 125 of 697 Specs in 2765.286 seconds
+SUCCESS! -- 125 Passed | 0 Failed | 0 Pending | 572 Skipped PASS

--- a/v1.8/giantswarm-aws/junit_01.xml
+++ b/v1.8/giantswarm-aws/junit_01.xml
@@ -1,0 +1,1844 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="125" failures="0" time="2765.286305649">
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="10.318652905"></testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] new files should be created with FSGroup ownership when container is root [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works [Conformance]" classname="Kubernetes e2e suite" time="7.358168661"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [Conformance]" classname="Kubernetes e2e suite" time="48.504978558"></testcase>
+      <testcase name="[k8s.io] Federation apiserver [Feature:Federation] Cluster objects [Serial] should be created and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching [Conformance]" classname="Kubernetes e2e suite" time="86.347012083"></testcase>
+      <testcase name="[k8s.io] Downward API volume should provide container&#39;s memory limit [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="10.245439026"></testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.247798365"></testcase>
+      <testcase name="[k8s.io] Pods should be updated [Conformance]" classname="Kubernetes e2e suite" time="30.753158349"></testcase>
+      <testcase name="[k8s.io] Downward API volume should provide container&#39;s memory request [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.248852155"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] volume on default medium should have the correct mode using FSGroup [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Upgrade [Feature:Upgrade] [k8s.io] Federation Control Plane upgrade should maintain a functioning federation [Feature:FCPUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.260254004"></testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume as non-root [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.274298066"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should update pod when spec was updated and update strategy is RollingUpdate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap updates should be reflected in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="26.255058685"></testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Federation] Federation API server authentication [NoCluster] should not accept cluster resources when the client has invalid HTTP Basic authentication credentials" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere volume operations storm should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services [Conformance]" classname="Kubernetes e2e suite" time="30.291704375"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP [Conformance]" classname="Kubernetes e2e suite" time="24.225496055"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run [Conformance]" classname="Kubernetes e2e suite" time="88.367741133"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.248162366"></testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide container&#39;s cpu limit [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.291797386"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [Slow] should not be deleted from underlying clusters when OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable from pods in volume with mappings [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.245346604"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected optional updates should be reflected in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="26.289193945"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should schedule a pod w/ a readonly PD on two hosts, then remove both ungracefully. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation namespace [Feature:Federation] Namespace objects all resources in the namespace should be deleted when namespace is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] Without Clusters [NoCluster] should succeed when a service is created" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment overlapping deployment should not fight with each other" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters Federated Service should be deleted from underlying clusters when OrphanDependents is false" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should rollback without unnecessary restarts" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] HostPath should support existing directory subPath [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation jobs [Feature:Federation] Federated Job should not be deleted from underlying clusters when OrphanDependents is true" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.249341962999999"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should set DefaultMode on files [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.248582941"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume with mappings [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.246455241"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.241119477"></testcase>
+      <testcase name="[k8s.io] Secrets should be consumable from pods in env vars [Conformance]" classname="Kubernetes e2e suite" time="10.249030056"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that a pod with an invalid NodeAffinity is rejected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected optional updates should be reflected in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="26.413178049"></testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API should provide default limits.cpu/memory from node allocatable [Conformance]" classname="Kubernetes e2e suite" time="10.259182012"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ReplicaSet [Feature:Federation] Features Preferences should create replicasets with min replicas preference" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource [Conformance]" classname="Kubernetes e2e suite" time="6.273511347"></testcase>
+      <testcase name="[sig-scheduling] Opaque resources [Feature:OpaqueResources] should account opaque integer resources in pods with multiple containers." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes volume on tmpfs should have the correct mode [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.240946259"></testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation jobs [Feature:Federation] Job objects [NoCluster] should be created and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.250161637"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount and write to the volume using one-command containers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters Federated Service should not be deleted from underlying clusters when OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback when there&#39;s replica set with no revision" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;secret&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [Slow] Ingress connectivity and DNS should be able to connect to a federated ingress via its load balancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ReplicaSet [Feature:Federation] ReplicaSet objects [NoCluster] should be created and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Opaque resources [Feature:OpaqueResources] should schedule pods that initially do not fit after enough opaque integer resources are freed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [Slow] should be deleted from underlying clusters when OrphanDependents is false" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should project all components that make up the projection API [Conformance] [sig-storage] [Projection]" classname="Kubernetes e2e suite" time="10.262859763"></testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (root,0666,default) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.250609009"></testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide podname only [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.252786151"></testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.337887848"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide container&#39;s cpu limit [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.247672387"></testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="130.381124506"></testcase>
+      <testcase name="[k8s.io] [Feature:Federation] Federation API server authentication [NoCluster] should accept cluster resources when the client has certificate authentication credentials" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf [Experimental] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha docker/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args [Conformance]" classname="Kubernetes e2e suite" time="10.286531463"></testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.244997292"></testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count [Conformance] [Slow]" classname="Kubernetes e2e suite" time="148.418940236"></testcase>
+      <testcase name="[k8s.io] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed [Conformance]" classname="Kubernetes e2e suite" time="22.235605301"></testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe [Conformance]" classname="Kubernetes e2e suite" time="32.283793168"></testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command [Conformance]" classname="Kubernetes e2e suite" time="10.284854738"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount and read from the volume using one-command containers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [Conformance]" classname="Kubernetes e2e suite" time="69.657757449"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters DNS non-local federated service should be able to discover a non-local federated service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to detach from a node whose api object was deleted [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart [Conformance]" classname="Kubernetes e2e suite" time="82.229144382"></testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;replicaset&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (root,0644,tmpfs) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.251419374"></testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (root,0777,tmpfs) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.246905668"></testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;deployment&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0 [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment scaled rollout deployment should not block on annotation check" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments [Conformance]" classname="Kubernetes e2e suite" time="10.246281557"></testcase>
+      <testcase name="[k8s.io] Projected should update labels on modification [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="28.760600804"></testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed [Conformance] [Flaky]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (non-root,0777,tmpfs) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="10.246464976"></testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should adopt existing pods when creating a RollingUpdate DaemonSet regardless of templateGeneration" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port [Conformance]" classname="Kubernetes e2e suite" time="6.30382558"></testcase>
+      <testcase name="[k8s.io] Federated ReplicaSet [Feature:Federation] Features Preferences should create replicasets with weight preference" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume as non-root [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.341665381"></testcase>
+      <testcase name="[sig-storage] Pod Disks Should schedule a pod w/ a RW PD, gracefully remove it, then schedule it on another host [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Federation] Federation API server authentication [NoCluster] should not accept cluster resources when the client has invalid token authentication credentials" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image [Conformance]" classname="Kubernetes e2e suite" time="16.248953207"></testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide container&#39;s cpu request [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.249053538"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere Volume fstype verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [Slow] should not be deleted from underlying clusters when OrphanDependents is true" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Multi-AZ Clusters should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should schedule a pod w/ a RW PD shared between multiple containers, write to PD, delete pod, verify contents, and repeat in rapid succession [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide container&#39;s memory limit [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.279111664"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (non-root,0644,default) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.239338118"></testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters Federated Service should recreate service shard in underlying clusters when service shard is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation apiserver [Feature:Federation] Admission control [NoCluster] should not be able to create resources if namespace does not exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API should provide host IP as an env var [Conformance]" classname="Kubernetes e2e suite" time="10.28122527"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource [Conformance]" classname="Kubernetes e2e suite" time="6.371145594"></testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;namespace&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation jobs [Feature:Federation] Federated Job should not be deleted from underlying clusters when OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.252037933"></testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Opaque resources [Feature:OpaqueResources] should not break pods that do not consume opaque integer resources." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPU] run Nvidia GPU tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.252897038"></testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] files with FSGroup ownership should support (root,0644,tmpfs) [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Upgrade [Feature:Upgrade] [k8s.io] Federated clusters upgrade should maintain a functioning federation [Feature:FederatedClustersUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching [Conformance]" classname="Kubernetes e2e suite" time="83.301733024"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods [Conformance]" classname="Kubernetes e2e suite" time="12.813678490000001"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount [Conformance]" classname="Kubernetes e2e suite" time="6.807421553"></testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should schedule a pod w/ a RW PD, ungracefully remove it, then schedule it on another host [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster [Conformance]" classname="Kubernetes e2e suite" time="30.280864172"></testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (root,0644,default) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.315356658"></testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor using proxy subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] nonexistent volume subPath should have the correct mode and owner using FSGroup [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when using local volume provisioner should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable via environment variable [Conformance]" classname="Kubernetes e2e suite" time="10.257120722"></testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters DNS should be able to discover a federated service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide container&#39;s memory request [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.244399496"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PreStop should call prestop when killing a pod [Conformance]" classname="Kubernetes e2e suite" time="53.272666206"></testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.OrphanDependents is true" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.270190272"></testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should update annotations on modification [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="28.773867872"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to detach from a node which was deleted [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;horizontalpodautoscaler&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [Slow] should create and update matching ingresses in underlying clusters" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide podname as non-root with fsgroup [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars [Conformance]" classname="Kubernetes e2e suite" time="10.252676948"></testcase>
+      <testcase name="[k8s.io] Upgrade [Feature:Upgrade] [k8s.io] FCP upgrade followed by federated clusters upgrade should maintain a functioning federation [Feature:FCPUpgradeFollowedByFederatedClustersUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters Federated Service should not be deleted from underlying clusters when OrphanDependents is true" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars [Conformance]" classname="Kubernetes e2e suite" time="10.248039143"></testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default commmand (docker entrypoint) [Conformance]" classname="Kubernetes e2e suite" time="8.242918386"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API should provide pod IP as an env var [Conformance]" classname="Kubernetes e2e suite" time="10.269910407"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart [Conformance]" classname="Kubernetes e2e suite" time="40.2311446"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] HostPath should give a volume the correct mode [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.263287651"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable in multiple volumes in a pod [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.269526721"></testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters Federated Service should create and update matching services in underlying clusters" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should schedule a pod w/two RW PDs both mounted to one container, write to PD, verify contents, delete pod, recreate pod, verify contents, and repeat in rapid succession [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation jobs [Feature:Federation] Federated Job should be deleted from underlying clusters when OrphanDependents is false" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ReplicaSet [Feature:Federation] Features Preferences should create replicasets and rebalance them" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [Conformance]" classname="Kubernetes e2e suite" time="46.495833174"></testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.249706309"></testcase>
+      <testcase name="[k8s.io] EmptyDir volumes volume on default medium should have the correct mode [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.242685106"></testcase>
+      <testcase name="[k8s.io] Downward API should provide pod name and namespace as env vars [Conformance]" classname="Kubernetes e2e suite" time="10.245515244"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks Should schedule a pod w/ a readonly PD on two hosts, then remove both gracefully. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation namespace [Feature:Federation] Namespace objects deletes replicasets in the namespace when the namespace is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.248231261"></testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide podname only [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.244066237"></testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] new files should be created with FSGroup ownership when container is non-root [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable from pods in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.262696932"></testcase>
+      <testcase name="[k8s.io] Projected should be consumable in multiple volumes in a pod [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.257778986"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable from pods in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.252090894"></testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should set mode on item file [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.257728179"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide container&#39;s cpu request [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.244941532"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Federation] Federation API server authentication [NoCluster] should accept cluster resources when the client has token authentication credentials" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high [Conformance]" classname="Kubernetes e2e suite" time="28.817975418"></testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should update labels on modification [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="111.16524583"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when two pods request one prebound PVC one after other should be able to mount volume, write from pod1, and read from pod2 using one-command containers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="58.307290488"></testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation jobs [Feature:Federation] Federated Job should create and update matching jobs in underlying clusters" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap should be consumable via the environment [Conformance]" classname="Kubernetes e2e suite" time="10.254737577"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Opaque resources [Feature:OpaqueResources] should not schedule pods that exceed the available amount of opaque integer resource." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with mappings [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.263152615"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [Conformance]" classname="Kubernetes e2e suite" time="46.499418045"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image [Conformance]" classname="Kubernetes e2e suite" time="16.271112936"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain Annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Upgrade [Feature:Upgrade] [k8s.io] Federated clusters upgrade followed by FCP upgrade should maintain a functioning federation [Feature:FederatedClustersUpgradeFollowedByFCPUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.259869391"></testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated Services [Feature:Federation] with clusters DNS non-local federated service [Slow] missing local service should never find DNS entries for a missing local service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should set mode on item file [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.243520285"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods [Conformance]" classname="Kubernetes e2e suite" time="15.342295645"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existent secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd) [Conformance]" classname="Kubernetes e2e suite" time="8.251877383"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank [Conformance]" classname="Kubernetes e2e suite" time="8.253204127"></testcase>
+      <testcase name="[k8s.io] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] volume on tmpfs should have the correct mode using FSGroup [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets optional updates should be reflected in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="116.657323048"></testcase>
+      <testcase name="[k8s.io] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.252580785"></testcase>
+      <testcase name="[sig-storage] vsphere Volume fstype verify disk format type - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected updates should be reflected in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="110.575217264"></testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods [Conformance]" classname="Kubernetes e2e suite" time="30.322113539"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federation events [Feature:Federation] Event objects [NoCluster] should be created and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;daemonset&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed [Conformance]" classname="Kubernetes e2e suite" time="20.665378423"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API volume should provide podname as non-root with fsgroup [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service [Conformance]" classname="Kubernetes e2e suite" time="6.21886053"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file [Conformance]" classname="Kubernetes e2e suite" time="42.583262249"></testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.272964038"></testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout [Conformance]" classname="Kubernetes e2e suite" time="6.223157016">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod [Conformance]" classname="Kubernetes e2e suite" time="16.763234773"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment lack of progress should be reported in the deployment status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.282764948"></testcase>
+      <testcase name="[k8s.io] Federated ReplicaSet [Feature:Federation] Features Preferences should create replicasets with max replicas preference" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] HostPath should support existing single file subPath [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.241496252"></testcase>
+      <testcase name="[k8s.io] PrivilegedPod should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Opaque resources [Feature:OpaqueResources] should schedule pods that do consume opaque integer resources." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] HostPath should support r/w [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should have a working scale subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe [Conformance]" classname="Kubernetes e2e suite" time="128.370439814"></testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Federation] Federation API server authentication [NoCluster] should accept cluster resources when the client has HTTP Basic authentication credentials" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit [Feature:Audit] should audit API calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Events should be sent by kubelets and the scheduler about pods scheduling and running [Conformance]" classname="Kubernetes e2e suite" time="12.253992311"></testcase>
+      <testcase name="[k8s.io] Projected should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup] [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Federation] Federation API server authentication [NoCluster] should not accept cluster resources when the client has no authentication credentials" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment can avoid hash collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node [Conformance]" classname="Kubernetes e2e suite" time="6.268856774"></testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (non-root,0666,default) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.237842596"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be consumable via the environment [Conformance]" classname="Kubernetes e2e suite" time="10.256787918"></testcase>
+      <testcase name="[k8s.io] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (non-root,0644,tmpfs) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.292901115"></testcase>
+      <testcase name="[k8s.io] Sysctls should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (non-root,0777,default) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.262380117"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [Slow] Ingress connectivity and DNS should be able to discover a federated ingress service via DNS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated types [Feature:Federation][Experimental]  Federated &#34;configmap&#34; resources should be created, read, updated and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [NoCluster] should be created and deleted successfully" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.245694854"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services [Conformance]" classname="Kubernetes e2e suite" time="18.384211472"></testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (non-root,0666,tmpfs) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.245597876"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (root,0777,default) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.248561072"></testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated [Conformance]" classname="Kubernetes e2e suite" time="10.748653115"></testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should set DefaultMode on files [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.249320905"></testcase>
+      <testcase name="[k8s.io] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ConfigMap optional updates should be reflected in volume [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="26.293863025"></testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should be consumable from pods in volume with mappings [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.256517975"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Projected should update annotations on modification [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="28.759752442"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should label adopted RSs and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] HostPath should support subPath [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vSphere Storage policy support for dynamic provisioning verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EmptyDir volumes should support (root,0666,tmpfs) [Conformance] [sig-storage]" classname="Kubernetes e2e suite" time="8.263955018"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.8/giantswarm-aws/version.txt
+++ b/v1.8/giantswarm-aws/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.2", GitCommit:"bdaeafa71f6c7c04636251031f93464384d54963", GitTreeState:"clean", BuildDate:"2017-10-24T21:08:42Z", GoVersion:"go1.9.1", Compiler:"gc", Platform:"darwin/amd64"}
+Server Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.1+coreos.0", GitCommit:"59359d9fdce74738ac9a672d2f31e9a346c5cece", GitTreeState:"clean", BuildDate:"2017-10-12T21:53:13Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}


### PR DESCRIPTION
vendor: Giant Swarm
name: Managed Kubernetes on AWS
version: stable-2017-11-17
website_url: https://giantswarm.io
documentation_url: https://docs.giantswarm.io
product_logo_url: https://www.dropbox.com/s/kydb137cjsix7du/giantswarm_ant.png

Note: I ran the tests as documented in https://github.com/cncf/k8s-conformance/blob/master/instructions.md twice, but I'm not getting any `versions.txt` out of sonobuoy. Any pointers as to how to get it or is it needed at all?