### PR TITLE
Update sonobuoy e2e to kube-conformance:v1.9

### DIFF
--- a/sonobuoy-conformance.yaml
+++ b/sonobuoy-conformance.yaml
@@ -52,7 +52,7 @@ metadata:
 data:
   config.json: |
     {
-        "Description": "CNCF v1.7 or v1.8 Conformance Results",
+        "Description": "CNCF v1.8 or v1.9 Conformance Results",
         "Filters": {
             "LabelSelector": "",
             "Namespaces": ".*"
@@ -92,7 +92,7 @@ data:
       - env:
         - name: E2E_FOCUS
           value: '\[Conformance\]'
-        image: gcr.io/heptio-images/kube-conformance:v1.8
+        image: gcr.io/heptio-images/kube-conformance:v1.9
         imagePullPolicy: Always
         name: e2e
         volumeMounts:


### PR DESCRIPTION
Updates the conformance tests for the tagged 1.9 suite.
Necessary for https://github.com/kubernetes/kubeadm/issues/617.

---

Still uses Sonobuoy `v0.9.0` -- setting to the `v0.10.0` or `master` fails to load the e2e config:
```
root@vagrant:~# kubectl -n sonobuoy logs -f sonobuoy
time="2018-01-04T07:09:10Z" level=info msg="Scanning plugins in ./plugins.d (pwd: /)"
time="2018-01-04T07:09:10Z" level=info msg="Directory (./plugins.d) does not exist"
time="2018-01-04T07:09:10Z" level=info msg="Scanning plugins in /etc/sonobuoy/plugins.d (pwd: /)"
time="2018-01-04T07:09:10Z" level=info msg="unknown template type" filename=..1981_04_01_07_09_08.908087323
time="2018-01-04T07:09:10Z" level=info msg="unknown template type" filename=..data
time="2018-01-04T07:09:10Z" level=info msg="unknown template type" filename=e2e.yaml
time="2018-01-04T07:09:10Z" level=info msg="Scanning plugins in ~/sonobuoy/plugins.d (pwd: /)"
time="2018-01-04T07:09:10Z" level=info msg="Directory (~/sonobuoy/plugins.d) does not exist"
time="2018-01-04T07:09:10Z" level=error msg="error loading sonobuoy configuration: Configured plugin e2e does not exist"
```