### PR TITLE
Update sonobuoy to v0.10.0

### DIFF
--- a/sonobuoy-conformance.yaml
+++ b/sonobuoy-conformance.yaml
@@ -72,7 +72,7 @@ data:
             "bindport": 8080,
             "timeoutseconds": 5400
         },
-        "Version": "v0.9.0"
+        "Version": "v0.10.0"
     }
 ---
 apiVersion: v1
@@ -83,10 +83,20 @@ metadata:
   name: sonobuoy-plugins-cm
   namespace: sonobuoy
 data:
-  e2e.yaml: |
-    driver: Job
-    name: e2e
-    resultType: e2e
+  e2e.tmpl: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      annotations:
+        sonobuoy-driver: Job
+        sonobuoy-plugin: e2e
+        sonobuoy-result-type: e2e
+      labels:
+        component: sonobuoy
+        sonobuoy-run: '{{.SessionID}}'
+        tier: analysis
+      name: sonobuoy-e2e-job-{{.SessionID}}
+      namespace: '{{.Namespace}}'
     spec:
       containers:
       - env:
@@ -98,6 +108,7 @@ data:
         volumeMounts:
         - mountPath: /tmp/results
           name: results
+          readOnly: false
       - command:
         - sh
         - -c
@@ -110,14 +121,17 @@ data:
               fieldPath: spec.nodeName
         - name: RESULTS_DIR
           value: /tmp/results
-        image: gcr.io/heptio-images/sonobuoy:v0.9.0
+        - name: MASTER_URL
+          value: '{{.MasterAddress}}'
+        - name: RESULT_TYPE
+          value: e2e
+        image: gcr.io/heptio-images/sonobuoy:v0.10.0
         imagePullPolicy: Always
         name: sonobuoy-worker
         volumeMounts:
-        - mountPath: /etc/sonobuoy
-          name: config
         - mountPath: /tmp/results
           name: results
+          readOnly: false
       restartPolicy: Never
       serviceAccountName: sonobuoy-serviceaccount
       tolerations:
@@ -129,9 +143,6 @@ data:
       volumes:
       - emptyDir: {}
         name: results
-      - configMap:
-          name: __SONOBUOY_CONFIGMAP__
-        name: config
 ---
 apiVersion: v1
 kind: Pod
@@ -153,7 +164,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
-    image: gcr.io/heptio-images/sonobuoy:v0.9.0
+    image: gcr.io/heptio-images/sonobuoy:v0.10.0
     imagePullPolicy: Always
     name: kube-sonobuoy
     volumeMounts:


### PR DESCRIPTION
This PR updates sonobuoy-conformance.yaml to use v0.10.0 of sonobuoy.

Resolves: https://github.com/cncf/k8s-conformance/issues/125

Signed-off-by: Jason DeTiberus <detiber@gmail.com>