### PR TITLE
Update conformance container to latest v1.9

### DIFF
--- a/sonobuoy-conformance.yaml
+++ b/sonobuoy-conformance.yaml
@@ -52,7 +52,7 @@ metadata:
 data:
   config.json: |
     {
-        "Description": "CNCF v1.7 or v1.8 Conformance Results",
+        "Description": "CNCF v1.7, v1.8, or v1.9 Conformance Results",
         "Filters": {
             "LabelSelector": "",
             "Namespaces": ".*"
@@ -92,7 +92,7 @@ data:
       - env:
         - name: E2E_FOCUS
           value: '\[Conformance\]'
-        image: gcr.io/heptio-images/kube-conformance:v1.8
+        image: gcr.io/heptio-images/kube-conformance:v1.9
         imagePullPolicy: Always
         name: e2e
         volumeMounts:


### PR DESCRIPTION
Now that https://github.com/heptio/kube-conformance/pull/8 is merged we can update the conformance tests to 1.9, too, so that people can start their tests for the new version.