### PR TITLE
Fix slack link in README-WG.md

### DIFF
--- a/README-WG.md
+++ b/README-WG.md
@@ -21,7 +21,7 @@ https://lists.cncf.io/mailman/listinfo/cncf-k8s-conformance
 
 # Slack
 
-[slack.k8s.io](slack.k8s.io) #k8s-conformance 
+[slack.k8s.io](http://slack.k8s.io) #k8s-conformance 
 
 # Documentation
 


### PR DESCRIPTION
Without the leading `http://` the link is interpreted as relative to
the github repo.