### PR TITLE
Conformance results for v1.9/sap-cp-*

### DIFF
--- a/v1.9/sap-cp-aws/PRODUCT.yaml
+++ b/v1.9/sap-cp-aws/PRODUCT.yaml
@@ -1,0 +1,6 @@
+vendor: SAP
+name: Cloud Platform - Gardener (https://github.com/gardener/gardener) shoot cluster deployed on Amazon Web Services
+version: 0.1.0 (changed with Open Source shipment)
+website_url: https://cloudplatform.sap.com/index.html
+documentation_url: https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/
+product_logo_url: https://www.sap.com/dam/application/shared/logos/sap-logo-svg.svg

--- a/v1.9/sap-cp-aws/README.md
+++ b/v1.9/sap-cp-aws/README.md
@@ -1,0 +1,43 @@
+# To reproduce:
+
+## Create Kubernetes Cluster
+
+Login to SAP Gardener Dashboard to create a Kubernetes Clusters on Amazon Web Services, Microsoft Azure, Google Cloud Platform, or OpenStack cloud provider.
+
+After the creation completed, copy the cluster's kubeconfig, which is provided by the Gardener Dashboard in the cluster's detail view, to ~/.kube/config and launch the Kubernetes E2E conformance tests.
+
+## Launch E2E Conformance Tests
+1. Launch e2e pod and sonobuoy master under namespace `sonobuoy`   
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+    ```
+
+2. Check logs of `sonobuoy` pod to see when test can be finished   
+Run
+
+    ```shell
+    kubectl logs -f -n sonobuoy sonobuoy
+    ```
+    and wait for line `no-exit was specified, sonobuoy is now blocking`.
+
+3. Use `kubectl cp` to copy the results to the client   
+Get the name of the <result archive> from the log output in step 2.
+
+    ```shell
+    kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy/<result archive> /home/result
+    ```
+
+4. Delete the conformance test resources
+
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl delete -f -
+    ```
+
+5. Untar the tarball
+
+    ```shell
+    cd /home/result
+    tar -xzf *_sonobuoy_*.tar.gz
+    ```
+
+    The result files `e2e.log` and `junit_01.xml` are located in the in the directory `plugins/e2e/results/`.

--- a/v1.9/sap-cp-aws/e2e.log
+++ b/v1.9/sap-cp-aws/e2e.log
@@ -1,0 +1,6324 @@
+Mar 16 12:02:05.244: INFO: Overriding default scale value of zero to 1
+Mar 16 12:02:05.244: INFO: Overriding default milliseconds value of zero to 5000
+I0316 12:02:05.371664      14 test_context.go:349] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-405699782
+I0316 12:02:05.371753      14 e2e.go:331] Starting e2e run "d81b3005-2911-11e8-a0aa-16411a5f38c2" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1521201725 - Will randomize all specs
+Will run 126 of 782 specs
+
+Mar 16 12:02:05.443: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:02:05.445: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
+Mar 16 12:02:05.465: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 16 12:02:05.547: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 16 12:02:05.547: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 16 12:02:05.550: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 16 12:02:05.550: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Mar 16 12:02:05.554: INFO: e2e test version: v1.9.4
+Mar 16 12:02:05.555: INFO: kube-apiserver version: v1.9.4
+SSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:02:05.555: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+Mar 16 12:02:05.592: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 16 12:02:05.602: INFO: Waiting up to 5m0s for pod "downward-api-d85d31bf-2911-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-pbdpg" to be "success or failure"
+Mar 16 12:02:05.605: INFO: Pod "downward-api-d85d31bf-2911-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.526015ms
+Mar 16 12:02:07.608: INFO: Pod "downward-api-d85d31bf-2911-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005685667s
+Mar 16 12:02:09.611: INFO: Pod "downward-api-d85d31bf-2911-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008878822s
+STEP: Saw pod success
+Mar 16 12:02:09.611: INFO: Pod "downward-api-d85d31bf-2911-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:02:09.613: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod downward-api-d85d31bf-2911-11e8-a0aa-16411a5f38c2 container dapi-container: <nil>
+STEP: delete the pod
+Mar 16 12:02:09.631: INFO: Waiting for pod downward-api-d85d31bf-2911-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:02:09.642: INFO: Pod downward-api-d85d31bf-2911-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:02:09.643: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-pbdpg" for this suite.
+Mar 16 12:02:15.655: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:02:15.757: INFO: namespace: e2e-tests-downward-api-pbdpg, resource: bindings, ignored listing per whitelist
+Mar 16 12:02:15.768: INFO: namespace e2e-tests-downward-api-pbdpg deletion completed in 6.121816188s
+
+• [SLOW TEST:10.212 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:02:15.768: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Mar 16 12:02:15.811: INFO: Waiting up to 5m0s for pod "pod-de73169e-2911-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-58n99" to be "success or failure"
+Mar 16 12:02:15.814: INFO: Pod "pod-de73169e-2911-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.16959ms
+Mar 16 12:02:17.817: INFO: Pod "pod-de73169e-2911-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006171573s
+STEP: Saw pod success
+Mar 16 12:02:17.817: INFO: Pod "pod-de73169e-2911-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:02:17.819: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-de73169e-2911-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:02:17.833: INFO: Waiting for pod pod-de73169e-2911-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:02:17.836: INFO: Pod pod-de73169e-2911-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:02:17.836: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-58n99" for this suite.
+Mar 16 12:02:23.847: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:02:23.906: INFO: namespace: e2e-tests-emptydir-58n99, resource: bindings, ignored listing per whitelist
+Mar 16 12:02:23.967: INFO: namespace e2e-tests-emptydir-58n99 deletion completed in 6.128457512s
+
+• [SLOW TEST:8.199 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:02:23.968: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap e2e-tests-configmap-78bxx/configmap-test-e356751e-2911-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:02:24.014: INFO: Waiting up to 5m0s for pod "pod-configmaps-e356dfdb-2911-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-configmap-78bxx" to be "success or failure"
+Mar 16 12:02:24.020: INFO: Pod "pod-configmaps-e356dfdb-2911-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.991153ms
+Mar 16 12:02:26.023: INFO: Pod "pod-configmaps-e356dfdb-2911-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007995411s
+Mar 16 12:02:28.026: INFO: Pod "pod-configmaps-e356dfdb-2911-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011016563s
+STEP: Saw pod success
+Mar 16 12:02:28.026: INFO: Pod "pod-configmaps-e356dfdb-2911-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:02:28.028: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-configmaps-e356dfdb-2911-11e8-a0aa-16411a5f38c2 container env-test: <nil>
+STEP: delete the pod
+Mar 16 12:02:28.046: INFO: Waiting for pod pod-configmaps-e356dfdb-2911-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:02:28.064: INFO: Pod pod-configmaps-e356dfdb-2911-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:02:28.064: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-78bxx" for this suite.
+Mar 16 12:02:34.076: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:02:34.169: INFO: namespace: e2e-tests-configmap-78bxx, resource: bindings, ignored listing per whitelist
+Mar 16 12:02:34.194: INFO: namespace e2e-tests-configmap-78bxx deletion completed in 6.126662024s
+
+• [SLOW TEST:10.226 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:02:34.194: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating secret e2e-tests-secrets-6njf2/secret-test-e96eb027-2911-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:02:34.239: INFO: Waiting up to 5m0s for pod "pod-configmaps-e96f1f4b-2911-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-secrets-6njf2" to be "success or failure"
+Mar 16 12:02:34.244: INFO: Pod "pod-configmaps-e96f1f4b-2911-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.05034ms
+Mar 16 12:02:36.247: INFO: Pod "pod-configmaps-e96f1f4b-2911-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007252964s
+Mar 16 12:02:38.250: INFO: Pod "pod-configmaps-e96f1f4b-2911-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010914637s
+STEP: Saw pod success
+Mar 16 12:02:38.250: INFO: Pod "pod-configmaps-e96f1f4b-2911-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:02:38.253: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-configmaps-e96f1f4b-2911-11e8-a0aa-16411a5f38c2 container env-test: <nil>
+STEP: delete the pod
+Mar 16 12:02:38.269: INFO: Waiting for pod pod-configmaps-e96f1f4b-2911-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:02:38.271: INFO: Pod pod-configmaps-e96f1f4b-2911-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:02:38.271: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-6njf2" for this suite.
+Mar 16 12:02:44.283: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:02:44.342: INFO: namespace: e2e-tests-secrets-6njf2, resource: bindings, ignored listing per whitelist
+Mar 16 12:02:44.394: INFO: namespace e2e-tests-secrets-6njf2 deletion completed in 6.120021822s
+
+• [SLOW TEST:10.201 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:02:44.395: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-pxl6p
+Mar 16 12:02:46.455: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-pxl6p
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 16 12:02:46.457: INFO: Initial restart count of pod liveness-http is 0
+Mar 16 12:03:04.487: INFO: Restart count of pod e2e-tests-container-probe-pxl6p/liveness-http is now 1 (18.029325511s elapsed)
+Mar 16 12:03:24.518: INFO: Restart count of pod e2e-tests-container-probe-pxl6p/liveness-http is now 2 (38.060455572s elapsed)
+Mar 16 12:03:44.553: INFO: Restart count of pod e2e-tests-container-probe-pxl6p/liveness-http is now 3 (58.095510545s elapsed)
+Mar 16 12:04:04.586: INFO: Restart count of pod e2e-tests-container-probe-pxl6p/liveness-http is now 4 (1m18.129052184s elapsed)
+Mar 16 12:05:04.688: INFO: Restart count of pod e2e-tests-container-probe-pxl6p/liveness-http is now 5 (2m18.230871917s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:05:04.695: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-pxl6p" for this suite.
+Mar 16 12:05:10.721: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:05:10.766: INFO: namespace: e2e-tests-container-probe-pxl6p, resource: bindings, ignored listing per whitelist
+Mar 16 12:05:10.834: INFO: namespace e2e-tests-container-probe-pxl6p deletion completed in 6.132320051s
+
+• [SLOW TEST:146.439 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:05:10.834: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:51
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-wrqnn
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-wrqnn to expose endpoints map[]
+Mar 16 12:05:10.896: INFO: Get endpoints failed (2.552771ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Mar 16 12:05:11.899: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-wrqnn exposes endpoints map[] (1.005201684s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-wrqnn
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-wrqnn to expose endpoints map[pod1:[80]]
+Mar 16 12:05:13.920: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-wrqnn exposes endpoints map[pod1:[80]] (2.014276767s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-wrqnn
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-wrqnn to expose endpoints map[pod1:[80] pod2:[80]]
+Mar 16 12:05:14.941: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-wrqnn exposes endpoints map[pod1:[80] pod2:[80]] (1.016867499s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-wrqnn
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-wrqnn to expose endpoints map[pod2:[80]]
+Mar 16 12:05:15.955: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-wrqnn exposes endpoints map[pod2:[80]] (1.010052096s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-wrqnn
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-wrqnn to expose endpoints map[]
+Mar 16 12:05:15.964: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-wrqnn exposes endpoints map[] (5.842561ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:05:15.975: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-wrqnn" for this suite.
+Mar 16 12:05:22.005: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:05:22.092: INFO: namespace: e2e-tests-services-wrqnn, resource: bindings, ignored listing per whitelist
+Mar 16 12:05:22.120: INFO: namespace e2e-tests-services-wrqnn deletion completed in 6.141689441s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:56
+
+• [SLOW TEST:11.285 seconds]
+[sig-network] Services
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:05:22.120: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap e2e-tests-configmap-86bwx/configmap-test-4d8664fc-2912-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:05:22.167: INFO: Waiting up to 5m0s for pod "pod-configmaps-4d86c921-2912-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-configmap-86bwx" to be "success or failure"
+Mar 16 12:05:22.169: INFO: Pod "pod-configmaps-4d86c921-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.259556ms
+Mar 16 12:05:24.173: INFO: Pod "pod-configmaps-4d86c921-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005380757s
+Mar 16 12:05:26.176: INFO: Pod "pod-configmaps-4d86c921-2912-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008385268s
+STEP: Saw pod success
+Mar 16 12:05:26.176: INFO: Pod "pod-configmaps-4d86c921-2912-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:05:26.178: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-configmaps-4d86c921-2912-11e8-a0aa-16411a5f38c2 container env-test: <nil>
+STEP: delete the pod
+Mar 16 12:05:26.205: INFO: Waiting for pod pod-configmaps-4d86c921-2912-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:05:26.208: INFO: Pod pod-configmaps-4d86c921-2912-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:05:26.208: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-86bwx" for this suite.
+Mar 16 12:05:32.219: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:05:32.324: INFO: namespace: e2e-tests-configmap-86bwx, resource: bindings, ignored listing per whitelist
+Mar 16 12:05:32.326: INFO: namespace e2e-tests-configmap-86bwx deletion completed in 6.115635258s
+
+• [SLOW TEST:10.207 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:05:32.327: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test substitution in container's args
+Mar 16 12:05:32.371: INFO: Waiting up to 5m0s for pod "var-expansion-539bb954-2912-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-var-expansion-swkd9" to be "success or failure"
+Mar 16 12:05:32.376: INFO: Pod "var-expansion-539bb954-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.749254ms
+Mar 16 12:05:34.379: INFO: Pod "var-expansion-539bb954-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007985873s
+Mar 16 12:05:36.382: INFO: Pod "var-expansion-539bb954-2912-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011202445s
+STEP: Saw pod success
+Mar 16 12:05:36.382: INFO: Pod "var-expansion-539bb954-2912-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:05:36.385: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod var-expansion-539bb954-2912-11e8-a0aa-16411a5f38c2 container dapi-container: <nil>
+STEP: delete the pod
+Mar 16 12:05:36.403: INFO: Waiting for pod var-expansion-539bb954-2912-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:05:36.405: INFO: Pod var-expansion-539bb954-2912-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:05:36.405: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-swkd9" for this suite.
+Mar 16 12:05:42.426: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:05:42.463: INFO: namespace: e2e-tests-var-expansion-swkd9, resource: bindings, ignored listing per whitelist
+Mar 16 12:05:42.534: INFO: namespace e2e-tests-var-expansion-swkd9 deletion completed in 6.125220221s
+
+• [SLOW TEST:10.207 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:05:42.534: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-59b10943-2912-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:05:42.581: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-59b18135-2912-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-hmtmq" to be "success or failure"
+Mar 16 12:05:42.585: INFO: Pod "pod-projected-configmaps-59b18135-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.826655ms
+Mar 16 12:05:44.589: INFO: Pod "pod-projected-configmaps-59b18135-2912-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008099287s
+STEP: Saw pod success
+Mar 16 12:05:44.589: INFO: Pod "pod-projected-configmaps-59b18135-2912-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:05:44.592: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-projected-configmaps-59b18135-2912-11e8-a0aa-16411a5f38c2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:05:44.610: INFO: Waiting for pod pod-projected-configmaps-59b18135-2912-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:05:44.612: INFO: Pod pod-projected-configmaps-59b18135-2912-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:05:44.612: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hmtmq" for this suite.
+Mar 16 12:05:50.624: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:05:50.712: INFO: namespace: e2e-tests-projected-hmtmq, resource: bindings, ignored listing per whitelist
+Mar 16 12:05:50.732: INFO: namespace e2e-tests-projected-hmtmq deletion completed in 6.116543851s
+
+• [SLOW TEST:8.199 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:05:50.732: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-upd-5e95aabc-2912-11e8-a0aa-16411a5f38c2
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-5e95aabc-2912-11e8-a0aa-16411a5f38c2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:05:54.861: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-dfnmw" for this suite.
+Mar 16 12:06:06.873: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:06:06.965: INFO: namespace: e2e-tests-configmap-dfnmw, resource: bindings, ignored listing per whitelist
+Mar 16 12:06:06.982: INFO: namespace e2e-tests-configmap-dfnmw deletion completed in 12.117972745s
+
+• [SLOW TEST:16.250 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:06:06.983: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-map-6843ceec-2912-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:06:07.030: INFO: Waiting up to 5m0s for pod "pod-secrets-684451df-2912-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-secrets-zxbf7" to be "success or failure"
+Mar 16 12:06:07.034: INFO: Pod "pod-secrets-684451df-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.82254ms
+Mar 16 12:06:09.037: INFO: Pod "pod-secrets-684451df-2912-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006449926s
+STEP: Saw pod success
+Mar 16 12:06:09.037: INFO: Pod "pod-secrets-684451df-2912-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:06:09.039: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-secrets-684451df-2912-11e8-a0aa-16411a5f38c2 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:06:09.055: INFO: Waiting for pod pod-secrets-684451df-2912-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:06:09.058: INFO: Pod pod-secrets-684451df-2912-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:06:09.058: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-zxbf7" for this suite.
+Mar 16 12:06:15.070: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:06:15.140: INFO: namespace: e2e-tests-secrets-zxbf7, resource: bindings, ignored listing per whitelist
+Mar 16 12:06:15.173: INFO: namespace e2e-tests-secrets-zxbf7 deletion completed in 6.111977792s
+
+• [SLOW TEST:8.190 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:06:15.174: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 16 12:06:15.220: INFO: (0) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.295521ms)
+Mar 16 12:06:15.224: INFO: (1) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.95546ms)
+Mar 16 12:06:15.228: INFO: (2) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.902904ms)
+Mar 16 12:06:15.232: INFO: (3) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.416581ms)
+Mar 16 12:06:15.236: INFO: (4) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.684668ms)
+Mar 16 12:06:15.239: INFO: (5) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.602194ms)
+Mar 16 12:06:15.243: INFO: (6) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.516808ms)
+Mar 16 12:06:15.246: INFO: (7) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.543936ms)
+Mar 16 12:06:15.250: INFO: (8) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.887162ms)
+Mar 16 12:06:15.254: INFO: (9) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.553615ms)
+Mar 16 12:06:15.257: INFO: (10) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.584672ms)
+Mar 16 12:06:15.261: INFO: (11) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.489708ms)
+Mar 16 12:06:15.264: INFO: (12) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.331205ms)
+Mar 16 12:06:15.268: INFO: (13) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.393834ms)
+Mar 16 12:06:15.272: INFO: (14) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.896618ms)
+Mar 16 12:06:15.275: INFO: (15) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.355138ms)
+Mar 16 12:06:15.279: INFO: (16) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.634535ms)
+Mar 16 12:06:15.282: INFO: (17) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.513914ms)
+Mar 16 12:06:15.286: INFO: (18) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.456227ms)
+Mar 16 12:06:15.289: INFO: (19) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.49866ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:06:15.289: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-f6h28" for this suite.
+Mar 16 12:06:21.302: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:06:21.344: INFO: namespace: e2e-tests-proxy-f6h28, resource: bindings, ignored listing per whitelist
+Mar 16 12:06:21.416: INFO: namespace e2e-tests-proxy-f6h28 deletion completed in 6.123786532s
+
+• [SLOW TEST:6.242 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:06:21.416: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir volume type on node default medium
+Mar 16 12:06:21.467: INFO: Waiting up to 5m0s for pod "pod-70de92a5-2912-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-8zxtd" to be "success or failure"
+Mar 16 12:06:21.471: INFO: Pod "pod-70de92a5-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.016272ms
+Mar 16 12:06:23.475: INFO: Pod "pod-70de92a5-2912-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007581295s
+STEP: Saw pod success
+Mar 16 12:06:23.475: INFO: Pod "pod-70de92a5-2912-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:06:23.479: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-70de92a5-2912-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:06:23.497: INFO: Waiting for pod pod-70de92a5-2912-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:06:23.501: INFO: Pod pod-70de92a5-2912-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:06:23.502: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-8zxtd" for this suite.
+Mar 16 12:06:29.519: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:06:29.596: INFO: namespace: e2e-tests-emptydir-8zxtd, resource: bindings, ignored listing per whitelist
+Mar 16 12:06:29.627: INFO: namespace e2e-tests-emptydir-8zxtd deletion completed in 6.121716959s
+
+• [SLOW TEST:8.211 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:06:29.627: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-75c3529b-2912-11e8-a0aa-16411a5f38c2
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-75c3529b-2912-11e8-a0aa-16411a5f38c2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:06:33.751: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-zcswb" for this suite.
+Mar 16 12:06:55.761: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:06:55.821: INFO: namespace: e2e-tests-projected-zcswb, resource: bindings, ignored listing per whitelist
+Mar 16 12:06:55.870: INFO: namespace e2e-tests-projected-zcswb deletion completed in 22.116310342s
+
+• [SLOW TEST:26.243 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:06:55.870: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Mar 16 12:06:55.919: INFO: Waiting up to 5m0s for pod "pod-856745e9-2912-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-bxmjt" to be "success or failure"
+Mar 16 12:06:55.922: INFO: Pod "pod-856745e9-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.509705ms
+Mar 16 12:06:57.926: INFO: Pod "pod-856745e9-2912-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006879466s
+STEP: Saw pod success
+Mar 16 12:06:57.926: INFO: Pod "pod-856745e9-2912-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:06:57.928: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-856745e9-2912-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:06:57.944: INFO: Waiting for pod pod-856745e9-2912-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:06:57.948: INFO: Pod pod-856745e9-2912-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:06:57.949: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-bxmjt" for this suite.
+Mar 16 12:07:03.973: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:07:04.037: INFO: namespace: e2e-tests-emptydir-bxmjt, resource: bindings, ignored listing per whitelist
+Mar 16 12:07:04.110: INFO: namespace e2e-tests-emptydir-bxmjt deletion completed in 6.158018407s
+
+• [SLOW TEST:8.240 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:07:04.111: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name projected-secret-test-8a504d3e-2912-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:07:04.153: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-8a50b42d-2912-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-5cslr" to be "success or failure"
+Mar 16 12:07:04.155: INFO: Pod "pod-projected-secrets-8a50b42d-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 1.985365ms
+Mar 16 12:07:06.158: INFO: Pod "pod-projected-secrets-8a50b42d-2912-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005131369s
+STEP: Saw pod success
+Mar 16 12:07:06.159: INFO: Pod "pod-projected-secrets-8a50b42d-2912-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:07:06.161: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-projected-secrets-8a50b42d-2912-11e8-a0aa-16411a5f38c2 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:07:06.181: INFO: Waiting for pod pod-projected-secrets-8a50b42d-2912-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:07:06.184: INFO: Pod pod-projected-secrets-8a50b42d-2912-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:07:06.184: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5cslr" for this suite.
+Mar 16 12:07:12.196: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:07:12.269: INFO: namespace: e2e-tests-projected-5cslr, resource: bindings, ignored listing per whitelist
+Mar 16 12:07:12.311: INFO: namespace e2e-tests-projected-5cslr deletion completed in 6.123082736s
+
+• [SLOW TEST:8.200 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:07:12.311: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:07:12.357: INFO: Waiting up to 5m0s for pod "downwardapi-volume-8f345f6a-2912-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-m8vfw" to be "success or failure"
+Mar 16 12:07:12.359: INFO: Pod "downwardapi-volume-8f345f6a-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 1.876054ms
+Mar 16 12:07:14.362: INFO: Pod "downwardapi-volume-8f345f6a-2912-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005068281s
+STEP: Saw pod success
+Mar 16 12:07:14.362: INFO: Pod "downwardapi-volume-8f345f6a-2912-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:07:14.365: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod downwardapi-volume-8f345f6a-2912-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:07:14.394: INFO: Waiting for pod downwardapi-volume-8f345f6a-2912-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:07:14.402: INFO: Pod downwardapi-volume-8f345f6a-2912-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:07:14.402: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-m8vfw" for this suite.
+Mar 16 12:07:20.417: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:07:20.475: INFO: namespace: e2e-tests-projected-m8vfw, resource: bindings, ignored listing per whitelist
+Mar 16 12:07:20.525: INFO: namespace e2e-tests-projected-m8vfw deletion completed in 6.118648825s
+
+• [SLOW TEST:8.214 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:07:20.525: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test env composition
+Mar 16 12:07:20.568: INFO: Waiting up to 5m0s for pod "var-expansion-94195f2b-2912-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-var-expansion-wnqwq" to be "success or failure"
+Mar 16 12:07:20.572: INFO: Pod "var-expansion-94195f2b-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.445383ms
+Mar 16 12:07:22.575: INFO: Pod "var-expansion-94195f2b-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006645444s
+Mar 16 12:07:24.579: INFO: Pod "var-expansion-94195f2b-2912-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011015018s
+STEP: Saw pod success
+Mar 16 12:07:24.579: INFO: Pod "var-expansion-94195f2b-2912-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:07:24.582: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod var-expansion-94195f2b-2912-11e8-a0aa-16411a5f38c2 container dapi-container: <nil>
+STEP: delete the pod
+Mar 16 12:07:24.595: INFO: Waiting for pod var-expansion-94195f2b-2912-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:07:24.598: INFO: Pod var-expansion-94195f2b-2912-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:07:24.598: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-wnqwq" for this suite.
+Mar 16 12:07:30.620: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:07:30.703: INFO: namespace: e2e-tests-var-expansion-wnqwq, resource: bindings, ignored listing per whitelist
+Mar 16 12:07:30.726: INFO: namespace e2e-tests-var-expansion-wnqwq deletion completed in 6.121671042s
+
+• [SLOW TEST:10.201 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:07:30.727: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-9a2ddedf-2912-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:07:30.772: INFO: Waiting up to 5m0s for pod "pod-secrets-9a2e516b-2912-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-secrets-zfnxr" to be "success or failure"
+Mar 16 12:07:30.778: INFO: Pod "pod-secrets-9a2e516b-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 6.605114ms
+Mar 16 12:07:32.782: INFO: Pod "pod-secrets-9a2e516b-2912-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010431162s
+STEP: Saw pod success
+Mar 16 12:07:32.782: INFO: Pod "pod-secrets-9a2e516b-2912-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:07:32.785: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-secrets-9a2e516b-2912-11e8-a0aa-16411a5f38c2 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:07:32.804: INFO: Waiting for pod pod-secrets-9a2e516b-2912-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:07:32.809: INFO: Pod pod-secrets-9a2e516b-2912-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:07:32.809: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-zfnxr" for this suite.
+Mar 16 12:07:38.832: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:07:38.923: INFO: namespace: e2e-tests-secrets-zfnxr, resource: bindings, ignored listing per whitelist
+Mar 16 12:07:38.941: INFO: namespace e2e-tests-secrets-zfnxr deletion completed in 6.127966554s
+
+• [SLOW TEST:8.214 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:07:38.941: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Mar 16 12:07:38.981: INFO: Waiting up to 5m0s for pod "pod-9f130a9a-2912-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-j6287" to be "success or failure"
+Mar 16 12:07:38.984: INFO: Pod "pod-9f130a9a-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.170386ms
+Mar 16 12:07:40.987: INFO: Pod "pod-9f130a9a-2912-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005079881s
+STEP: Saw pod success
+Mar 16 12:07:40.987: INFO: Pod "pod-9f130a9a-2912-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:07:40.991: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-9f130a9a-2912-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:07:41.010: INFO: Waiting for pod pod-9f130a9a-2912-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:07:41.012: INFO: Pod pod-9f130a9a-2912-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:07:41.012: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-j6287" for this suite.
+Mar 16 12:07:47.023: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:07:47.112: INFO: namespace: e2e-tests-emptydir-j6287, resource: bindings, ignored listing per whitelist
+Mar 16 12:07:47.138: INFO: namespace e2e-tests-emptydir-j6287 deletion completed in 6.123365485s
+
+• [SLOW TEST:8.198 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:07:47.139: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:07:47.183: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a3f64428-2912-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-mz4cg" to be "success or failure"
+Mar 16 12:07:47.191: INFO: Pod "downwardapi-volume-a3f64428-2912-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 8.024995ms
+Mar 16 12:07:49.194: INFO: Pod "downwardapi-volume-a3f64428-2912-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010976427s
+STEP: Saw pod success
+Mar 16 12:07:49.194: INFO: Pod "downwardapi-volume-a3f64428-2912-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:07:49.196: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod downwardapi-volume-a3f64428-2912-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:07:49.214: INFO: Waiting for pod downwardapi-volume-a3f64428-2912-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:07:49.225: INFO: Pod downwardapi-volume-a3f64428-2912-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:07:49.233: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-mz4cg" for this suite.
+Mar 16 12:07:55.277: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:07:55.333: INFO: namespace: e2e-tests-projected-mz4cg, resource: bindings, ignored listing per whitelist
+Mar 16 12:07:55.392: INFO: namespace e2e-tests-projected-mz4cg deletion completed in 6.126233441s
+
+• [SLOW TEST:8.253 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:07:55.392: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name s-test-opt-del-a8e43445-2912-11e8-a0aa-16411a5f38c2
+STEP: Creating secret with name s-test-opt-upd-a8e4349d-2912-11e8-a0aa-16411a5f38c2
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-a8e43445-2912-11e8-a0aa-16411a5f38c2
+STEP: Updating secret s-test-opt-upd-a8e4349d-2912-11e8-a0aa-16411a5f38c2
+STEP: Creating secret with name s-test-opt-create-a8e434bb-2912-11e8-a0aa-16411a5f38c2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:07:59.716: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-2nqpf" for this suite.
+Mar 16 12:08:21.728: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:08:21.813: INFO: namespace: e2e-tests-secrets-2nqpf, resource: bindings, ignored listing per whitelist
+Mar 16 12:08:21.837: INFO: namespace e2e-tests-secrets-2nqpf deletion completed in 22.117187536s
+
+• [SLOW TEST:26.445 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:08:21.837: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 16 12:08:24.423: INFO: Successfully updated pod "annotationupdateb8a4aba9-2912-11e8-a0aa-16411a5f38c2"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:09:54.086: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-x7s7l" for this suite.
+Mar 16 12:10:16.100: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:10:16.208: INFO: namespace: e2e-tests-projected-x7s7l, resource: bindings, ignored listing per whitelist
+Mar 16 12:10:16.208: INFO: namespace e2e-tests-projected-x7s7l deletion completed in 22.118999452s
+
+• [SLOW TEST:114.371 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:10:16.210: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-fcd10108-2912-11e8-a0aa-16411a5f38c2,GenerateName:,Namespace:e2e-tests-events-4k782,SelfLink:/api/v1/namespaces/e2e-tests-events-4k782/pods/send-events-fcd10108-2912-11e8-a0aa-16411a5f38c2,UID:fcd10b1a-2912-11e8-9302-5e442cbf7090,ResourceVersion:118903,Generation:0,CreationTimestamp:2018-03-16 12:10:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 250605749,},Annotations:map[string]string{cni.projectcalico.org/podIP: 100.96.1.185/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-qhdg4 {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-qhdg4,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-qhdg4 true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:ip-10-250-28-245.eu-west-1.compute.internal,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc420c94bb0} {node.kubernetes.io/unreachable Exists  NoExecute 0xc420c94bd0}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-03-16 12:10:16 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-03-16 12:10:17 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-03-16 12:10:16 +0000 UTC  }],Message:,Reason:,HostIP:10.250.28.245,PodIP:100.96.1.185,StartTime:2018-03-16 12:10:16 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-03-16 12:10:17 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://1e9c69b230d1319fd2b712ee8baa9bee6da67f3fb4b975430f5da83d219c2329}],QOSClass:BestEffort,InitContainerStatuses:[],},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:10:22.280: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-4k782" for this suite.
+Mar 16 12:10:28.291: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:10:28.354: INFO: namespace: e2e-tests-events-4k782, resource: bindings, ignored listing per whitelist
+Mar 16 12:10:28.395: INFO: namespace e2e-tests-events-4k782 deletion completed in 6.112358493s
+
+• [SLOW TEST:12.186 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:10:28.396: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:10:28.438: INFO: Waiting up to 5m0s for pod "downwardapi-volume-041409fb-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-fxhzg" to be "success or failure"
+Mar 16 12:10:28.441: INFO: Pod "downwardapi-volume-041409fb-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.736545ms
+Mar 16 12:10:30.444: INFO: Pod "downwardapi-volume-041409fb-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006054831s
+STEP: Saw pod success
+Mar 16 12:10:30.444: INFO: Pod "downwardapi-volume-041409fb-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:10:30.447: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod downwardapi-volume-041409fb-2913-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:10:30.461: INFO: Waiting for pod downwardapi-volume-041409fb-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:10:30.465: INFO: Pod downwardapi-volume-041409fb-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:10:30.465: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fxhzg" for this suite.
+Mar 16 12:10:36.483: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:10:36.598: INFO: namespace: e2e-tests-projected-fxhzg, resource: bindings, ignored listing per whitelist
+Mar 16 12:10:36.607: INFO: namespace e2e-tests-projected-fxhzg deletion completed in 6.137868491s
+
+• [SLOW TEST:8.212 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:10:36.607: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 16 12:10:36.650: INFO: Waiting up to 5m0s for pod "downward-api-08f90b50-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-ctkw6" to be "success or failure"
+Mar 16 12:10:36.654: INFO: Pod "downward-api-08f90b50-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.662378ms
+Mar 16 12:10:38.657: INFO: Pod "downward-api-08f90b50-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006953764s
+Mar 16 12:10:40.661: INFO: Pod "downward-api-08f90b50-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010434836s
+STEP: Saw pod success
+Mar 16 12:10:40.661: INFO: Pod "downward-api-08f90b50-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:10:40.663: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod downward-api-08f90b50-2913-11e8-a0aa-16411a5f38c2 container dapi-container: <nil>
+STEP: delete the pod
+Mar 16 12:10:40.678: INFO: Waiting for pod downward-api-08f90b50-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:10:40.680: INFO: Pod downward-api-08f90b50-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:10:40.681: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-ctkw6" for this suite.
+Mar 16 12:10:46.693: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:10:46.770: INFO: namespace: e2e-tests-downward-api-ctkw6, resource: bindings, ignored listing per whitelist
+Mar 16 12:10:46.810: INFO: namespace e2e-tests-downward-api-ctkw6 deletion completed in 6.12519497s
+
+• [SLOW TEST:10.202 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:10:46.810: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Mar 16 12:10:46.867: INFO: Waiting up to 5m0s for pod "pod-0f0fe4ac-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-hrwfl" to be "success or failure"
+Mar 16 12:10:46.875: INFO: Pod "pod-0f0fe4ac-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 7.526511ms
+Mar 16 12:10:48.880: INFO: Pod "pod-0f0fe4ac-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012290791s
+STEP: Saw pod success
+Mar 16 12:10:48.880: INFO: Pod "pod-0f0fe4ac-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:10:48.882: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-0f0fe4ac-2913-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:10:48.899: INFO: Waiting for pod pod-0f0fe4ac-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:10:48.905: INFO: Pod pod-0f0fe4ac-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:10:48.905: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-hrwfl" for this suite.
+Mar 16 12:10:54.935: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:10:55.024: INFO: namespace: e2e-tests-emptydir-hrwfl, resource: bindings, ignored listing per whitelist
+Mar 16 12:10:55.049: INFO: namespace e2e-tests-emptydir-hrwfl deletion completed in 6.136923098s
+
+• [SLOW TEST:8.239 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:10:55.049: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-map-13f8d01e-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:10:55.106: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-13f93edc-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-x22xx" to be "success or failure"
+Mar 16 12:10:55.110: INFO: Pod "pod-projected-configmaps-13f93edc-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.27798ms
+Mar 16 12:10:57.113: INFO: Pod "pod-projected-configmaps-13f93edc-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007541668s
+STEP: Saw pod success
+Mar 16 12:10:57.113: INFO: Pod "pod-projected-configmaps-13f93edc-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:10:57.116: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-projected-configmaps-13f93edc-2913-11e8-a0aa-16411a5f38c2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:10:57.130: INFO: Waiting for pod pod-projected-configmaps-13f93edc-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:10:57.132: INFO: Pod pod-projected-configmaps-13f93edc-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:10:57.132: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-x22xx" for this suite.
+Mar 16 12:11:03.149: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:11:03.230: INFO: namespace: e2e-tests-projected-x22xx, resource: bindings, ignored listing per whitelist
+Mar 16 12:11:03.265: INFO: namespace e2e-tests-projected-x22xx deletion completed in 6.129927374s
+
+• [SLOW TEST:8.217 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:11:03.265: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Mar 16 12:11:03.309: INFO: Waiting up to 5m0s for pod "pod-18dce60f-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-r7swd" to be "success or failure"
+Mar 16 12:11:03.313: INFO: Pod "pod-18dce60f-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.802916ms
+Mar 16 12:11:05.316: INFO: Pod "pod-18dce60f-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006714387s
+STEP: Saw pod success
+Mar 16 12:11:05.316: INFO: Pod "pod-18dce60f-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:11:05.318: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-18dce60f-2913-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:11:05.336: INFO: Waiting for pod pod-18dce60f-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:11:05.346: INFO: Pod pod-18dce60f-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:11:05.352: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-r7swd" for this suite.
+Mar 16 12:11:11.364: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:11:11.406: INFO: namespace: e2e-tests-emptydir-r7swd, resource: bindings, ignored listing per whitelist
+Mar 16 12:11:11.477: INFO: namespace e2e-tests-emptydir-r7swd deletion completed in 6.121635555s
+
+• [SLOW TEST:8.211 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:11:11.477: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 16 12:11:13.540: INFO: Waiting up to 5m0s for pod "client-envvars-1ef6104d-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-pods-2mdt9" to be "success or failure"
+Mar 16 12:11:13.543: INFO: Pod "client-envvars-1ef6104d-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.84311ms
+Mar 16 12:11:15.547: INFO: Pod "client-envvars-1ef6104d-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00666767s
+Mar 16 12:11:17.550: INFO: Pod "client-envvars-1ef6104d-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.00966398s
+STEP: Saw pod success
+Mar 16 12:11:17.550: INFO: Pod "client-envvars-1ef6104d-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:11:17.552: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod client-envvars-1ef6104d-2913-11e8-a0aa-16411a5f38c2 container env3cont: <nil>
+STEP: delete the pod
+Mar 16 12:11:17.569: INFO: Waiting for pod client-envvars-1ef6104d-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:11:17.573: INFO: Pod client-envvars-1ef6104d-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:11:17.579: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-2mdt9" for this suite.
+Mar 16 12:11:39.603: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:11:39.696: INFO: namespace: e2e-tests-pods-2mdt9, resource: bindings, ignored listing per whitelist
+Mar 16 12:11:39.712: INFO: namespace e2e-tests-pods-2mdt9 deletion completed in 22.116468868s
+
+• [SLOW TEST:28.235 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:11:39.712: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-2e966b24-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:11:39.760: INFO: Waiting up to 5m0s for pod "pod-secrets-2e96e969-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-secrets-wj944" to be "success or failure"
+Mar 16 12:11:39.762: INFO: Pod "pod-secrets-2e96e969-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.024377ms
+Mar 16 12:11:41.766: INFO: Pod "pod-secrets-2e96e969-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005610743s
+STEP: Saw pod success
+Mar 16 12:11:41.766: INFO: Pod "pod-secrets-2e96e969-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:11:41.768: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-secrets-2e96e969-2913-11e8-a0aa-16411a5f38c2 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:11:41.786: INFO: Waiting for pod pod-secrets-2e96e969-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:11:41.790: INFO: Pod pod-secrets-2e96e969-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:11:41.790: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-wj944" for this suite.
+Mar 16 12:11:47.802: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:11:47.864: INFO: namespace: e2e-tests-secrets-wj944, resource: bindings, ignored listing per whitelist
+Mar 16 12:11:47.917: INFO: namespace e2e-tests-secrets-wj944 deletion completed in 6.124665879s
+
+• [SLOW TEST:8.206 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default commmand (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:11:47.918: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default commmand (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test override command
+Mar 16 12:11:47.960: INFO: Waiting up to 5m0s for pod "client-containers-337a1777-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-containers-sb5mk" to be "success or failure"
+Mar 16 12:11:47.965: INFO: Pod "client-containers-337a1777-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 5.021313ms
+Mar 16 12:11:49.968: INFO: Pod "client-containers-337a1777-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007926604s
+STEP: Saw pod success
+Mar 16 12:11:49.968: INFO: Pod "client-containers-337a1777-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:11:49.970: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod client-containers-337a1777-2913-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:11:49.990: INFO: Waiting for pod client-containers-337a1777-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:11:50.001: INFO: Pod client-containers-337a1777-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:11:50.001: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-sb5mk" for this suite.
+Mar 16 12:11:56.021: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:11:56.092: INFO: namespace: e2e-tests-containers-sb5mk, resource: bindings, ignored listing per whitelist
+Mar 16 12:11:56.139: INFO: namespace e2e-tests-containers-sb5mk deletion completed in 6.133561771s
+
+• [SLOW TEST:8.221 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be able to override the image's default commmand (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:11:56.139: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:11:56.180: INFO: Waiting up to 5m0s for pod "downwardapi-volume-3860692a-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-p4jnk" to be "success or failure"
+Mar 16 12:11:56.182: INFO: Pod "downwardapi-volume-3860692a-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.173697ms
+Mar 16 12:11:58.185: INFO: Pod "downwardapi-volume-3860692a-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005260506s
+STEP: Saw pod success
+Mar 16 12:11:58.186: INFO: Pod "downwardapi-volume-3860692a-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:11:58.188: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod downwardapi-volume-3860692a-2913-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:11:58.211: INFO: Waiting for pod downwardapi-volume-3860692a-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:11:58.213: INFO: Pod downwardapi-volume-3860692a-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:11:58.214: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-p4jnk" for this suite.
+Mar 16 12:12:04.225: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:12:04.310: INFO: namespace: e2e-tests-downward-api-p4jnk, resource: bindings, ignored listing per whitelist
+Mar 16 12:12:04.338: INFO: namespace e2e-tests-downward-api-p4jnk deletion completed in 6.121784044s
+
+• [SLOW TEST:8.199 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:12:04.339: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Mar 16 12:12:06.898: INFO: Successfully updated pod "pod-update-activedeadlineseconds-3d4396c5-2913-11e8-a0aa-16411a5f38c2"
+Mar 16 12:12:06.898: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-3d4396c5-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-pods-742mb" to be "terminated due to deadline exceeded"
+Mar 16 12:12:06.908: INFO: Pod "pod-update-activedeadlineseconds-3d4396c5-2913-11e8-a0aa-16411a5f38c2": Phase="Running", Reason="", readiness=true. Elapsed: 9.976752ms
+Mar 16 12:12:08.911: INFO: Pod "pod-update-activedeadlineseconds-3d4396c5-2913-11e8-a0aa-16411a5f38c2": Phase="Running", Reason="", readiness=true. Elapsed: 2.012828406s
+Mar 16 12:12:10.914: INFO: Pod "pod-update-activedeadlineseconds-3d4396c5-2913-11e8-a0aa-16411a5f38c2": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 4.016230676s
+Mar 16 12:12:10.914: INFO: Pod "pod-update-activedeadlineseconds-3d4396c5-2913-11e8-a0aa-16411a5f38c2" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:12:10.915: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-742mb" for this suite.
+Mar 16 12:12:16.934: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:12:16.983: INFO: namespace: e2e-tests-pods-742mb, resource: bindings, ignored listing per whitelist
+Mar 16 12:12:17.052: INFO: namespace e2e-tests-pods-742mb deletion completed in 6.134322602s
+
+• [SLOW TEST:12.714 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:12:17.052: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 16 12:12:17.091: INFO: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:12:17.092: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-62bfd" for this suite.
+Mar 16 12:12:23.103: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:12:23.153: INFO: namespace: e2e-tests-container-probe-62bfd, resource: bindings, ignored listing per whitelist
+Mar 16 12:12:23.216: INFO: namespace e2e-tests-container-probe-62bfd deletion completed in 6.12086113s
+
+S [SKIPPING] [6.164 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be restarted with a docker exec liveness probe with timeout  [Conformance] [It]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+
+  Mar 16 12:12:17.091: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:289
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:12:23.217: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-zgb2m in namespace e2e-tests-proxy-5bxfn
+I0316 12:12:23.266491      14 runners.go:178] Created replication controller with name: proxy-service-zgb2m, namespace: e2e-tests-proxy-5bxfn, replica count: 1
+I0316 12:12:24.266748      14 runners.go:178] proxy-service-zgb2m Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0316 12:12:25.266958      14 runners.go:178] proxy-service-zgb2m Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0316 12:12:26.267193      14 runners.go:178] proxy-service-zgb2m Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0316 12:12:27.267408      14 runners.go:178] proxy-service-zgb2m Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0316 12:12:28.267609      14 runners.go:178] proxy-service-zgb2m Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Mar 16 12:12:28.270: INFO: setup took 5.014647608s, starting test cases
+STEP: running 34 cases, 20 attempts per case, 680 total attempts
+Mar 16 12:12:28.281: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 10.775131ms)
+Mar 16 12:12:28.281: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 10.943199ms)
+Mar 16 12:12:28.282: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 11.055284ms)
+Mar 16 12:12:28.283: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 11.893875ms)
+Mar 16 12:12:28.283: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 11.790708ms)
+Mar 16 12:12:28.288: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 18.174916ms)
+Mar 16 12:12:28.288: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 18.56495ms)
+Mar 16 12:12:28.291: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 20.96188ms)
+Mar 16 12:12:28.292: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 20.707154ms)
+Mar 16 12:12:28.304: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 32.846442ms)
+Mar 16 12:12:28.305: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 33.743429ms)
+Mar 16 12:12:28.305: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 33.453225ms)
+Mar 16 12:12:28.305: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 32.96513ms)
+Mar 16 12:12:28.306: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 34.430631ms)
+Mar 16 12:12:28.306: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 33.841285ms)
+Mar 16 12:12:28.306: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 36.027355ms)
+Mar 16 12:12:28.307: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 36.039386ms)
+Mar 16 12:12:28.307: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 35.582603ms)
+Mar 16 12:12:28.307: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 35.684069ms)
+Mar 16 12:12:28.308: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 35.954606ms)
+Mar 16 12:12:28.308: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 35.952342ms)
+Mar 16 12:12:28.309: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 37.286879ms)
+Mar 16 12:12:28.311: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 38.841331ms)
+Mar 16 12:12:28.311: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 39.154182ms)
+Mar 16 12:12:28.311: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 39.425244ms)
+Mar 16 12:12:28.317: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 46.05296ms)
+Mar 16 12:12:28.318: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 45.769035ms)
+Mar 16 12:12:28.318: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 47.171845ms)
+Mar 16 12:12:28.318: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 46.139429ms)
+Mar 16 12:12:28.318: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 48.016046ms)
+Mar 16 12:12:28.319: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 46.026993ms)
+Mar 16 12:12:28.321: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 51.11183ms)
+Mar 16 12:12:28.321: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 49.288358ms)
+Mar 16 12:12:28.325: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 52.84916ms)
+Mar 16 12:12:28.333: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 7.169199ms)
+Mar 16 12:12:28.333: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 7.453012ms)
+Mar 16 12:12:28.333: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 7.549366ms)
+Mar 16 12:12:28.333: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 7.850928ms)
+Mar 16 12:12:28.335: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 8.787748ms)
+Mar 16 12:12:28.336: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 9.086663ms)
+Mar 16 12:12:28.336: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 9.631471ms)
+Mar 16 12:12:28.336: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 9.806761ms)
+Mar 16 12:12:28.336: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 10.249623ms)
+Mar 16 12:12:28.337: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 11.323713ms)
+Mar 16 12:12:28.337: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 11.099648ms)
+Mar 16 12:12:28.337: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 11.770055ms)
+Mar 16 12:12:28.337: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 11.484145ms)
+Mar 16 12:12:28.338: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 11.47182ms)
+Mar 16 12:12:28.338: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 11.236797ms)
+Mar 16 12:12:28.338: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 11.699722ms)
+Mar 16 12:12:28.338: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 11.051145ms)
+Mar 16 12:12:28.338: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 12.779176ms)
+Mar 16 12:12:28.338: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 11.713087ms)
+Mar 16 12:12:28.339: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 12.174742ms)
+Mar 16 12:12:28.339: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 12.620141ms)
+Mar 16 12:12:28.339: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 13.093359ms)
+Mar 16 12:12:28.339: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 12.991106ms)
+Mar 16 12:12:28.339: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 13.39726ms)
+Mar 16 12:12:28.340: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 12.69164ms)
+Mar 16 12:12:28.340: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 13.83003ms)
+Mar 16 12:12:28.340: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 13.597604ms)
+Mar 16 12:12:28.341: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 14.03021ms)
+Mar 16 12:12:28.341: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 13.890981ms)
+Mar 16 12:12:28.341: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 14.731924ms)
+Mar 16 12:12:28.341: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 14.630429ms)
+Mar 16 12:12:28.341: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 14.582747ms)
+Mar 16 12:12:28.341: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 14.414103ms)
+Mar 16 12:12:28.341: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 14.59951ms)
+Mar 16 12:12:28.348: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 6.206625ms)
+Mar 16 12:12:28.351: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 9.308571ms)
+Mar 16 12:12:28.351: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 9.084775ms)
+Mar 16 12:12:28.352: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 9.538868ms)
+Mar 16 12:12:28.354: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 11.668242ms)
+Mar 16 12:12:28.355: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 12.723193ms)
+Mar 16 12:12:28.355: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 12.817385ms)
+Mar 16 12:12:28.357: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 14.568784ms)
+Mar 16 12:12:28.357: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 14.337396ms)
+Mar 16 12:12:28.357: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 15.047972ms)
+Mar 16 12:12:28.359: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 16.262449ms)
+Mar 16 12:12:28.359: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 16.086321ms)
+Mar 16 12:12:28.359: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 16.547373ms)
+Mar 16 12:12:28.359: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 17.447427ms)
+Mar 16 12:12:28.360: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 16.8986ms)
+Mar 16 12:12:28.360: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 16.417525ms)
+Mar 16 12:12:28.360: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 16.69493ms)
+Mar 16 12:12:28.360: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 16.757939ms)
+Mar 16 12:12:28.360: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 16.861774ms)
+Mar 16 12:12:28.360: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 16.964037ms)
+Mar 16 12:12:28.360: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 17.452269ms)
+Mar 16 12:12:28.360: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 17.611316ms)
+Mar 16 12:12:28.360: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 16.781237ms)
+Mar 16 12:12:28.361: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 19.399438ms)
+Mar 16 12:12:28.361: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 18.280562ms)
+Mar 16 12:12:28.361: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 19.167976ms)
+Mar 16 12:12:28.362: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 18.722901ms)
+Mar 16 12:12:28.362: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 18.452556ms)
+Mar 16 12:12:28.362: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 19.188533ms)
+Mar 16 12:12:28.363: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 20.153528ms)
+Mar 16 12:12:28.363: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 20.180202ms)
+Mar 16 12:12:28.363: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 19.916116ms)
+Mar 16 12:12:28.363: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 20.817934ms)
+Mar 16 12:12:28.363: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 20.760919ms)
+Mar 16 12:12:28.372: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 8.676135ms)
+Mar 16 12:12:28.373: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 9.375961ms)
+Mar 16 12:12:28.373: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 9.856113ms)
+Mar 16 12:12:28.373: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 10.350929ms)
+Mar 16 12:12:28.374: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 10.495022ms)
+Mar 16 12:12:28.374: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 8.966512ms)
+Mar 16 12:12:28.374: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 9.996884ms)
+Mar 16 12:12:28.375: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 10.334167ms)
+Mar 16 12:12:28.375: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 10.6339ms)
+Mar 16 12:12:28.375: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 10.050817ms)
+Mar 16 12:12:28.375: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 10.827506ms)
+Mar 16 12:12:28.376: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 11.354245ms)
+Mar 16 12:12:28.376: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 12.013605ms)
+Mar 16 12:12:28.376: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 12.61423ms)
+Mar 16 12:12:28.377: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 12.692261ms)
+Mar 16 12:12:28.377: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 11.585416ms)
+Mar 16 12:12:28.377: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 13.366303ms)
+Mar 16 12:12:28.377: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 12.2353ms)
+Mar 16 12:12:28.378: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 12.219667ms)
+Mar 16 12:12:28.378: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 12.644467ms)
+Mar 16 12:12:28.378: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 14.0425ms)
+Mar 16 12:12:28.378: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 14.342148ms)
+Mar 16 12:12:28.378: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 14.377932ms)
+Mar 16 12:12:28.378: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 14.972854ms)
+Mar 16 12:12:28.378: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 13.911461ms)
+Mar 16 12:12:28.378: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 14.05921ms)
+Mar 16 12:12:28.379: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 13.331903ms)
+Mar 16 12:12:28.379: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 14.681908ms)
+Mar 16 12:12:28.379: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 14.376171ms)
+Mar 16 12:12:28.380: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 14.276119ms)
+Mar 16 12:12:28.380: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 14.897584ms)
+Mar 16 12:12:28.380: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 14.43133ms)
+Mar 16 12:12:28.380: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 16.335647ms)
+Mar 16 12:12:28.380: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 14.692644ms)
+Mar 16 12:12:28.388: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 7.38711ms)
+Mar 16 12:12:28.390: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 9.507883ms)
+Mar 16 12:12:28.390: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 9.942331ms)
+Mar 16 12:12:28.391: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 10.42396ms)
+Mar 16 12:12:28.391: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 10.016193ms)
+Mar 16 12:12:28.391: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 10.14843ms)
+Mar 16 12:12:28.391: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 10.297203ms)
+Mar 16 12:12:28.391: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 10.457231ms)
+Mar 16 12:12:28.391: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 10.528194ms)
+Mar 16 12:12:28.392: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 11.001223ms)
+Mar 16 12:12:28.392: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 11.324575ms)
+Mar 16 12:12:28.392: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 11.606044ms)
+Mar 16 12:12:28.392: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 11.120939ms)
+Mar 16 12:12:28.393: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 11.290777ms)
+Mar 16 12:12:28.393: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 10.997459ms)
+Mar 16 12:12:28.393: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 12.525277ms)
+Mar 16 12:12:28.394: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 12.174159ms)
+Mar 16 12:12:28.394: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 11.779652ms)
+Mar 16 12:12:28.394: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 12.593165ms)
+Mar 16 12:12:28.394: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 12.427766ms)
+Mar 16 12:12:28.394: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 13.512361ms)
+Mar 16 12:12:28.395: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 12.915465ms)
+Mar 16 12:12:28.395: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 13.854196ms)
+Mar 16 12:12:28.395: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 13.548633ms)
+Mar 16 12:12:28.395: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 13.688152ms)
+Mar 16 12:12:28.395: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 13.699544ms)
+Mar 16 12:12:28.396: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 15.072785ms)
+Mar 16 12:12:28.396: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 14.615878ms)
+Mar 16 12:12:28.397: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 15.215133ms)
+Mar 16 12:12:28.397: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 15.004676ms)
+Mar 16 12:12:28.397: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 14.611918ms)
+Mar 16 12:12:28.397: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 15.030593ms)
+Mar 16 12:12:28.397: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 15.173241ms)
+Mar 16 12:12:28.402: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 20.287887ms)
+Mar 16 12:12:34.829: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 6.426352564s)
+Mar 16 12:12:34.829: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 6.425978361s)
+Mar 16 12:12:34.829: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 6.426278736s)
+Mar 16 12:12:34.829: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 6.425069201s)
+Mar 16 12:12:34.829: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 6.426252859s)
+Mar 16 12:12:34.829: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 6.426549841s)
+Mar 16 12:12:34.829: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 6.426195605s)
+Mar 16 12:12:34.830: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 6.427238409s)
+Mar 16 12:12:34.830: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 6.426703004s)
+Mar 16 12:12:34.830: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 6.427450873s)
+Mar 16 12:12:34.831: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 6.427502022s)
+Mar 16 12:12:34.831: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 6.427832763s)
+Mar 16 12:12:34.831: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 6.428050357s)
+Mar 16 12:12:34.832: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 6.428279377s)
+Mar 16 12:12:34.832: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 6.428885097s)
+Mar 16 12:12:34.832: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 6.42975966s)
+Mar 16 12:12:34.833: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 6.429688465s)
+Mar 16 12:12:34.833: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 6.429852448s)
+Mar 16 12:12:34.834: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 6.429886701s)
+Mar 16 12:12:34.834: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 6.43041556s)
+Mar 16 12:12:34.834: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 6.431144879s)
+Mar 16 12:12:34.835: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 6.431705728s)
+Mar 16 12:12:34.835: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 6.431770292s)
+Mar 16 12:12:34.872: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 6.468841407s)
+Mar 16 12:12:34.893: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 6.488877546s)
+Mar 16 12:12:34.893: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 6.488923711s)
+Mar 16 12:12:34.893: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 6.489214042s)
+Mar 16 12:12:34.893: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 6.489962632s)
+Mar 16 12:12:34.893: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 6.490612168s)
+Mar 16 12:12:34.893: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 6.489712939s)
+Mar 16 12:12:34.893: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 6.490430581s)
+Mar 16 12:12:34.893: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 6.489344925s)
+Mar 16 12:12:34.893: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 6.489690759s)
+Mar 16 12:12:34.893: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 6.489723508s)
+Mar 16 12:12:34.903: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 9.537726ms)
+Mar 16 12:12:34.904: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 9.743845ms)
+Mar 16 12:12:34.904: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 9.979072ms)
+Mar 16 12:12:34.904: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 10.574592ms)
+Mar 16 12:12:34.904: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 10.863388ms)
+Mar 16 12:12:34.905: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 10.068881ms)
+Mar 16 12:12:34.905: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 10.883062ms)
+Mar 16 12:12:34.905: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 11.0256ms)
+Mar 16 12:12:34.905: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 11.969718ms)
+Mar 16 12:12:34.906: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 12.066672ms)
+Mar 16 12:12:34.907: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 11.648932ms)
+Mar 16 12:12:34.907: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 12.090932ms)
+Mar 16 12:12:34.910: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 15.460592ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 16.191575ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 15.06613ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 15.084964ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 15.163029ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 15.367225ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 15.4741ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 15.675935ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 15.691792ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 15.922286ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 16.200625ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 16.305175ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 16.598346ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 16.703532ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 16.91627ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 16.9811ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 17.356877ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 17.481886ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 16.517496ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 16.3212ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 16.59854ms)
+Mar 16 12:12:34.911: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 16.733474ms)
+Mar 16 12:12:34.921: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 9.2561ms)
+Mar 16 12:12:34.921: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 9.464718ms)
+Mar 16 12:12:34.921: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 8.965861ms)
+Mar 16 12:12:34.921: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 9.692988ms)
+Mar 16 12:12:34.921: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 9.670414ms)
+Mar 16 12:12:34.921: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 9.740163ms)
+Mar 16 12:12:34.921: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 9.93686ms)
+Mar 16 12:12:34.921: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 10.058296ms)
+Mar 16 12:12:34.921: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 10.063261ms)
+Mar 16 12:12:34.925: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 12.801412ms)
+Mar 16 12:12:34.925: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 12.964744ms)
+Mar 16 12:12:34.925: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 12.971847ms)
+Mar 16 12:12:34.926: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 13.477668ms)
+Mar 16 12:12:34.926: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 13.818386ms)
+Mar 16 12:12:34.926: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 13.972914ms)
+Mar 16 12:12:34.926: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 14.109514ms)
+Mar 16 12:12:34.927: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 13.936559ms)
+Mar 16 12:12:34.927: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 13.621851ms)
+Mar 16 12:12:34.927: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 13.907608ms)
+Mar 16 12:12:34.927: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 15.087602ms)
+Mar 16 12:12:34.928: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 15.976836ms)
+Mar 16 12:12:34.928: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 16.482979ms)
+Mar 16 12:12:34.928: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 15.245346ms)
+Mar 16 12:12:34.928: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 15.58506ms)
+Mar 16 12:12:34.928: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 15.468881ms)
+Mar 16 12:12:34.928: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 16.782558ms)
+Mar 16 12:12:34.929: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 16.155312ms)
+Mar 16 12:12:34.929: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 17.14952ms)
+Mar 16 12:12:34.929: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 16.471015ms)
+Mar 16 12:12:34.929: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 16.70441ms)
+Mar 16 12:12:34.929: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 17.113136ms)
+Mar 16 12:12:34.929: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 17.661414ms)
+Mar 16 12:12:34.929: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 16.219187ms)
+Mar 16 12:12:34.929: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 16.502063ms)
+Mar 16 12:12:34.935: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 5.211327ms)
+Mar 16 12:12:34.935: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 5.534567ms)
+Mar 16 12:12:34.936: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 6.464527ms)
+Mar 16 12:12:34.936: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 6.304692ms)
+Mar 16 12:12:34.936: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 7.047415ms)
+Mar 16 12:12:34.937: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 7.539173ms)
+Mar 16 12:12:34.937: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 8.133124ms)
+Mar 16 12:12:34.937: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 7.737381ms)
+Mar 16 12:12:34.940: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 10.095749ms)
+Mar 16 12:12:34.941: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 10.318555ms)
+Mar 16 12:12:34.941: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 10.988342ms)
+Mar 16 12:12:34.942: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 11.153549ms)
+Mar 16 12:12:34.942: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 12.139891ms)
+Mar 16 12:12:34.942: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 12.717507ms)
+Mar 16 12:12:34.943: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 12.725142ms)
+Mar 16 12:12:34.943: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 12.855804ms)
+Mar 16 12:12:34.943: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 13.277205ms)
+Mar 16 12:12:34.943: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 12.288355ms)
+Mar 16 12:12:34.943: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 13.066565ms)
+Mar 16 12:12:34.943: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 12.696762ms)
+Mar 16 12:12:34.944: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 12.676195ms)
+Mar 16 12:12:34.944: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 13.072378ms)
+Mar 16 12:12:34.944: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 13.593675ms)
+Mar 16 12:12:34.944: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 13.653048ms)
+Mar 16 12:12:34.945: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 14.653437ms)
+Mar 16 12:12:34.946: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 15.861937ms)
+Mar 16 12:12:34.946: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 15.992312ms)
+Mar 16 12:12:34.946: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 15.776921ms)
+Mar 16 12:12:34.946: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 15.466866ms)
+Mar 16 12:12:34.947: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 15.695063ms)
+Mar 16 12:12:34.947: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 17.290593ms)
+Mar 16 12:12:34.947: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 16.897198ms)
+Mar 16 12:12:34.947: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 17.312083ms)
+Mar 16 12:12:34.947: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 16.600929ms)
+Mar 16 12:12:34.958: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 10.543486ms)
+Mar 16 12:12:34.959: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 10.802361ms)
+Mar 16 12:12:34.959: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 11.388746ms)
+Mar 16 12:12:34.960: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 11.976476ms)
+Mar 16 12:12:34.960: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 12.573741ms)
+Mar 16 12:12:34.960: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 12.237937ms)
+Mar 16 12:12:34.961: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 12.058968ms)
+Mar 16 12:12:34.962: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 12.367771ms)
+Mar 16 12:12:34.962: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 14.365489ms)
+Mar 16 12:12:34.962: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 11.911332ms)
+Mar 16 12:12:34.964: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 14.847436ms)
+Mar 16 12:12:34.965: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 16.311139ms)
+Mar 16 12:12:34.965: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 14.622128ms)
+Mar 16 12:12:34.965: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 14.984456ms)
+Mar 16 12:12:34.965: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 15.155939ms)
+Mar 16 12:12:34.965: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 15.349688ms)
+Mar 16 12:12:34.965: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 15.669669ms)
+Mar 16 12:12:34.965: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 16.054821ms)
+Mar 16 12:12:34.965: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 17.092802ms)
+Mar 16 12:12:34.965: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 16.951619ms)
+Mar 16 12:12:34.966: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 16.828917ms)
+Mar 16 12:12:34.966: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 16.804054ms)
+Mar 16 12:12:34.966: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 17.079036ms)
+Mar 16 12:12:34.966: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 17.232413ms)
+Mar 16 12:12:34.966: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 17.713193ms)
+Mar 16 12:12:34.966: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 17.45475ms)
+Mar 16 12:12:34.966: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 16.690884ms)
+Mar 16 12:12:34.966: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 16.189644ms)
+Mar 16 12:12:34.966: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 17.102921ms)
+Mar 16 12:12:34.966: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 18.334471ms)
+Mar 16 12:12:34.966: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 17.232878ms)
+Mar 16 12:12:34.967: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 17.780853ms)
+Mar 16 12:12:34.968: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 17.587173ms)
+Mar 16 12:12:34.968: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 17.723152ms)
+Mar 16 12:12:34.973: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 4.473519ms)
+Mar 16 12:12:34.976: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 7.853521ms)
+Mar 16 12:12:34.978: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 9.512384ms)
+Mar 16 12:12:34.978: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 10.20149ms)
+Mar 16 12:12:34.978: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 10.346753ms)
+Mar 16 12:12:34.979: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 10.297034ms)
+Mar 16 12:12:34.979: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 10.464886ms)
+Mar 16 12:12:34.980: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 9.207604ms)
+Mar 16 12:12:34.980: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 10.941701ms)
+Mar 16 12:12:34.980: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 11.558381ms)
+Mar 16 12:12:34.981: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 12.761016ms)
+Mar 16 12:12:34.981: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 12.442002ms)
+Mar 16 12:12:34.981: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 12.831874ms)
+Mar 16 12:12:34.981: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 11.997958ms)
+Mar 16 12:12:34.982: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 12.360582ms)
+Mar 16 12:12:34.982: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 13.060778ms)
+Mar 16 12:12:34.982: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 12.242339ms)
+Mar 16 12:12:34.982: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 12.035295ms)
+Mar 16 12:12:34.983: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 12.293598ms)
+Mar 16 12:12:34.984: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 13.448755ms)
+Mar 16 12:12:34.984: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 13.053592ms)
+Mar 16 12:12:34.984: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 13.792679ms)
+Mar 16 12:12:34.984: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 13.691668ms)
+Mar 16 12:12:34.984: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 14.967623ms)
+Mar 16 12:12:34.984: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 14.430407ms)
+Mar 16 12:12:34.984: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 13.770876ms)
+Mar 16 12:12:34.984: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 14.658898ms)
+Mar 16 12:12:34.984: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 14.486455ms)
+Mar 16 12:12:34.985: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 15.674252ms)
+Mar 16 12:12:34.985: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 14.542285ms)
+Mar 16 12:12:34.985: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 16.425031ms)
+Mar 16 12:12:34.985: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 16.068084ms)
+Mar 16 12:12:34.986: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 15.637491ms)
+Mar 16 12:12:34.986: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 16.147187ms)
+Mar 16 12:12:34.995: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 7.932962ms)
+Mar 16 12:12:34.995: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 9.484231ms)
+Mar 16 12:12:34.996: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 9.686144ms)
+Mar 16 12:12:34.996: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 9.536077ms)
+Mar 16 12:12:34.996: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 9.693426ms)
+Mar 16 12:12:34.996: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 9.560064ms)
+Mar 16 12:12:34.996: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 10.467727ms)
+Mar 16 12:12:34.997: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 9.692218ms)
+Mar 16 12:12:34.997: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 9.427489ms)
+Mar 16 12:12:34.998: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 11.539581ms)
+Mar 16 12:12:34.998: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 10.324126ms)
+Mar 16 12:12:34.998: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 10.829751ms)
+Mar 16 12:12:34.999: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 12.782444ms)
+Mar 16 12:12:34.999: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 12.527874ms)
+Mar 16 12:12:35.000: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 12.405886ms)
+Mar 16 12:12:35.000: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 12.805347ms)
+Mar 16 12:12:35.000: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 13.412775ms)
+Mar 16 12:12:35.000: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 13.524946ms)
+Mar 16 12:12:35.001: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 13.862919ms)
+Mar 16 12:12:35.001: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 14.507272ms)
+Mar 16 12:12:35.001: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 13.86122ms)
+Mar 16 12:12:35.001: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 13.86123ms)
+Mar 16 12:12:35.001: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 14.563667ms)
+Mar 16 12:12:35.001: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 15.388653ms)
+Mar 16 12:12:35.002: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 14.934282ms)
+Mar 16 12:12:35.002: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 15.371129ms)
+Mar 16 12:12:35.002: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 15.575608ms)
+Mar 16 12:12:35.002: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 15.67155ms)
+Mar 16 12:12:35.002: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 15.390581ms)
+Mar 16 12:12:35.003: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 15.131563ms)
+Mar 16 12:12:35.003: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 16.211568ms)
+Mar 16 12:12:35.003: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 16.593494ms)
+Mar 16 12:12:35.003: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 16.417089ms)
+Mar 16 12:12:35.003: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 17.199423ms)
+Mar 16 12:12:35.014: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 10.479735ms)
+Mar 16 12:12:35.014: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 10.293879ms)
+Mar 16 12:12:35.014: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 10.272572ms)
+Mar 16 12:12:35.014: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 10.584216ms)
+Mar 16 12:12:35.015: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 10.858413ms)
+Mar 16 12:12:35.015: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 10.922949ms)
+Mar 16 12:12:35.015: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 11.404917ms)
+Mar 16 12:12:35.015: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 10.313869ms)
+Mar 16 12:12:35.016: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 11.424025ms)
+Mar 16 12:12:35.016: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 10.792543ms)
+Mar 16 12:12:35.017: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 12.513713ms)
+Mar 16 12:12:35.017: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 12.465059ms)
+Mar 16 12:12:35.017: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 12.254821ms)
+Mar 16 12:12:35.018: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 12.974154ms)
+Mar 16 12:12:35.018: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 13.192614ms)
+Mar 16 12:12:35.018: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 13.633244ms)
+Mar 16 12:12:35.018: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 13.004169ms)
+Mar 16 12:12:35.019: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 14.022838ms)
+Mar 16 12:12:35.019: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 13.383866ms)
+Mar 16 12:12:35.019: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 13.988533ms)
+Mar 16 12:12:35.020: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 14.990927ms)
+Mar 16 12:12:35.021: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 16.826267ms)
+Mar 16 12:12:35.026: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 21.221304ms)
+Mar 16 12:12:35.026: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 22.04691ms)
+Mar 16 12:12:35.026: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 20.600273ms)
+Mar 16 12:12:35.026: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 22.104616ms)
+Mar 16 12:12:35.027: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 20.764089ms)
+Mar 16 12:12:35.027: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 20.713542ms)
+Mar 16 12:12:35.027: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 21.277397ms)
+Mar 16 12:12:35.027: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 21.460593ms)
+Mar 16 12:12:35.027: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 21.326808ms)
+Mar 16 12:12:35.027: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 23.255315ms)
+Mar 16 12:12:35.027: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 21.329954ms)
+Mar 16 12:12:35.027: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 22.336054ms)
+Mar 16 12:12:35.036: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 7.594381ms)
+Mar 16 12:12:35.039: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 10.654886ms)
+Mar 16 12:12:35.039: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 11.430788ms)
+Mar 16 12:12:35.039: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 9.896293ms)
+Mar 16 12:12:35.039: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 11.738092ms)
+Mar 16 12:12:35.040: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 10.152078ms)
+Mar 16 12:12:35.041: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 10.298852ms)
+Mar 16 12:12:35.041: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 10.207018ms)
+Mar 16 12:12:35.041: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 12.112348ms)
+Mar 16 12:12:35.042: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 11.499101ms)
+Mar 16 12:12:35.042: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 13.328967ms)
+Mar 16 12:12:35.042: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 12.939236ms)
+Mar 16 12:12:35.042: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 11.95835ms)
+Mar 16 12:12:35.042: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 12.616955ms)
+Mar 16 12:12:35.044: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 13.036543ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 17.196783ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 14.18626ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 17.034148ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 14.058377ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 14.007545ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 14.409363ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 14.18049ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 14.270246ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 13.993763ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 14.722205ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 14.519662ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 13.892471ms)
+Mar 16 12:12:35.045: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 13.984224ms)
+Mar 16 12:12:35.046: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 15.249893ms)
+Mar 16 12:12:35.046: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 15.945521ms)
+Mar 16 12:12:35.046: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 14.515504ms)
+Mar 16 12:12:35.046: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 16.946321ms)
+Mar 16 12:12:35.046: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 14.736159ms)
+Mar 16 12:12:35.046: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 13.967042ms)
+Mar 16 12:12:35.056: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 9.389349ms)
+Mar 16 12:12:35.057: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 10.904017ms)
+Mar 16 12:12:35.057: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 10.839352ms)
+Mar 16 12:12:35.057: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 11.482181ms)
+Mar 16 12:12:35.058: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 11.273492ms)
+Mar 16 12:12:35.058: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 12.027959ms)
+Mar 16 12:12:35.058: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 11.960988ms)
+Mar 16 12:12:35.059: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 12.490871ms)
+Mar 16 12:12:35.059: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 12.49744ms)
+Mar 16 12:12:35.059: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 12.190754ms)
+Mar 16 12:12:35.059: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 11.9837ms)
+Mar 16 12:12:35.059: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 12.826056ms)
+Mar 16 12:12:35.060: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 12.856928ms)
+Mar 16 12:12:35.060: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 12.588907ms)
+Mar 16 12:12:35.060: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 13.419049ms)
+Mar 16 12:12:35.061: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 14.552496ms)
+Mar 16 12:12:35.061: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 13.905033ms)
+Mar 16 12:12:35.061: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 14.283578ms)
+Mar 16 12:12:35.061: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 14.977063ms)
+Mar 16 12:12:35.061: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 15.209693ms)
+Mar 16 12:12:35.062: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 14.626537ms)
+Mar 16 12:12:35.062: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 15.217724ms)
+Mar 16 12:12:35.063: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 15.218322ms)
+Mar 16 12:12:35.063: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 15.837881ms)
+Mar 16 12:12:35.063: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 15.713613ms)
+Mar 16 12:12:35.063: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 15.80063ms)
+Mar 16 12:12:35.063: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 15.621513ms)
+Mar 16 12:12:35.063: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 16.60532ms)
+Mar 16 12:12:35.063: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 16.08767ms)
+Mar 16 12:12:35.064: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 16.745435ms)
+Mar 16 12:12:35.064: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 17.453134ms)
+Mar 16 12:12:35.064: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 17.026049ms)
+Mar 16 12:12:35.065: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 17.354381ms)
+Mar 16 12:12:35.065: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 18.237396ms)
+Mar 16 12:12:35.075: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 8.908814ms)
+Mar 16 12:12:35.075: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 9.408211ms)
+Mar 16 12:12:35.075: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 9.663086ms)
+Mar 16 12:12:35.075: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 9.33455ms)
+Mar 16 12:12:35.075: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 10.189264ms)
+Mar 16 12:12:35.075: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 9.681407ms)
+Mar 16 12:12:35.075: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 9.730151ms)
+Mar 16 12:12:35.075: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 10.251575ms)
+Mar 16 12:12:35.076: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 10.254395ms)
+Mar 16 12:12:35.076: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 9.297158ms)
+Mar 16 12:12:35.076: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 10.32462ms)
+Mar 16 12:12:35.077: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 10.92603ms)
+Mar 16 12:12:35.077: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 11.364027ms)
+Mar 16 12:12:35.077: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 10.940966ms)
+Mar 16 12:12:35.078: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 11.888522ms)
+Mar 16 12:12:35.078: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 12.107079ms)
+Mar 16 12:12:35.078: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 12.977033ms)
+Mar 16 12:12:35.078: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 13.165385ms)
+Mar 16 12:12:35.079: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 13.281441ms)
+Mar 16 12:12:35.079: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 12.496885ms)
+Mar 16 12:12:35.079: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 13.72248ms)
+Mar 16 12:12:35.080: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 13.0534ms)
+Mar 16 12:12:35.080: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 12.990017ms)
+Mar 16 12:12:35.080: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 13.060466ms)
+Mar 16 12:12:35.080: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 14.039263ms)
+Mar 16 12:12:35.080: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 13.662108ms)
+Mar 16 12:12:35.080: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 13.644803ms)
+Mar 16 12:12:35.081: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 15.043325ms)
+Mar 16 12:12:35.081: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 14.702764ms)
+Mar 16 12:12:35.081: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 14.64027ms)
+Mar 16 12:12:35.081: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 15.02123ms)
+Mar 16 12:12:35.082: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 14.835909ms)
+Mar 16 12:12:35.082: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 15.481721ms)
+Mar 16 12:12:35.082: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 16.153641ms)
+Mar 16 12:12:35.097: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 13.974239ms)
+Mar 16 12:12:35.097: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 14.422478ms)
+Mar 16 12:12:35.098: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 15.433283ms)
+Mar 16 12:12:35.098: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 15.523086ms)
+Mar 16 12:12:35.105: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 21.903974ms)
+Mar 16 12:12:35.108: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 24.175405ms)
+Mar 16 12:12:35.108: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 24.102973ms)
+Mar 16 12:12:35.109: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 25.264987ms)
+Mar 16 12:12:35.109: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 24.738339ms)
+Mar 16 12:12:35.109: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 25.643542ms)
+Mar 16 12:12:35.109: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 25.859323ms)
+Mar 16 12:12:35.109: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 26.109863ms)
+Mar 16 12:12:35.109: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 26.25997ms)
+Mar 16 12:12:35.109: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 26.088451ms)
+Mar 16 12:12:35.110: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 25.917531ms)
+Mar 16 12:12:35.110: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 25.438292ms)
+Mar 16 12:12:35.110: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 26.511331ms)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 4.93250183s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 4.932085207s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 4.932390158s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 4.932640428s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 4.931697493s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 4.932218318s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 4.93191483s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 4.933072167s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 4.933088356s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 4.932659449s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 4.932615782s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 4.932236496s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 4.932133375s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 4.932207972s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 4.932143788s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 4.932007055s)
+Mar 16 12:12:40.016: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 4.932680152s)
+Mar 16 12:12:40.028: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 11.062221ms)
+Mar 16 12:12:40.029: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 11.440885ms)
+Mar 16 12:12:40.029: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 12.842224ms)
+Mar 16 12:12:40.030: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 12.149052ms)
+Mar 16 12:12:40.030: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 12.038495ms)
+Mar 16 12:12:40.030: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 13.728207ms)
+Mar 16 12:12:40.030: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 12.602737ms)
+Mar 16 12:12:40.031: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 13.357501ms)
+Mar 16 12:12:40.031: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 13.928352ms)
+Mar 16 12:12:40.032: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 14.335583ms)
+Mar 16 12:12:40.032: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 15.140592ms)
+Mar 16 12:12:40.032: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 14.211072ms)
+Mar 16 12:12:40.032: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 14.376554ms)
+Mar 16 12:12:40.032: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 14.856047ms)
+Mar 16 12:12:40.032: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 15.121553ms)
+Mar 16 12:12:40.032: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 15.512159ms)
+Mar 16 12:12:40.032: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 15.719448ms)
+Mar 16 12:12:40.033: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 14.83665ms)
+Mar 16 12:12:40.033: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 14.64111ms)
+Mar 16 12:12:40.033: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 15.503181ms)
+Mar 16 12:12:40.033: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 16.05519ms)
+Mar 16 12:12:40.033: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 15.151619ms)
+Mar 16 12:12:40.034: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 16.606126ms)
+Mar 16 12:12:40.034: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 15.731026ms)
+Mar 16 12:12:40.034: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 17.461476ms)
+Mar 16 12:12:40.035: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 17.44582ms)
+Mar 16 12:12:40.036: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 17.622507ms)
+Mar 16 12:12:40.036: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 18.499102ms)
+Mar 16 12:12:40.036: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 18.761263ms)
+Mar 16 12:12:40.036: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 19.320101ms)
+Mar 16 12:12:40.036: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 18.755115ms)
+Mar 16 12:12:40.036: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 19.700127ms)
+Mar 16 12:12:40.037: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 19.004723ms)
+Mar 16 12:12:40.094: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 77.521175ms)
+Mar 16 12:12:40.107: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 11.934613ms)
+Mar 16 12:12:40.107: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 12.262759ms)
+Mar 16 12:12:40.108: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 12.92373ms)
+Mar 16 12:12:40.108: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 13.801034ms)
+Mar 16 12:12:40.108: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 13.211821ms)
+Mar 16 12:12:40.109: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 13.641639ms)
+Mar 16 12:12:40.109: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 14.343558ms)
+Mar 16 12:12:40.110: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 14.852902ms)
+Mar 16 12:12:40.110: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 14.824417ms)
+Mar 16 12:12:40.110: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 15.106264ms)
+Mar 16 12:12:40.110: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 14.86815ms)
+Mar 16 12:12:40.110: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 14.102378ms)
+Mar 16 12:12:40.110: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 14.579582ms)
+Mar 16 12:12:40.110: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 14.679677ms)
+Mar 16 12:12:40.111: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 15.980103ms)
+Mar 16 12:12:40.111: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 15.12399ms)
+Mar 16 12:12:40.111: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 15.349738ms)
+Mar 16 12:12:40.114: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 17.881656ms)
+Mar 16 12:12:40.114: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 17.803206ms)
+Mar 16 12:12:40.114: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 17.777108ms)
+Mar 16 12:12:40.114: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 18.149094ms)
+Mar 16 12:12:40.114: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 18.38594ms)
+Mar 16 12:12:40.114: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 19.132889ms)
+Mar 16 12:12:40.114: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 18.75488ms)
+Mar 16 12:12:40.114: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 19.974311ms)
+Mar 16 12:12:40.114: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 18.457767ms)
+Mar 16 12:12:40.115: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 19.21451ms)
+Mar 16 12:12:40.115: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 19.185438ms)
+Mar 16 12:12:40.115: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 18.991959ms)
+Mar 16 12:12:40.115: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 19.091448ms)
+Mar 16 12:12:40.115: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 19.17035ms)
+Mar 16 12:12:40.115: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 19.571003ms)
+Mar 16 12:12:40.115: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 20.078152ms)
+Mar 16 12:12:40.115: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 19.136906ms)
+Mar 16 12:12:40.127: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:462/proxy/: tls qux (200; 11.506076ms)
+Mar 16 12:12:40.127: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/: foo (200; 11.963872ms)
+Mar 16 12:12:40.127: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:460/proxy/: tls baz (200; 12.204872ms)
+Mar 16 12:12:40.127: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/proxy/rewri... (200; 11.714606ms)
+Mar 16 12:12:40.128: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 12.759887ms)
+Mar 16 12:12:40.128: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/https:proxy-service-zgb2m-htcg7:443/proxy/... (200; 12.730109ms)
+Mar 16 12:12:40.132: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/proxy/: tls baz (200; 16.999941ms)
+Mar 16 12:12:40.132: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7/proxy/rewriteme"... (200; 15.825449ms)
+Mar 16 12:12:40.132: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:81/: bar (200; 16.896334ms)
+Mar 16 12:12:40.132: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/: foo (200; 16.650542ms)
+Mar 16 12:12:40.133: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/proxy/: tls qux (200; 16.240823ms)
+Mar 16 12:12:40.133: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/proxy/... (200; 16.221935ms)
+Mar 16 12:12:40.135: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 18.476764ms)
+Mar 16 12:12:40.135: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname1/: tls baz (200; 18.892741ms)
+Mar 16 12:12:40.135: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:tlsportname2/: tls qux (200; 18.208781ms)
+Mar 16 12:12:40.135: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/: bar (200; 19.818595ms)
+Mar 16 12:12:40.137: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:443/: tls baz (200; 20.67347ms)
+Mar 16 12:12:40.138: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname2/proxy/: bar (200; 22.13007ms)
+Mar 16 12:12:40.138: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:1080/rewri... (200; 20.902456ms)
+Mar 16 12:12:40.138: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/: bar (200; 21.785152ms)
+Mar 16 12:12:40.138: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/proxy/: foo (200; 21.503957ms)
+Mar 16 12:12:40.138: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/proxy/: foo (200; 22.36099ms)
+Mar 16 12:12:40.138: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/proxy/: bar (200; 22.846878ms)
+Mar 16 12:12:40.138: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:81/: bar (200; 22.833608ms)
+Mar 16 12:12:40.138: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname1/proxy/: foo (200; 21.592663ms)
+Mar 16 12:12:40.138: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:1080/... (200; 22.213674ms)
+Mar 16 12:12:40.138: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:160/: foo (200; 22.226609ms)
+Mar 16 12:12:40.138: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/https:proxy-service-zgb2m:444/: tls qux (200; 22.439131ms)
+Mar 16 12:12:40.138: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:portname2/: bar (200; 22.083926ms)
+Mar 16 12:12:40.139: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/pods/http:proxy-service-zgb2m-htcg7:162/: bar (200; 21.712771ms)
+Mar 16 12:12:40.139: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:portname1/: foo (200; 22.679392ms)
+Mar 16 12:12:40.139: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-5bxfn/pods/proxy-service-zgb2m-htcg7:162/proxy/: bar (200; 21.704199ms)
+Mar 16 12:12:40.139: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/http:proxy-service-zgb2m:80/: foo (200; 21.913897ms)
+Mar 16 12:12:40.139: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-5bxfn/services/proxy-service-zgb2m:80/: foo (200; 22.953861ms)
+STEP: deleting { ReplicationController} proxy-service-zgb2m in namespace e2e-tests-proxy-5bxfn
+Mar 16 12:12:40.266: INFO: Deleting { ReplicationController} proxy-service-zgb2m took: 25.27794ms
+Mar 16 12:12:40.266: INFO: Terminating { ReplicationController} proxy-service-zgb2m pods took: 116.783µs
+Mar 16 12:12:50.867: INFO: Garbage collecting { ReplicationController} proxy-service-zgb2m pods took: 10.625581775s
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:12:50.867: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-5bxfn" for this suite.
+Mar 16 12:12:56.879: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:12:56.991: INFO: namespace: e2e-tests-proxy-5bxfn, resource: bindings, ignored listing per whitelist
+Mar 16 12:12:56.993: INFO: namespace e2e-tests-proxy-5bxfn deletion completed in 6.123187043s
+
+• [SLOW TEST:33.777 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:12:56.994: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:12:57.046: INFO: Waiting up to 5m0s for pod "downwardapi-volume-5ca7a25d-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-ssx9n" to be "success or failure"
+Mar 16 12:12:57.050: INFO: Pod "downwardapi-volume-5ca7a25d-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.093334ms
+Mar 16 12:12:59.054: INFO: Pod "downwardapi-volume-5ca7a25d-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007481654s
+STEP: Saw pod success
+Mar 16 12:12:59.054: INFO: Pod "downwardapi-volume-5ca7a25d-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:12:59.056: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod downwardapi-volume-5ca7a25d-2913-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:12:59.070: INFO: Waiting for pod downwardapi-volume-5ca7a25d-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:12:59.073: INFO: Pod downwardapi-volume-5ca7a25d-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:12:59.073: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-ssx9n" for this suite.
+Mar 16 12:13:05.098: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:13:05.204: INFO: namespace: e2e-tests-downward-api-ssx9n, resource: bindings, ignored listing per whitelist
+Mar 16 12:13:05.211: INFO: namespace e2e-tests-downward-api-ssx9n deletion completed in 6.128727306s
+
+• [SLOW TEST:8.217 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:13:05.211: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Mar 16 12:13:05.262: INFO: Waiting up to 5m0s for pod "pod-618d045f-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-4nbv5" to be "success or failure"
+Mar 16 12:13:05.267: INFO: Pod "pod-618d045f-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.762236ms
+Mar 16 12:13:07.271: INFO: Pod "pod-618d045f-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00866957s
+STEP: Saw pod success
+Mar 16 12:13:07.271: INFO: Pod "pod-618d045f-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:13:07.273: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-618d045f-2913-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:13:07.289: INFO: Waiting for pod pod-618d045f-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:13:07.292: INFO: Pod pod-618d045f-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:13:07.292: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-4nbv5" for this suite.
+Mar 16 12:13:13.308: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:13:13.345: INFO: namespace: e2e-tests-emptydir-4nbv5, resource: bindings, ignored listing per whitelist
+Mar 16 12:13:13.427: INFO: namespace e2e-tests-emptydir-4nbv5 deletion completed in 6.132037832s
+
+• [SLOW TEST:8.216 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:13:13.427: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Mar 16 12:13:13.475: INFO: Waiting up to 5m0s for pod "pod-6672981d-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-k6n49" to be "success or failure"
+Mar 16 12:13:13.477: INFO: Pod "pod-6672981d-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.781315ms
+Mar 16 12:13:15.483: INFO: Pod "pod-6672981d-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008168715s
+STEP: Saw pod success
+Mar 16 12:13:15.483: INFO: Pod "pod-6672981d-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:13:15.485: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-6672981d-2913-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:13:15.510: INFO: Waiting for pod pod-6672981d-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:13:15.517: INFO: Pod pod-6672981d-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:13:15.522: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-k6n49" for this suite.
+Mar 16 12:13:21.537: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:13:21.585: INFO: namespace: e2e-tests-emptydir-k6n49, resource: bindings, ignored listing per whitelist
+Mar 16 12:13:21.648: INFO: namespace e2e-tests-emptydir-k6n49 deletion completed in 6.122583101s
+
+• [SLOW TEST:8.221 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:13:21.648: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-map-6b5843c0-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:13:21.694: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-6b58b556-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-fx9w2" to be "success or failure"
+Mar 16 12:13:21.696: INFO: Pod "pod-projected-configmaps-6b58b556-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.839949ms
+Mar 16 12:13:23.700: INFO: Pod "pod-projected-configmaps-6b58b556-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006092098s
+STEP: Saw pod success
+Mar 16 12:13:23.700: INFO: Pod "pod-projected-configmaps-6b58b556-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:13:23.702: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-projected-configmaps-6b58b556-2913-11e8-a0aa-16411a5f38c2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:13:23.719: INFO: Waiting for pod pod-projected-configmaps-6b58b556-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:13:23.723: INFO: Pod pod-projected-configmaps-6b58b556-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:13:23.723: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fx9w2" for this suite.
+Mar 16 12:13:29.735: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:13:29.818: INFO: namespace: e2e-tests-projected-fx9w2, resource: bindings, ignored listing per whitelist
+Mar 16 12:13:29.848: INFO: namespace e2e-tests-projected-fx9w2 deletion completed in 6.122547002s
+
+• [SLOW TEST:8.200 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:13:29.849: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-703b642d-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:13:29.893: INFO: Waiting up to 5m0s for pod "pod-configmaps-703bd258-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-configmap-6xbgk" to be "success or failure"
+Mar 16 12:13:29.901: INFO: Pod "pod-configmaps-703bd258-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 8.558548ms
+Mar 16 12:13:31.905: INFO: Pod "pod-configmaps-703bd258-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012024117s
+STEP: Saw pod success
+Mar 16 12:13:31.905: INFO: Pod "pod-configmaps-703bd258-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:13:31.907: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-configmaps-703bd258-2913-11e8-a0aa-16411a5f38c2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:13:31.923: INFO: Waiting for pod pod-configmaps-703bd258-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:13:31.928: INFO: Pod pod-configmaps-703bd258-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:13:31.936: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-6xbgk" for this suite.
+Mar 16 12:13:37.953: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:13:38.044: INFO: namespace: e2e-tests-configmap-6xbgk, resource: bindings, ignored listing per whitelist
+Mar 16 12:13:38.066: INFO: namespace e2e-tests-configmap-6xbgk deletion completed in 6.120890271s
+
+• [SLOW TEST:8.217 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:13:38.066: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-dzssp
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 16 12:13:38.103: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 16 12:13:54.159: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.195:8080/dial?request=hostName&protocol=http&host=100.96.0.154&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-dzssp PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:13:54.159: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:13:54.277: INFO: Waiting for endpoints: map[]
+Mar 16 12:13:54.280: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.195:8080/dial?request=hostName&protocol=http&host=100.96.1.194&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-dzssp PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:13:54.281: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:13:54.437: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:13:54.437: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-dzssp" for this suite.
+Mar 16 12:14:16.450: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:14:16.499: INFO: namespace: e2e-tests-pod-network-test-dzssp, resource: bindings, ignored listing per whitelist
+Mar 16 12:14:16.568: INFO: namespace e2e-tests-pod-network-test-dzssp deletion completed in 22.127967711s
+
+• [SLOW TEST:38.502 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:14:16.568: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating server pod server in namespace e2e-tests-prestop-8fq5t
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-8fq5t
+STEP: Deleting pre-stop pod
+Mar 16 12:14:29.675: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:14:29.679: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-8fq5t" for this suite.
+Mar 16 12:15:07.690: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:15:07.737: INFO: namespace: e2e-tests-prestop-8fq5t, resource: bindings, ignored listing per whitelist
+Mar 16 12:15:07.820: INFO: namespace e2e-tests-prestop-8fq5t deletion completed in 38.137314604s
+
+• [SLOW TEST:51.252 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:15:07.820: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Mar 16 12:15:08.391: INFO: Waiting up to 5m0s for pod "pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-5rshj" in namespace "e2e-tests-svcaccounts-4jv6p" to be "success or failure"
+Mar 16 12:15:08.396: INFO: Pod "pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-5rshj": Phase="Pending", Reason="", readiness=false. Elapsed: 4.478053ms
+Mar 16 12:15:10.399: INFO: Pod "pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-5rshj": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007744057s
+STEP: Saw pod success
+Mar 16 12:15:10.399: INFO: Pod "pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-5rshj" satisfied condition "success or failure"
+Mar 16 12:15:10.401: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-5rshj container token-test: <nil>
+STEP: delete the pod
+Mar 16 12:15:10.417: INFO: Waiting for pod pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-5rshj to disappear
+Mar 16 12:15:10.420: INFO: Pod pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-5rshj no longer exists
+STEP: Creating a pod to test consume service account root CA
+Mar 16 12:15:10.424: INFO: Waiting up to 5m0s for pod "pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-qx2cp" in namespace "e2e-tests-svcaccounts-4jv6p" to be "success or failure"
+Mar 16 12:15:10.427: INFO: Pod "pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-qx2cp": Phase="Pending", Reason="", readiness=false. Elapsed: 2.303569ms
+Mar 16 12:15:12.431: INFO: Pod "pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-qx2cp": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007017509s
+STEP: Saw pod success
+Mar 16 12:15:12.431: INFO: Pod "pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-qx2cp" satisfied condition "success or failure"
+Mar 16 12:15:12.434: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-qx2cp container root-ca-test: <nil>
+STEP: delete the pod
+Mar 16 12:15:12.448: INFO: Waiting for pod pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-qx2cp to disappear
+Mar 16 12:15:12.485: INFO: Pod pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-qx2cp no longer exists
+STEP: Creating a pod to test consume service account namespace
+Mar 16 12:15:12.489: INFO: Waiting up to 5m0s for pod "pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-j4hbc" in namespace "e2e-tests-svcaccounts-4jv6p" to be "success or failure"
+Mar 16 12:15:12.492: INFO: Pod "pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-j4hbc": Phase="Pending", Reason="", readiness=false. Elapsed: 2.636086ms
+Mar 16 12:15:14.496: INFO: Pod "pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-j4hbc": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006342153s
+STEP: Saw pod success
+Mar 16 12:15:14.496: INFO: Pod "pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-j4hbc" satisfied condition "success or failure"
+Mar 16 12:15:14.498: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-j4hbc container namespace-test: <nil>
+STEP: delete the pod
+Mar 16 12:15:14.513: INFO: Waiting for pod pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-j4hbc to disappear
+Mar 16 12:15:14.515: INFO: Pod pod-service-account-aaf17889-2913-11e8-a0aa-16411a5f38c2-j4hbc no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:15:14.515: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-4jv6p" for this suite.
+Mar 16 12:15:20.530: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:15:20.599: INFO: namespace: e2e-tests-svcaccounts-4jv6p, resource: bindings, ignored listing per whitelist
+Mar 16 12:15:20.647: INFO: namespace e2e-tests-svcaccounts-4jv6p deletion completed in 6.129420528s
+
+• [SLOW TEST:12.828 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:15:20.648: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:15:20.702: INFO: Waiting up to 5m0s for pod "downwardapi-volume-b2460c0d-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-gxzhg" to be "success or failure"
+Mar 16 12:15:20.710: INFO: Pod "downwardapi-volume-b2460c0d-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.645018ms
+Mar 16 12:15:22.713: INFO: Pod "downwardapi-volume-b2460c0d-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007112918s
+STEP: Saw pod success
+Mar 16 12:15:22.713: INFO: Pod "downwardapi-volume-b2460c0d-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:15:22.716: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod downwardapi-volume-b2460c0d-2913-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:15:22.733: INFO: Waiting for pod downwardapi-volume-b2460c0d-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:15:22.736: INFO: Pod downwardapi-volume-b2460c0d-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:15:22.736: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-gxzhg" for this suite.
+Mar 16 12:15:28.761: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:15:28.859: INFO: namespace: e2e-tests-projected-gxzhg, resource: bindings, ignored listing per whitelist
+Mar 16 12:15:28.869: INFO: namespace e2e-tests-projected-gxzhg deletion completed in 6.117221871s
+
+• [SLOW TEST:8.221 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:15:28.869: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-map-b72c7fb2-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:15:28.914: INFO: Waiting up to 5m0s for pod "pod-configmaps-b72ce891-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-configmap-dk8fk" to be "success or failure"
+Mar 16 12:15:28.915: INFO: Pod "pod-configmaps-b72ce891-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 1.907039ms
+Mar 16 12:15:30.918: INFO: Pod "pod-configmaps-b72ce891-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004846417s
+STEP: Saw pod success
+Mar 16 12:15:30.918: INFO: Pod "pod-configmaps-b72ce891-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:15:30.921: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-configmaps-b72ce891-2913-11e8-a0aa-16411a5f38c2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:15:30.934: INFO: Waiting for pod pod-configmaps-b72ce891-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:15:30.936: INFO: Pod pod-configmaps-b72ce891-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:15:30.936: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-dk8fk" for this suite.
+Mar 16 12:15:36.947: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:15:37.033: INFO: namespace: e2e-tests-configmap-dk8fk, resource: bindings, ignored listing per whitelist
+Mar 16 12:15:37.052: INFO: namespace e2e-tests-configmap-dk8fk deletion completed in 6.113267298s
+
+• [SLOW TEST:8.183 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:15:37.053: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-wpbzr A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-wpbzr;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-wpbzr A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-wpbzr;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-wpbzr.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-wpbzr.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-wpbzr.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-wpbzr.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-wpbzr.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-wpbzr.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-wpbzr.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-wpbzr.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-wpbzr.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-wpbzr.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-wpbzr.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-wpbzr.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-wpbzr.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 35.173.66.100.in-addr.arpa. PTR)" && echo OK > /results/100.66.173.35_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 35.173.66.100.in-addr.arpa. PTR)" && echo OK > /results/100.66.173.35_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-wpbzr A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-wpbzr;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-wpbzr A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-wpbzr;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-wpbzr.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-wpbzr.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-wpbzr.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-wpbzr.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-wpbzr.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-wpbzr.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-wpbzr.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-wpbzr.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-wpbzr.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-wpbzr.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-wpbzr.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-wpbzr.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-wpbzr.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 35.173.66.100.in-addr.arpa. PTR)" && echo OK > /results/100.66.173.35_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 35.173.66.100.in-addr.arpa. PTR)" && echo OK > /results/100.66.173.35_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Mar 16 12:15:50.358: INFO: DNS probes using dns-test-bc0f09b3-2913-11e8-a0aa-16411a5f38c2 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:15:50.441: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-wpbzr" for this suite.
+Mar 16 12:15:56.468: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:15:56.561: INFO: namespace: e2e-tests-dns-wpbzr, resource: bindings, ignored listing per whitelist
+Mar 16 12:15:56.588: INFO: namespace e2e-tests-dns-wpbzr deletion completed in 6.13567293s
+
+• [SLOW TEST:19.536 seconds]
+[sig-network] DNS
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:15:56.589: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-c7b3d0eb-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:15:56.648: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-c7b4a916-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-4cp7g" to be "success or failure"
+Mar 16 12:15:56.650: INFO: Pod "pod-projected-configmaps-c7b4a916-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.135775ms
+Mar 16 12:15:58.653: INFO: Pod "pod-projected-configmaps-c7b4a916-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00486953s
+STEP: Saw pod success
+Mar 16 12:15:58.653: INFO: Pod "pod-projected-configmaps-c7b4a916-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:15:58.655: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-projected-configmaps-c7b4a916-2913-11e8-a0aa-16411a5f38c2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:15:58.669: INFO: Waiting for pod pod-projected-configmaps-c7b4a916-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:15:58.671: INFO: Pod pod-projected-configmaps-c7b4a916-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:15:58.671: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4cp7g" for this suite.
+Mar 16 12:16:04.682: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:16:04.795: INFO: namespace: e2e-tests-projected-4cp7g, resource: bindings, ignored listing per whitelist
+Mar 16 12:16:04.795: INFO: namespace e2e-tests-projected-4cp7g deletion completed in 6.121684179s
+
+• [SLOW TEST:8.206 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:16:04.795: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-cc9672b8-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:16:04.840: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-cc96f4ad-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-hglx8" to be "success or failure"
+Mar 16 12:16:04.843: INFO: Pod "pod-projected-configmaps-cc96f4ad-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.889762ms
+Mar 16 12:16:06.847: INFO: Pod "pod-projected-configmaps-cc96f4ad-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006223315s
+STEP: Saw pod success
+Mar 16 12:16:06.847: INFO: Pod "pod-projected-configmaps-cc96f4ad-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:16:06.849: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-projected-configmaps-cc96f4ad-2913-11e8-a0aa-16411a5f38c2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:16:06.865: INFO: Waiting for pod pod-projected-configmaps-cc96f4ad-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:16:06.869: INFO: Pod pod-projected-configmaps-cc96f4ad-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:16:06.869: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hglx8" for this suite.
+Mar 16 12:16:12.883: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:16:12.965: INFO: namespace: e2e-tests-projected-hglx8, resource: bindings, ignored listing per whitelist
+Mar 16 12:16:12.996: INFO: namespace e2e-tests-projected-hglx8 deletion completed in 6.123861954s
+
+• [SLOW TEST:8.200 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:16:12.996: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-d17c4dba-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:16:13.060: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-d17d07a7-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-gttmt" to be "success or failure"
+Mar 16 12:16:13.062: INFO: Pod "pod-projected-secrets-d17d07a7-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.254361ms
+Mar 16 12:16:15.065: INFO: Pod "pod-projected-secrets-d17d07a7-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005779005s
+STEP: Saw pod success
+Mar 16 12:16:15.065: INFO: Pod "pod-projected-secrets-d17d07a7-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:16:15.068: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-projected-secrets-d17d07a7-2913-11e8-a0aa-16411a5f38c2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:16:15.087: INFO: Waiting for pod pod-projected-secrets-d17d07a7-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:16:15.090: INFO: Pod pod-projected-secrets-d17d07a7-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:16:15.090: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-gttmt" for this suite.
+Mar 16 12:16:21.101: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:16:21.218: INFO: namespace: e2e-tests-projected-gttmt, resource: bindings, ignored listing per whitelist
+Mar 16 12:16:21.218: INFO: namespace e2e-tests-projected-gttmt deletion completed in 6.125393441s
+
+• [SLOW TEST:8.222 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:16:21.218: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-map-d66088c1-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:16:21.264: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-d6610de8-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-lhml2" to be "success or failure"
+Mar 16 12:16:21.266: INFO: Pod "pod-projected-configmaps-d6610de8-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.192579ms
+Mar 16 12:16:23.269: INFO: Pod "pod-projected-configmaps-d6610de8-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004992694s
+STEP: Saw pod success
+Mar 16 12:16:23.269: INFO: Pod "pod-projected-configmaps-d6610de8-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:16:23.272: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-projected-configmaps-d6610de8-2913-11e8-a0aa-16411a5f38c2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:16:23.294: INFO: Waiting for pod pod-projected-configmaps-d6610de8-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:16:23.304: INFO: Pod pod-projected-configmaps-d6610de8-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:16:23.306: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lhml2" for this suite.
+Mar 16 12:16:29.326: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:16:29.396: INFO: namespace: e2e-tests-projected-lhml2, resource: bindings, ignored listing per whitelist
+Mar 16 12:16:29.439: INFO: namespace e2e-tests-projected-lhml2 deletion completed in 6.122417677s
+
+• [SLOW TEST:8.221 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:16:29.440: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-map-db489d2d-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:16:29.496: INFO: Waiting up to 5m0s for pod "pod-configmaps-db490cb1-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-configmap-2crfw" to be "success or failure"
+Mar 16 12:16:29.498: INFO: Pod "pod-configmaps-db490cb1-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.7385ms
+Mar 16 12:16:31.502: INFO: Pod "pod-configmaps-db490cb1-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00612792s
+STEP: Saw pod success
+Mar 16 12:16:31.502: INFO: Pod "pod-configmaps-db490cb1-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:16:31.504: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-configmaps-db490cb1-2913-11e8-a0aa-16411a5f38c2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:16:31.521: INFO: Waiting for pod pod-configmaps-db490cb1-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:16:31.523: INFO: Pod pod-configmaps-db490cb1-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:16:31.523: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-2crfw" for this suite.
+Mar 16 12:16:37.534: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:16:37.590: INFO: namespace: e2e-tests-configmap-2crfw, resource: bindings, ignored listing per whitelist
+Mar 16 12:16:37.640: INFO: namespace e2e-tests-configmap-2crfw deletion completed in 6.113985907s
+
+• [SLOW TEST:8.200 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:16:37.640: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name cm-test-opt-del-e02a9c02-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating configMap with name cm-test-opt-upd-e02a9c39-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-e02a9c02-2913-11e8-a0aa-16411a5f38c2
+STEP: Updating configmap cm-test-opt-upd-e02a9c39-2913-11e8-a0aa-16411a5f38c2
+STEP: Creating configMap with name cm-test-opt-create-e02a9c58-2913-11e8-a0aa-16411a5f38c2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:16:41.943: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-mpmgn" for this suite.
+Mar 16 12:17:03.955: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:17:04.008: INFO: namespace: e2e-tests-configmap-mpmgn, resource: bindings, ignored listing per whitelist
+Mar 16 12:17:04.079: INFO: namespace e2e-tests-configmap-mpmgn deletion completed in 22.132274954s
+
+• [SLOW TEST:26.438 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:17:04.079: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Mar 16 12:17:06.657: INFO: Successfully updated pod "pod-update-efef6c91-2913-11e8-a0aa-16411a5f38c2"
+STEP: verifying the updated pod is in kubernetes
+Mar 16 12:17:06.661: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:17:06.661: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-t2gpg" for this suite.
+Mar 16 12:17:28.672: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:17:28.762: INFO: namespace: e2e-tests-pods-t2gpg, resource: bindings, ignored listing per whitelist
+Mar 16 12:17:28.781: INFO: namespace e2e-tests-pods-t2gpg deletion completed in 22.116746808s
+
+• [SLOW TEST:24.702 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:17:28.781: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test override all
+Mar 16 12:17:28.823: INFO: Waiting up to 5m0s for pod "client-containers-fea5b5d9-2913-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-containers-wxsrk" to be "success or failure"
+Mar 16 12:17:28.827: INFO: Pod "client-containers-fea5b5d9-2913-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.485828ms
+Mar 16 12:17:30.830: INFO: Pod "client-containers-fea5b5d9-2913-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006948992s
+STEP: Saw pod success
+Mar 16 12:17:30.830: INFO: Pod "client-containers-fea5b5d9-2913-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:17:30.832: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod client-containers-fea5b5d9-2913-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:17:30.847: INFO: Waiting for pod client-containers-fea5b5d9-2913-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:17:30.867: INFO: Pod client-containers-fea5b5d9-2913-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:17:30.867: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-wxsrk" for this suite.
+Mar 16 12:17:36.889: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:17:36.999: INFO: namespace: e2e-tests-containers-wxsrk, resource: bindings, ignored listing per whitelist
+Mar 16 12:17:37.004: INFO: namespace e2e-tests-containers-wxsrk deletion completed in 6.12660385s
+
+• [SLOW TEST:8.223 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:17:37.004: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-tf9qv.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-tf9qv.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-tf9qv.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-tf9qv.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-tf9qv.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-tf9qv.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Mar 16 12:17:51.934: INFO: DNS probes using dns-test-038c5c38-2914-11e8-a0aa-16411a5f38c2 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:17:51.942: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-tf9qv" for this suite.
+Mar 16 12:17:57.953: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:17:58.035: INFO: namespace: e2e-tests-dns-tf9qv, resource: bindings, ignored listing per whitelist
+Mar 16 12:17:58.070: INFO: namespace e2e-tests-dns-tf9qv deletion completed in 6.124854222s
+
+• [SLOW TEST:21.066 seconds]
+[sig-network] DNS
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:17:58.070: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Mar 16 12:18:00.136: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-101c615d-2914-11e8-a0aa-16411a5f38c2", GenerateName:"", Namespace:"e2e-tests-pods-7n776", SelfLink:"/api/v1/namespaces/e2e-tests-pods-7n776/pods/pod-submit-remove-101c615d-2914-11e8-a0aa-16411a5f38c2", UID:"101d28da-2914-11e8-9302-5e442cbf7090", ResourceVersion:"120190", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63656799478, loc:(*time.Location)(0x619f460)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"118031326"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"100.96.0.163/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-rr2zc", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc4212c50c0), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"gcr.io/google-containers/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-rr2zc", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc421092c18), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"ip-10-250-0-66.eu-west-1.compute.internal", HostNetwork:false, HostPID:false, HostIPC:false, SecurityContext:(*v1.PodSecurityContext)(0xc4212c5180), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc421092c50)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc421092c70)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63656799478, loc:(*time.Location)(0x619f460)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63656799479, loc:(*time.Location)(0x619f460)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63656799478, loc:(*time.Location)(0x619f460)}}, Reason:"", Message:""}}, Message:"", Reason:"", HostIP:"10.250.0.66", PodIP:"100.96.0.163", StartTime:(*v1.Time)(0xc4214f9500), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc4214f9540), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"gcr.io/google-containers/nginx-slim-amd64:0.20", ImageID:"docker-pullable://gcr.io/google-containers/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://09c01318f8586140d3052cf3c5d6ac4ec2aac451e4ab2b012495cca6a089833f"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+Mar 16 12:18:05.157: INFO: no pod exists with the name we were looking for, assuming the termination request was observed and completed
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:18:05.160: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-7n776" for this suite.
+Mar 16 12:18:11.172: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:18:11.211: INFO: namespace: e2e-tests-pods-7n776, resource: bindings, ignored listing per whitelist
+Mar 16 12:18:11.281: INFO: namespace e2e-tests-pods-7n776 deletion completed in 6.117819903s
+
+• [SLOW TEST:13.211 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:18:11.282: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name s-test-opt-del-17fb6d70-2914-11e8-a0aa-16411a5f38c2
+STEP: Creating secret with name s-test-opt-upd-17fb6dc2-2914-11e8-a0aa-16411a5f38c2
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-17fb6d70-2914-11e8-a0aa-16411a5f38c2
+STEP: Updating secret s-test-opt-upd-17fb6dc2-2914-11e8-a0aa-16411a5f38c2
+STEP: Creating secret with name s-test-opt-create-17fb6df2-2914-11e8-a0aa-16411a5f38c2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:18:15.591: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fch9c" for this suite.
+Mar 16 12:20:01.606: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:20:01.724: INFO: namespace: e2e-tests-projected-fch9c, resource: bindings, ignored listing per whitelist
+Mar 16 12:20:01.878: INFO: namespace e2e-tests-projected-fch9c deletion completed in 1m46.283809139s
+
+• [SLOW TEST:110.596 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:20:01.878: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-d9f95
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 16 12:20:01.926: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 16 12:20:20.010: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.0.164 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-d9f95 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:20:20.010: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:20:21.115: INFO: Found all expected endpoints: [netserver-0]
+Mar 16 12:20:21.118: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.1.206 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-d9f95 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:20:21.118: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:20:22.124: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.1.206 8081 | grep -v '^\\s*$'": command terminated with exit code 137, stdout: "", stderr: ""
+Mar 16 12:20:22.124: INFO: Waiting for [netserver-1] endpoints (expected=[netserver-1], actual=[])
+Mar 16 12:20:24.128: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.1.206 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-d9f95 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:20:24.128: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:20:25.308: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:20:25.308: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-d9f95" for this suite.
+Mar 16 12:20:47.321: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:20:47.424: INFO: namespace: e2e-tests-pod-network-test-d9f95, resource: bindings, ignored listing per whitelist
+Mar 16 12:20:47.424: INFO: namespace e2e-tests-pod-network-test-d9f95 deletion completed in 22.112046702s
+
+• [SLOW TEST:45.546 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:20:47.424: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:20:47.468: INFO: Waiting up to 5m0s for pod "downwardapi-volume-750c5e9e-2914-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-jccvf" to be "success or failure"
+Mar 16 12:20:47.472: INFO: Pod "downwardapi-volume-750c5e9e-2914-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.885019ms
+Mar 16 12:20:49.475: INFO: Pod "downwardapi-volume-750c5e9e-2914-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007238079s
+STEP: Saw pod success
+Mar 16 12:20:49.475: INFO: Pod "downwardapi-volume-750c5e9e-2914-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:20:49.478: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod downwardapi-volume-750c5e9e-2914-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:20:49.495: INFO: Waiting for pod downwardapi-volume-750c5e9e-2914-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:20:49.513: INFO: Pod downwardapi-volume-750c5e9e-2914-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:20:49.516: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-jccvf" for this suite.
+Mar 16 12:20:55.532: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:20:55.571: INFO: namespace: e2e-tests-downward-api-jccvf, resource: bindings, ignored listing per whitelist
+Mar 16 12:20:55.647: INFO: namespace e2e-tests-downward-api-jccvf deletion completed in 6.122977795s
+
+• [SLOW TEST:8.223 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:20:55.647: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-79f389be-2914-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:20:55.696: INFO: Waiting up to 5m0s for pod "pod-secrets-79f40329-2914-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-secrets-6f2h2" to be "success or failure"
+Mar 16 12:20:55.699: INFO: Pod "pod-secrets-79f40329-2914-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.900702ms
+Mar 16 12:20:57.702: INFO: Pod "pod-secrets-79f40329-2914-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006221386s
+STEP: Saw pod success
+Mar 16 12:20:57.702: INFO: Pod "pod-secrets-79f40329-2914-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:20:57.705: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-secrets-79f40329-2914-11e8-a0aa-16411a5f38c2 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:20:57.729: INFO: Waiting for pod pod-secrets-79f40329-2914-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:20:57.732: INFO: Pod pod-secrets-79f40329-2914-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:20:57.732: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-6f2h2" for this suite.
+Mar 16 12:21:03.747: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:21:03.803: INFO: namespace: e2e-tests-secrets-6f2h2, resource: bindings, ignored listing per whitelist
+Mar 16 12:21:03.859: INFO: namespace e2e-tests-secrets-6f2h2 deletion completed in 6.122813852s
+
+• [SLOW TEST:8.212 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:21:03.859: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-7ed82d85-2914-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:21:03.905: INFO: Waiting up to 5m0s for pod "pod-secrets-7ed89248-2914-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-secrets-qm45l" to be "success or failure"
+Mar 16 12:21:03.909: INFO: Pod "pod-secrets-7ed89248-2914-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.220518ms
+Mar 16 12:21:05.912: INFO: Pod "pod-secrets-7ed89248-2914-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006175166s
+STEP: Saw pod success
+Mar 16 12:21:05.912: INFO: Pod "pod-secrets-7ed89248-2914-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:21:05.914: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-secrets-7ed89248-2914-11e8-a0aa-16411a5f38c2 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:21:05.930: INFO: Waiting for pod pod-secrets-7ed89248-2914-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:21:05.932: INFO: Pod pod-secrets-7ed89248-2914-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:21:05.932: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-qm45l" for this suite.
+Mar 16 12:21:11.964: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:21:12.039: INFO: namespace: e2e-tests-secrets-qm45l, resource: bindings, ignored listing per whitelist
+Mar 16 12:21:12.075: INFO: namespace e2e-tests-secrets-qm45l deletion completed in 6.12269328s
+
+• [SLOW TEST:8.216 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:21:12.075: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 16 12:21:12.124: INFO: Creating ReplicaSet my-hostname-basic-83bf67ca-2914-11e8-a0aa-16411a5f38c2
+Mar 16 12:21:12.130: INFO: Pod name my-hostname-basic-83bf67ca-2914-11e8-a0aa-16411a5f38c2: Found 0 pods out of 1
+Mar 16 12:21:17.133: INFO: Pod name my-hostname-basic-83bf67ca-2914-11e8-a0aa-16411a5f38c2: Found 1 pods out of 1
+Mar 16 12:21:17.133: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-83bf67ca-2914-11e8-a0aa-16411a5f38c2" is running
+Mar 16 12:21:17.135: INFO: Pod "my-hostname-basic-83bf67ca-2914-11e8-a0aa-16411a5f38c2-jpn9f" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-16 12:21:12 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-16 12:21:13 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-16 12:21:12 +0000 UTC Reason: Message:}])
+Mar 16 12:21:17.135: INFO: Trying to dial the pod
+Mar 16 12:21:22.188: INFO: Controller my-hostname-basic-83bf67ca-2914-11e8-a0aa-16411a5f38c2: Got expected result from replica 1 [my-hostname-basic-83bf67ca-2914-11e8-a0aa-16411a5f38c2-jpn9f]: "my-hostname-basic-83bf67ca-2914-11e8-a0aa-16411a5f38c2-jpn9f", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:21:22.188: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-qcz6m" for this suite.
+Mar 16 12:21:28.200: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:21:28.253: INFO: namespace: e2e-tests-replicaset-qcz6m, resource: bindings, ignored listing per whitelist
+Mar 16 12:21:28.308: INFO: namespace e2e-tests-replicaset-qcz6m deletion completed in 6.116813743s
+
+• [SLOW TEST:16.233 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:21:28.309: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Mar 16 12:21:28.348: INFO: Waiting up to 1m0s for all nodes to be ready
+Mar 16 12:22:28.369: INFO: Waiting for terminating namespaces to be deleted...
+Mar 16 12:22:28.373: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 16 12:22:28.383: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 16 12:22:28.383: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 16 12:22:28.386: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 16 12:22:28.386: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-0-66.eu-west-1.compute.internal before test
+Mar 16 12:22:28.394: INFO: addons-heapster-e3b0c-b9ff79bbd-tx8w5 from kube-system started at 2018-03-15 13:15:45 +0000 UTC (2 container statuses recorded)
+Mar 16 12:22:28.394: INFO: 	Container heapster ready: true, restart count 0
+Mar 16 12:22:28.394: INFO: 	Container heapster-nanny ready: true, restart count 0
+Mar 16 12:22:28.394: INFO: sonobuoy from sonobuoy started at 2018-03-16 12:01:56 +0000 UTC (1 container statuses recorded)
+Mar 16 12:22:28.394: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Mar 16 12:22:28.394: INFO: calico-node-rh9qr from kube-system started at 2018-03-15 13:14:51 +0000 UTC (2 container statuses recorded)
+Mar 16 12:22:28.394: INFO: 	Container calico-node ready: true, restart count 0
+Mar 16 12:22:28.394: INFO: 	Container install-cni ready: true, restart count 0
+Mar 16 12:22:28.395: INFO: node-exporter-mqwj7 from kube-system started at 2018-03-15 13:14:51 +0000 UTC (1 container statuses recorded)
+Mar 16 12:22:28.395: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 16 12:22:28.395: INFO: sonobuoy-e2e-job-d76ff835c57041be from sonobuoy started at 2018-03-16 12:01:58 +0000 UTC (2 container statuses recorded)
+Mar 16 12:22:28.395: INFO: 	Container e2e ready: true, restart count 0
+Mar 16 12:22:28.395: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Mar 16 12:22:28.395: INFO: kube-proxy-kdv5w from kube-system started at 2018-03-15 13:14:51 +0000 UTC (1 container statuses recorded)
+Mar 16 12:22:28.395: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 16 12:22:28.395: INFO: kube-dns-858cbcf6ff-vzkxb from kube-system started at 2018-03-15 13:15:44 +0000 UTC (3 container statuses recorded)
+Mar 16 12:22:28.395: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 16 12:22:28.395: INFO: 	Container kubedns ready: true, restart count 0
+Mar 16 12:22:28.395: INFO: 	Container sidecar ready: true, restart count 0
+Mar 16 12:22:28.395: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-28-245.eu-west-1.compute.internal before test
+Mar 16 12:22:28.404: INFO: kube-proxy-9dql4 from kube-system started at 2018-03-15 13:14:55 +0000 UTC (1 container statuses recorded)
+Mar 16 12:22:28.404: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 16 12:22:28.404: INFO: addons-kubernetes-dashboard-7fc5877997-jp7rq from kube-system started at 2018-03-15 13:15:44 +0000 UTC (1 container statuses recorded)
+Mar 16 12:22:28.404: INFO: 	Container main ready: true, restart count 0
+Mar 16 12:22:28.404: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-k78n6 from kube-system started at 2018-03-15 13:15:45 +0000 UTC (1 container statuses recorded)
+Mar 16 12:22:28.404: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Mar 16 12:22:28.404: INFO: kube-dns-858cbcf6ff-ns6n2 from kube-system started at 2018-03-15 13:15:48 +0000 UTC (3 container statuses recorded)
+Mar 16 12:22:28.404: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 16 12:22:28.404: INFO: 	Container kubedns ready: true, restart count 0
+Mar 16 12:22:28.404: INFO: 	Container sidecar ready: true, restart count 0
+Mar 16 12:22:28.404: INFO: vpn-shoot-598b8754f7-dr95x from kube-system started at 2018-03-15 15:26:16 +0000 UTC (1 container statuses recorded)
+Mar 16 12:22:28.404: INFO: 	Container vpn-shoot ready: true, restart count 2
+Mar 16 12:22:28.404: INFO: calico-node-zhc44 from kube-system started at 2018-03-15 13:14:55 +0000 UTC (2 container statuses recorded)
+Mar 16 12:22:28.404: INFO: 	Container calico-node ready: true, restart count 0
+Mar 16 12:22:28.404: INFO: 	Container install-cni ready: true, restart count 0
+Mar 16 12:22:28.404: INFO: node-exporter-nv6rc from kube-system started at 2018-03-15 13:14:55 +0000 UTC (1 container statuses recorded)
+Mar 16 12:22:28.404: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 16 12:22:28.404: INFO: kube-dns-autoscaler-6966fd6fb6-mqqq9 from kube-system started at 2018-03-15 13:15:44 +0000 UTC (1 container statuses recorded)
+Mar 16 12:22:28.404: INFO: 	Container autoscaler ready: true, restart count 0
+Mar 16 12:22:28.404: INFO: addons-nginx-ingress-controller-5dbb8df879-gsndg from kube-system started at 2018-03-15 13:15:44 +0000 UTC (1 container statuses recorded)
+Mar 16 12:22:28.404: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-b26b8c5d-2914-11e8-a0aa-16411a5f38c2 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-b26b8c5d-2914-11e8-a0aa-16411a5f38c2 off the node ip-10-250-0-66.eu-west-1.compute.internal
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-b26b8c5d-2914-11e8-a0aa-16411a5f38c2
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:22:34.483: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-xhmmb" for this suite.
+Mar 16 12:22:56.500: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:22:56.612: INFO: namespace: e2e-tests-sched-pred-xhmmb, resource: bindings, ignored listing per whitelist
+Mar 16 12:22:56.631: INFO: namespace e2e-tests-sched-pred-xhmmb deletion completed in 22.14453271s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:88.322 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[k8s.io] Pods 
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:22:56.631: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating pod
+Mar 16 12:22:58.687: INFO: Pod pod-hostip-c2101680-2914-11e8-a0aa-16411a5f38c2 has hostIP: 10.250.28.245
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:22:58.687: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-446wt" for this suite.
+Mar 16 12:23:20.699: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:23:20.778: INFO: namespace: e2e-tests-pods-446wt, resource: bindings, ignored listing per whitelist
+Mar 16 12:23:20.811: INFO: namespace e2e-tests-pods-446wt deletion completed in 22.120664167s
+
+• [SLOW TEST:24.179 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:23:20.811: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Mar 16 12:23:20.876: INFO: Waiting up to 5m0s for pod "pod-d07caa92-2914-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-b24xz" to be "success or failure"
+Mar 16 12:23:20.880: INFO: Pod "pod-d07caa92-2914-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.989503ms
+Mar 16 12:23:22.883: INFO: Pod "pod-d07caa92-2914-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007157557s
+STEP: Saw pod success
+Mar 16 12:23:22.883: INFO: Pod "pod-d07caa92-2914-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:23:22.886: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-d07caa92-2914-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:23:22.901: INFO: Waiting for pod pod-d07caa92-2914-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:23:22.907: INFO: Pod pod-d07caa92-2914-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:23:22.913: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-b24xz" for this suite.
+Mar 16 12:23:28.935: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:23:28.992: INFO: namespace: e2e-tests-emptydir-b24xz, resource: bindings, ignored listing per whitelist
+Mar 16 12:23:29.043: INFO: namespace e2e-tests-emptydir-b24xz deletion completed in 6.117240344s
+
+• [SLOW TEST:8.233 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:23:29.044: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-n8ql8
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 16 12:23:29.082: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 16 12:23:47.133: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.0.171:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-n8ql8 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:23:47.133: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:23:52.120: INFO: Found all expected endpoints: [netserver-0]
+Mar 16 12:23:52.123: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.1.210:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-n8ql8 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:23:52.123: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:23:52.237: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:23:52.237: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-n8ql8" for this suite.
+Mar 16 12:24:14.249: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:24:14.317: INFO: namespace: e2e-tests-pod-network-test-n8ql8, resource: bindings, ignored listing per whitelist
+Mar 16 12:24:14.357: INFO: namespace e2e-tests-pod-network-test-n8ql8 deletion completed in 22.116429368s
+
+• [SLOW TEST:45.313 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:24:14.357: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Mar 16 12:24:14.419: INFO: Waiting up to 5m0s for pod "pod-f066c619-2914-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-p79vl" to be "success or failure"
+Mar 16 12:24:14.423: INFO: Pod "pod-f066c619-2914-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.004491ms
+Mar 16 12:24:16.427: INFO: Pod "pod-f066c619-2914-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007349461s
+STEP: Saw pod success
+Mar 16 12:24:16.427: INFO: Pod "pod-f066c619-2914-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:24:16.429: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-f066c619-2914-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:24:16.445: INFO: Waiting for pod pod-f066c619-2914-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:24:16.447: INFO: Pod pod-f066c619-2914-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:24:16.447: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-p79vl" for this suite.
+Mar 16 12:24:22.457: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:24:22.563: INFO: namespace: e2e-tests-emptydir-p79vl, resource: bindings, ignored listing per whitelist
+Mar 16 12:24:22.566: INFO: namespace e2e-tests-emptydir-p79vl deletion completed in 6.116314137s
+
+• [SLOW TEST:8.209 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:24:22.566: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-f5483a62-2914-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:24:22.611: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-f548a570-2914-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-2wxwf" to be "success or failure"
+Mar 16 12:24:22.616: INFO: Pod "pod-projected-secrets-f548a570-2914-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.762464ms
+Mar 16 12:24:24.619: INFO: Pod "pod-projected-secrets-f548a570-2914-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007795517s
+STEP: Saw pod success
+Mar 16 12:24:24.619: INFO: Pod "pod-projected-secrets-f548a570-2914-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:24:24.621: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-projected-secrets-f548a570-2914-11e8-a0aa-16411a5f38c2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:24:24.639: INFO: Waiting for pod pod-projected-secrets-f548a570-2914-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:24:24.647: INFO: Pod pod-projected-secrets-f548a570-2914-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:24:24.656: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2wxwf" for this suite.
+Mar 16 12:24:30.670: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:24:30.719: INFO: namespace: e2e-tests-projected-2wxwf, resource: bindings, ignored listing per whitelist
+Mar 16 12:24:30.780: INFO: namespace e2e-tests-projected-2wxwf deletion completed in 6.119945133s
+
+• [SLOW TEST:8.214 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:24:30.780: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating replication controller my-hostname-basic-fa2deb15-2914-11e8-a0aa-16411a5f38c2
+Mar 16 12:24:30.825: INFO: Pod name my-hostname-basic-fa2deb15-2914-11e8-a0aa-16411a5f38c2: Found 0 pods out of 1
+Mar 16 12:24:35.829: INFO: Pod name my-hostname-basic-fa2deb15-2914-11e8-a0aa-16411a5f38c2: Found 1 pods out of 1
+Mar 16 12:24:35.829: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-fa2deb15-2914-11e8-a0aa-16411a5f38c2" are running
+Mar 16 12:24:35.832: INFO: Pod "my-hostname-basic-fa2deb15-2914-11e8-a0aa-16411a5f38c2-dbpmw" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-16 12:24:30 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-16 12:24:32 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-16 12:24:30 +0000 UTC Reason: Message:}])
+Mar 16 12:24:35.832: INFO: Trying to dial the pod
+Mar 16 12:24:40.886: INFO: Controller my-hostname-basic-fa2deb15-2914-11e8-a0aa-16411a5f38c2: Got expected result from replica 1 [my-hostname-basic-fa2deb15-2914-11e8-a0aa-16411a5f38c2-dbpmw]: "my-hostname-basic-fa2deb15-2914-11e8-a0aa-16411a5f38c2-dbpmw", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:24:40.886: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-d24ss" for this suite.
+Mar 16 12:24:46.900: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:24:46.984: INFO: namespace: e2e-tests-replication-controller-d24ss, resource: bindings, ignored listing per whitelist
+Mar 16 12:24:47.021: INFO: namespace e2e-tests-replication-controller-d24ss deletion completed in 6.130531705s
+
+• [SLOW TEST:16.241 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:24:47.021: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 16 12:24:49.588: INFO: Successfully updated pod "labelsupdate03dbf5a1-2915-11e8-a0aa-16411a5f38c2"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:24:53.619: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fn2mm" for this suite.
+Mar 16 12:25:15.631: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:25:15.707: INFO: namespace: e2e-tests-projected-fn2mm, resource: bindings, ignored listing per whitelist
+Mar 16 12:25:15.745: INFO: namespace e2e-tests-projected-fn2mm deletion completed in 22.122762833s
+
+• [SLOW TEST:28.724 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:25:15.745: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 16 12:25:15.783: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:25:16.323: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-sxcs6" for this suite.
+Mar 16 12:25:22.339: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:25:22.416: INFO: namespace: e2e-tests-custom-resource-definition-sxcs6, resource: bindings, ignored listing per whitelist
+Mar 16 12:25:22.451: INFO: namespace e2e-tests-custom-resource-definition-sxcs6 deletion completed in 6.123281642s
+
+• [SLOW TEST:6.706 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:25:22.451: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 16 12:25:22.495: INFO: Waiting up to 5m0s for pod "downward-api-18fa44f8-2915-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-rrn4b" to be "success or failure"
+Mar 16 12:25:22.498: INFO: Pod "downward-api-18fa44f8-2915-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.969373ms
+Mar 16 12:25:24.501: INFO: Pod "downward-api-18fa44f8-2915-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006059418s
+Mar 16 12:25:26.504: INFO: Pod "downward-api-18fa44f8-2915-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009076162s
+STEP: Saw pod success
+Mar 16 12:25:26.505: INFO: Pod "downward-api-18fa44f8-2915-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:25:26.507: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod downward-api-18fa44f8-2915-11e8-a0aa-16411a5f38c2 container dapi-container: <nil>
+STEP: delete the pod
+Mar 16 12:25:26.521: INFO: Waiting for pod downward-api-18fa44f8-2915-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:25:26.524: INFO: Pod downward-api-18fa44f8-2915-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:25:26.524: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-rrn4b" for this suite.
+Mar 16 12:25:32.537: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:25:32.625: INFO: namespace: e2e-tests-downward-api-rrn4b, resource: bindings, ignored listing per whitelist
+Mar 16 12:25:32.651: INFO: namespace e2e-tests-downward-api-rrn4b deletion completed in 6.12391931s
+
+• [SLOW TEST:10.200 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:25:32.651: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-s95cq
+Mar 16 12:25:36.714: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-s95cq
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 16 12:25:36.717: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:27:36.924: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-s95cq" for this suite.
+Mar 16 12:27:42.942: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:27:43.051: INFO: namespace: e2e-tests-container-probe-s95cq, resource: bindings, ignored listing per whitelist
+Mar 16 12:27:43.053: INFO: namespace e2e-tests-container-probe-s95cq deletion completed in 6.125314536s
+
+• [SLOW TEST:130.401 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:27:43.053: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-projected-all-test-volume-6cc84678-2915-11e8-a0aa-16411a5f38c2
+STEP: Creating secret with name secret-projected-all-test-volume-6cc84651-2915-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Mar 16 12:27:43.102: INFO: Waiting up to 5m0s for pod "projected-volume-6cc8460f-2915-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-m2rlr" to be "success or failure"
+Mar 16 12:27:43.106: INFO: Pod "projected-volume-6cc8460f-2915-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.793165ms
+Mar 16 12:27:45.109: INFO: Pod "projected-volume-6cc8460f-2915-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006870113s
+Mar 16 12:27:47.113: INFO: Pod "projected-volume-6cc8460f-2915-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010317381s
+STEP: Saw pod success
+Mar 16 12:27:47.113: INFO: Pod "projected-volume-6cc8460f-2915-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:27:47.115: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod projected-volume-6cc8460f-2915-11e8-a0aa-16411a5f38c2 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:27:47.135: INFO: Waiting for pod projected-volume-6cc8460f-2915-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:27:47.137: INFO: Pod projected-volume-6cc8460f-2915-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:27:47.137: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-m2rlr" for this suite.
+Mar 16 12:27:53.148: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:27:53.231: INFO: namespace: e2e-tests-projected-m2rlr, resource: bindings, ignored listing per whitelist
+Mar 16 12:27:53.252: INFO: namespace e2e-tests-projected-m2rlr deletion completed in 6.112086364s
+
+• [SLOW TEST:10.199 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:27:53.252: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-map-72dca3f0-2915-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:27:53.299: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-72dd1a10-2915-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-t2n4q" to be "success or failure"
+Mar 16 12:27:53.302: INFO: Pod "pod-projected-secrets-72dd1a10-2915-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.032617ms
+Mar 16 12:27:55.305: INFO: Pod "pod-projected-secrets-72dd1a10-2915-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006593394s
+STEP: Saw pod success
+Mar 16 12:27:55.305: INFO: Pod "pod-projected-secrets-72dd1a10-2915-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:27:55.308: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-projected-secrets-72dd1a10-2915-11e8-a0aa-16411a5f38c2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:27:55.328: INFO: Waiting for pod pod-projected-secrets-72dd1a10-2915-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:27:55.330: INFO: Pod pod-projected-secrets-72dd1a10-2915-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:27:55.331: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-t2n4q" for this suite.
+Mar 16 12:28:01.346: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:28:01.475: INFO: namespace: e2e-tests-projected-t2n4q, resource: bindings, ignored listing per whitelist
+Mar 16 12:28:01.489: INFO: namespace e2e-tests-projected-t2n4q deletion completed in 6.151669528s
+
+• [SLOW TEST:8.237 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:28:01.490: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-77c5794a-2915-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:28:01.536: INFO: Waiting up to 5m0s for pod "pod-secrets-77c5ff6a-2915-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-secrets-kgzjs" to be "success or failure"
+Mar 16 12:28:01.539: INFO: Pod "pod-secrets-77c5ff6a-2915-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.093297ms
+Mar 16 12:28:03.542: INFO: Pod "pod-secrets-77c5ff6a-2915-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006216305s
+Mar 16 12:28:05.546: INFO: Pod "pod-secrets-77c5ff6a-2915-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009756442s
+STEP: Saw pod success
+Mar 16 12:28:05.546: INFO: Pod "pod-secrets-77c5ff6a-2915-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:28:05.549: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-secrets-77c5ff6a-2915-11e8-a0aa-16411a5f38c2 container secret-env-test: <nil>
+STEP: delete the pod
+Mar 16 12:28:05.563: INFO: Waiting for pod pod-secrets-77c5ff6a-2915-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:28:05.565: INFO: Pod pod-secrets-77c5ff6a-2915-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:28:05.565: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-kgzjs" for this suite.
+Mar 16 12:28:11.577: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:28:11.628: INFO: namespace: e2e-tests-secrets-kgzjs, resource: bindings, ignored listing per whitelist
+Mar 16 12:28:11.686: INFO: namespace e2e-tests-secrets-kgzjs deletion completed in 6.11751479s
+
+• [SLOW TEST:10.196 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:28:11.686: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Mar 16 12:28:11.730: INFO: Waiting up to 5m0s for pod "pod-7dd973b8-2915-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-ztppb" to be "success or failure"
+Mar 16 12:28:11.741: INFO: Pod "pod-7dd973b8-2915-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 11.174303ms
+Mar 16 12:28:13.744: INFO: Pod "pod-7dd973b8-2915-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.014426758s
+STEP: Saw pod success
+Mar 16 12:28:13.744: INFO: Pod "pod-7dd973b8-2915-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:28:13.747: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-7dd973b8-2915-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:28:13.764: INFO: Waiting for pod pod-7dd973b8-2915-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:28:13.769: INFO: Pod pod-7dd973b8-2915-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:28:13.769: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-ztppb" for this suite.
+Mar 16 12:28:19.783: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:28:19.846: INFO: namespace: e2e-tests-emptydir-ztppb, resource: bindings, ignored listing per whitelist
+Mar 16 12:28:19.888: INFO: namespace e2e-tests-emptydir-ztppb deletion completed in 6.11518558s
+
+• [SLOW TEST:8.203 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:28:19.889: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:28:19.929: INFO: Waiting up to 5m0s for pod "downwardapi-volume-82bc8bce-2915-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-8jfbf" to be "success or failure"
+Mar 16 12:28:19.934: INFO: Pod "downwardapi-volume-82bc8bce-2915-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.378112ms
+Mar 16 12:28:21.937: INFO: Pod "downwardapi-volume-82bc8bce-2915-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007290396s
+STEP: Saw pod success
+Mar 16 12:28:21.937: INFO: Pod "downwardapi-volume-82bc8bce-2915-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:28:21.939: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod downwardapi-volume-82bc8bce-2915-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:28:21.953: INFO: Waiting for pod downwardapi-volume-82bc8bce-2915-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:28:21.956: INFO: Pod downwardapi-volume-82bc8bce-2915-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:28:21.956: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-8jfbf" for this suite.
+Mar 16 12:28:27.967: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:28:28.034: INFO: namespace: e2e-tests-downward-api-8jfbf, resource: bindings, ignored listing per whitelist
+Mar 16 12:28:28.071: INFO: namespace e2e-tests-downward-api-8jfbf deletion completed in 6.112683683s
+
+• [SLOW TEST:8.183 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:28:28.071: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-9mwms
+Mar 16 12:28:30.126: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-9mwms
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 16 12:28:30.128: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:30:30.340: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-9mwms" for this suite.
+Mar 16 12:30:36.360: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:30:36.460: INFO: namespace: e2e-tests-container-probe-9mwms, resource: bindings, ignored listing per whitelist
+Mar 16 12:30:36.468: INFO: namespace e2e-tests-container-probe-9mwms deletion completed in 6.121510284s
+
+• [SLOW TEST:128.397 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:30:36.468: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 16 12:30:36.517: INFO: (0) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.332272ms)
+Mar 16 12:30:36.520: INFO: (1) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.639736ms)
+Mar 16 12:30:36.524: INFO: (2) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.693184ms)
+Mar 16 12:30:36.528: INFO: (3) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.953649ms)
+Mar 16 12:30:36.532: INFO: (4) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.661045ms)
+Mar 16 12:30:36.536: INFO: (5) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.637431ms)
+Mar 16 12:30:36.539: INFO: (6) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.782569ms)
+Mar 16 12:30:36.543: INFO: (7) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.865125ms)
+Mar 16 12:30:36.547: INFO: (8) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.786773ms)
+Mar 16 12:30:36.551: INFO: (9) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.889076ms)
+Mar 16 12:30:36.555: INFO: (10) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.657498ms)
+Mar 16 12:30:36.558: INFO: (11) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.687382ms)
+Mar 16 12:30:36.562: INFO: (12) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.779348ms)
+Mar 16 12:30:36.566: INFO: (13) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.818754ms)
+Mar 16 12:30:36.572: INFO: (14) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.24149ms)
+Mar 16 12:30:36.576: INFO: (15) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.649041ms)
+Mar 16 12:30:36.580: INFO: (16) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.931682ms)
+Mar 16 12:30:36.584: INFO: (17) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.14985ms)
+Mar 16 12:30:36.588: INFO: (18) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.863509ms)
+Mar 16 12:30:36.592: INFO: (19) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.206049ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:30:36.592: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-6jv44" for this suite.
+Mar 16 12:30:42.611: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:30:42.674: INFO: namespace: e2e-tests-proxy-6jv44, resource: bindings, ignored listing per whitelist
+Mar 16 12:30:42.716: INFO: namespace e2e-tests-proxy-6jv44 deletion completed in 6.117434549s
+
+• [SLOW TEST:6.248 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:30:42.716: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-map-d7deace5-2915-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:30:42.763: INFO: Waiting up to 5m0s for pod "pod-configmaps-d7df16e0-2915-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-configmap-bgb2d" to be "success or failure"
+Mar 16 12:30:42.765: INFO: Pod "pod-configmaps-d7df16e0-2915-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.764162ms
+Mar 16 12:30:44.769: INFO: Pod "pod-configmaps-d7df16e0-2915-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006078613s
+STEP: Saw pod success
+Mar 16 12:30:44.769: INFO: Pod "pod-configmaps-d7df16e0-2915-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:30:44.771: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-configmaps-d7df16e0-2915-11e8-a0aa-16411a5f38c2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:30:44.788: INFO: Waiting for pod pod-configmaps-d7df16e0-2915-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:30:44.791: INFO: Pod pod-configmaps-d7df16e0-2915-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:30:44.791: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-bgb2d" for this suite.
+Mar 16 12:30:50.803: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:30:50.919: INFO: namespace: e2e-tests-configmap-bgb2d, resource: bindings, ignored listing per whitelist
+Mar 16 12:30:50.931: INFO: namespace e2e-tests-configmap-bgb2d deletion completed in 6.1368928s
+
+• [SLOW TEST:8.215 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:30:50.931: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Mar 16 12:30:50.975: INFO: Waiting up to 5m0s for pod "pod-dcc41c09-2915-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-fcppq" to be "success or failure"
+Mar 16 12:30:50.980: INFO: Pod "pod-dcc41c09-2915-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 5.216248ms
+Mar 16 12:30:52.983: INFO: Pod "pod-dcc41c09-2915-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00856229s
+STEP: Saw pod success
+Mar 16 12:30:52.983: INFO: Pod "pod-dcc41c09-2915-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:30:52.985: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-dcc41c09-2915-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:30:52.999: INFO: Waiting for pod pod-dcc41c09-2915-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:30:53.007: INFO: Pod pod-dcc41c09-2915-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:30:53.012: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-fcppq" for this suite.
+Mar 16 12:30:59.031: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:30:59.093: INFO: namespace: e2e-tests-emptydir-fcppq, resource: bindings, ignored listing per whitelist
+Mar 16 12:30:59.142: INFO: namespace e2e-tests-emptydir-fcppq deletion completed in 6.122797286s
+
+• [SLOW TEST:8.211 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:30:59.142: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:30:59.202: INFO: Waiting up to 5m0s for pod "downwardapi-volume-e1ab8398-2915-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-sx95d" to be "success or failure"
+Mar 16 12:30:59.207: INFO: Pod "downwardapi-volume-e1ab8398-2915-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.037963ms
+Mar 16 12:31:01.215: INFO: Pod "downwardapi-volume-e1ab8398-2915-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012335487s
+STEP: Saw pod success
+Mar 16 12:31:01.215: INFO: Pod "downwardapi-volume-e1ab8398-2915-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:31:01.218: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod downwardapi-volume-e1ab8398-2915-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:31:01.234: INFO: Waiting for pod downwardapi-volume-e1ab8398-2915-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:31:01.237: INFO: Pod downwardapi-volume-e1ab8398-2915-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:31:01.237: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-sx95d" for this suite.
+Mar 16 12:31:07.249: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:31:07.304: INFO: namespace: e2e-tests-projected-sx95d, resource: bindings, ignored listing per whitelist
+Mar 16 12:31:07.359: INFO: namespace e2e-tests-projected-sx95d deletion completed in 6.119248925s
+
+• [SLOW TEST:8.217 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:31:07.359: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 16 12:31:09.925: INFO: Successfully updated pod "labelsupdatee68ef725-2915-11e8-a0aa-16411a5f38c2"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:32:42.220: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-cxdq8" for this suite.
+Mar 16 12:33:04.232: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:33:04.341: INFO: namespace: e2e-tests-downward-api-cxdq8, resource: bindings, ignored listing per whitelist
+Mar 16 12:33:04.341: INFO: namespace e2e-tests-downward-api-cxdq8 deletion completed in 22.117843024s
+
+• [SLOW TEST:116.982 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:33:04.342: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 16 12:33:04.386: INFO: Waiting up to 5m0s for pod "downward-api-2c4955a8-2916-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-j5nzz" to be "success or failure"
+Mar 16 12:33:04.389: INFO: Pod "downward-api-2c4955a8-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.835038ms
+Mar 16 12:33:06.393: INFO: Pod "downward-api-2c4955a8-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006077353s
+Mar 16 12:33:08.395: INFO: Pod "downward-api-2c4955a8-2916-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008889213s
+STEP: Saw pod success
+Mar 16 12:33:08.395: INFO: Pod "downward-api-2c4955a8-2916-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:33:08.398: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod downward-api-2c4955a8-2916-11e8-a0aa-16411a5f38c2 container dapi-container: <nil>
+STEP: delete the pod
+Mar 16 12:33:08.425: INFO: Waiting for pod downward-api-2c4955a8-2916-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:33:08.427: INFO: Pod downward-api-2c4955a8-2916-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:33:08.427: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-j5nzz" for this suite.
+Mar 16 12:33:14.447: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:33:14.508: INFO: namespace: e2e-tests-downward-api-j5nzz, resource: bindings, ignored listing per whitelist
+Mar 16 12:33:14.555: INFO: namespace e2e-tests-downward-api-j5nzz deletion completed in 6.118988975s
+
+• [SLOW TEST:10.214 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:33:14.556: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 16 12:33:14.602: INFO: Waiting up to 5m0s for pod "downward-api-325fdda8-2916-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-hffm5" to be "success or failure"
+Mar 16 12:33:14.607: INFO: Pod "downward-api-325fdda8-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.453624ms
+Mar 16 12:33:16.610: INFO: Pod "downward-api-325fdda8-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007490364s
+Mar 16 12:33:18.613: INFO: Pod "downward-api-325fdda8-2916-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010702976s
+STEP: Saw pod success
+Mar 16 12:33:18.613: INFO: Pod "downward-api-325fdda8-2916-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:33:18.615: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod downward-api-325fdda8-2916-11e8-a0aa-16411a5f38c2 container dapi-container: <nil>
+STEP: delete the pod
+Mar 16 12:33:18.632: INFO: Waiting for pod downward-api-325fdda8-2916-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:33:18.637: INFO: Pod downward-api-325fdda8-2916-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:33:18.638: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-hffm5" for this suite.
+Mar 16 12:33:24.666: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:33:24.759: INFO: namespace: e2e-tests-downward-api-hffm5, resource: bindings, ignored listing per whitelist
+Mar 16 12:33:24.776: INFO: namespace e2e-tests-downward-api-hffm5 deletion completed in 6.118997544s
+
+• [SLOW TEST:10.220 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:33:24.776: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-map-387752bf-2916-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:33:24.823: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-3877cbde-2916-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-bs72m" to be "success or failure"
+Mar 16 12:33:24.828: INFO: Pod "pod-projected-secrets-3877cbde-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.122558ms
+Mar 16 12:33:26.831: INFO: Pod "pod-projected-secrets-3877cbde-2916-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007544447s
+STEP: Saw pod success
+Mar 16 12:33:26.831: INFO: Pod "pod-projected-secrets-3877cbde-2916-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:33:26.834: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-projected-secrets-3877cbde-2916-11e8-a0aa-16411a5f38c2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:33:26.850: INFO: Waiting for pod pod-projected-secrets-3877cbde-2916-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:33:26.853: INFO: Pod pod-projected-secrets-3877cbde-2916-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:33:26.853: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-bs72m" for this suite.
+Mar 16 12:33:32.869: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:33:32.933: INFO: namespace: e2e-tests-projected-bs72m, resource: bindings, ignored listing per whitelist
+Mar 16 12:33:32.976: INFO: namespace e2e-tests-projected-bs72m deletion completed in 6.120292877s
+
+• [SLOW TEST:8.201 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:33:32.977: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 16 12:33:33.019: INFO: (0) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.229658ms)
+Mar 16 12:33:33.023: INFO: (1) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.036491ms)
+Mar 16 12:33:33.027: INFO: (2) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.817471ms)
+Mar 16 12:33:33.031: INFO: (3) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.876682ms)
+Mar 16 12:33:33.035: INFO: (4) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.768741ms)
+Mar 16 12:33:33.039: INFO: (5) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.895333ms)
+Mar 16 12:33:33.043: INFO: (6) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.152365ms)
+Mar 16 12:33:33.047: INFO: (7) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.9679ms)
+Mar 16 12:33:33.051: INFO: (8) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.804053ms)
+Mar 16 12:33:33.055: INFO: (9) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.008567ms)
+Mar 16 12:33:33.059: INFO: (10) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.148626ms)
+Mar 16 12:33:33.063: INFO: (11) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.92937ms)
+Mar 16 12:33:33.067: INFO: (12) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.944776ms)
+Mar 16 12:33:33.071: INFO: (13) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.074551ms)
+Mar 16 12:33:33.075: INFO: (14) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.759596ms)
+Mar 16 12:33:33.079: INFO: (15) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.877154ms)
+Mar 16 12:33:33.082: INFO: (16) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.725602ms)
+Mar 16 12:33:33.087: INFO: (17) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.170669ms)
+Mar 16 12:33:33.091: INFO: (18) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.034949ms)
+Mar 16 12:33:33.095: INFO: (19) /api/v1/proxy/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.889917ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:33:33.095: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-rj2df" for this suite.
+Mar 16 12:33:39.105: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:33:39.198: INFO: namespace: e2e-tests-proxy-rj2df, resource: bindings, ignored listing per whitelist
+Mar 16 12:33:39.211: INFO: namespace e2e-tests-proxy-rj2df deletion completed in 6.113184528s
+
+• [SLOW TEST:6.234 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node with explicit kubelet port  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:33:39.211: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:37
+[It] should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test hostPath mode
+Mar 16 12:33:39.256: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-nk499" to be "success or failure"
+Mar 16 12:33:39.261: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 4.724979ms
+Mar 16 12:33:41.264: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008206742s
+STEP: Saw pod success
+Mar 16 12:33:41.264: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Mar 16 12:33:41.267: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Mar 16 12:33:41.291: INFO: Waiting for pod pod-host-path-test to disappear
+Mar 16 12:33:41.307: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:33:41.307: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-nk499" for this suite.
+Mar 16 12:33:47.321: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:33:47.421: INFO: namespace: e2e-tests-hostpath-nk499, resource: bindings, ignored listing per whitelist
+Mar 16 12:33:47.432: INFO: namespace e2e-tests-hostpath-nk499 deletion completed in 6.119780095s
+
+• [SLOW TEST:8.221 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:34
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:33:47.432: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-45f93870-2916-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:33:47.488: INFO: Waiting up to 5m0s for pod "pod-configmaps-45f9c383-2916-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-configmap-dtml4" to be "success or failure"
+Mar 16 12:33:47.491: INFO: Pod "pod-configmaps-45f9c383-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.300151ms
+Mar 16 12:33:49.494: INFO: Pod "pod-configmaps-45f9c383-2916-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006285629s
+STEP: Saw pod success
+Mar 16 12:33:49.494: INFO: Pod "pod-configmaps-45f9c383-2916-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:33:49.496: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-configmaps-45f9c383-2916-11e8-a0aa-16411a5f38c2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:33:49.512: INFO: Waiting for pod pod-configmaps-45f9c383-2916-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:33:49.514: INFO: Pod pod-configmaps-45f9c383-2916-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:33:49.514: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-dtml4" for this suite.
+Mar 16 12:33:55.525: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:33:55.603: INFO: namespace: e2e-tests-configmap-dtml4, resource: bindings, ignored listing per whitelist
+Mar 16 12:33:55.639: INFO: namespace e2e-tests-configmap-dtml4 deletion completed in 6.122108216s
+
+• [SLOW TEST:8.208 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:33:55.640: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: getting the auto-created API token
+Mar 16 12:33:56.203: INFO: created pod pod-service-account-defaultsa
+Mar 16 12:33:56.203: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Mar 16 12:33:56.210: INFO: created pod pod-service-account-mountsa
+Mar 16 12:33:56.211: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Mar 16 12:33:56.215: INFO: created pod pod-service-account-nomountsa
+Mar 16 12:33:56.215: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Mar 16 12:33:56.220: INFO: created pod pod-service-account-defaultsa-mountspec
+Mar 16 12:33:56.220: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Mar 16 12:33:56.223: INFO: created pod pod-service-account-mountsa-mountspec
+Mar 16 12:33:56.223: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Mar 16 12:33:56.226: INFO: created pod pod-service-account-nomountsa-mountspec
+Mar 16 12:33:56.226: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Mar 16 12:33:56.229: INFO: created pod pod-service-account-defaultsa-nomountspec
+Mar 16 12:33:56.229: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Mar 16 12:33:56.232: INFO: created pod pod-service-account-mountsa-nomountspec
+Mar 16 12:33:56.233: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Mar 16 12:33:56.237: INFO: created pod pod-service-account-nomountsa-nomountspec
+Mar 16 12:33:56.237: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:33:56.238: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-x9w5f" for this suite.
+Mar 16 12:34:02.250: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:34:02.331: INFO: namespace: e2e-tests-svcaccounts-x9w5f, resource: bindings, ignored listing per whitelist
+Mar 16 12:34:02.367: INFO: namespace e2e-tests-svcaccounts-x9w5f deletion completed in 6.125512455s
+
+• [SLOW TEST:6.727 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:34:02.367: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-4edf03a5-2916-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:34:02.413: INFO: Waiting up to 5m0s for pod "pod-configmaps-4edf72ac-2916-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-configmap-nwbhg" to be "success or failure"
+Mar 16 12:34:02.416: INFO: Pod "pod-configmaps-4edf72ac-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.058053ms
+Mar 16 12:34:04.419: INFO: Pod "pod-configmaps-4edf72ac-2916-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006096544s
+STEP: Saw pod success
+Mar 16 12:34:04.419: INFO: Pod "pod-configmaps-4edf72ac-2916-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:34:04.422: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-configmaps-4edf72ac-2916-11e8-a0aa-16411a5f38c2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:34:04.456: INFO: Waiting for pod pod-configmaps-4edf72ac-2916-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:34:04.458: INFO: Pod pod-configmaps-4edf72ac-2916-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:34:04.458: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-nwbhg" for this suite.
+Mar 16 12:34:10.471: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:34:10.607: INFO: namespace: e2e-tests-configmap-nwbhg, resource: bindings, ignored listing per whitelist
+Mar 16 12:34:10.607: INFO: namespace e2e-tests-configmap-nwbhg deletion completed in 6.146487343s
+
+• [SLOW TEST:8.241 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:34:10.608: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Mar 16 12:34:10.644: INFO: Waiting up to 1m0s for all nodes to be ready
+Mar 16 12:35:10.668: INFO: Waiting for terminating namespaces to be deleted...
+Mar 16 12:35:10.673: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 16 12:35:10.683: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 16 12:35:10.683: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 16 12:35:10.687: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 16 12:35:10.687: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-0-66.eu-west-1.compute.internal before test
+Mar 16 12:35:10.697: INFO: addons-heapster-e3b0c-b9ff79bbd-tx8w5 from kube-system started at 2018-03-15 13:15:45 +0000 UTC (2 container statuses recorded)
+Mar 16 12:35:10.697: INFO: 	Container heapster ready: true, restart count 0
+Mar 16 12:35:10.697: INFO: 	Container heapster-nanny ready: true, restart count 0
+Mar 16 12:35:10.697: INFO: sonobuoy from sonobuoy started at 2018-03-16 12:01:56 +0000 UTC (1 container statuses recorded)
+Mar 16 12:35:10.697: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Mar 16 12:35:10.697: INFO: calico-node-rh9qr from kube-system started at 2018-03-15 13:14:51 +0000 UTC (2 container statuses recorded)
+Mar 16 12:35:10.697: INFO: 	Container calico-node ready: true, restart count 0
+Mar 16 12:35:10.697: INFO: 	Container install-cni ready: true, restart count 0
+Mar 16 12:35:10.697: INFO: node-exporter-mqwj7 from kube-system started at 2018-03-15 13:14:51 +0000 UTC (1 container statuses recorded)
+Mar 16 12:35:10.697: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 16 12:35:10.697: INFO: sonobuoy-e2e-job-d76ff835c57041be from sonobuoy started at 2018-03-16 12:01:58 +0000 UTC (2 container statuses recorded)
+Mar 16 12:35:10.697: INFO: 	Container e2e ready: true, restart count 0
+Mar 16 12:35:10.697: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Mar 16 12:35:10.697: INFO: kube-proxy-kdv5w from kube-system started at 2018-03-15 13:14:51 +0000 UTC (1 container statuses recorded)
+Mar 16 12:35:10.697: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 16 12:35:10.697: INFO: kube-dns-858cbcf6ff-vzkxb from kube-system started at 2018-03-15 13:15:44 +0000 UTC (3 container statuses recorded)
+Mar 16 12:35:10.697: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 16 12:35:10.697: INFO: 	Container kubedns ready: true, restart count 0
+Mar 16 12:35:10.697: INFO: 	Container sidecar ready: true, restart count 0
+Mar 16 12:35:10.697: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-28-245.eu-west-1.compute.internal before test
+Mar 16 12:35:10.709: INFO: calico-node-zhc44 from kube-system started at 2018-03-15 13:14:55 +0000 UTC (2 container statuses recorded)
+Mar 16 12:35:10.709: INFO: 	Container calico-node ready: true, restart count 0
+Mar 16 12:35:10.709: INFO: 	Container install-cni ready: true, restart count 0
+Mar 16 12:35:10.709: INFO: node-exporter-nv6rc from kube-system started at 2018-03-15 13:14:55 +0000 UTC (1 container statuses recorded)
+Mar 16 12:35:10.709: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 16 12:35:10.709: INFO: kube-dns-autoscaler-6966fd6fb6-mqqq9 from kube-system started at 2018-03-15 13:15:44 +0000 UTC (1 container statuses recorded)
+Mar 16 12:35:10.709: INFO: 	Container autoscaler ready: true, restart count 0
+Mar 16 12:35:10.709: INFO: addons-nginx-ingress-controller-5dbb8df879-gsndg from kube-system started at 2018-03-15 13:15:44 +0000 UTC (1 container statuses recorded)
+Mar 16 12:35:10.709: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Mar 16 12:35:10.709: INFO: kube-proxy-9dql4 from kube-system started at 2018-03-15 13:14:55 +0000 UTC (1 container statuses recorded)
+Mar 16 12:35:10.709: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 16 12:35:10.709: INFO: addons-kubernetes-dashboard-7fc5877997-jp7rq from kube-system started at 2018-03-15 13:15:44 +0000 UTC (1 container statuses recorded)
+Mar 16 12:35:10.709: INFO: 	Container main ready: true, restart count 0
+Mar 16 12:35:10.709: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-k78n6 from kube-system started at 2018-03-15 13:15:45 +0000 UTC (1 container statuses recorded)
+Mar 16 12:35:10.709: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Mar 16 12:35:10.709: INFO: kube-dns-858cbcf6ff-ns6n2 from kube-system started at 2018-03-15 13:15:48 +0000 UTC (3 container statuses recorded)
+Mar 16 12:35:10.709: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 16 12:35:10.709: INFO: 	Container kubedns ready: true, restart count 0
+Mar 16 12:35:10.709: INFO: 	Container sidecar ready: true, restart count 0
+Mar 16 12:35:10.709: INFO: vpn-shoot-598b8754f7-dr95x from kube-system started at 2018-03-15 15:26:16 +0000 UTC (1 container statuses recorded)
+Mar 16 12:35:10.709: INFO: 	Container vpn-shoot ready: true, restart count 2
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.151c66b718aacdbe], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 MatchNodeSelector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:35:11.729: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-g7w48" for this suite.
+Mar 16 12:35:33.741: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:35:33.806: INFO: namespace: e2e-tests-sched-pred-g7w48, resource: bindings, ignored listing per whitelist
+Mar 16 12:35:33.850: INFO: namespace e2e-tests-sched-pred-g7w48 deletion completed in 22.117671849s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.242 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:35:33.850: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Mar 16 12:35:33.893: INFO: Waiting up to 5m0s for pod "pod-85663b69-2916-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-7scmw" to be "success or failure"
+Mar 16 12:35:33.899: INFO: Pod "pod-85663b69-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 5.527883ms
+Mar 16 12:35:35.904: INFO: Pod "pod-85663b69-2916-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.01101045s
+STEP: Saw pod success
+Mar 16 12:35:35.904: INFO: Pod "pod-85663b69-2916-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:35:35.908: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-85663b69-2916-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:35:35.938: INFO: Waiting for pod pod-85663b69-2916-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:35:35.942: INFO: Pod pod-85663b69-2916-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:35:35.942: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-7scmw" for this suite.
+Mar 16 12:35:41.964: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:35:42.087: INFO: namespace: e2e-tests-emptydir-7scmw, resource: bindings, ignored listing per whitelist
+Mar 16 12:35:42.092: INFO: namespace e2e-tests-emptydir-7scmw deletion completed in 6.145937155s
+
+• [SLOW TEST:8.242 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:35:42.092: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:35:42.195: INFO: Waiting up to 5m0s for pod "downwardapi-volume-8a59100b-2916-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-xbjlf" to be "success or failure"
+Mar 16 12:35:42.198: INFO: Pod "downwardapi-volume-8a59100b-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.24618ms
+Mar 16 12:35:44.201: INFO: Pod "downwardapi-volume-8a59100b-2916-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005526471s
+STEP: Saw pod success
+Mar 16 12:35:44.201: INFO: Pod "downwardapi-volume-8a59100b-2916-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:35:44.203: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod downwardapi-volume-8a59100b-2916-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:35:44.217: INFO: Waiting for pod downwardapi-volume-8a59100b-2916-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:35:44.219: INFO: Pod downwardapi-volume-8a59100b-2916-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:35:44.219: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-xbjlf" for this suite.
+Mar 16 12:35:50.230: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:35:50.300: INFO: namespace: e2e-tests-downward-api-xbjlf, resource: bindings, ignored listing per whitelist
+Mar 16 12:35:50.348: INFO: namespace e2e-tests-downward-api-xbjlf deletion completed in 6.125407695s
+
+• [SLOW TEST:8.256 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:35:50.348: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Mar 16 12:35:50.391: INFO: Waiting up to 5m0s for pod "pod-8f3b9ed7-2916-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-emptydir-zv6mm" to be "success or failure"
+Mar 16 12:35:50.393: INFO: Pod "pod-8f3b9ed7-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.733734ms
+Mar 16 12:35:52.397: INFO: Pod "pod-8f3b9ed7-2916-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00583703s
+STEP: Saw pod success
+Mar 16 12:35:52.397: INFO: Pod "pod-8f3b9ed7-2916-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:35:52.399: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-8f3b9ed7-2916-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:35:52.414: INFO: Waiting for pod pod-8f3b9ed7-2916-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:35:52.418: INFO: Pod pod-8f3b9ed7-2916-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:35:52.430: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-zv6mm" for this suite.
+Mar 16 12:35:58.452: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:35:58.530: INFO: namespace: e2e-tests-emptydir-zv6mm, resource: bindings, ignored listing per whitelist
+Mar 16 12:35:58.555: INFO: namespace e2e-tests-emptydir-zv6mm deletion completed in 6.120568701s
+
+• [SLOW TEST:8.208 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:35:58.556: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 16 12:36:22.613: INFO: Container started at 2018-03-16 12:35:59 +0000 UTC, pod became ready at 2018-03-16 12:36:22 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:36:22.613: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-7m9sb" for this suite.
+Mar 16 12:36:44.627: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:36:44.704: INFO: namespace: e2e-tests-container-probe-7m9sb, resource: bindings, ignored listing per whitelist
+Mar 16 12:36:44.728: INFO: namespace e2e-tests-container-probe-7m9sb deletion completed in 22.110272996s
+
+• [SLOW TEST:46.173 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:36:44.728: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name cm-test-opt-del-afa5b3da-2916-11e8-a0aa-16411a5f38c2
+STEP: Creating configMap with name cm-test-opt-upd-afa5b412-2916-11e8-a0aa-16411a5f38c2
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-afa5b3da-2916-11e8-a0aa-16411a5f38c2
+STEP: Updating configmap cm-test-opt-upd-afa5b412-2916-11e8-a0aa-16411a5f38c2
+STEP: Creating configMap with name cm-test-opt-create-afa5b42f-2916-11e8-a0aa-16411a5f38c2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:36:51.069: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wxr7p" for this suite.
+Mar 16 12:37:13.081: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:37:13.159: INFO: namespace: e2e-tests-projected-wxr7p, resource: bindings, ignored listing per whitelist
+Mar 16 12:37:13.191: INFO: namespace e2e-tests-projected-wxr7p deletion completed in 22.11832264s
+
+• [SLOW TEST:28.462 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:37:13.191: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:51
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:37:13.235: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-7brrw" for this suite.
+Mar 16 12:37:19.245: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:37:19.309: INFO: namespace: e2e-tests-services-7brrw, resource: bindings, ignored listing per whitelist
+Mar 16 12:37:19.361: INFO: namespace e2e-tests-services-7brrw deletion completed in 6.123953631s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:56
+
+• [SLOW TEST:6.171 seconds]
+[sig-network] Services
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:37:19.362: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Mar 16 12:37:23.436: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-k2qf9 PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:37:23.436: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:37:23.539: INFO: Exec stderr: ""
+Mar 16 12:37:23.540: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-k2qf9 PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:37:23.540: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:37:23.686: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Mar 16 12:37:23.686: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-k2qf9 PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:37:23.686: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:37:23.795: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Mar 16 12:37:23.795: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-k2qf9 PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:37:23.795: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:37:23.960: INFO: Exec stderr: ""
+Mar 16 12:37:23.960: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-k2qf9 PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:37:23.960: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:37:24.071: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:37:24.071: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-k2qf9" for this suite.
+Mar 16 12:38:08.083: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:38:08.180: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-k2qf9, resource: bindings, ignored listing per whitelist
+Mar 16 12:38:08.218: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-k2qf9 deletion completed in 44.144215943s
+
+• [SLOW TEST:48.856 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:38:08.218: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:38:08.282: INFO: Waiting up to 5m0s for pod "downwardapi-volume-e16bccee-2916-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-f5tnf" to be "success or failure"
+Mar 16 12:38:08.286: INFO: Pod "downwardapi-volume-e16bccee-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.95313ms
+Mar 16 12:38:10.289: INFO: Pod "downwardapi-volume-e16bccee-2916-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006976358s
+STEP: Saw pod success
+Mar 16 12:38:10.289: INFO: Pod "downwardapi-volume-e16bccee-2916-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:38:10.291: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod downwardapi-volume-e16bccee-2916-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:38:10.308: INFO: Waiting for pod downwardapi-volume-e16bccee-2916-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:38:10.310: INFO: Pod downwardapi-volume-e16bccee-2916-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:38:10.310: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-f5tnf" for this suite.
+Mar 16 12:38:16.322: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:38:16.403: INFO: namespace: e2e-tests-downward-api-f5tnf, resource: bindings, ignored listing per whitelist
+Mar 16 12:38:16.437: INFO: namespace e2e-tests-downward-api-f5tnf deletion completed in 6.12387435s
+
+• [SLOW TEST:8.218 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:38:16.437: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-e64eaaec-2916-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:38:16.481: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-e64f22b6-2916-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-qpw2p" to be "success or failure"
+Mar 16 12:38:16.485: INFO: Pod "pod-projected-configmaps-e64f22b6-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.328446ms
+Mar 16 12:38:18.489: INFO: Pod "pod-projected-configmaps-e64f22b6-2916-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00767784s
+Mar 16 12:38:20.491: INFO: Pod "pod-projected-configmaps-e64f22b6-2916-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010625517s
+STEP: Saw pod success
+Mar 16 12:38:20.492: INFO: Pod "pod-projected-configmaps-e64f22b6-2916-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:38:20.494: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-projected-configmaps-e64f22b6-2916-11e8-a0aa-16411a5f38c2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:38:20.511: INFO: Waiting for pod pod-projected-configmaps-e64f22b6-2916-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:38:20.515: INFO: Pod pod-projected-configmaps-e64f22b6-2916-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:38:20.521: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qpw2p" for this suite.
+Mar 16 12:38:26.534: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:38:26.633: INFO: namespace: e2e-tests-projected-qpw2p, resource: bindings, ignored listing per whitelist
+Mar 16 12:38:26.648: INFO: namespace e2e-tests-projected-qpw2p deletion completed in 6.123498264s
+
+• [SLOW TEST:10.211 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:38:26.648: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Mar 16 12:38:26.685: INFO: Waiting up to 1m0s for all nodes to be ready
+Mar 16 12:39:26.706: INFO: Waiting for terminating namespaces to be deleted...
+Mar 16 12:39:26.711: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 16 12:39:26.721: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 16 12:39:26.721: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 16 12:39:26.724: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 16 12:39:26.724: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-0-66.eu-west-1.compute.internal before test
+Mar 16 12:39:26.732: INFO: kube-proxy-kdv5w from kube-system started at 2018-03-15 13:14:51 +0000 UTC (1 container statuses recorded)
+Mar 16 12:39:26.732: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 16 12:39:26.732: INFO: kube-dns-858cbcf6ff-vzkxb from kube-system started at 2018-03-15 13:15:44 +0000 UTC (3 container statuses recorded)
+Mar 16 12:39:26.732: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 16 12:39:26.732: INFO: 	Container kubedns ready: true, restart count 0
+Mar 16 12:39:26.732: INFO: 	Container sidecar ready: true, restart count 0
+Mar 16 12:39:26.732: INFO: sonobuoy-e2e-job-d76ff835c57041be from sonobuoy started at 2018-03-16 12:01:58 +0000 UTC (2 container statuses recorded)
+Mar 16 12:39:26.732: INFO: 	Container e2e ready: true, restart count 0
+Mar 16 12:39:26.732: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Mar 16 12:39:26.733: INFO: calico-node-rh9qr from kube-system started at 2018-03-15 13:14:51 +0000 UTC (2 container statuses recorded)
+Mar 16 12:39:26.733: INFO: 	Container calico-node ready: true, restart count 0
+Mar 16 12:39:26.733: INFO: 	Container install-cni ready: true, restart count 0
+Mar 16 12:39:26.733: INFO: node-exporter-mqwj7 from kube-system started at 2018-03-15 13:14:51 +0000 UTC (1 container statuses recorded)
+Mar 16 12:39:26.733: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 16 12:39:26.733: INFO: addons-heapster-e3b0c-b9ff79bbd-tx8w5 from kube-system started at 2018-03-15 13:15:45 +0000 UTC (2 container statuses recorded)
+Mar 16 12:39:26.733: INFO: 	Container heapster ready: true, restart count 0
+Mar 16 12:39:26.733: INFO: 	Container heapster-nanny ready: true, restart count 0
+Mar 16 12:39:26.733: INFO: sonobuoy from sonobuoy started at 2018-03-16 12:01:56 +0000 UTC (1 container statuses recorded)
+Mar 16 12:39:26.733: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Mar 16 12:39:26.733: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-28-245.eu-west-1.compute.internal before test
+Mar 16 12:39:26.742: INFO: addons-kubernetes-dashboard-7fc5877997-jp7rq from kube-system started at 2018-03-15 13:15:44 +0000 UTC (1 container statuses recorded)
+Mar 16 12:39:26.742: INFO: 	Container main ready: true, restart count 0
+Mar 16 12:39:26.742: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-k78n6 from kube-system started at 2018-03-15 13:15:45 +0000 UTC (1 container statuses recorded)
+Mar 16 12:39:26.742: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Mar 16 12:39:26.742: INFO: kube-dns-858cbcf6ff-ns6n2 from kube-system started at 2018-03-15 13:15:48 +0000 UTC (3 container statuses recorded)
+Mar 16 12:39:26.742: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 16 12:39:26.742: INFO: 	Container kubedns ready: true, restart count 0
+Mar 16 12:39:26.742: INFO: 	Container sidecar ready: true, restart count 0
+Mar 16 12:39:26.742: INFO: vpn-shoot-598b8754f7-dr95x from kube-system started at 2018-03-15 15:26:16 +0000 UTC (1 container statuses recorded)
+Mar 16 12:39:26.742: INFO: 	Container vpn-shoot ready: true, restart count 2
+Mar 16 12:39:26.742: INFO: kube-proxy-9dql4 from kube-system started at 2018-03-15 13:14:55 +0000 UTC (1 container statuses recorded)
+Mar 16 12:39:26.742: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 16 12:39:26.742: INFO: node-exporter-nv6rc from kube-system started at 2018-03-15 13:14:55 +0000 UTC (1 container statuses recorded)
+Mar 16 12:39:26.742: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 16 12:39:26.742: INFO: kube-dns-autoscaler-6966fd6fb6-mqqq9 from kube-system started at 2018-03-15 13:15:44 +0000 UTC (1 container statuses recorded)
+Mar 16 12:39:26.742: INFO: 	Container autoscaler ready: true, restart count 0
+Mar 16 12:39:26.742: INFO: addons-nginx-ingress-controller-5dbb8df879-gsndg from kube-system started at 2018-03-15 13:15:44 +0000 UTC (1 container statuses recorded)
+Mar 16 12:39:26.742: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Mar 16 12:39:26.742: INFO: calico-node-zhc44 from kube-system started at 2018-03-15 13:14:55 +0000 UTC (2 container statuses recorded)
+Mar 16 12:39:26.742: INFO: 	Container calico-node ready: true, restart count 0
+Mar 16 12:39:26.742: INFO: 	Container install-cni ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: verifying the node has the label node ip-10-250-0-66.eu-west-1.compute.internal
+STEP: verifying the node has the label node ip-10-250-28-245.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod addons-heapster-e3b0c-b9ff79bbd-tx8w5 requesting resource cpu=50m on Node ip-10-250-0-66.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod addons-kubernetes-dashboard-7fc5877997-jp7rq requesting resource cpu=100m on Node ip-10-250-28-245.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod addons-nginx-ingress-controller-5dbb8df879-gsndg requesting resource cpu=0m on Node ip-10-250-28-245.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-k78n6 requesting resource cpu=0m on Node ip-10-250-28-245.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod calico-node-rh9qr requesting resource cpu=250m on Node ip-10-250-0-66.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod calico-node-zhc44 requesting resource cpu=250m on Node ip-10-250-28-245.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod kube-dns-858cbcf6ff-ns6n2 requesting resource cpu=260m on Node ip-10-250-28-245.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod kube-dns-858cbcf6ff-vzkxb requesting resource cpu=260m on Node ip-10-250-0-66.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod kube-dns-autoscaler-6966fd6fb6-mqqq9 requesting resource cpu=20m on Node ip-10-250-28-245.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod kube-proxy-9dql4 requesting resource cpu=100m on Node ip-10-250-28-245.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod kube-proxy-kdv5w requesting resource cpu=100m on Node ip-10-250-0-66.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod node-exporter-mqwj7 requesting resource cpu=100m on Node ip-10-250-0-66.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod node-exporter-nv6rc requesting resource cpu=100m on Node ip-10-250-28-245.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod vpn-shoot-598b8754f7-dr95x requesting resource cpu=100m on Node ip-10-250-28-245.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod sonobuoy requesting resource cpu=0m on Node ip-10-250-0-66.eu-west-1.compute.internal
+Mar 16 12:39:26.768: INFO: Pod sonobuoy-e2e-job-d76ff835c57041be requesting resource cpu=0m on Node ip-10-250-0-66.eu-west-1.compute.internal
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-1034cf3d-2917-11e8-a0aa-16411a5f38c2.151c66f2b6849762], Reason = [Scheduled], Message = [Successfully assigned filler-pod-1034cf3d-2917-11e8-a0aa-16411a5f38c2 to ip-10-250-0-66.eu-west-1.compute.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-1034cf3d-2917-11e8-a0aa-16411a5f38c2.151c66f2c4507d16], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-xbr78" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-1034cf3d-2917-11e8-a0aa-16411a5f38c2.151c66f2e9acdd03], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-1034cf3d-2917-11e8-a0aa-16411a5f38c2.151c66f2eba9f519], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-1034cf3d-2917-11e8-a0aa-16411a5f38c2.151c66f2f40dcd78], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-1035d656-2917-11e8-a0aa-16411a5f38c2.151c66f2b6d35c51], Reason = [Scheduled], Message = [Successfully assigned filler-pod-1035d656-2917-11e8-a0aa-16411a5f38c2 to ip-10-250-28-245.eu-west-1.compute.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-1035d656-2917-11e8-a0aa-16411a5f38c2.151c66f2c5466fa5], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-xbr78" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-1035d656-2917-11e8-a0aa-16411a5f38c2.151c66f2eb6d61a7], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-1035d656-2917-11e8-a0aa-16411a5f38c2.151c66f2eddc5214], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-1035d656-2917-11e8-a0aa-16411a5f38c2.151c66f2f3a7835b], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.151c66f32ef5a40e], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 Insufficient cpu.]
+STEP: removing the label node off the node ip-10-250-0-66.eu-west-1.compute.internal
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node ip-10-250-28-245.eu-west-1.compute.internal
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:39:29.835: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-vz4vw" for this suite.
+Mar 16 12:39:51.851: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:39:51.932: INFO: namespace: e2e-tests-sched-pred-vz4vw, resource: bindings, ignored listing per whitelist
+Mar 16 12:39:51.962: INFO: namespace e2e-tests-sched-pred-vz4vw deletion completed in 22.123671809s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:85.314 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:39:51.962: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:51
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-8hh4n
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-8hh4n to expose endpoints map[]
+Mar 16 12:39:52.011: INFO: Get endpoints failed (2.779857ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Mar 16 12:39:53.014: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-8hh4n exposes endpoints map[] (1.005611159s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-8hh4n
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-8hh4n to expose endpoints map[pod1:[100]]
+Mar 16 12:39:55.035: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-8hh4n exposes endpoints map[pod1:[100]] (2.014510211s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-8hh4n
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-8hh4n to expose endpoints map[pod1:[100] pod2:[101]]
+Mar 16 12:39:57.069: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-8hh4n exposes endpoints map[pod1:[100] pod2:[101]] (2.029854015s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-8hh4n
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-8hh4n to expose endpoints map[pod2:[101]]
+Mar 16 12:39:57.080: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-8hh4n exposes endpoints map[pod2:[101]] (5.130032ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-8hh4n
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-8hh4n to expose endpoints map[]
+Mar 16 12:39:57.089: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-8hh4n exposes endpoints map[] (4.515902ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:39:57.102: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-8hh4n" for this suite.
+Mar 16 12:40:03.121: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:40:03.234: INFO: namespace: e2e-tests-services-8hh4n, resource: bindings, ignored listing per whitelist
+Mar 16 12:40:03.236: INFO: namespace e2e-tests-services-8hh4n deletion completed in 6.127227409s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:56
+
+• [SLOW TEST:11.273 seconds]
+[sig-network] Services
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:40:03.236: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 16 12:40:05.809: INFO: Successfully updated pod "annotationupdate25f730cc-2917-11e8-a0aa-16411a5f38c2"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:41:24.638: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-4tjn8" for this suite.
+Mar 16 12:41:46.651: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:41:46.732: INFO: namespace: e2e-tests-downward-api-4tjn8, resource: bindings, ignored listing per whitelist
+Mar 16 12:41:46.761: INFO: namespace e2e-tests-downward-api-4tjn8 deletion completed in 22.120153604s
+
+• [SLOW TEST:103.525 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:41:46.761: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-63ac738d-2917-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume configMaps
+Mar 16 12:41:46.811: INFO: Waiting up to 5m0s for pod "pod-configmaps-63acefc1-2917-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-configmap-95tbd" to be "success or failure"
+Mar 16 12:41:46.818: INFO: Pod "pod-configmaps-63acefc1-2917-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 7.341403ms
+Mar 16 12:41:48.821: INFO: Pod "pod-configmaps-63acefc1-2917-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010105004s
+STEP: Saw pod success
+Mar 16 12:41:48.821: INFO: Pod "pod-configmaps-63acefc1-2917-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:41:48.823: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-configmaps-63acefc1-2917-11e8-a0aa-16411a5f38c2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:41:48.842: INFO: Waiting for pod pod-configmaps-63acefc1-2917-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:41:48.857: INFO: Pod pod-configmaps-63acefc1-2917-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:41:48.857: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-95tbd" for this suite.
+Mar 16 12:41:54.870: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:41:54.915: INFO: namespace: e2e-tests-configmap-95tbd, resource: bindings, ignored listing per whitelist
+Mar 16 12:41:54.980: INFO: namespace e2e-tests-configmap-95tbd deletion completed in 6.119216622s
+
+• [SLOW TEST:8.219 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:41:54.980: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:41:55.021: INFO: Waiting up to 5m0s for pod "downwardapi-volume-6891c241-2917-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-4mhwl" to be "success or failure"
+Mar 16 12:41:55.024: INFO: Pod "downwardapi-volume-6891c241-2917-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.900103ms
+Mar 16 12:41:57.028: INFO: Pod "downwardapi-volume-6891c241-2917-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006428541s
+STEP: Saw pod success
+Mar 16 12:41:57.028: INFO: Pod "downwardapi-volume-6891c241-2917-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:41:57.030: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod downwardapi-volume-6891c241-2917-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:41:57.045: INFO: Waiting for pod downwardapi-volume-6891c241-2917-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:41:57.047: INFO: Pod downwardapi-volume-6891c241-2917-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:41:57.047: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4mhwl" for this suite.
+Mar 16 12:42:03.059: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:42:03.138: INFO: namespace: e2e-tests-projected-4mhwl, resource: bindings, ignored listing per whitelist
+Mar 16 12:42:03.172: INFO: namespace e2e-tests-projected-4mhwl deletion completed in 6.122329921s
+
+• [SLOW TEST:8.192 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:42:03.173: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:43:03.221: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-8xcjv" for this suite.
+Mar 16 12:43:25.233: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:43:25.282: INFO: namespace: e2e-tests-container-probe-8xcjv, resource: bindings, ignored listing per whitelist
+Mar 16 12:43:25.352: INFO: namespace e2e-tests-container-probe-8xcjv deletion completed in 22.128185444s
+
+• [SLOW TEST:82.180 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:43:25.353: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-ck64v
+Mar 16 12:43:29.417: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-ck64v
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 16 12:43:29.419: INFO: Initial restart count of pod liveness-exec is 0
+Mar 16 12:44:19.506: INFO: Restart count of pod e2e-tests-container-probe-ck64v/liveness-exec is now 1 (50.086482022s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:44:19.512: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-ck64v" for this suite.
+Mar 16 12:44:25.526: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:44:25.610: INFO: namespace: e2e-tests-container-probe-ck64v, resource: bindings, ignored listing per whitelist
+Mar 16 12:44:25.638: INFO: namespace e2e-tests-container-probe-ck64v deletion completed in 6.122411149s
+
+• [SLOW TEST:60.285 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:44:25.638: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:44:25.688: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c25f8760-2917-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-c5rzj" to be "success or failure"
+Mar 16 12:44:25.690: INFO: Pod "downwardapi-volume-c25f8760-2917-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.522206ms
+Mar 16 12:44:27.695: INFO: Pod "downwardapi-volume-c25f8760-2917-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00704583s
+STEP: Saw pod success
+Mar 16 12:44:27.695: INFO: Pod "downwardapi-volume-c25f8760-2917-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:44:27.697: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod downwardapi-volume-c25f8760-2917-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:44:27.713: INFO: Waiting for pod downwardapi-volume-c25f8760-2917-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:44:27.717: INFO: Pod downwardapi-volume-c25f8760-2917-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:44:27.717: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-c5rzj" for this suite.
+Mar 16 12:44:33.728: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:44:33.841: INFO: namespace: e2e-tests-downward-api-c5rzj, resource: bindings, ignored listing per whitelist
+Mar 16 12:44:33.841: INFO: namespace e2e-tests-downward-api-c5rzj deletion completed in 6.121360369s
+
+• [SLOW TEST:8.203 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:44:33.841: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test override arguments
+Mar 16 12:44:33.883: INFO: Waiting up to 5m0s for pod "client-containers-c7421f8c-2917-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-containers-2l5hl" to be "success or failure"
+Mar 16 12:44:33.885: INFO: Pod "client-containers-c7421f8c-2917-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.548154ms
+Mar 16 12:44:35.889: INFO: Pod "client-containers-c7421f8c-2917-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00665084s
+STEP: Saw pod success
+Mar 16 12:44:35.889: INFO: Pod "client-containers-c7421f8c-2917-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:44:35.893: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod client-containers-c7421f8c-2917-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:44:35.912: INFO: Waiting for pod client-containers-c7421f8c-2917-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:44:35.915: INFO: Pod client-containers-c7421f8c-2917-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:44:35.915: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-2l5hl" for this suite.
+Mar 16 12:44:41.927: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:44:41.984: INFO: namespace: e2e-tests-containers-2l5hl, resource: bindings, ignored listing per whitelist
+Mar 16 12:44:42.035: INFO: namespace e2e-tests-containers-2l5hl deletion completed in 6.117502884s
+
+• [SLOW TEST:8.194 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:44:42.035: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:44:42.106: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-5xpnt" for this suite.
+Mar 16 12:45:04.119: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:45:04.187: INFO: namespace: e2e-tests-pods-5xpnt, resource: bindings, ignored listing per whitelist
+Mar 16 12:45:04.233: INFO: namespace e2e-tests-pods-5xpnt deletion completed in 22.122794594s
+
+• [SLOW TEST:22.197 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:45:04.233: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:45:04.276: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d95fad98-2917-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-g7b64" to be "success or failure"
+Mar 16 12:45:04.279: INFO: Pod "downwardapi-volume-d95fad98-2917-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.246099ms
+Mar 16 12:45:06.282: INFO: Pod "downwardapi-volume-d95fad98-2917-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005801708s
+STEP: Saw pod success
+Mar 16 12:45:06.282: INFO: Pod "downwardapi-volume-d95fad98-2917-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:45:06.284: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod downwardapi-volume-d95fad98-2917-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:45:06.297: INFO: Waiting for pod downwardapi-volume-d95fad98-2917-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:45:06.299: INFO: Pod downwardapi-volume-d95fad98-2917-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:45:06.300: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-g7b64" for this suite.
+Mar 16 12:45:12.322: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:45:12.380: INFO: namespace: e2e-tests-projected-g7b64, resource: bindings, ignored listing per whitelist
+Mar 16 12:45:12.435: INFO: namespace e2e-tests-projected-g7b64 deletion completed in 6.126844612s
+
+• [SLOW TEST:8.202 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:45:12.435: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test use defaults
+Mar 16 12:45:12.478: INFO: Waiting up to 5m0s for pod "client-containers-de433b30-2917-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-containers-4gknv" to be "success or failure"
+Mar 16 12:45:12.482: INFO: Pod "client-containers-de433b30-2917-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.191419ms
+Mar 16 12:45:14.485: INFO: Pod "client-containers-de433b30-2917-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007383514s
+STEP: Saw pod success
+Mar 16 12:45:14.485: INFO: Pod "client-containers-de433b30-2917-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:45:14.487: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod client-containers-de433b30-2917-11e8-a0aa-16411a5f38c2 container test-container: <nil>
+STEP: delete the pod
+Mar 16 12:45:14.504: INFO: Waiting for pod client-containers-de433b30-2917-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:45:14.508: INFO: Pod client-containers-de433b30-2917-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:45:14.516: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-4gknv" for this suite.
+Mar 16 12:45:20.533: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:45:20.600: INFO: namespace: e2e-tests-containers-4gknv, resource: bindings, ignored listing per whitelist
+Mar 16 12:45:20.646: INFO: namespace e2e-tests-containers-4gknv deletion completed in 6.122371656s
+
+• [SLOW TEST:8.211 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:45:20.646: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-hzkjg
+I0316 12:45:20.691116      14 runners.go:178] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-hzkjg, replica count: 1
+I0316 12:45:21.691464      14 runners.go:178] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0316 12:45:22.691810      14 runners.go:178] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Mar 16 12:45:22.800: INFO: Created: latency-svc-vdx2n
+Mar 16 12:45:22.804: INFO: Got endpoints: latency-svc-vdx2n [12.834392ms]
+Mar 16 12:45:22.814: INFO: Created: latency-svc-nzkrq
+Mar 16 12:45:22.818: INFO: Got endpoints: latency-svc-nzkrq [12.922012ms]
+Mar 16 12:45:22.819: INFO: Created: latency-svc-fqchp
+Mar 16 12:45:22.823: INFO: Got endpoints: latency-svc-fqchp [16.289158ms]
+Mar 16 12:45:22.824: INFO: Created: latency-svc-6kw89
+Mar 16 12:45:22.826: INFO: Got endpoints: latency-svc-6kw89 [21.143079ms]
+Mar 16 12:45:22.829: INFO: Created: latency-svc-s7l4n
+Mar 16 12:45:22.831: INFO: Got endpoints: latency-svc-s7l4n [26.370171ms]
+Mar 16 12:45:22.836: INFO: Created: latency-svc-lmwld
+Mar 16 12:45:22.838: INFO: Got endpoints: latency-svc-lmwld [32.772867ms]
+Mar 16 12:45:22.841: INFO: Created: latency-svc-hxgsb
+Mar 16 12:45:22.845: INFO: Created: latency-svc-rb77d
+Mar 16 12:45:22.845: INFO: Got endpoints: latency-svc-hxgsb [40.221856ms]
+Mar 16 12:45:22.851: INFO: Created: latency-svc-8slr9
+Mar 16 12:45:22.852: INFO: Got endpoints: latency-svc-rb77d [46.670143ms]
+Mar 16 12:45:22.857: INFO: Created: latency-svc-llqhc
+Mar 16 12:45:22.858: INFO: Got endpoints: latency-svc-8slr9 [51.793517ms]
+Mar 16 12:45:22.862: INFO: Got endpoints: latency-svc-llqhc [56.208429ms]
+Mar 16 12:45:22.863: INFO: Created: latency-svc-mws55
+Mar 16 12:45:22.867: INFO: Got endpoints: latency-svc-mws55 [60.871408ms]
+Mar 16 12:45:22.867: INFO: Created: latency-svc-5tllh
+Mar 16 12:45:22.870: INFO: Got endpoints: latency-svc-5tllh [63.81695ms]
+Mar 16 12:45:22.873: INFO: Created: latency-svc-vk7wl
+Mar 16 12:45:22.876: INFO: Got endpoints: latency-svc-vk7wl [69.464884ms]
+Mar 16 12:45:22.879: INFO: Created: latency-svc-22nq8
+Mar 16 12:45:22.884: INFO: Got endpoints: latency-svc-22nq8 [77.442471ms]
+Mar 16 12:45:22.887: INFO: Created: latency-svc-cnb4q
+Mar 16 12:45:22.890: INFO: Got endpoints: latency-svc-cnb4q [83.188276ms]
+Mar 16 12:45:22.891: INFO: Created: latency-svc-2bmzk
+Mar 16 12:45:22.896: INFO: Got endpoints: latency-svc-2bmzk [88.365484ms]
+Mar 16 12:45:22.900: INFO: Created: latency-svc-jnpgz
+Mar 16 12:45:22.906: INFO: Got endpoints: latency-svc-jnpgz [88.009082ms]
+Mar 16 12:45:22.907: INFO: Created: latency-svc-4zpxx
+Mar 16 12:45:22.913: INFO: Created: latency-svc-t9lrj
+Mar 16 12:45:22.913: INFO: Got endpoints: latency-svc-4zpxx [89.566466ms]
+Mar 16 12:45:22.917: INFO: Got endpoints: latency-svc-t9lrj [90.931502ms]
+Mar 16 12:45:22.921: INFO: Created: latency-svc-bh2g5
+Mar 16 12:45:22.930: INFO: Got endpoints: latency-svc-bh2g5 [98.572495ms]
+Mar 16 12:45:22.934: INFO: Created: latency-svc-sngbt
+Mar 16 12:45:22.939: INFO: Got endpoints: latency-svc-sngbt [100.783242ms]
+Mar 16 12:45:22.939: INFO: Created: latency-svc-qpmxb
+Mar 16 12:45:22.944: INFO: Got endpoints: latency-svc-qpmxb [98.781362ms]
+Mar 16 12:45:22.946: INFO: Created: latency-svc-clbwm
+Mar 16 12:45:22.950: INFO: Got endpoints: latency-svc-clbwm [97.340897ms]
+Mar 16 12:45:22.950: INFO: Created: latency-svc-xgkjn
+Mar 16 12:45:22.951: INFO: Got endpoints: latency-svc-xgkjn [93.838589ms]
+Mar 16 12:45:22.955: INFO: Created: latency-svc-zjm6b
+Mar 16 12:45:22.966: INFO: Created: latency-svc-55c4w
+Mar 16 12:45:22.968: INFO: Got endpoints: latency-svc-zjm6b [105.954808ms]
+Mar 16 12:45:22.970: INFO: Created: latency-svc-wmnzh
+Mar 16 12:45:22.972: INFO: Got endpoints: latency-svc-55c4w [104.847049ms]
+Mar 16 12:45:22.976: INFO: Got endpoints: latency-svc-wmnzh [106.173796ms]
+Mar 16 12:45:22.978: INFO: Created: latency-svc-ngzkk
+Mar 16 12:45:22.982: INFO: Created: latency-svc-8lclq
+Mar 16 12:45:22.982: INFO: Got endpoints: latency-svc-ngzkk [106.527829ms]
+Mar 16 12:45:22.988: INFO: Got endpoints: latency-svc-8lclq [103.889689ms]
+Mar 16 12:45:22.990: INFO: Created: latency-svc-jf28b
+Mar 16 12:45:22.993: INFO: Got endpoints: latency-svc-jf28b [102.442389ms]
+Mar 16 12:45:22.997: INFO: Created: latency-svc-4vlpz
+Mar 16 12:45:22.998: INFO: Got endpoints: latency-svc-4vlpz [102.375912ms]
+Mar 16 12:45:23.002: INFO: Created: latency-svc-dz4qt
+Mar 16 12:45:23.008: INFO: Got endpoints: latency-svc-dz4qt [101.625176ms]
+Mar 16 12:45:23.008: INFO: Created: latency-svc-vtk2p
+Mar 16 12:45:23.014: INFO: Got endpoints: latency-svc-vtk2p [100.779144ms]
+Mar 16 12:45:23.016: INFO: Created: latency-svc-v44dh
+Mar 16 12:45:23.020: INFO: Created: latency-svc-rp564
+Mar 16 12:45:23.021: INFO: Got endpoints: latency-svc-v44dh [104.441233ms]
+Mar 16 12:45:23.025: INFO: Created: latency-svc-t9rbl
+Mar 16 12:45:23.025: INFO: Got endpoints: latency-svc-rp564 [94.878896ms]
+Mar 16 12:45:23.030: INFO: Created: latency-svc-drzwh
+Mar 16 12:45:23.035: INFO: Created: latency-svc-j5496
+Mar 16 12:45:23.041: INFO: Created: latency-svc-fgftd
+Mar 16 12:45:23.043: INFO: Got endpoints: latency-svc-t9rbl [104.499052ms]
+Mar 16 12:45:23.047: INFO: Created: latency-svc-zg27c
+Mar 16 12:45:23.052: INFO: Created: latency-svc-xldsn
+Mar 16 12:45:23.058: INFO: Created: latency-svc-985rz
+Mar 16 12:45:23.063: INFO: Created: latency-svc-jzg9k
+Mar 16 12:45:23.070: INFO: Created: latency-svc-cdzlh
+Mar 16 12:45:23.074: INFO: Created: latency-svc-6rknl
+Mar 16 12:45:23.078: INFO: Created: latency-svc-ztjtr
+Mar 16 12:45:23.083: INFO: Created: latency-svc-74n6b
+Mar 16 12:45:23.089: INFO: Created: latency-svc-f6tjb
+Mar 16 12:45:23.094: INFO: Created: latency-svc-2t9rr
+Mar 16 12:45:23.094: INFO: Got endpoints: latency-svc-drzwh [149.999228ms]
+Mar 16 12:45:23.100: INFO: Created: latency-svc-7zlz9
+Mar 16 12:45:23.110: INFO: Created: latency-svc-7kfbn
+Mar 16 12:45:23.115: INFO: Created: latency-svc-whq6j
+Mar 16 12:45:23.143: INFO: Got endpoints: latency-svc-j5496 [193.603311ms]
+Mar 16 12:45:23.153: INFO: Created: latency-svc-wcff9
+Mar 16 12:45:23.194: INFO: Got endpoints: latency-svc-fgftd [242.041134ms]
+Mar 16 12:45:23.203: INFO: Created: latency-svc-gpvbr
+Mar 16 12:45:23.268: INFO: Got endpoints: latency-svc-zg27c [300.650983ms]
+Mar 16 12:45:23.282: INFO: Created: latency-svc-8phgs
+Mar 16 12:45:23.294: INFO: Got endpoints: latency-svc-xldsn [322.593792ms]
+Mar 16 12:45:23.305: INFO: Created: latency-svc-8mk94
+Mar 16 12:45:23.343: INFO: Got endpoints: latency-svc-985rz [367.053676ms]
+Mar 16 12:45:23.353: INFO: Created: latency-svc-b4xmm
+Mar 16 12:45:23.394: INFO: Got endpoints: latency-svc-jzg9k [410.406505ms]
+Mar 16 12:45:23.403: INFO: Created: latency-svc-zx9w4
+Mar 16 12:45:23.443: INFO: Got endpoints: latency-svc-cdzlh [455.066316ms]
+Mar 16 12:45:23.453: INFO: Created: latency-svc-2vbrd
+Mar 16 12:45:23.494: INFO: Got endpoints: latency-svc-6rknl [500.949611ms]
+Mar 16 12:45:23.503: INFO: Created: latency-svc-p5dg4
+Mar 16 12:45:23.544: INFO: Got endpoints: latency-svc-ztjtr [546.048526ms]
+Mar 16 12:45:23.552: INFO: Created: latency-svc-nttk5
+Mar 16 12:45:23.593: INFO: Got endpoints: latency-svc-74n6b [584.919863ms]
+Mar 16 12:45:23.602: INFO: Created: latency-svc-dkhzl
+Mar 16 12:45:23.643: INFO: Got endpoints: latency-svc-f6tjb [629.353104ms]
+Mar 16 12:45:23.654: INFO: Created: latency-svc-44v5g
+Mar 16 12:45:23.698: INFO: Got endpoints: latency-svc-2t9rr [677.016836ms]
+Mar 16 12:45:23.707: INFO: Created: latency-svc-6f674
+Mar 16 12:45:23.744: INFO: Got endpoints: latency-svc-7zlz9 [718.881478ms]
+Mar 16 12:45:23.752: INFO: Created: latency-svc-k57pq
+Mar 16 12:45:23.793: INFO: Got endpoints: latency-svc-7kfbn [749.509648ms]
+Mar 16 12:45:23.801: INFO: Created: latency-svc-g8ddq
+Mar 16 12:45:23.843: INFO: Got endpoints: latency-svc-whq6j [748.615207ms]
+Mar 16 12:45:23.852: INFO: Created: latency-svc-t7bsk
+Mar 16 12:45:23.893: INFO: Got endpoints: latency-svc-wcff9 [749.510347ms]
+Mar 16 12:45:23.902: INFO: Created: latency-svc-5gfcf
+Mar 16 12:45:23.943: INFO: Got endpoints: latency-svc-gpvbr [749.611466ms]
+Mar 16 12:45:23.957: INFO: Created: latency-svc-2946t
+Mar 16 12:45:23.994: INFO: Got endpoints: latency-svc-8phgs [723.339565ms]
+Mar 16 12:45:24.009: INFO: Created: latency-svc-lthh2
+Mar 16 12:45:24.045: INFO: Got endpoints: latency-svc-8mk94 [750.860809ms]
+Mar 16 12:45:24.054: INFO: Created: latency-svc-sfsx9
+Mar 16 12:45:24.093: INFO: Got endpoints: latency-svc-b4xmm [749.367848ms]
+Mar 16 12:45:24.102: INFO: Created: latency-svc-tjflw
+Mar 16 12:45:24.143: INFO: Got endpoints: latency-svc-zx9w4 [748.947396ms]
+Mar 16 12:45:24.153: INFO: Created: latency-svc-skdxw
+Mar 16 12:45:24.193: INFO: Got endpoints: latency-svc-2vbrd [749.983878ms]
+Mar 16 12:45:24.203: INFO: Created: latency-svc-8r6tf
+Mar 16 12:45:24.245: INFO: Got endpoints: latency-svc-p5dg4 [751.101727ms]
+Mar 16 12:45:24.261: INFO: Created: latency-svc-4scp8
+Mar 16 12:45:24.293: INFO: Got endpoints: latency-svc-nttk5 [749.089542ms]
+Mar 16 12:45:24.302: INFO: Created: latency-svc-h6x6f
+Mar 16 12:45:24.343: INFO: Got endpoints: latency-svc-dkhzl [750.288499ms]
+Mar 16 12:45:24.353: INFO: Created: latency-svc-2mrkm
+Mar 16 12:45:24.393: INFO: Got endpoints: latency-svc-44v5g [749.985146ms]
+Mar 16 12:45:24.402: INFO: Created: latency-svc-kl247
+Mar 16 12:45:24.444: INFO: Got endpoints: latency-svc-6f674 [745.883675ms]
+Mar 16 12:45:24.456: INFO: Created: latency-svc-wzvs8
+Mar 16 12:45:24.494: INFO: Got endpoints: latency-svc-k57pq [750.19692ms]
+Mar 16 12:45:24.506: INFO: Created: latency-svc-zb5zp
+Mar 16 12:45:24.543: INFO: Got endpoints: latency-svc-g8ddq [750.199972ms]
+Mar 16 12:45:24.556: INFO: Created: latency-svc-skwqr
+Mar 16 12:45:24.598: INFO: Got endpoints: latency-svc-t7bsk [754.26165ms]
+Mar 16 12:45:24.607: INFO: Created: latency-svc-k97nk
+Mar 16 12:45:24.643: INFO: Got endpoints: latency-svc-5gfcf [749.948138ms]
+Mar 16 12:45:24.652: INFO: Created: latency-svc-fhv2h
+Mar 16 12:45:24.694: INFO: Got endpoints: latency-svc-2946t [745.091723ms]
+Mar 16 12:45:24.703: INFO: Created: latency-svc-8hzf8
+Mar 16 12:45:24.743: INFO: Got endpoints: latency-svc-lthh2 [749.526282ms]
+Mar 16 12:45:24.753: INFO: Created: latency-svc-4kqjn
+Mar 16 12:45:24.793: INFO: Got endpoints: latency-svc-sfsx9 [748.069821ms]
+Mar 16 12:45:24.804: INFO: Created: latency-svc-2t5m6
+Mar 16 12:45:24.843: INFO: Got endpoints: latency-svc-tjflw [749.853723ms]
+Mar 16 12:45:24.852: INFO: Created: latency-svc-hjt2z
+Mar 16 12:45:24.893: INFO: Got endpoints: latency-svc-skdxw [749.568648ms]
+Mar 16 12:45:24.902: INFO: Created: latency-svc-xrdbj
+Mar 16 12:45:24.943: INFO: Got endpoints: latency-svc-8r6tf [749.932006ms]
+Mar 16 12:45:24.953: INFO: Created: latency-svc-fznbl
+Mar 16 12:45:24.996: INFO: Got endpoints: latency-svc-4scp8 [751.299246ms]
+Mar 16 12:45:25.005: INFO: Created: latency-svc-pf869
+Mar 16 12:45:25.044: INFO: Got endpoints: latency-svc-h6x6f [750.555267ms]
+Mar 16 12:45:25.053: INFO: Created: latency-svc-bjsn8
+Mar 16 12:45:25.094: INFO: Got endpoints: latency-svc-2mrkm [750.780877ms]
+Mar 16 12:45:25.103: INFO: Created: latency-svc-8rqtx
+Mar 16 12:45:25.143: INFO: Got endpoints: latency-svc-kl247 [750.008993ms]
+Mar 16 12:45:25.152: INFO: Created: latency-svc-xvfpp
+Mar 16 12:45:25.194: INFO: Got endpoints: latency-svc-wzvs8 [749.355196ms]
+Mar 16 12:45:25.203: INFO: Created: latency-svc-kfdtg
+Mar 16 12:45:25.243: INFO: Got endpoints: latency-svc-zb5zp [748.745171ms]
+Mar 16 12:45:25.251: INFO: Created: latency-svc-4k4m4
+Mar 16 12:45:25.293: INFO: Got endpoints: latency-svc-skwqr [749.823611ms]
+Mar 16 12:45:25.301: INFO: Created: latency-svc-2fxq8
+Mar 16 12:45:25.344: INFO: Got endpoints: latency-svc-k97nk [746.721965ms]
+Mar 16 12:45:25.356: INFO: Created: latency-svc-rwhtw
+Mar 16 12:45:25.394: INFO: Got endpoints: latency-svc-fhv2h [751.092124ms]
+Mar 16 12:45:25.403: INFO: Created: latency-svc-pswwr
+Mar 16 12:45:25.444: INFO: Got endpoints: latency-svc-8hzf8 [749.238511ms]
+Mar 16 12:45:25.452: INFO: Created: latency-svc-h4t4g
+Mar 16 12:45:25.493: INFO: Got endpoints: latency-svc-4kqjn [749.89384ms]
+Mar 16 12:45:25.502: INFO: Created: latency-svc-pqsnk
+Mar 16 12:45:25.543: INFO: Got endpoints: latency-svc-2t5m6 [748.341688ms]
+Mar 16 12:45:25.551: INFO: Created: latency-svc-2gtj7
+Mar 16 12:45:25.593: INFO: Got endpoints: latency-svc-hjt2z [749.901344ms]
+Mar 16 12:45:25.602: INFO: Created: latency-svc-t45w4
+Mar 16 12:45:25.644: INFO: Got endpoints: latency-svc-xrdbj [750.670347ms]
+Mar 16 12:45:25.654: INFO: Created: latency-svc-4t8q6
+Mar 16 12:45:25.693: INFO: Got endpoints: latency-svc-fznbl [749.312328ms]
+Mar 16 12:45:25.701: INFO: Created: latency-svc-lx58r
+Mar 16 12:45:25.743: INFO: Got endpoints: latency-svc-pf869 [746.650681ms]
+Mar 16 12:45:25.751: INFO: Created: latency-svc-x5qrl
+Mar 16 12:45:25.793: INFO: Got endpoints: latency-svc-bjsn8 [749.207496ms]
+Mar 16 12:45:25.802: INFO: Created: latency-svc-srxj4
+Mar 16 12:45:25.843: INFO: Got endpoints: latency-svc-8rqtx [749.007124ms]
+Mar 16 12:45:25.852: INFO: Created: latency-svc-mph4k
+Mar 16 12:45:25.895: INFO: Got endpoints: latency-svc-xvfpp [751.149417ms]
+Mar 16 12:45:25.905: INFO: Created: latency-svc-t75nl
+Mar 16 12:45:25.947: INFO: Got endpoints: latency-svc-kfdtg [752.800737ms]
+Mar 16 12:45:25.957: INFO: Created: latency-svc-wb46w
+Mar 16 12:45:25.996: INFO: Got endpoints: latency-svc-4k4m4 [753.246416ms]
+Mar 16 12:45:26.005: INFO: Created: latency-svc-2dfsn
+Mar 16 12:45:26.044: INFO: Got endpoints: latency-svc-2fxq8 [750.440086ms]
+Mar 16 12:45:26.053: INFO: Created: latency-svc-pg6dx
+Mar 16 12:45:26.095: INFO: Got endpoints: latency-svc-rwhtw [750.351525ms]
+Mar 16 12:45:26.106: INFO: Created: latency-svc-rh9k5
+Mar 16 12:45:26.143: INFO: Got endpoints: latency-svc-pswwr [749.130785ms]
+Mar 16 12:45:26.152: INFO: Created: latency-svc-s6twt
+Mar 16 12:45:26.194: INFO: Got endpoints: latency-svc-h4t4g [750.630142ms]
+Mar 16 12:45:26.212: INFO: Created: latency-svc-64wb8
+Mar 16 12:45:26.245: INFO: Got endpoints: latency-svc-pqsnk [751.786157ms]
+Mar 16 12:45:26.256: INFO: Created: latency-svc-w99f7
+Mar 16 12:45:26.301: INFO: Got endpoints: latency-svc-2gtj7 [758.278624ms]
+Mar 16 12:45:26.310: INFO: Created: latency-svc-xkbzp
+Mar 16 12:45:26.343: INFO: Got endpoints: latency-svc-t45w4 [750.202606ms]
+Mar 16 12:45:26.351: INFO: Created: latency-svc-bbhhp
+Mar 16 12:45:26.394: INFO: Got endpoints: latency-svc-4t8q6 [750.259954ms]
+Mar 16 12:45:26.416: INFO: Created: latency-svc-86hqw
+Mar 16 12:45:26.445: INFO: Got endpoints: latency-svc-lx58r [751.835534ms]
+Mar 16 12:45:26.453: INFO: Created: latency-svc-7mp8p
+Mar 16 12:45:26.494: INFO: Got endpoints: latency-svc-x5qrl [750.573566ms]
+Mar 16 12:45:26.503: INFO: Created: latency-svc-b47ff
+Mar 16 12:45:26.544: INFO: Got endpoints: latency-svc-srxj4 [750.417414ms]
+Mar 16 12:45:26.553: INFO: Created: latency-svc-7zct7
+Mar 16 12:45:26.595: INFO: Got endpoints: latency-svc-mph4k [751.79054ms]
+Mar 16 12:45:26.608: INFO: Created: latency-svc-w5zsw
+Mar 16 12:45:26.648: INFO: Got endpoints: latency-svc-t75nl [753.702064ms]
+Mar 16 12:45:26.657: INFO: Created: latency-svc-fvfzr
+Mar 16 12:45:26.694: INFO: Got endpoints: latency-svc-wb46w [747.01997ms]
+Mar 16 12:45:26.702: INFO: Created: latency-svc-6skv5
+Mar 16 12:45:26.744: INFO: Got endpoints: latency-svc-2dfsn [747.425369ms]
+Mar 16 12:45:26.752: INFO: Created: latency-svc-mp7dt
+Mar 16 12:45:26.794: INFO: Got endpoints: latency-svc-pg6dx [750.432766ms]
+Mar 16 12:45:26.804: INFO: Created: latency-svc-f9png
+Mar 16 12:45:26.843: INFO: Got endpoints: latency-svc-rh9k5 [748.154473ms]
+Mar 16 12:45:26.853: INFO: Created: latency-svc-4dc79
+Mar 16 12:45:26.893: INFO: Got endpoints: latency-svc-s6twt [749.918207ms]
+Mar 16 12:45:26.903: INFO: Created: latency-svc-57qmr
+Mar 16 12:45:26.943: INFO: Got endpoints: latency-svc-64wb8 [749.0054ms]
+Mar 16 12:45:26.952: INFO: Created: latency-svc-skv7x
+Mar 16 12:45:26.995: INFO: Got endpoints: latency-svc-w99f7 [749.228636ms]
+Mar 16 12:45:27.006: INFO: Created: latency-svc-bl2qd
+Mar 16 12:45:27.044: INFO: Got endpoints: latency-svc-xkbzp [742.169327ms]
+Mar 16 12:45:27.053: INFO: Created: latency-svc-bmn5r
+Mar 16 12:45:27.093: INFO: Got endpoints: latency-svc-bbhhp [749.803407ms]
+Mar 16 12:45:27.102: INFO: Created: latency-svc-rlskl
+Mar 16 12:45:27.143: INFO: Got endpoints: latency-svc-86hqw [749.135604ms]
+Mar 16 12:45:27.152: INFO: Created: latency-svc-nv8m4
+Mar 16 12:45:27.193: INFO: Got endpoints: latency-svc-7mp8p [748.73971ms]
+Mar 16 12:45:27.201: INFO: Created: latency-svc-wnwst
+Mar 16 12:45:27.243: INFO: Got endpoints: latency-svc-b47ff [749.752517ms]
+Mar 16 12:45:27.253: INFO: Created: latency-svc-w5w4j
+Mar 16 12:45:27.294: INFO: Got endpoints: latency-svc-7zct7 [749.773037ms]
+Mar 16 12:45:27.303: INFO: Created: latency-svc-jqvmx
+Mar 16 12:45:27.343: INFO: Got endpoints: latency-svc-w5zsw [747.706764ms]
+Mar 16 12:45:27.352: INFO: Created: latency-svc-gc9q2
+Mar 16 12:45:27.393: INFO: Got endpoints: latency-svc-fvfzr [744.885843ms]
+Mar 16 12:45:27.402: INFO: Created: latency-svc-7cc25
+Mar 16 12:45:27.445: INFO: Got endpoints: latency-svc-6skv5 [750.787937ms]
+Mar 16 12:45:27.455: INFO: Created: latency-svc-4sptk
+Mar 16 12:45:27.493: INFO: Got endpoints: latency-svc-mp7dt [749.50464ms]
+Mar 16 12:45:27.502: INFO: Created: latency-svc-2s7qn
+Mar 16 12:45:27.544: INFO: Got endpoints: latency-svc-f9png [749.380761ms]
+Mar 16 12:45:27.552: INFO: Created: latency-svc-nhgn7
+Mar 16 12:45:27.593: INFO: Got endpoints: latency-svc-4dc79 [749.991019ms]
+Mar 16 12:45:27.601: INFO: Created: latency-svc-pthnr
+Mar 16 12:45:27.644: INFO: Got endpoints: latency-svc-57qmr [750.627939ms]
+Mar 16 12:45:27.652: INFO: Created: latency-svc-9f65l
+Mar 16 12:45:27.694: INFO: Got endpoints: latency-svc-skv7x [750.221428ms]
+Mar 16 12:45:27.702: INFO: Created: latency-svc-p89x8
+Mar 16 12:45:27.743: INFO: Got endpoints: latency-svc-bl2qd [748.708036ms]
+Mar 16 12:45:27.753: INFO: Created: latency-svc-mpqhb
+Mar 16 12:45:27.793: INFO: Got endpoints: latency-svc-bmn5r [749.601096ms]
+Mar 16 12:45:27.808: INFO: Created: latency-svc-6kmln
+Mar 16 12:45:27.843: INFO: Got endpoints: latency-svc-rlskl [749.686373ms]
+Mar 16 12:45:27.853: INFO: Created: latency-svc-nsnkg
+Mar 16 12:45:27.893: INFO: Got endpoints: latency-svc-nv8m4 [749.049948ms]
+Mar 16 12:45:27.900: INFO: Created: latency-svc-nw67q
+Mar 16 12:45:27.943: INFO: Got endpoints: latency-svc-wnwst [749.83514ms]
+Mar 16 12:45:27.955: INFO: Created: latency-svc-wp4cz
+Mar 16 12:45:27.993: INFO: Got endpoints: latency-svc-w5w4j [749.587668ms]
+Mar 16 12:45:28.001: INFO: Created: latency-svc-pm2hp
+Mar 16 12:45:28.043: INFO: Got endpoints: latency-svc-jqvmx [749.539355ms]
+Mar 16 12:45:28.056: INFO: Created: latency-svc-ffv6r
+Mar 16 12:45:28.094: INFO: Got endpoints: latency-svc-gc9q2 [750.973174ms]
+Mar 16 12:45:28.107: INFO: Created: latency-svc-jjslz
+Mar 16 12:45:28.144: INFO: Got endpoints: latency-svc-7cc25 [750.899399ms]
+Mar 16 12:45:28.155: INFO: Created: latency-svc-g86bn
+Mar 16 12:45:28.193: INFO: Got endpoints: latency-svc-4sptk [748.149386ms]
+Mar 16 12:45:28.252: INFO: Created: latency-svc-wjnmt
+Mar 16 12:45:28.253: INFO: Got endpoints: latency-svc-2s7qn [759.028924ms]
+Mar 16 12:45:28.263: INFO: Created: latency-svc-ppszz
+Mar 16 12:45:28.293: INFO: Got endpoints: latency-svc-nhgn7 [749.670924ms]
+Mar 16 12:45:28.302: INFO: Created: latency-svc-l7c9g
+Mar 16 12:45:28.343: INFO: Got endpoints: latency-svc-pthnr [749.972194ms]
+Mar 16 12:45:28.352: INFO: Created: latency-svc-vbnq6
+Mar 16 12:45:28.393: INFO: Got endpoints: latency-svc-9f65l [748.744419ms]
+Mar 16 12:45:28.402: INFO: Created: latency-svc-kb8qr
+Mar 16 12:45:28.443: INFO: Got endpoints: latency-svc-p89x8 [749.482591ms]
+Mar 16 12:45:28.452: INFO: Created: latency-svc-ttdbg
+Mar 16 12:45:28.493: INFO: Got endpoints: latency-svc-mpqhb [749.915295ms]
+Mar 16 12:45:28.502: INFO: Created: latency-svc-pp6j8
+Mar 16 12:45:28.543: INFO: Got endpoints: latency-svc-6kmln [750.128004ms]
+Mar 16 12:45:28.553: INFO: Created: latency-svc-x4h5r
+Mar 16 12:45:28.593: INFO: Got endpoints: latency-svc-nsnkg [749.675695ms]
+Mar 16 12:45:28.620: INFO: Created: latency-svc-gclkp
+Mar 16 12:45:28.643: INFO: Got endpoints: latency-svc-nw67q [750.220237ms]
+Mar 16 12:45:28.651: INFO: Created: latency-svc-rslsh
+Mar 16 12:45:28.693: INFO: Got endpoints: latency-svc-wp4cz [749.547131ms]
+Mar 16 12:45:28.702: INFO: Created: latency-svc-zvd5b
+Mar 16 12:45:28.743: INFO: Got endpoints: latency-svc-pm2hp [750.150679ms]
+Mar 16 12:45:28.753: INFO: Created: latency-svc-h6tv5
+Mar 16 12:45:28.793: INFO: Got endpoints: latency-svc-ffv6r [749.817608ms]
+Mar 16 12:45:28.801: INFO: Created: latency-svc-zjjk6
+Mar 16 12:45:28.843: INFO: Got endpoints: latency-svc-jjslz [748.422394ms]
+Mar 16 12:45:28.852: INFO: Created: latency-svc-xjn5k
+Mar 16 12:45:28.893: INFO: Got endpoints: latency-svc-g86bn [748.833569ms]
+Mar 16 12:45:28.901: INFO: Created: latency-svc-5klmj
+Mar 16 12:45:28.943: INFO: Got endpoints: latency-svc-wjnmt [750.045104ms]
+Mar 16 12:45:28.955: INFO: Created: latency-svc-2x28t
+Mar 16 12:45:28.994: INFO: Got endpoints: latency-svc-ppszz [741.592812ms]
+Mar 16 12:45:29.003: INFO: Created: latency-svc-bx4j5
+Mar 16 12:45:29.043: INFO: Got endpoints: latency-svc-l7c9g [749.547499ms]
+Mar 16 12:45:29.052: INFO: Created: latency-svc-9r49r
+Mar 16 12:45:29.093: INFO: Got endpoints: latency-svc-vbnq6 [750.108794ms]
+Mar 16 12:45:29.105: INFO: Created: latency-svc-pnbvz
+Mar 16 12:45:29.143: INFO: Got endpoints: latency-svc-kb8qr [750.122941ms]
+Mar 16 12:45:29.153: INFO: Created: latency-svc-8slkz
+Mar 16 12:45:29.194: INFO: Got endpoints: latency-svc-ttdbg [750.926053ms]
+Mar 16 12:45:29.205: INFO: Created: latency-svc-6cfg9
+Mar 16 12:45:29.244: INFO: Got endpoints: latency-svc-pp6j8 [750.919184ms]
+Mar 16 12:45:29.253: INFO: Created: latency-svc-ndcts
+Mar 16 12:45:29.293: INFO: Got endpoints: latency-svc-x4h5r [749.737929ms]
+Mar 16 12:45:29.303: INFO: Created: latency-svc-tz6vp
+Mar 16 12:45:29.343: INFO: Got endpoints: latency-svc-gclkp [750.021263ms]
+Mar 16 12:45:29.353: INFO: Created: latency-svc-c65ms
+Mar 16 12:45:29.394: INFO: Got endpoints: latency-svc-rslsh [750.816365ms]
+Mar 16 12:45:29.404: INFO: Created: latency-svc-nj9n2
+Mar 16 12:45:29.443: INFO: Got endpoints: latency-svc-zvd5b [749.758945ms]
+Mar 16 12:45:29.452: INFO: Created: latency-svc-mn4np
+Mar 16 12:45:29.493: INFO: Got endpoints: latency-svc-h6tv5 [749.702225ms]
+Mar 16 12:45:29.504: INFO: Created: latency-svc-hkwvw
+Mar 16 12:45:29.543: INFO: Got endpoints: latency-svc-zjjk6 [750.13156ms]
+Mar 16 12:45:29.552: INFO: Created: latency-svc-kznlk
+Mar 16 12:45:29.595: INFO: Got endpoints: latency-svc-xjn5k [751.733586ms]
+Mar 16 12:45:29.603: INFO: Created: latency-svc-r45m6
+Mar 16 12:45:29.643: INFO: Got endpoints: latency-svc-5klmj [749.669374ms]
+Mar 16 12:45:29.653: INFO: Created: latency-svc-rxfkn
+Mar 16 12:45:29.693: INFO: Got endpoints: latency-svc-2x28t [750.308211ms]
+Mar 16 12:45:29.703: INFO: Created: latency-svc-c269f
+Mar 16 12:45:29.744: INFO: Got endpoints: latency-svc-bx4j5 [749.126024ms]
+Mar 16 12:45:29.752: INFO: Created: latency-svc-58dzt
+Mar 16 12:45:29.794: INFO: Got endpoints: latency-svc-9r49r [751.245338ms]
+Mar 16 12:45:29.803: INFO: Created: latency-svc-gwkvj
+Mar 16 12:45:29.843: INFO: Got endpoints: latency-svc-pnbvz [749.525116ms]
+Mar 16 12:45:29.851: INFO: Created: latency-svc-2bgcz
+Mar 16 12:45:29.893: INFO: Got endpoints: latency-svc-8slkz [749.366152ms]
+Mar 16 12:45:29.901: INFO: Created: latency-svc-ll2js
+Mar 16 12:45:29.943: INFO: Got endpoints: latency-svc-6cfg9 [748.727179ms]
+Mar 16 12:45:29.952: INFO: Created: latency-svc-vvrjc
+Mar 16 12:45:29.998: INFO: Got endpoints: latency-svc-ndcts [753.923836ms]
+Mar 16 12:45:30.009: INFO: Created: latency-svc-snt69
+Mar 16 12:45:30.044: INFO: Got endpoints: latency-svc-tz6vp [750.399509ms]
+Mar 16 12:45:30.053: INFO: Created: latency-svc-thw7t
+Mar 16 12:45:30.093: INFO: Got endpoints: latency-svc-c65ms [748.994556ms]
+Mar 16 12:45:30.111: INFO: Created: latency-svc-5c7f7
+Mar 16 12:45:30.145: INFO: Got endpoints: latency-svc-nj9n2 [751.055018ms]
+Mar 16 12:45:30.160: INFO: Created: latency-svc-cbhqb
+Mar 16 12:45:30.193: INFO: Got endpoints: latency-svc-mn4np [750.130275ms]
+Mar 16 12:45:30.201: INFO: Created: latency-svc-khfcd
+Mar 16 12:45:30.243: INFO: Got endpoints: latency-svc-hkwvw [750.024841ms]
+Mar 16 12:45:30.251: INFO: Created: latency-svc-5mtgs
+Mar 16 12:45:30.293: INFO: Got endpoints: latency-svc-kznlk [749.499113ms]
+Mar 16 12:45:30.301: INFO: Created: latency-svc-x7cv9
+Mar 16 12:45:30.344: INFO: Got endpoints: latency-svc-r45m6 [749.118157ms]
+Mar 16 12:45:30.357: INFO: Created: latency-svc-njg65
+Mar 16 12:45:30.393: INFO: Got endpoints: latency-svc-rxfkn [750.189199ms]
+Mar 16 12:45:30.404: INFO: Created: latency-svc-mvgbz
+Mar 16 12:45:30.443: INFO: Got endpoints: latency-svc-c269f [749.867481ms]
+Mar 16 12:45:30.451: INFO: Created: latency-svc-7hvft
+Mar 16 12:45:30.493: INFO: Got endpoints: latency-svc-58dzt [749.760516ms]
+Mar 16 12:45:30.505: INFO: Created: latency-svc-q4pnj
+Mar 16 12:45:30.544: INFO: Got endpoints: latency-svc-gwkvj [749.331396ms]
+Mar 16 12:45:30.554: INFO: Created: latency-svc-tcwpp
+Mar 16 12:45:30.594: INFO: Got endpoints: latency-svc-2bgcz [750.581417ms]
+Mar 16 12:45:30.643: INFO: Got endpoints: latency-svc-ll2js [750.559689ms]
+Mar 16 12:45:30.694: INFO: Got endpoints: latency-svc-vvrjc [749.850774ms]
+Mar 16 12:45:30.743: INFO: Got endpoints: latency-svc-snt69 [744.923345ms]
+Mar 16 12:45:30.793: INFO: Got endpoints: latency-svc-thw7t [749.006182ms]
+Mar 16 12:45:30.844: INFO: Got endpoints: latency-svc-5c7f7 [751.044626ms]
+Mar 16 12:45:30.894: INFO: Got endpoints: latency-svc-cbhqb [748.883024ms]
+Mar 16 12:45:30.944: INFO: Got endpoints: latency-svc-khfcd [750.764255ms]
+Mar 16 12:45:30.994: INFO: Got endpoints: latency-svc-5mtgs [750.282379ms]
+Mar 16 12:45:31.045: INFO: Got endpoints: latency-svc-x7cv9 [752.016786ms]
+Mar 16 12:45:31.093: INFO: Got endpoints: latency-svc-njg65 [745.249108ms]
+Mar 16 12:45:31.144: INFO: Got endpoints: latency-svc-mvgbz [750.196447ms]
+Mar 16 12:45:31.195: INFO: Got endpoints: latency-svc-7hvft [751.616041ms]
+Mar 16 12:45:31.244: INFO: Got endpoints: latency-svc-q4pnj [750.26565ms]
+Mar 16 12:45:31.296: INFO: Got endpoints: latency-svc-tcwpp [752.530987ms]
+Mar 16 12:45:31.296: INFO: Latencies: [12.922012ms 16.289158ms 21.143079ms 26.370171ms 32.772867ms 40.221856ms 46.670143ms 51.793517ms 56.208429ms 60.871408ms 63.81695ms 69.464884ms 77.442471ms 83.188276ms 88.009082ms 88.365484ms 89.566466ms 90.931502ms 93.838589ms 94.878896ms 97.340897ms 98.572495ms 98.781362ms 100.779144ms 100.783242ms 101.625176ms 102.375912ms 102.442389ms 103.889689ms 104.441233ms 104.499052ms 104.847049ms 105.954808ms 106.173796ms 106.527829ms 149.999228ms 193.603311ms 242.041134ms 300.650983ms 322.593792ms 367.053676ms 410.406505ms 455.066316ms 500.949611ms 546.048526ms 584.919863ms 629.353104ms 677.016836ms 718.881478ms 723.339565ms 741.592812ms 742.169327ms 744.885843ms 744.923345ms 745.091723ms 745.249108ms 745.883675ms 746.650681ms 746.721965ms 747.01997ms 747.425369ms 747.706764ms 748.069821ms 748.149386ms 748.154473ms 748.341688ms 748.422394ms 748.615207ms 748.708036ms 748.727179ms 748.73971ms 748.744419ms 748.745171ms 748.833569ms 748.883024ms 748.947396ms 748.994556ms 749.0054ms 749.006182ms 749.007124ms 749.049948ms 749.089542ms 749.118157ms 749.126024ms 749.130785ms 749.135604ms 749.207496ms 749.228636ms 749.238511ms 749.312328ms 749.331396ms 749.355196ms 749.366152ms 749.367848ms 749.380761ms 749.482591ms 749.499113ms 749.50464ms 749.509648ms 749.510347ms 749.525116ms 749.526282ms 749.539355ms 749.547131ms 749.547499ms 749.568648ms 749.587668ms 749.601096ms 749.611466ms 749.669374ms 749.670924ms 749.675695ms 749.686373ms 749.702225ms 749.737929ms 749.752517ms 749.758945ms 749.760516ms 749.773037ms 749.803407ms 749.817608ms 749.823611ms 749.83514ms 749.850774ms 749.853723ms 749.867481ms 749.89384ms 749.901344ms 749.915295ms 749.918207ms 749.932006ms 749.948138ms 749.972194ms 749.983878ms 749.985146ms 749.991019ms 750.008993ms 750.021263ms 750.024841ms 750.045104ms 750.108794ms 750.122941ms 750.128004ms 750.130275ms 750.13156ms 750.150679ms 750.189199ms 750.196447ms 750.19692ms 750.199972ms 750.202606ms 750.220237ms 750.221428ms 750.259954ms 750.26565ms 750.282379ms 750.288499ms 750.308211ms 750.351525ms 750.399509ms 750.417414ms 750.432766ms 750.440086ms 750.555267ms 750.559689ms 750.573566ms 750.581417ms 750.627939ms 750.630142ms 750.670347ms 750.764255ms 750.780877ms 750.787937ms 750.816365ms 750.860809ms 750.899399ms 750.919184ms 750.926053ms 750.973174ms 751.044626ms 751.055018ms 751.092124ms 751.101727ms 751.149417ms 751.245338ms 751.299246ms 751.616041ms 751.733586ms 751.786157ms 751.79054ms 751.835534ms 752.016786ms 752.530987ms 752.800737ms 753.246416ms 753.702064ms 753.923836ms 754.26165ms 758.278624ms 759.028924ms]
+Mar 16 12:45:31.297: INFO: 50 %ile: 749.525116ms
+Mar 16 12:45:31.297: INFO: 90 %ile: 751.055018ms
+Mar 16 12:45:31.297: INFO: 99 %ile: 758.278624ms
+Mar 16 12:45:31.297: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:45:31.297: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-hzkjg" for this suite.
+Mar 16 12:46:01.311: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:46:01.415: INFO: namespace: e2e-tests-svc-latency-hzkjg, resource: bindings, ignored listing per whitelist
+Mar 16 12:46:01.426: INFO: namespace e2e-tests-svc-latency-hzkjg deletion completed in 30.122335434s
+
+• [SLOW TEST:40.780 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:46:01.426: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 16 12:46:01.484: INFO: (0) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 9.793997ms)
+Mar 16 12:46:01.489: INFO: (1) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.863032ms)
+Mar 16 12:46:01.495: INFO: (2) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.440801ms)
+Mar 16 12:46:01.499: INFO: (3) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.440109ms)
+Mar 16 12:46:01.503: INFO: (4) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.006883ms)
+Mar 16 12:46:01.509: INFO: (5) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.812902ms)
+Mar 16 12:46:01.522: INFO: (6) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 13.189471ms)
+Mar 16 12:46:01.527: INFO: (7) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.478789ms)
+Mar 16 12:46:01.531: INFO: (8) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.151549ms)
+Mar 16 12:46:01.535: INFO: (9) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.193986ms)
+Mar 16 12:46:01.541: INFO: (10) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.691339ms)
+Mar 16 12:46:01.550: INFO: (11) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 8.476316ms)
+Mar 16 12:46:01.554: INFO: (12) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.593382ms)
+Mar 16 12:46:01.564: INFO: (13) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 10.008781ms)
+Mar 16 12:46:01.573: INFO: (14) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 9.040369ms)
+Mar 16 12:46:01.578: INFO: (15) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.115124ms)
+Mar 16 12:46:01.584: INFO: (16) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.283651ms)
+Mar 16 12:46:08.984: INFO: (17) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 7.400268561s)
+Mar 16 12:46:08.988: INFO: (18) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.154364ms)
+Mar 16 12:46:08.992: INFO: (19) /api/v1/nodes/ip-10-250-0-66.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.551924ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:46:08.992: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-qsw22" for this suite.
+Mar 16 12:46:15.003: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:46:15.079: INFO: namespace: e2e-tests-proxy-qsw22, resource: bindings, ignored listing per whitelist
+Mar 16 12:46:15.114: INFO: namespace e2e-tests-proxy-qsw22 deletion completed in 6.119019323s
+
+• [SLOW TEST:13.688 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:46:15.115: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test substitution in container's command
+Mar 16 12:46:15.158: INFO: Waiting up to 5m0s for pod "var-expansion-039f717b-2918-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-var-expansion-brftz" to be "success or failure"
+Mar 16 12:46:15.166: INFO: Pod "var-expansion-039f717b-2918-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 7.183301ms
+Mar 16 12:46:17.169: INFO: Pod "var-expansion-039f717b-2918-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01031278s
+Mar 16 12:46:19.172: INFO: Pod "var-expansion-039f717b-2918-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013544242s
+STEP: Saw pod success
+Mar 16 12:46:19.172: INFO: Pod "var-expansion-039f717b-2918-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:46:19.174: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod var-expansion-039f717b-2918-11e8-a0aa-16411a5f38c2 container dapi-container: <nil>
+STEP: delete the pod
+Mar 16 12:46:19.196: INFO: Waiting for pod var-expansion-039f717b-2918-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:46:19.211: INFO: Pod var-expansion-039f717b-2918-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:46:19.211: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-brftz" for this suite.
+Mar 16 12:46:25.228: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:46:25.336: INFO: namespace: e2e-tests-var-expansion-brftz, resource: bindings, ignored listing per whitelist
+Mar 16 12:46:25.351: INFO: namespace e2e-tests-var-expansion-brftz deletion completed in 6.133007753s
+
+• [SLOW TEST:10.236 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:46:25.351: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-map-09bae8bc-2918-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:46:25.408: INFO: Waiting up to 5m0s for pod "pod-secrets-09bb763f-2918-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-secrets-rnjjm" to be "success or failure"
+Mar 16 12:46:25.411: INFO: Pod "pod-secrets-09bb763f-2918-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.878465ms
+Mar 16 12:46:27.414: INFO: Pod "pod-secrets-09bb763f-2918-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005748844s
+STEP: Saw pod success
+Mar 16 12:46:27.414: INFO: Pod "pod-secrets-09bb763f-2918-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:46:27.416: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod pod-secrets-09bb763f-2918-11e8-a0aa-16411a5f38c2 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:46:27.433: INFO: Waiting for pod pod-secrets-09bb763f-2918-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:46:27.435: INFO: Pod pod-secrets-09bb763f-2918-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:46:27.435: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-rnjjm" for this suite.
+Mar 16 12:46:33.446: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:46:33.532: INFO: namespace: e2e-tests-secrets-rnjjm, resource: bindings, ignored listing per whitelist
+Mar 16 12:46:33.569: INFO: namespace e2e-tests-secrets-rnjjm deletion completed in 6.130852609s
+
+• [SLOW TEST:8.218 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:46:33.569: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-mxsqc
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 16 12:46:33.606: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 16 12:46:53.669: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.200:8080/dial?request=hostName&protocol=udp&host=100.96.1.241&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-mxsqc PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:46:53.669: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:46:53.852: INFO: Waiting for endpoints: map[]
+Mar 16 12:46:53.854: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.200:8080/dial?request=hostName&protocol=udp&host=100.96.0.199&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-mxsqc PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 16 12:46:53.854: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+Mar 16 12:46:54.039: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:46:54.039: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-mxsqc" for this suite.
+Mar 16 12:47:16.051: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:47:16.161: INFO: namespace: e2e-tests-pod-network-test-mxsqc, resource: bindings, ignored listing per whitelist
+Mar 16 12:47:16.172: INFO: namespace e2e-tests-pod-network-test-mxsqc deletion completed in 22.129032031s
+
+• [SLOW TEST:42.603 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:47:16.172: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-28053d69-2918-11e8-a0aa-16411a5f38c2
+STEP: Creating a pod to test consume secrets
+Mar 16 12:47:16.225: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-2805ad7d-2918-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-vc5xx" to be "success or failure"
+Mar 16 12:47:16.228: INFO: Pod "pod-projected-secrets-2805ad7d-2918-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.041254ms
+Mar 16 12:47:18.231: INFO: Pod "pod-projected-secrets-2805ad7d-2918-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005391224s
+STEP: Saw pod success
+Mar 16 12:47:18.231: INFO: Pod "pod-projected-secrets-2805ad7d-2918-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:47:18.233: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod pod-projected-secrets-2805ad7d-2918-11e8-a0aa-16411a5f38c2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 16 12:47:18.249: INFO: Waiting for pod pod-projected-secrets-2805ad7d-2918-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:47:18.255: INFO: Pod pod-projected-secrets-2805ad7d-2918-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:47:18.256: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-vc5xx" for this suite.
+Mar 16 12:47:24.267: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:47:24.310: INFO: namespace: e2e-tests-projected-vc5xx, resource: bindings, ignored listing per whitelist
+Mar 16 12:47:24.373: INFO: namespace e2e-tests-projected-vc5xx deletion completed in 6.114202275s
+
+• [SLOW TEST:8.201 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:47:24.373: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:47:24.428: INFO: Waiting up to 5m0s for pod "downwardapi-volume-2ce93c32-2918-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-99rrw" to be "success or failure"
+Mar 16 12:47:24.431: INFO: Pod "downwardapi-volume-2ce93c32-2918-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.580698ms
+Mar 16 12:47:26.434: INFO: Pod "downwardapi-volume-2ce93c32-2918-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005896159s
+STEP: Saw pod success
+Mar 16 12:47:26.434: INFO: Pod "downwardapi-volume-2ce93c32-2918-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:47:26.437: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod downwardapi-volume-2ce93c32-2918-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:47:26.452: INFO: Waiting for pod downwardapi-volume-2ce93c32-2918-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:47:26.455: INFO: Pod downwardapi-volume-2ce93c32-2918-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:47:26.455: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-99rrw" for this suite.
+Mar 16 12:47:32.466: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:47:32.555: INFO: namespace: e2e-tests-downward-api-99rrw, resource: bindings, ignored listing per whitelist
+Mar 16 12:47:32.572: INFO: namespace e2e-tests-downward-api-99rrw deletion completed in 6.114199825s
+
+• [SLOW TEST:8.199 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:47:32.572: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:47:32.616: INFO: Waiting up to 5m0s for pod "downwardapi-volume-31ca6477-2918-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-lbm2d" to be "success or failure"
+Mar 16 12:47:32.621: INFO: Pod "downwardapi-volume-31ca6477-2918-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.827914ms
+Mar 16 12:47:34.624: INFO: Pod "downwardapi-volume-31ca6477-2918-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008085626s
+STEP: Saw pod success
+Mar 16 12:47:34.624: INFO: Pod "downwardapi-volume-31ca6477-2918-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:47:34.626: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod downwardapi-volume-31ca6477-2918-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:47:34.643: INFO: Waiting for pod downwardapi-volume-31ca6477-2918-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:47:34.645: INFO: Pod downwardapi-volume-31ca6477-2918-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:47:34.645: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lbm2d" for this suite.
+Mar 16 12:47:40.663: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:47:40.779: INFO: namespace: e2e-tests-projected-lbm2d, resource: bindings, ignored listing per whitelist
+Mar 16 12:47:40.784: INFO: namespace e2e-tests-projected-lbm2d deletion completed in 6.129857082s
+
+• [SLOW TEST:8.211 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:47:40.784: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-wlpg2
+Mar 16 12:47:42.841: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-wlpg2
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 16 12:47:42.843: INFO: Initial restart count of pod liveness-http is 0
+Mar 16 12:48:04.881: INFO: Restart count of pod e2e-tests-container-probe-wlpg2/liveness-http is now 1 (22.038082406s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:48:04.886: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-wlpg2" for this suite.
+Mar 16 12:48:10.898: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:48:10.942: INFO: namespace: e2e-tests-container-probe-wlpg2, resource: bindings, ignored listing per whitelist
+Mar 16 12:48:11.013: INFO: namespace e2e-tests-container-probe-wlpg2 deletion completed in 6.123516405s
+
+• [SLOW TEST:30.229 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:48:11.013: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:48:11.066: INFO: Waiting up to 5m0s for pod "downwardapi-volume-48b59c4f-2918-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-downward-api-5w84c" to be "success or failure"
+Mar 16 12:48:11.069: INFO: Pod "downwardapi-volume-48b59c4f-2918-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.065087ms
+Mar 16 12:48:13.072: INFO: Pod "downwardapi-volume-48b59c4f-2918-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006294527s
+STEP: Saw pod success
+Mar 16 12:48:13.072: INFO: Pod "downwardapi-volume-48b59c4f-2918-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:48:13.074: INFO: Trying to get logs from node ip-10-250-0-66.eu-west-1.compute.internal pod downwardapi-volume-48b59c4f-2918-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:48:13.098: INFO: Waiting for pod downwardapi-volume-48b59c4f-2918-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:48:13.101: INFO: Pod downwardapi-volume-48b59c4f-2918-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:48:13.101: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-5w84c" for this suite.
+Mar 16 12:48:19.125: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:48:19.185: INFO: namespace: e2e-tests-downward-api-5w84c, resource: bindings, ignored listing per whitelist
+Mar 16 12:48:19.251: INFO: namespace e2e-tests-downward-api-5w84c deletion completed in 6.13357558s
+
+• [SLOW TEST:8.238 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 16 12:48:19.252: INFO: >>> kubeConfig: /tmp/kubeconfig-405699782
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 16 12:48:19.300: INFO: Waiting up to 5m0s for pod "downwardapi-volume-4d9e00e9-2918-11e8-a0aa-16411a5f38c2" in namespace "e2e-tests-projected-dwf57" to be "success or failure"
+Mar 16 12:48:19.302: INFO: Pod "downwardapi-volume-4d9e00e9-2918-11e8-a0aa-16411a5f38c2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.8073ms
+Mar 16 12:48:21.306: INFO: Pod "downwardapi-volume-4d9e00e9-2918-11e8-a0aa-16411a5f38c2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006545536s
+STEP: Saw pod success
+Mar 16 12:48:21.306: INFO: Pod "downwardapi-volume-4d9e00e9-2918-11e8-a0aa-16411a5f38c2" satisfied condition "success or failure"
+Mar 16 12:48:21.309: INFO: Trying to get logs from node ip-10-250-28-245.eu-west-1.compute.internal pod downwardapi-volume-4d9e00e9-2918-11e8-a0aa-16411a5f38c2 container client-container: <nil>
+STEP: delete the pod
+Mar 16 12:48:21.323: INFO: Waiting for pod downwardapi-volume-4d9e00e9-2918-11e8-a0aa-16411a5f38c2 to disappear
+Mar 16 12:48:21.325: INFO: Pod downwardapi-volume-4d9e00e9-2918-11e8-a0aa-16411a5f38c2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 16 12:48:21.325: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-dwf57" for this suite.
+Mar 16 12:48:27.340: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 16 12:48:27.444: INFO: namespace: e2e-tests-projected-dwf57, resource: bindings, ignored listing per whitelist
+Mar 16 12:48:27.446: INFO: namespace e2e-tests-projected-dwf57 deletion completed in 6.115167423s
+
+• [SLOW TEST:8.194 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+Mar 16 12:48:27.446: INFO: Running AfterSuite actions on all node
+Mar 16 12:48:27.446: INFO: Running AfterSuite actions on node 1
+Mar 16 12:48:27.446: INFO: Skipping dumping logs from cluster
+
+Ran 125 of 782 Specs in 2782.003 seconds
+SUCCESS! -- 125 Passed | 0 Failed | 0 Pending | 657 Skipped PASS
+
+Ginkgo ran 1 suite in 46m22.455850735s
+Test Suite Passed

--- a/v1.9/sap-cp-aws/junit_01.xml
+++ b/v1.9/sap-cp-aws/junit_01.xml
@@ -1,0 +1,2099 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="125" failures="0" time="2782.003283903">
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.21248306"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.198999506"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod using local volume with non-existant path should not be able to mount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.226113399"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.200515351"></testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count  [Slow] [Conformance]" classname="Kubernetes e2e suite" time="146.439482109"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="11.285481469"></testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable  [Conformance]" classname="Kubernetes e2e suite" time="10.206527377"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args  [Conformance]" classname="Kubernetes e2e suite" time="10.207004564"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.198590818"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that a pod with an invalid NodeAffinity is rejected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="16.24971126"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set  [Conformance]" classname="Kubernetes e2e suite" time="8.190493152"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.242355746"></testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.210509687"></testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.243068329"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="8.23996648"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [Conformance]" classname="Kubernetes e2e suite" time="8.199875669"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [Conformance]" classname="Kubernetes e2e suite" time="8.214241456"></testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate crd" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.200921651"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should adopt existing pods when creating a RollingUpdate DaemonSet regardless of templateGeneration" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]" classname="Kubernetes e2e suite" time="8.213859239"></testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation [Feature:MountPropagation] should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should rollback without unnecessary restarts" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.197665414"></testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [Conformance]" classname="Kubernetes e2e suite" time="8.253315238"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.OrphanDependents is true" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.444677754"></testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [Conformance]" classname="Kubernetes e2e suite" time="114.37096052"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="12.185797929"></testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [Conformance]" classname="Kubernetes e2e suite" time="8.211591205"></testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.202415755"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.23882512"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.216516735999999"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.211130847"></testcase>
+      <testcase name="[sig-storage] HostPath should support subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services  [Conformance]" classname="Kubernetes e2e suite" time="28.234708629"></testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.205672415"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod&#39;s node is different from PV&#39;s NodeName should not be able to mount due to different NodeName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod&#39;s node is different from PV&#39;s NodeName should not be able to mount due to different NodeName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default commmand (docker entrypoint)  [Conformance]" classname="Kubernetes e2e suite" time="8.221064677"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request  [Conformance]" classname="Kubernetes e2e suite" time="8.199400569"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated  [Conformance]" classname="Kubernetes e2e suite" time="12.713762587"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout  [Conformance]" classname="Kubernetes e2e suite" time="6.163605427">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="33.776821907"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit  [Conformance]" classname="Kubernetes e2e suite" time="8.217014218"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.216328927"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.22091531"></testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.200200243"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.217033223"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="38.502111686"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="51.251632029"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="12.82755886"></testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [Conformance]" classname="Kubernetes e2e suite" time="8.220827394"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.183186215"></testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="19.535748741"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod&#39;s node is different from PV&#39;s NodeName should not be able to mount due to different NodeName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.206341633"></testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.20044199"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.222084302"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [DisabledForLargeClusters] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.221089661"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.200361788"></testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.438290297"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPU] run Nvidia GPU tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated  [Conformance]" classname="Kubernetes e2e suite" time="24.702193542"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod using local volume with non-existant path should not be able to mount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments  [Conformance]" classname="Kubernetes e2e suite" time="8.22274856"></testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="21.066197989"></testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="13.211158029"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="110.59614262"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should autoscale with Custom Metrics from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="45.546117801"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file  [Conformance]" classname="Kubernetes e2e suite" time="8.22256789"></testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.21160422"></testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod  [Conformance]" classname="Kubernetes e2e suite" time="8.216421733"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.233257624"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="88.322327691"></testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP  [Conformance]" classname="Kubernetes e2e suite" time="24.179458447"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] LimitRange should create a LimitRange with default ephemeral storage and ensure pod has the default applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.232561437"></testcase>
+      <testcase name="[sig-storage] HostPath should support r/w" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="45.313091831"></testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.209096254"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.213566822"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.241005329"></testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [Conformance]" classname="Kubernetes e2e suite" time="28.723554415"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="6.706341955"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var  [Conformance]" classname="Kubernetes e2e suite" time="10.199841206"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when using local volume provisioner should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="130.401417261"></testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor using proxy subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection] [Conformance]" classname="Kubernetes e2e suite" time="10.199036559"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [Conformance]" classname="Kubernetes e2e suite" time="8.236948955"></testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when StatefulSet has pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.196079944"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.20250388"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.182510694"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="128.39717528"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Node Auto Repairs [Slow] [Disruptive] should repair node [Feature:NodeAutoRepairs]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node  [Conformance]" classname="Kubernetes e2e suite" time="6.247527187"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.214605052"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existent secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.211033849"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should update pod when spec was updated and update strategy is RollingUpdate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.216965418"></testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification  [Conformance]" classname="Kubernetes e2e suite" time="116.981763735"></testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha docker/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.213922764"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable  [Conformance]" classname="Kubernetes e2e suite" time="10.219967485"></testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.200781385"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should schedule pods in the same zones as statically provisioned PVs [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port  [Conformance]" classname="Kubernetes e2e suite" time="6.234072452"></testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.220666949"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod  [Conformance]" classname="Kubernetes e2e suite" time="8.20781392"></testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="6.72699454"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.240696002"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [DisabledForLargeClusters] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.24211752"></testcase>
+      <testcase name="[k8s.io] Sysctls should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="8.242021866"></testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files  [Conformance]" classname="Kubernetes e2e suite" time="8.255633344"></testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.207565624"></testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart  [Conformance]" classname="Kubernetes e2e suite" time="46.172522533"></testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="28.462385638"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.170558213"></testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file  [Conformance]" classname="Kubernetes e2e suite" time="48.856316098"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit  [Conformance]" classname="Kubernetes e2e suite" time="8.218467087"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [Conformance]" classname="Kubernetes e2e suite" time="10.210828157"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="85.31442864"></testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="11.273467023"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification  [Conformance]" classname="Kubernetes e2e suite" time="103.524748572"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.2188184"></testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod using local volume with non-existant path should not be able to mount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [Conformance]" classname="Kubernetes e2e suite" time="8.19230887"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart  [Conformance]" classname="Kubernetes e2e suite" time="82.179523526"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="60.285267775"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should have a working scale subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only  [Conformance]" classname="Kubernetes e2e suite" time="8.203042014"></testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd)  [Conformance]" classname="Kubernetes e2e suite" time="8.193889971"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.197377814"></testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [Conformance]" classname="Kubernetes e2e suite" time="8.202351788"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank  [Conformance]" classname="Kubernetes e2e suite" time="8.210813033"></testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="40.779506053"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="13.68791881"></testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command  [Conformance]" classname="Kubernetes e2e suite" time="10.236135792"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.217802129"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="42.602584506"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]" classname="Kubernetes e2e suite" time="8.200729368"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request  [Conformance]" classname="Kubernetes e2e suite" time="8.199316901"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [Conformance]" classname="Kubernetes e2e suite" time="8.211447801"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="30.229231509"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.238140874"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.194305557"></testcase>
+  </testsuite>

--- a/v1.9/sap-cp-aws/version.txt
+++ b/v1.9/sap-cp-aws/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.4", GitCommit:"bee2d1505c4fe820744d26d41ecd3fdd4a3d6546", GitTreeState:"clean", BuildDate:"2018-03-12T16:29:47Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.4", GitCommit:"bee2d1505c4fe820744d26d41ecd3fdd4a3d6546", GitTreeState:"clean", BuildDate:"2018-03-12T16:21:35Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}

--- a/v1.9/sap-cp-azure/PRODUCT.yaml
+++ b/v1.9/sap-cp-azure/PRODUCT.yaml
@@ -1,0 +1,6 @@
+vendor: SAP
+name: Cloud Platform - Gardener (https://github.com/gardener/gardener) shoot cluster deployed on Microsoft Azure
+version: 0.1.0 (changed with Open Source shipment)
+website_url: https://cloudplatform.sap.com/index.html
+documentation_url: https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/
+product_logo_url: https://www.sap.com/dam/application/shared/logos/sap-logo-svg.svg

--- a/v1.9/sap-cp-azure/README.md
+++ b/v1.9/sap-cp-azure/README.md
@@ -1,0 +1,43 @@
+# To reproduce:
+
+## Create Kubernetes Cluster
+
+Login to SAP Gardener Dashboard to create a Kubernetes Clusters on Amazon Web Services, Microsoft Azure, Google Cloud Platform, or OpenStack cloud provider.
+
+After the creation completed, copy the cluster's kubeconfig, which is provided by the Gardener Dashboard in the cluster's detail view, to ~/.kube/config and launch the Kubernetes E2E conformance tests.
+
+## Launch E2E Conformance Tests
+1. Launch e2e pod and sonobuoy master under namespace `sonobuoy`   
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+    ```
+
+2. Check logs of `sonobuoy` pod to see when test can be finished   
+Run
+
+    ```shell
+    kubectl logs -f -n sonobuoy sonobuoy
+    ```
+    and wait for line `no-exit was specified, sonobuoy is now blocking`.
+
+3. Use `kubectl cp` to copy the results to the client   
+Get the name of the <result archive> from the log output in step 2.
+
+    ```shell
+    kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy/<result archive> /home/result
+    ```
+
+4. Delete the conformance test resources
+
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl delete -f -
+    ```
+
+5. Untar the tarball
+
+    ```shell
+    cd /home/result
+    tar -xzf *_sonobuoy_*.tar.gz
+    ```
+
+    The result files `e2e.log` and `junit_01.xml` are located in the in the directory `plugins/e2e/results/`.

--- a/v1.9/sap-cp-azure/e2e.log
+++ b/v1.9/sap-cp-azure/e2e.log
@@ -1,0 +1,6462 @@
+Mar 19 14:51:05.402: INFO: Overriding default scale value of zero to 1
+Mar 19 14:51:05.402: INFO: Overriding default milliseconds value of zero to 5000
+I0319 14:51:05.542202      14 test_context.go:349] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-881496793
+I0319 14:51:05.542408      14 e2e.go:331] Starting e2e run "f357a488-2b84-11e8-945a-764aeb95b32d" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1521471065 - Will randomize all specs
+Will run 126 of 782 specs
+
+Mar 19 14:51:05.614: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 14:51:05.616: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
+Mar 19 14:51:05.636: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 19 14:51:05.731: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 19 14:51:05.731: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 19 14:51:05.735: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 19 14:51:06.277: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Mar 19 14:51:06.281: INFO: e2e test version: v1.9.4
+Mar 19 14:51:06.283: INFO: kube-apiserver version: v1.9.4
+S
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:51:06.283: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+Mar 19 14:51:06.437: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating server pod server in namespace e2e-tests-prestop-8v5sl
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-8v5sl
+STEP: Deleting pre-stop pod
+Mar 19 14:51:21.532: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:51:21.535: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-8v5sl" for this suite.
+Mar 19 14:51:57.561: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:51:57.626: INFO: namespace: e2e-tests-prestop-8v5sl, resource: bindings, ignored listing per whitelist
+Mar 19 14:51:57.705: INFO: namespace e2e-tests-prestop-8v5sl deletion completed in 36.163692489s
+
+• [SLOW TEST:51.422 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:51:57.705: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 14:51:57.796: INFO: Waiting up to 5m0s for pod "downwardapi-volume-129fba24-2b85-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-jcbg4" to be "success or failure"
+Mar 19 14:51:57.802: INFO: Pod "downwardapi-volume-129fba24-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 6.427623ms
+Mar 19 14:51:59.806: INFO: Pod "downwardapi-volume-129fba24-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010216307s
+Mar 19 14:52:01.810: INFO: Pod "downwardapi-volume-129fba24-2b85-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013828729s
+STEP: Saw pod success
+Mar 19 14:52:01.810: INFO: Pod "downwardapi-volume-129fba24-2b85-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:52:01.812: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-129fba24-2b85-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 14:52:01.843: INFO: Waiting for pod downwardapi-volume-129fba24-2b85-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:52:01.856: INFO: Pod downwardapi-volume-129fba24-2b85-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:52:01.856: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jcbg4" for this suite.
+Mar 19 14:52:07.879: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:52:07.958: INFO: namespace: e2e-tests-projected-jcbg4, resource: bindings, ignored listing per whitelist
+Mar 19 14:52:08.019: INFO: namespace e2e-tests-projected-jcbg4 deletion completed in 6.158501707s
+
+• [SLOW TEST:10.314 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:52:08.020: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 14:52:08.089: INFO: Waiting up to 5m0s for pod "downwardapi-volume-18c1c81e-2b85-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-5kk8g" to be "success or failure"
+Mar 19 14:52:08.094: INFO: Pod "downwardapi-volume-18c1c81e-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.502616ms
+Mar 19 14:52:10.097: INFO: Pod "downwardapi-volume-18c1c81e-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00791741s
+Mar 19 14:52:12.101: INFO: Pod "downwardapi-volume-18c1c81e-2b85-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011945839s
+STEP: Saw pod success
+Mar 19 14:52:12.101: INFO: Pod "downwardapi-volume-18c1c81e-2b85-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:52:12.106: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-18c1c81e-2b85-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 14:52:12.186: INFO: Waiting for pod downwardapi-volume-18c1c81e-2b85-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:52:12.206: INFO: Pod downwardapi-volume-18c1c81e-2b85-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:52:12.206: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5kk8g" for this suite.
+Mar 19 14:52:18.238: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:52:18.350: INFO: namespace: e2e-tests-projected-5kk8g, resource: bindings, ignored listing per whitelist
+Mar 19 14:52:18.410: INFO: namespace e2e-tests-projected-5kk8g deletion completed in 6.190333745s
+
+• [SLOW TEST:10.391 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:52:18.411: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Mar 19 14:52:18.498: INFO: Waiting up to 5m0s for pod "pod-1ef66656-2b85-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-llzxr" to be "success or failure"
+Mar 19 14:52:18.502: INFO: Pod "pod-1ef66656-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.897914ms
+Mar 19 14:52:20.505: INFO: Pod "pod-1ef66656-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007278654s
+Mar 19 14:52:22.509: INFO: Pod "pod-1ef66656-2b85-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010865736s
+STEP: Saw pod success
+Mar 19 14:52:22.509: INFO: Pod "pod-1ef66656-2b85-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:52:22.512: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-1ef66656-2b85-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 14:52:22.576: INFO: Waiting for pod pod-1ef66656-2b85-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:52:22.583: INFO: Pod pod-1ef66656-2b85-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:52:22.583: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-llzxr" for this suite.
+Mar 19 14:52:28.605: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:52:28.699: INFO: namespace: e2e-tests-emptydir-llzxr, resource: bindings, ignored listing per whitelist
+Mar 19 14:52:28.743: INFO: namespace e2e-tests-emptydir-llzxr deletion completed in 6.149334133s
+
+• [SLOW TEST:10.332 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:52:28.744: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 14:52:28.819: INFO: Waiting up to 5m0s for pod "downwardapi-volume-251d6f3a-2b85-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-4cnwq" to be "success or failure"
+Mar 19 14:52:28.863: INFO: Pod "downwardapi-volume-251d6f3a-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 43.727722ms
+Mar 19 14:52:30.867: INFO: Pod "downwardapi-volume-251d6f3a-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.047647124s
+Mar 19 14:52:32.870: INFO: Pod "downwardapi-volume-251d6f3a-2b85-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.051311903s
+STEP: Saw pod success
+Mar 19 14:52:32.870: INFO: Pod "downwardapi-volume-251d6f3a-2b85-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:52:32.873: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-251d6f3a-2b85-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 14:52:32.917: INFO: Waiting for pod downwardapi-volume-251d6f3a-2b85-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:52:32.925: INFO: Pod downwardapi-volume-251d6f3a-2b85-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:52:32.925: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4cnwq" for this suite.
+Mar 19 14:52:38.942: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:52:39.051: INFO: namespace: e2e-tests-projected-4cnwq, resource: bindings, ignored listing per whitelist
+Mar 19 14:52:39.075: INFO: namespace e2e-tests-projected-4cnwq deletion completed in 6.144075262s
+
+• [SLOW TEST:10.331 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:52:39.076: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 14:53:03.166: INFO: Container started at 2018-03-19 14:52:41 +0000 UTC, pod became ready at 2018-03-19 14:53:01 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:53:03.166: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-cwnsm" for this suite.
+Mar 19 14:53:25.183: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:53:25.317: INFO: namespace: e2e-tests-container-probe-cwnsm, resource: bindings, ignored listing per whitelist
+Mar 19 14:53:25.317: INFO: namespace e2e-tests-container-probe-cwnsm deletion completed in 22.147249283s
+
+• [SLOW TEST:46.241 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:53:25.317: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-map-46d7b888-2b85-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 14:53:25.421: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-46da4134-2b85-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-nl46n" to be "success or failure"
+Mar 19 14:53:25.426: INFO: Pod "pod-projected-secrets-46da4134-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.833114ms
+Mar 19 14:53:27.429: INFO: Pod "pod-projected-secrets-46da4134-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008769566s
+Mar 19 14:53:29.435: INFO: Pod "pod-projected-secrets-46da4134-2b85-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013783281s
+STEP: Saw pod success
+Mar 19 14:53:29.435: INFO: Pod "pod-projected-secrets-46da4134-2b85-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:53:29.437: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-secrets-46da4134-2b85-11e8-945a-764aeb95b32d container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 14:53:29.457: INFO: Waiting for pod pod-projected-secrets-46da4134-2b85-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:53:29.489: INFO: Pod pod-projected-secrets-46da4134-2b85-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:53:29.489: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-nl46n" for this suite.
+Mar 19 14:53:35.543: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:53:35.632: INFO: namespace: e2e-tests-projected-nl46n, resource: bindings, ignored listing per whitelist
+Mar 19 14:53:35.674: INFO: namespace e2e-tests-projected-nl46n deletion completed in 6.182140186s
+
+• [SLOW TEST:10.357 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:53:35.674: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Mar 19 14:53:35.743: INFO: Waiting up to 5m0s for pod "pod-4d00eb04-2b85-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-66g64" to be "success or failure"
+Mar 19 14:53:35.747: INFO: Pod "pod-4d00eb04-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.353515ms
+Mar 19 14:53:37.751: INFO: Pod "pod-4d00eb04-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008419547s
+Mar 19 14:53:39.755: INFO: Pod "pod-4d00eb04-2b85-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012284968s
+STEP: Saw pod success
+Mar 19 14:53:39.755: INFO: Pod "pod-4d00eb04-2b85-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:53:39.758: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-4d00eb04-2b85-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 14:53:39.784: INFO: Waiting for pod pod-4d00eb04-2b85-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:53:39.808: INFO: Pod pod-4d00eb04-2b85-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:53:39.813: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-66g64" for this suite.
+Mar 19 14:53:45.837: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:53:45.897: INFO: namespace: e2e-tests-emptydir-66g64, resource: bindings, ignored listing per whitelist
+Mar 19 14:53:45.967: INFO: namespace e2e-tests-emptydir-66g64 deletion completed in 6.142088709s
+
+• [SLOW TEST:10.292 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:53:45.967: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-533ebbf1-2b85-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 14:53:46.219: INFO: Waiting up to 5m0s for pod "pod-configmaps-533fde7d-2b85-11e8-945a-764aeb95b32d" in namespace "e2e-tests-configmap-9xsg8" to be "success or failure"
+Mar 19 14:53:46.267: INFO: Pod "pod-configmaps-533fde7d-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 47.26825ms
+Mar 19 14:53:48.270: INFO: Pod "pod-configmaps-533fde7d-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.050760668s
+Mar 19 14:53:50.274: INFO: Pod "pod-configmaps-533fde7d-2b85-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.054335753s
+STEP: Saw pod success
+Mar 19 14:53:50.274: INFO: Pod "pod-configmaps-533fde7d-2b85-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:53:50.276: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-configmaps-533fde7d-2b85-11e8-945a-764aeb95b32d container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 14:53:50.327: INFO: Waiting for pod pod-configmaps-533fde7d-2b85-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:53:50.352: INFO: Pod pod-configmaps-533fde7d-2b85-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:53:50.352: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-9xsg8" for this suite.
+Mar 19 14:53:56.370: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:53:56.462: INFO: namespace: e2e-tests-configmap-9xsg8, resource: bindings, ignored listing per whitelist
+Mar 19 14:53:56.512: INFO: namespace e2e-tests-configmap-9xsg8 deletion completed in 6.15489632s
+
+• [SLOW TEST:10.545 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:53:56.513: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-p2wwv
+Mar 19 14:54:00.579: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-p2wwv
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 19 14:54:00.582: INFO: Initial restart count of pod liveness-http is 0
+Mar 19 14:54:22.622: INFO: Restart count of pod e2e-tests-container-probe-p2wwv/liveness-http is now 1 (22.040268487s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:54:22.646: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-p2wwv" for this suite.
+Mar 19 14:54:28.677: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:54:28.743: INFO: namespace: e2e-tests-container-probe-p2wwv, resource: bindings, ignored listing per whitelist
+Mar 19 14:54:28.821: INFO: namespace e2e-tests-container-probe-p2wwv deletion completed in 6.157490847s
+
+• [SLOW TEST:32.308 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:54:28.822: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 14:54:28.885: INFO: Waiting up to 5m0s for pod "downwardapi-volume-6cae1358-2b85-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-jr9wg" to be "success or failure"
+Mar 19 14:54:28.888: INFO: Pod "downwardapi-volume-6cae1358-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.719313ms
+Mar 19 14:54:30.892: INFO: Pod "downwardapi-volume-6cae1358-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007685413s
+Mar 19 14:54:32.896: INFO: Pod "downwardapi-volume-6cae1358-2b85-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011745873s
+STEP: Saw pod success
+Mar 19 14:54:32.897: INFO: Pod "downwardapi-volume-6cae1358-2b85-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:54:32.899: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-6cae1358-2b85-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 14:54:32.925: INFO: Waiting for pod downwardapi-volume-6cae1358-2b85-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:54:32.931: INFO: Pod downwardapi-volume-6cae1358-2b85-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:54:32.931: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-jr9wg" for this suite.
+Mar 19 14:54:38.951: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:54:39.039: INFO: namespace: e2e-tests-downward-api-jr9wg, resource: bindings, ignored listing per whitelist
+Mar 19 14:54:39.082: INFO: namespace e2e-tests-downward-api-jr9wg deletion completed in 6.147651737s
+
+• [SLOW TEST:10.261 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:54:39.083: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 19 14:54:43.713: INFO: Successfully updated pod "labelsupdate72d0fb4b-2b85-11e8-945a-764aeb95b32d"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:55:58.418: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-vc8xn" for this suite.
+Mar 19 14:56:20.459: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:56:20.522: INFO: namespace: e2e-tests-projected-vc8xn, resource: bindings, ignored listing per whitelist
+Mar 19 14:56:20.598: INFO: namespace e2e-tests-projected-vc8xn deletion completed in 22.174111517s
+
+• [SLOW TEST:101.515 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:56:20.599: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-cpz9r
+I0319 14:56:20.665039      14 runners.go:178] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-cpz9r, replica count: 1
+I0319 14:56:21.665398      14 runners.go:178] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0319 14:56:22.665707      14 runners.go:178] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Mar 19 14:56:22.805: INFO: Created: latency-svc-z4cpl
+Mar 19 14:56:22.814: INFO: Got endpoints: latency-svc-z4cpl [48.809354ms]
+Mar 19 14:56:22.854: INFO: Created: latency-svc-qc8f6
+Mar 19 14:56:22.883: INFO: Created: latency-svc-cv8dx
+Mar 19 14:56:22.883: INFO: Got endpoints: latency-svc-qc8f6 [68.331916ms]
+Mar 19 14:56:22.883: INFO: Got endpoints: latency-svc-cv8dx [68.104616ms]
+Mar 19 14:56:22.917: INFO: Created: latency-svc-kbz6k
+Mar 19 14:56:22.923: INFO: Got endpoints: latency-svc-kbz6k [107.985342ms]
+Mar 19 14:56:22.932: INFO: Created: latency-svc-2xhhk
+Mar 19 14:56:22.969: INFO: Got endpoints: latency-svc-2xhhk [153.642887ms]
+Mar 19 14:56:22.978: INFO: Created: latency-svc-7d4bb
+Mar 19 14:56:23.003: INFO: Got endpoints: latency-svc-7d4bb [188.6143ms]
+Mar 19 14:56:23.012: INFO: Created: latency-svc-j4dm6
+Mar 19 14:56:23.012: INFO: Got endpoints: latency-svc-j4dm6 [196.264233ms]
+Mar 19 14:56:23.026: INFO: Created: latency-svc-g9fg5
+Mar 19 14:56:23.026: INFO: Got endpoints: latency-svc-g9fg5 [210.688496ms]
+Mar 19 14:56:23.036: INFO: Created: latency-svc-8gnjc
+Mar 19 14:56:23.036: INFO: Got endpoints: latency-svc-8gnjc [220.250537ms]
+Mar 19 14:56:23.046: INFO: Created: latency-svc-xh22c
+Mar 19 14:56:23.063: INFO: Got endpoints: latency-svc-xh22c [247.410655ms]
+Mar 19 14:56:23.072: INFO: Created: latency-svc-l57r5
+Mar 19 14:56:23.075: INFO: Got endpoints: latency-svc-l57r5 [259.841909ms]
+Mar 19 14:56:23.089: INFO: Created: latency-svc-gkmrt
+Mar 19 14:56:23.095: INFO: Got endpoints: latency-svc-gkmrt [279.451394ms]
+Mar 19 14:56:23.148: INFO: Created: latency-svc-5x8p5
+Mar 19 14:56:23.167: INFO: Got endpoints: latency-svc-5x8p5 [351.717006ms]
+Mar 19 14:56:23.174: INFO: Created: latency-svc-bbjnk
+Mar 19 14:56:23.178: INFO: Got endpoints: latency-svc-bbjnk [361.98345ms]
+Mar 19 14:56:23.184: INFO: Created: latency-svc-njlth
+Mar 19 14:56:23.190: INFO: Got endpoints: latency-svc-njlth [373.935202ms]
+Mar 19 14:56:23.201: INFO: Created: latency-svc-j65mv
+Mar 19 14:56:23.201: INFO: Got endpoints: latency-svc-j65mv [385.672153ms]
+Mar 19 14:56:23.231: INFO: Created: latency-svc-rmwfh
+Mar 19 14:56:23.237: INFO: Got endpoints: latency-svc-rmwfh [353.998994ms]
+Mar 19 14:56:23.273: INFO: Created: latency-svc-lg2cs
+Mar 19 14:56:23.277: INFO: Got endpoints: latency-svc-lg2cs [393.504865ms]
+Mar 19 14:56:23.299: INFO: Created: latency-svc-pwzp7
+Mar 19 14:56:24.192: INFO: Got endpoints: latency-svc-pwzp7 [1.268468294s]
+Mar 19 14:56:24.283: INFO: Created: latency-svc-xzb9b
+Mar 19 14:56:24.681: INFO: Got endpoints: latency-svc-xzb9b [1.712344365s]
+Mar 19 14:56:25.025: INFO: Created: latency-svc-45kp2
+Mar 19 14:56:25.042: INFO: Got endpoints: latency-svc-45kp2 [2.03807091s]
+Mar 19 14:56:25.196: INFO: Created: latency-svc-wtg9x
+Mar 19 14:56:25.236: INFO: Got endpoints: latency-svc-wtg9x [2.224230515s]
+Mar 19 14:56:25.237: INFO: Created: latency-svc-z72jj
+Mar 19 14:56:25.257: INFO: Got endpoints: latency-svc-z72jj [2.230644342s]
+Mar 19 14:56:25.285: INFO: Created: latency-svc-rnhzz
+Mar 19 14:56:25.293: INFO: Got endpoints: latency-svc-rnhzz [2.257431958s]
+Mar 19 14:56:25.329: INFO: Created: latency-svc-hhnq9
+Mar 19 14:56:25.329: INFO: Got endpoints: latency-svc-hhnq9 [2.266404396s]
+Mar 19 14:56:25.365: INFO: Created: latency-svc-s4l4s
+Mar 19 14:56:25.370: INFO: Got endpoints: latency-svc-s4l4s [2.294536318s]
+Mar 19 14:56:25.383: INFO: Created: latency-svc-w8xd7
+Mar 19 14:56:25.387: INFO: Got endpoints: latency-svc-w8xd7 [2.291907607s]
+Mar 19 14:56:25.397: INFO: Created: latency-svc-fnjwj
+Mar 19 14:56:25.403: INFO: Got endpoints: latency-svc-fnjwj [2.235304762s]
+Mar 19 14:56:25.415: INFO: Created: latency-svc-2bpfv
+Mar 19 14:56:25.434: INFO: Got endpoints: latency-svc-2bpfv [2.256729054s]
+Mar 19 14:56:25.439: INFO: Created: latency-svc-24mmb
+Mar 19 14:56:25.444: INFO: Got endpoints: latency-svc-24mmb [2.242337692s]
+Mar 19 14:56:25.481: INFO: Created: latency-svc-frhrh
+Mar 19 14:56:25.481: INFO: Got endpoints: latency-svc-frhrh [2.291311603s]
+Mar 19 14:56:25.489: INFO: Created: latency-svc-t6xt9
+Mar 19 14:56:25.495: INFO: Got endpoints: latency-svc-t6xt9 [2.258294561s]
+Mar 19 14:56:25.503: INFO: Created: latency-svc-jpmrp
+Mar 19 14:56:25.507: INFO: Got endpoints: latency-svc-jpmrp [2.230276839s]
+Mar 19 14:56:25.516: INFO: Created: latency-svc-vw92j
+Mar 19 14:56:25.520: INFO: Got endpoints: latency-svc-vw92j [1.32835384s]
+Mar 19 14:56:25.562: INFO: Created: latency-svc-wkhh2
+Mar 19 14:56:25.567: INFO: Got endpoints: latency-svc-wkhh2 [885.579726ms]
+Mar 19 14:56:25.580: INFO: Created: latency-svc-j569b
+Mar 19 14:56:25.584: INFO: Got endpoints: latency-svc-j569b [541.886241ms]
+Mar 19 14:56:25.593: INFO: Created: latency-svc-dl8bm
+Mar 19 14:56:25.600: INFO: Got endpoints: latency-svc-dl8bm [364.059472ms]
+Mar 19 14:56:25.607: INFO: Created: latency-svc-74tcs
+Mar 19 14:56:25.622: INFO: Created: latency-svc-xxb5z
+Mar 19 14:56:25.622: INFO: Got endpoints: latency-svc-74tcs [365.212478ms]
+Mar 19 14:56:25.626: INFO: Got endpoints: latency-svc-xxb5z [332.715937ms]
+Mar 19 14:56:25.642: INFO: Created: latency-svc-cktp7
+Mar 19 14:56:25.646: INFO: Got endpoints: latency-svc-cktp7 [316.661168ms]
+Mar 19 14:56:25.684: INFO: Created: latency-svc-rgm9l
+Mar 19 14:56:25.687: INFO: Got endpoints: latency-svc-rgm9l [316.831269ms]
+Mar 19 14:56:25.704: INFO: Created: latency-svc-z4vjg
+Mar 19 14:56:25.720: INFO: Got endpoints: latency-svc-z4vjg [332.999739ms]
+Mar 19 14:56:25.728: INFO: Created: latency-svc-lr7sr
+Mar 19 14:56:25.736: INFO: Got endpoints: latency-svc-lr7sr [333.097439ms]
+Mar 19 14:56:25.746: INFO: Created: latency-svc-s2g9c
+Mar 19 14:56:25.753: INFO: Got endpoints: latency-svc-s2g9c [318.001174ms]
+Mar 19 14:56:25.761: INFO: Created: latency-svc-nq5mv
+Mar 19 14:56:25.768: INFO: Got endpoints: latency-svc-nq5mv [324.1706ms]
+Mar 19 14:56:25.776: INFO: Created: latency-svc-q8gc7
+Mar 19 14:56:25.784: INFO: Got endpoints: latency-svc-q8gc7 [302.365906ms]
+Mar 19 14:56:25.810: INFO: Created: latency-svc-n2hh5
+Mar 19 14:56:25.821: INFO: Created: latency-svc-46rz8
+Mar 19 14:56:25.821: INFO: Got endpoints: latency-svc-n2hh5 [326.025809ms]
+Mar 19 14:56:25.830: INFO: Got endpoints: latency-svc-46rz8 [322.589494ms]
+Mar 19 14:56:25.839: INFO: Created: latency-svc-m4zv2
+Mar 19 14:56:25.843: INFO: Got endpoints: latency-svc-m4zv2 [322.619293ms]
+Mar 19 14:56:25.852: INFO: Created: latency-svc-lmz9l
+Mar 19 14:56:25.855: INFO: Got endpoints: latency-svc-lmz9l [288.178245ms]
+Mar 19 14:56:25.863: INFO: Created: latency-svc-k4wrr
+Mar 19 14:56:25.870: INFO: Got endpoints: latency-svc-k4wrr [286.167537ms]
+Mar 19 14:56:25.880: INFO: Created: latency-svc-n2m7n
+Mar 19 14:56:25.935: INFO: Created: latency-svc-bnkft
+Mar 19 14:56:25.936: INFO: Got endpoints: latency-svc-n2m7n [335.348949ms]
+Mar 19 14:56:25.939: INFO: Got endpoints: latency-svc-bnkft [316.621068ms]
+Mar 19 14:56:25.954: INFO: Created: latency-svc-78klt
+Mar 19 14:56:25.958: INFO: Got endpoints: latency-svc-78klt [332.069135ms]
+Mar 19 14:56:25.976: INFO: Created: latency-svc-rtc86
+Mar 19 14:56:25.980: INFO: Got endpoints: latency-svc-rtc86 [334.040743ms]
+Mar 19 14:56:25.989: INFO: Created: latency-svc-whvwv
+Mar 19 14:56:25.993: INFO: Got endpoints: latency-svc-whvwv [306.207923ms]
+Mar 19 14:56:26.004: INFO: Created: latency-svc-zm75j
+Mar 19 14:56:26.009: INFO: Got endpoints: latency-svc-zm75j [289.101049ms]
+Mar 19 14:56:26.019: INFO: Created: latency-svc-btlnf
+Mar 19 14:56:26.030: INFO: Created: latency-svc-v9fdx
+Mar 19 14:56:26.030: INFO: Got endpoints: latency-svc-btlnf [294.175171ms]
+Mar 19 14:56:26.056: INFO: Got endpoints: latency-svc-v9fdx [303.14521ms]
+Mar 19 14:56:26.057: INFO: Created: latency-svc-srzj4
+Mar 19 14:56:26.062: INFO: Got endpoints: latency-svc-srzj4 [294.216971ms]
+Mar 19 14:56:26.070: INFO: Created: latency-svc-lvmb2
+Mar 19 14:56:26.074: INFO: Got endpoints: latency-svc-lvmb2 [289.869652ms]
+Mar 19 14:56:26.082: INFO: Created: latency-svc-slbh9
+Mar 19 14:56:26.098: INFO: Got endpoints: latency-svc-slbh9 [276.894096ms]
+Mar 19 14:56:26.107: INFO: Created: latency-svc-lc249
+Mar 19 14:56:26.111: INFO: Got endpoints: latency-svc-lc249 [281.273015ms]
+Mar 19 14:56:26.122: INFO: Created: latency-svc-x4wc6
+Mar 19 14:56:26.126: INFO: Got endpoints: latency-svc-x4wc6 [283.235123ms]
+Mar 19 14:56:26.136: INFO: Created: latency-svc-zbccp
+Mar 19 14:56:26.140: INFO: Got endpoints: latency-svc-zbccp [285.311032ms]
+Mar 19 14:56:26.149: INFO: Created: latency-svc-9nxnl
+Mar 19 14:56:26.152: INFO: Got endpoints: latency-svc-9nxnl [282.212319ms]
+Mar 19 14:56:26.188: INFO: Created: latency-svc-fzfnp
+Mar 19 14:56:26.190: INFO: Got endpoints: latency-svc-fzfnp [254.8169ms]
+Mar 19 14:56:26.204: INFO: Created: latency-svc-txw8h
+Mar 19 14:56:26.208: INFO: Got endpoints: latency-svc-txw8h [268.871961ms]
+Mar 19 14:56:26.216: INFO: Created: latency-svc-wn6k6
+Mar 19 14:56:26.225: INFO: Got endpoints: latency-svc-wn6k6 [266.711852ms]
+Mar 19 14:56:26.234: INFO: Created: latency-svc-f96kl
+Mar 19 14:56:26.238: INFO: Got endpoints: latency-svc-f96kl [257.912014ms]
+Mar 19 14:56:26.251: INFO: Created: latency-svc-7mb4p
+Mar 19 14:56:26.255: INFO: Got endpoints: latency-svc-7mb4p [261.998432ms]
+Mar 19 14:56:26.265: INFO: Created: latency-svc-s4dnb
+Mar 19 14:56:26.268: INFO: Got endpoints: latency-svc-s4dnb [258.693417ms]
+Mar 19 14:56:26.283: INFO: Created: latency-svc-f6zsk
+Mar 19 14:56:26.286: INFO: Got endpoints: latency-svc-f6zsk [255.624004ms]
+Mar 19 14:56:26.320: INFO: Created: latency-svc-dvxxq
+Mar 19 14:56:26.331: INFO: Got endpoints: latency-svc-dvxxq [275.58619ms]
+Mar 19 14:56:26.332: INFO: Created: latency-svc-kwt8s
+Mar 19 14:56:26.356: INFO: Created: latency-svc-jdz97
+Mar 19 14:56:26.368: INFO: Got endpoints: latency-svc-kwt8s [305.542819ms]
+Mar 19 14:56:26.368: INFO: Created: latency-svc-lz8zs
+Mar 19 14:56:26.381: INFO: Created: latency-svc-mtrfp
+Mar 19 14:56:26.413: INFO: Got endpoints: latency-svc-jdz97 [339.461866ms]
+Mar 19 14:56:26.413: INFO: Created: latency-svc-r4xlq
+Mar 19 14:56:26.453: INFO: Created: latency-svc-khr5l
+Mar 19 14:56:26.472: INFO: Created: latency-svc-th7f5
+Mar 19 14:56:26.471: INFO: Got endpoints: latency-svc-lz8zs [372.88661ms]
+Mar 19 14:56:26.482: INFO: Created: latency-svc-98hft
+Mar 19 14:56:26.500: INFO: Created: latency-svc-nxb7v
+Mar 19 14:56:26.527: INFO: Got endpoints: latency-svc-mtrfp [415.581494ms]
+Mar 19 14:56:26.527: INFO: Created: latency-svc-8wc8j
+Mar 19 14:56:26.620: INFO: Created: latency-svc-pm5zn
+Mar 19 14:56:26.621: INFO: Got endpoints: latency-svc-khr5l [480.450475ms]
+Mar 19 14:56:26.621: INFO: Got endpoints: latency-svc-r4xlq [494.507635ms]
+Mar 19 14:56:26.660: INFO: Created: latency-svc-578gq
+Mar 19 14:56:26.670: INFO: Created: latency-svc-492zg
+Mar 19 14:56:26.670: INFO: Got endpoints: latency-svc-th7f5 [517.808736ms]
+Mar 19 14:56:26.683: INFO: Created: latency-svc-qzx6l
+Mar 19 14:56:26.696: INFO: Created: latency-svc-s67xt
+Mar 19 14:56:26.734: INFO: Got endpoints: latency-svc-98hft [543.969549ms]
+Mar 19 14:56:26.734: INFO: Created: latency-svc-mv7km
+Mar 19 14:56:26.758: INFO: Created: latency-svc-nmgls
+Mar 19 14:56:26.777: INFO: Got endpoints: latency-svc-nxb7v [568.525355ms]
+Mar 19 14:56:26.777: INFO: Created: latency-svc-kdbvd
+Mar 19 14:56:26.796: INFO: Created: latency-svc-knmjp
+Mar 19 14:56:26.806: INFO: Created: latency-svc-j6l42
+Mar 19 14:56:26.820: INFO: Got endpoints: latency-svc-8wc8j [594.557368ms]
+Mar 19 14:56:26.821: INFO: Created: latency-svc-nlkqz
+Mar 19 14:56:26.860: INFO: Created: latency-svc-qtl7z
+Mar 19 14:56:26.862: INFO: Got endpoints: latency-svc-pm5zn [624.182696ms]
+Mar 19 14:56:26.878: INFO: Created: latency-svc-lq4dc
+Mar 19 14:56:26.901: INFO: Created: latency-svc-hq7tb
+Mar 19 14:56:26.967: INFO: Created: latency-svc-4lf57
+Mar 19 14:56:26.967: INFO: Got endpoints: latency-svc-578gq [711.343972ms]
+Mar 19 14:56:26.967: INFO: Created: latency-svc-xcwss
+Mar 19 14:56:26.975: INFO: Got endpoints: latency-svc-492zg [707.116953ms]
+Mar 19 14:56:27.010: INFO: Created: latency-svc-k6s2s
+Mar 19 14:56:27.022: INFO: Got endpoints: latency-svc-qzx6l [735.940478ms]
+Mar 19 14:56:27.024: INFO: Created: latency-svc-md9fd
+Mar 19 14:56:27.043: INFO: Created: latency-svc-6wq5k
+Mar 19 14:56:27.062: INFO: Got endpoints: latency-svc-s67xt [730.507454ms]
+Mar 19 14:56:27.096: INFO: Created: latency-svc-68kzx
+Mar 19 14:56:27.114: INFO: Got endpoints: latency-svc-mv7km [746.311522ms]
+Mar 19 14:56:27.168: INFO: Got endpoints: latency-svc-nmgls [755.03766ms]
+Mar 19 14:56:27.169: INFO: Created: latency-svc-pxjgp
+Mar 19 14:56:27.184: INFO: Created: latency-svc-4txmp
+Mar 19 14:56:27.212: INFO: Got endpoints: latency-svc-kdbvd [739.952295ms]
+Mar 19 14:56:27.232: INFO: Created: latency-svc-cggr9
+Mar 19 14:56:27.263: INFO: Got endpoints: latency-svc-knmjp [735.654676ms]
+Mar 19 14:56:27.288: INFO: Created: latency-svc-4vpcj
+Mar 19 14:56:27.329: INFO: Got endpoints: latency-svc-j6l42 [706.976653ms]
+Mar 19 14:56:27.347: INFO: Created: latency-svc-bz6jm
+Mar 19 14:56:27.362: INFO: Got endpoints: latency-svc-nlkqz [739.503893ms]
+Mar 19 14:56:27.453: INFO: Got endpoints: latency-svc-qtl7z [780.680671ms]
+Mar 19 14:56:27.454: INFO: Created: latency-svc-hflz6
+Mar 19 14:56:27.468: INFO: Got endpoints: latency-svc-lq4dc [733.436366ms]
+Mar 19 14:56:27.468: INFO: Created: latency-svc-5jxrq
+Mar 19 14:56:27.505: INFO: Created: latency-svc-mjb8p
+Mar 19 14:56:27.511: INFO: Got endpoints: latency-svc-hq7tb [734.508471ms]
+Mar 19 14:56:27.552: INFO: Created: latency-svc-2br8x
+Mar 19 14:56:27.624: INFO: Got endpoints: latency-svc-4lf57 [761.294786ms]
+Mar 19 14:56:27.624: INFO: Got endpoints: latency-svc-xcwss [804.021071ms]
+Mar 19 14:56:27.667: INFO: Created: latency-svc-75v8x
+Mar 19 14:56:27.667: INFO: Got endpoints: latency-svc-k6s2s [700.160022ms]
+Mar 19 14:56:27.679: INFO: Created: latency-svc-bnwmn
+Mar 19 14:56:27.694: INFO: Created: latency-svc-b8mvc
+Mar 19 14:56:27.714: INFO: Got endpoints: latency-svc-md9fd [738.770489ms]
+Mar 19 14:56:27.743: INFO: Created: latency-svc-gpqls
+Mar 19 14:56:27.762: INFO: Got endpoints: latency-svc-6wq5k [739.350191ms]
+Mar 19 14:56:27.782: INFO: Created: latency-svc-hvfj6
+Mar 19 14:56:27.812: INFO: Got endpoints: latency-svc-68kzx [749.790836ms]
+Mar 19 14:56:27.837: INFO: Created: latency-svc-rgbpq
+Mar 19 14:56:28.003: INFO: Got endpoints: latency-svc-cggr9 [790.770113ms]
+Mar 19 14:56:28.003: INFO: Got endpoints: latency-svc-pxjgp [888.224334ms]
+Mar 19 14:56:28.004: INFO: Got endpoints: latency-svc-4txmp [835.182306ms]
+Mar 19 14:56:28.032: INFO: Created: latency-svc-gzltg
+Mar 19 14:56:28.048: INFO: Got endpoints: latency-svc-4vpcj [785.476491ms]
+Mar 19 14:56:28.054: INFO: Created: latency-svc-zcccn
+Mar 19 14:56:28.054: INFO: Created: latency-svc-r6c9d
+Mar 19 14:56:28.082: INFO: Got endpoints: latency-svc-bz6jm [752.218047ms]
+Mar 19 14:56:28.095: INFO: Created: latency-svc-8f8n6
+Mar 19 14:56:28.154: INFO: Got endpoints: latency-svc-hflz6 [791.518217ms]
+Mar 19 14:56:28.155: INFO: Created: latency-svc-4nbbv
+Mar 19 14:56:28.161: INFO: Got endpoints: latency-svc-5jxrq [708.191157ms]
+Mar 19 14:56:28.180: INFO: Created: latency-svc-b2flx
+Mar 19 14:56:28.196: INFO: Created: latency-svc-jkh9v
+Mar 19 14:56:28.213: INFO: Got endpoints: latency-svc-mjb8p [744.502113ms]
+Mar 19 14:56:28.229: INFO: Created: latency-svc-f8nbg
+Mar 19 14:56:28.273: INFO: Got endpoints: latency-svc-2br8x [761.443186ms]
+Mar 19 14:56:28.289: INFO: Created: latency-svc-vl2f2
+Mar 19 14:56:28.312: INFO: Got endpoints: latency-svc-75v8x [687.950369ms]
+Mar 19 14:56:28.330: INFO: Created: latency-svc-fw6c8
+Mar 19 14:56:28.362: INFO: Got endpoints: latency-svc-bnwmn [737.926085ms]
+Mar 19 14:56:28.392: INFO: Created: latency-svc-q4bfs
+Mar 19 14:56:28.412: INFO: Got endpoints: latency-svc-b8mvc [744.569614ms]
+Mar 19 14:56:28.427: INFO: Created: latency-svc-pd9zd
+Mar 19 14:56:28.462: INFO: Got endpoints: latency-svc-gpqls [747.187225ms]
+Mar 19 14:56:28.480: INFO: Created: latency-svc-6ks82
+Mar 19 14:56:28.517: INFO: Got endpoints: latency-svc-hvfj6 [755.013858ms]
+Mar 19 14:56:28.539: INFO: Created: latency-svc-79ktd
+Mar 19 14:56:28.562: INFO: Got endpoints: latency-svc-rgbpq [750.236637ms]
+Mar 19 14:56:28.586: INFO: Created: latency-svc-t5ntc
+Mar 19 14:56:28.614: INFO: Got endpoints: latency-svc-gzltg [611.289338ms]
+Mar 19 14:56:28.631: INFO: Created: latency-svc-8hf9z
+Mar 19 14:56:28.662: INFO: Got endpoints: latency-svc-r6c9d [659.310745ms]
+Mar 19 14:56:28.678: INFO: Created: latency-svc-9hzgj
+Mar 19 14:56:28.739: INFO: Got endpoints: latency-svc-zcccn [735.304773ms]
+Mar 19 14:56:28.756: INFO: Created: latency-svc-7vnp7
+Mar 19 14:56:28.762: INFO: Got endpoints: latency-svc-8f8n6 [713.173677ms]
+Mar 19 14:56:28.778: INFO: Created: latency-svc-x5mv9
+Mar 19 14:56:28.812: INFO: Got endpoints: latency-svc-4nbbv [730.669953ms]
+Mar 19 14:56:28.831: INFO: Created: latency-svc-8tswg
+Mar 19 14:56:28.862: INFO: Got endpoints: latency-svc-b2flx [708.554958ms]
+Mar 19 14:56:28.882: INFO: Created: latency-svc-4bq7c
+Mar 19 14:56:28.911: INFO: Got endpoints: latency-svc-jkh9v [749.846136ms]
+Mar 19 14:56:28.928: INFO: Created: latency-svc-vc5cd
+Mar 19 14:56:28.961: INFO: Got endpoints: latency-svc-f8nbg [748.400929ms]
+Mar 19 14:56:28.981: INFO: Created: latency-svc-696xs
+Mar 19 14:56:29.011: INFO: Got endpoints: latency-svc-vl2f2 [738.599087ms]
+Mar 19 14:56:29.032: INFO: Created: latency-svc-cwzsw
+Mar 19 14:56:29.074: INFO: Got endpoints: latency-svc-fw6c8 [761.741187ms]
+Mar 19 14:56:29.089: INFO: Created: latency-svc-cqkgd
+Mar 19 14:56:29.113: INFO: Got endpoints: latency-svc-q4bfs [750.576138ms]
+Mar 19 14:56:29.133: INFO: Created: latency-svc-h6fpm
+Mar 19 14:56:29.162: INFO: Got endpoints: latency-svc-pd9zd [749.753235ms]
+Mar 19 14:56:29.193: INFO: Created: latency-svc-dtzwl
+Mar 19 14:56:29.211: INFO: Got endpoints: latency-svc-6ks82 [749.697935ms]
+Mar 19 14:56:29.230: INFO: Created: latency-svc-nhb6v
+Mar 19 14:56:29.263: INFO: Got endpoints: latency-svc-79ktd [745.765418ms]
+Mar 19 14:56:29.279: INFO: Created: latency-svc-mxrv7
+Mar 19 14:56:29.313: INFO: Got endpoints: latency-svc-t5ntc [750.382737ms]
+Mar 19 14:56:29.328: INFO: Created: latency-svc-ht4dp
+Mar 19 14:56:29.362: INFO: Got endpoints: latency-svc-8hf9z [747.893226ms]
+Mar 19 14:56:29.377: INFO: Created: latency-svc-5z4vx
+Mar 19 14:56:29.417: INFO: Got endpoints: latency-svc-9hzgj [755.333259ms]
+Mar 19 14:56:29.435: INFO: Created: latency-svc-7mr4l
+Mar 19 14:56:29.462: INFO: Got endpoints: latency-svc-7vnp7 [723.34462ms]
+Mar 19 14:56:29.486: INFO: Created: latency-svc-5b277
+Mar 19 14:56:29.512: INFO: Got endpoints: latency-svc-x5mv9 [750.129735ms]
+Mar 19 14:56:29.535: INFO: Created: latency-svc-v8fpn
+Mar 19 14:56:29.563: INFO: Got endpoints: latency-svc-8tswg [750.391236ms]
+Mar 19 14:56:29.578: INFO: Created: latency-svc-mxvnr
+Mar 19 14:56:29.612: INFO: Got endpoints: latency-svc-4bq7c [749.615233ms]
+Mar 19 14:56:29.698: INFO: Created: latency-svc-fc9fh
+Mar 19 14:56:29.701: INFO: Got endpoints: latency-svc-vc5cd [789.848007ms]
+Mar 19 14:56:29.724: INFO: Created: latency-svc-8jxqz
+Mar 19 14:56:29.726: INFO: Got endpoints: latency-svc-696xs [764.400698ms]
+Mar 19 14:56:29.820: INFO: Created: latency-svc-x7vkt
+Mar 19 14:56:29.820: INFO: Got endpoints: latency-svc-cqkgd [746.132918ms]
+Mar 19 14:56:29.820: INFO: Got endpoints: latency-svc-cwzsw [808.355387ms]
+Mar 19 14:56:29.835: INFO: Created: latency-svc-nlcp6
+Mar 19 14:56:29.856: INFO: Created: latency-svc-k5zxv
+Mar 19 14:56:29.862: INFO: Got endpoints: latency-svc-h6fpm [748.92673ms]
+Mar 19 14:56:29.881: INFO: Created: latency-svc-xg44b
+Mar 19 14:56:29.912: INFO: Got endpoints: latency-svc-dtzwl [749.959934ms]
+Mar 19 14:56:29.946: INFO: Created: latency-svc-9m7pw
+Mar 19 14:56:29.964: INFO: Got endpoints: latency-svc-nhb6v [752.202945ms]
+Mar 19 14:56:29.985: INFO: Created: latency-svc-2bpv2
+Mar 19 14:56:30.012: INFO: Got endpoints: latency-svc-mxrv7 [749.631633ms]
+Mar 19 14:56:30.032: INFO: Created: latency-svc-hfn7r
+Mar 19 14:56:30.062: INFO: Got endpoints: latency-svc-ht4dp [748.84173ms]
+Mar 19 14:56:30.095: INFO: Created: latency-svc-dsmmc
+Mar 19 14:56:30.113: INFO: Got endpoints: latency-svc-5z4vx [750.157635ms]
+Mar 19 14:56:30.132: INFO: Created: latency-svc-gz5cc
+Mar 19 14:56:30.207: INFO: Got endpoints: latency-svc-7mr4l [789.278704ms]
+Mar 19 14:56:30.213: INFO: Got endpoints: latency-svc-5b277 [749.436232ms]
+Mar 19 14:56:30.225: INFO: Created: latency-svc-4mjsx
+Mar 19 14:56:30.239: INFO: Created: latency-svc-gxjsr
+Mar 19 14:56:30.261: INFO: Got endpoints: latency-svc-v8fpn [749.176831ms]
+Mar 19 14:56:30.285: INFO: Created: latency-svc-6tqdt
+Mar 19 14:56:30.342: INFO: Got endpoints: latency-svc-mxvnr [778.585057ms]
+Mar 19 14:56:30.372: INFO: Created: latency-svc-m4wv5
+Mar 19 14:56:30.372: INFO: Got endpoints: latency-svc-fc9fh [760.189778ms]
+Mar 19 14:56:30.394: INFO: Created: latency-svc-lstqh
+Mar 19 14:56:30.422: INFO: Got endpoints: latency-svc-8jxqz [720.370807ms]
+Mar 19 14:56:30.442: INFO: Created: latency-svc-sgg2g
+Mar 19 14:56:30.491: INFO: Got endpoints: latency-svc-x7vkt [764.904398ms]
+Mar 19 14:56:30.507: INFO: Created: latency-svc-h2z9h
+Mar 19 14:56:30.511: INFO: Got endpoints: latency-svc-nlcp6 [691.15118ms]
+Mar 19 14:56:30.527: INFO: Created: latency-svc-wfppv
+Mar 19 14:56:30.562: INFO: Got endpoints: latency-svc-k5zxv [740.731694ms]
+Mar 19 14:56:30.579: INFO: Created: latency-svc-vmqhg
+Mar 19 14:56:30.613: INFO: Got endpoints: latency-svc-xg44b [750.679036ms]
+Mar 19 14:56:30.647: INFO: Created: latency-svc-54g4v
+Mar 19 14:56:30.672: INFO: Got endpoints: latency-svc-9m7pw [758.207269ms]
+Mar 19 14:56:30.691: INFO: Created: latency-svc-k888v
+Mar 19 14:56:30.713: INFO: Got endpoints: latency-svc-2bpv2 [748.813129ms]
+Mar 19 14:56:30.781: INFO: Got endpoints: latency-svc-hfn7r [768.870915ms]
+Mar 19 14:56:30.792: INFO: Created: latency-svc-bxv84
+Mar 19 14:56:30.856: INFO: Created: latency-svc-vfrh4
+Mar 19 14:56:30.857: INFO: Got endpoints: latency-svc-dsmmc [794.757727ms]
+Mar 19 14:56:30.861: INFO: Got endpoints: latency-svc-gz5cc [748.487427ms]
+Mar 19 14:56:30.875: INFO: Created: latency-svc-zmqmx
+Mar 19 14:56:30.935: INFO: Created: latency-svc-9bq2f
+Mar 19 14:56:30.935: INFO: Got endpoints: latency-svc-4mjsx [728.563642ms]
+Mar 19 14:56:30.961: INFO: Created: latency-svc-n9ph8
+Mar 19 14:56:30.988: INFO: Got endpoints: latency-svc-gxjsr [774.975641ms]
+Mar 19 14:56:31.005: INFO: Created: latency-svc-wsr96
+Mar 19 14:56:31.012: INFO: Got endpoints: latency-svc-6tqdt [750.672737ms]
+Mar 19 14:56:31.031: INFO: Created: latency-svc-wjwdt
+Mar 19 14:56:31.062: INFO: Got endpoints: latency-svc-m4wv5 [719.899303ms]
+Mar 19 14:56:31.127: INFO: Got endpoints: latency-svc-lstqh [754.922254ms]
+Mar 19 14:56:31.128: INFO: Created: latency-svc-62trr
+Mar 19 14:56:31.143: INFO: Created: latency-svc-6jn5l
+Mar 19 14:56:31.164: INFO: Got endpoints: latency-svc-sgg2g [741.842398ms]
+Mar 19 14:56:31.202: INFO: Created: latency-svc-xjnwb
+Mar 19 14:56:31.212: INFO: Got endpoints: latency-svc-h2z9h [721.011608ms]
+Mar 19 14:56:31.263: INFO: Got endpoints: latency-svc-wfppv [751.430939ms]
+Mar 19 14:56:31.263: INFO: Created: latency-svc-rkbmh
+Mar 19 14:56:31.279: INFO: Created: latency-svc-5tn66
+Mar 19 14:56:31.311: INFO: Got endpoints: latency-svc-vmqhg [749.778232ms]
+Mar 19 14:56:31.327: INFO: Created: latency-svc-fnbbz
+Mar 19 14:56:31.362: INFO: Got endpoints: latency-svc-54g4v [749.28333ms]
+Mar 19 14:56:31.405: INFO: Created: latency-svc-xsftz
+Mar 19 14:56:31.423: INFO: Got endpoints: latency-svc-k888v [751.491339ms]
+Mar 19 14:56:31.447: INFO: Created: latency-svc-pngnm
+Mar 19 14:56:31.465: INFO: Got endpoints: latency-svc-bxv84 [751.254939ms]
+Mar 19 14:56:31.520: INFO: Got endpoints: latency-svc-vfrh4 [737.182677ms]
+Mar 19 14:56:31.520: INFO: Created: latency-svc-jxjc2
+Mar 19 14:56:31.553: INFO: Created: latency-svc-58bv4
+Mar 19 14:56:31.562: INFO: Got endpoints: latency-svc-zmqmx [705.34874ms]
+Mar 19 14:56:31.579: INFO: Created: latency-svc-pjbxp
+Mar 19 14:56:31.611: INFO: Got endpoints: latency-svc-9bq2f [749.351329ms]
+Mar 19 14:56:31.639: INFO: Created: latency-svc-v6v5v
+Mar 19 14:56:31.662: INFO: Got endpoints: latency-svc-n9ph8 [726.475531ms]
+Mar 19 14:56:31.683: INFO: Created: latency-svc-2z54c
+Mar 19 14:56:31.712: INFO: Got endpoints: latency-svc-wsr96 [724.827124ms]
+Mar 19 14:56:31.734: INFO: Created: latency-svc-f2tl8
+Mar 19 14:56:31.767: INFO: Got endpoints: latency-svc-wjwdt [754.696152ms]
+Mar 19 14:56:31.785: INFO: Created: latency-svc-k8gc7
+Mar 19 14:56:31.812: INFO: Got endpoints: latency-svc-62trr [749.345329ms]
+Mar 19 14:56:31.830: INFO: Created: latency-svc-wpnks
+Mar 19 14:56:31.870: INFO: Got endpoints: latency-svc-6jn5l [741.628796ms]
+Mar 19 14:56:31.887: INFO: Created: latency-svc-69rfx
+Mar 19 14:56:31.912: INFO: Got endpoints: latency-svc-xjnwb [747.834123ms]
+Mar 19 14:56:31.930: INFO: Created: latency-svc-bj9mq
+Mar 19 14:56:31.962: INFO: Got endpoints: latency-svc-rkbmh [749.52303ms]
+Mar 19 14:56:32.012: INFO: Got endpoints: latency-svc-5tn66 [748.611826ms]
+Mar 19 14:56:32.062: INFO: Got endpoints: latency-svc-fnbbz [750.797935ms]
+Mar 19 14:56:32.115: INFO: Got endpoints: latency-svc-xsftz [752.699943ms]
+Mar 19 14:56:32.162: INFO: Got endpoints: latency-svc-pngnm [738.540283ms]
+Mar 19 14:56:32.213: INFO: Got endpoints: latency-svc-jxjc2 [748.540726ms]
+Mar 19 14:56:32.273: INFO: Got endpoints: latency-svc-58bv4 [752.938445ms]
+Mar 19 14:56:32.314: INFO: Got endpoints: latency-svc-pjbxp [751.561438ms]
+Mar 19 14:56:32.362: INFO: Got endpoints: latency-svc-v6v5v [750.211532ms]
+Mar 19 14:56:32.413: INFO: Got endpoints: latency-svc-2z54c [750.064032ms]
+Mar 19 14:56:32.465: INFO: Got endpoints: latency-svc-f2tl8 [752.116741ms]
+Mar 19 14:56:32.512: INFO: Got endpoints: latency-svc-k8gc7 [744.774809ms]
+Mar 19 14:56:32.562: INFO: Got endpoints: latency-svc-wpnks [750.120632ms]
+Mar 19 14:56:32.612: INFO: Got endpoints: latency-svc-69rfx [741.695195ms]
+Mar 19 14:56:32.677: INFO: Got endpoints: latency-svc-bj9mq [765.583098ms]
+Mar 19 14:56:32.678: INFO: Latencies: [68.104616ms 68.331916ms 107.985342ms 153.642887ms 188.6143ms 196.264233ms 210.688496ms 220.250537ms 247.410655ms 254.8169ms 255.624004ms 257.912014ms 258.693417ms 259.841909ms 261.998432ms 266.711852ms 268.871961ms 275.58619ms 276.894096ms 279.451394ms 281.273015ms 282.212319ms 283.235123ms 285.311032ms 286.167537ms 288.178245ms 289.101049ms 289.869652ms 294.175171ms 294.216971ms 302.365906ms 303.14521ms 305.542819ms 306.207923ms 316.621068ms 316.661168ms 316.831269ms 318.001174ms 322.589494ms 322.619293ms 324.1706ms 326.025809ms 332.069135ms 332.715937ms 332.999739ms 333.097439ms 334.040743ms 335.348949ms 339.461866ms 351.717006ms 353.998994ms 361.98345ms 364.059472ms 365.212478ms 372.88661ms 373.935202ms 385.672153ms 393.504865ms 415.581494ms 480.450475ms 494.507635ms 517.808736ms 541.886241ms 543.969549ms 568.525355ms 594.557368ms 611.289338ms 624.182696ms 659.310745ms 687.950369ms 691.15118ms 700.160022ms 705.34874ms 706.976653ms 707.116953ms 708.191157ms 708.554958ms 711.343972ms 713.173677ms 719.899303ms 720.370807ms 721.011608ms 723.34462ms 724.827124ms 726.475531ms 728.563642ms 730.507454ms 730.669953ms 733.436366ms 734.508471ms 735.304773ms 735.654676ms 735.940478ms 737.182677ms 737.926085ms 738.540283ms 738.599087ms 738.770489ms 739.350191ms 739.503893ms 739.952295ms 740.731694ms 741.628796ms 741.695195ms 741.842398ms 744.502113ms 744.569614ms 744.774809ms 745.765418ms 746.132918ms 746.311522ms 747.187225ms 747.834123ms 747.893226ms 748.400929ms 748.487427ms 748.540726ms 748.611826ms 748.813129ms 748.84173ms 748.92673ms 749.176831ms 749.28333ms 749.345329ms 749.351329ms 749.436232ms 749.52303ms 749.615233ms 749.631633ms 749.697935ms 749.753235ms 749.778232ms 749.790836ms 749.846136ms 749.959934ms 750.064032ms 750.120632ms 750.129735ms 750.157635ms 750.211532ms 750.236637ms 750.382737ms 750.391236ms 750.576138ms 750.672737ms 750.679036ms 750.797935ms 751.254939ms 751.430939ms 751.491339ms 751.561438ms 752.116741ms 752.202945ms 752.218047ms 752.699943ms 752.938445ms 754.696152ms 754.922254ms 755.013858ms 755.03766ms 755.333259ms 758.207269ms 760.189778ms 761.294786ms 761.443186ms 761.741187ms 764.400698ms 764.904398ms 765.583098ms 768.870915ms 774.975641ms 778.585057ms 780.680671ms 785.476491ms 789.278704ms 789.848007ms 790.770113ms 791.518217ms 794.757727ms 804.021071ms 808.355387ms 835.182306ms 885.579726ms 888.224334ms 1.268468294s 1.32835384s 1.712344365s 2.03807091s 2.224230515s 2.230276839s 2.230644342s 2.235304762s 2.242337692s 2.256729054s 2.257431958s 2.258294561s 2.266404396s 2.291311603s 2.291907607s 2.294536318s]
+Mar 19 14:56:32.678: INFO: 50 %ile: 739.952295ms
+Mar 19 14:56:32.679: INFO: 90 %ile: 808.355387ms
+Mar 19 14:56:32.679: INFO: 99 %ile: 2.291907607s
+Mar 19 14:56:32.679: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:56:32.680: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-cpz9r" for this suite.
+Mar 19 14:56:46.717: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:56:46.846: INFO: namespace: e2e-tests-svc-latency-cpz9r, resource: bindings, ignored listing per whitelist
+Mar 19 14:56:46.846: INFO: namespace e2e-tests-svc-latency-cpz9r deletion completed in 14.154627295s
+
+• [SLOW TEST:26.247 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:56:46.847: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name cm-test-opt-del-bef66372-2b85-11e8-945a-764aeb95b32d
+STEP: Creating configMap with name cm-test-opt-upd-bef663dc-2b85-11e8-945a-764aeb95b32d
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-bef66372-2b85-11e8-945a-764aeb95b32d
+STEP: Updating configmap cm-test-opt-upd-bef663dc-2b85-11e8-945a-764aeb95b32d
+STEP: Creating configMap with name cm-test-opt-create-bef663f5-2b85-11e8-945a-764aeb95b32d
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:58:11.800: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-8wjfw" for this suite.
+Mar 19 14:58:33.814: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:58:33.937: INFO: namespace: e2e-tests-configmap-8wjfw, resource: bindings, ignored listing per whitelist
+Mar 19 14:58:33.952: INFO: namespace e2e-tests-configmap-8wjfw deletion completed in 22.149105063s
+
+• [SLOW TEST:107.106 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:58:33.953: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-fecbcc13-2b85-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 14:58:34.037: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-fecd5b2a-2b85-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-njvvv" to be "success or failure"
+Mar 19 14:58:34.046: INFO: Pod "pod-projected-configmaps-fecd5b2a-2b85-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 8.687833ms
+Mar 19 14:58:36.049: INFO: Pod "pod-projected-configmaps-fecd5b2a-2b85-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011728637s
+STEP: Saw pod success
+Mar 19 14:58:36.049: INFO: Pod "pod-projected-configmaps-fecd5b2a-2b85-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:58:36.051: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-configmaps-fecd5b2a-2b85-11e8-945a-764aeb95b32d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 14:58:39.065: INFO: Waiting for pod pod-projected-configmaps-fecd5b2a-2b85-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:58:39.092: INFO: Pod pod-projected-configmaps-fecd5b2a-2b85-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:58:39.093: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-njvvv" for this suite.
+Mar 19 14:58:45.110: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:58:45.178: INFO: namespace: e2e-tests-projected-njvvv, resource: bindings, ignored listing per whitelist
+Mar 19 14:58:45.251: INFO: namespace e2e-tests-projected-njvvv deletion completed in 6.153311606s
+
+• [SLOW TEST:11.299 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:58:45.256: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-54b9p in namespace e2e-tests-proxy-nxlms
+I0319 14:58:45.351390      14 runners.go:178] Created replication controller with name: proxy-service-54b9p, namespace: e2e-tests-proxy-nxlms, replica count: 1
+I0319 14:58:46.351642      14 runners.go:178] proxy-service-54b9p Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0319 14:58:47.351883      14 runners.go:178] proxy-service-54b9p Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0319 14:58:48.352052      14 runners.go:178] proxy-service-54b9p Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0319 14:58:49.352299      14 runners.go:178] proxy-service-54b9p Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0319 14:58:50.352509      14 runners.go:178] proxy-service-54b9p Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0319 14:58:51.352844      14 runners.go:178] proxy-service-54b9p Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0319 14:58:52.353046      14 runners.go:178] proxy-service-54b9p Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0319 14:58:53.353262      14 runners.go:178] proxy-service-54b9p Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0319 14:58:54.353487      14 runners.go:178] proxy-service-54b9p Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0319 14:58:55.353700      14 runners.go:178] proxy-service-54b9p Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Mar 19 14:58:55.356: INFO: setup took 10.038960363s, starting test cases
+STEP: running 34 cases, 20 attempts per case, 680 total attempts
+Mar 19 14:58:55.371: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 14.546153ms)
+Mar 19 14:58:55.371: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 14.962654ms)
+Mar 19 14:58:55.371: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 13.976851ms)
+Mar 19 14:58:55.371: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 14.360852ms)
+Mar 19 14:58:55.376: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 19.53617ms)
+Mar 19 14:58:55.376: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 20.223072ms)
+Mar 19 14:58:55.376: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 19.857571ms)
+Mar 19 14:58:55.379: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 22.713382ms)
+Mar 19 14:58:55.380: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 24.046687ms)
+Mar 19 14:58:55.380: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 23.811886ms)
+Mar 19 14:58:55.383: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 26.486695ms)
+Mar 19 14:58:55.383: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 26.662196ms)
+Mar 19 14:58:55.383: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 26.502796ms)
+Mar 19 14:58:55.383: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 26.787197ms)
+Mar 19 14:58:55.383: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 26.482396ms)
+Mar 19 14:58:55.383: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 26.732397ms)
+Mar 19 14:58:55.391: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 34.279024ms)
+Mar 19 14:58:55.391: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 34.164923ms)
+Mar 19 14:58:55.391: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 34.265923ms)
+Mar 19 14:58:55.394: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 37.153033ms)
+Mar 19 14:58:55.396: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 39.431642ms)
+Mar 19 14:58:55.396: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 39.438742ms)
+Mar 19 14:58:55.396: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 39.035541ms)
+Mar 19 14:58:55.397: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 40.270845ms)
+Mar 19 14:58:55.397: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 40.019244ms)
+Mar 19 14:58:55.397: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 40.259345ms)
+Mar 19 14:58:55.397: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 40.278145ms)
+Mar 19 14:58:55.397: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 40.514146ms)
+Mar 19 14:58:55.398: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 41.63135ms)
+Mar 19 14:58:55.398: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 41.62375ms)
+Mar 19 14:58:55.398: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 41.57965ms)
+Mar 19 14:58:55.398: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 41.72985ms)
+Mar 19 14:58:55.399: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 41.72225ms)
+Mar 19 14:58:55.402: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 45.276163ms)
+Mar 19 14:58:55.414: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 11.431541ms)
+Mar 19 14:58:55.414: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 11.12274ms)
+Mar 19 14:58:55.414: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 11.518542ms)
+Mar 19 14:58:55.414: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 10.229537ms)
+Mar 19 14:58:55.415: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 11.583741ms)
+Mar 19 14:58:55.415: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 11.545042ms)
+Mar 19 14:58:55.415: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 12.140144ms)
+Mar 19 14:58:55.416: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 12.659346ms)
+Mar 19 14:58:55.416: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 12.810646ms)
+Mar 19 14:58:55.416: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 13.253948ms)
+Mar 19 14:58:55.417: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 13.88835ms)
+Mar 19 14:58:55.417: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 14.261652ms)
+Mar 19 14:58:55.418: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 14.647853ms)
+Mar 19 14:58:55.419: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 15.313055ms)
+Mar 19 14:58:55.419: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 14.597352ms)
+Mar 19 14:58:55.419: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 14.752253ms)
+Mar 19 14:58:55.419: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 15.017854ms)
+Mar 19 14:58:55.419: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 14.833753ms)
+Mar 19 14:58:55.419: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 15.323156ms)
+Mar 19 14:58:55.419: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 16.089858ms)
+Mar 19 14:58:55.420: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 15.816757ms)
+Mar 19 14:58:55.420: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 16.791461ms)
+Mar 19 14:58:55.420: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 16.348759ms)
+Mar 19 14:58:55.420: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 16.67456ms)
+Mar 19 14:58:55.420: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 16.69126ms)
+Mar 19 14:58:55.421: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 16.529759ms)
+Mar 19 14:58:55.421: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 17.189362ms)
+Mar 19 14:58:55.421: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 18.133966ms)
+Mar 19 14:58:55.422: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 17.965564ms)
+Mar 19 14:58:55.422: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 18.114365ms)
+Mar 19 14:58:55.422: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 18.512866ms)
+Mar 19 14:58:55.423: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 18.487067ms)
+Mar 19 14:58:55.423: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 19.17787ms)
+Mar 19 14:58:55.423: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 19.017869ms)
+Mar 19 14:58:55.435: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 11.13304ms)
+Mar 19 14:58:55.435: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 11.383741ms)
+Mar 19 14:58:55.435: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 10.97434ms)
+Mar 19 14:58:55.435: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 11.09614ms)
+Mar 19 14:58:55.435: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 11.786143ms)
+Mar 19 14:58:55.435: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 11.02104ms)
+Mar 19 14:58:55.436: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 12.290044ms)
+Mar 19 14:58:55.436: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 12.281144ms)
+Mar 19 14:58:55.437: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 12.275444ms)
+Mar 19 14:58:55.437: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 12.518145ms)
+Mar 19 14:58:55.437: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 12.657146ms)
+Mar 19 14:58:55.437: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 11.948643ms)
+Mar 19 14:58:55.437: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 13.222748ms)
+Mar 19 14:58:55.437: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 13.218548ms)
+Mar 19 14:58:55.439: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 14.557153ms)
+Mar 19 14:58:55.439: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 14.113151ms)
+Mar 19 14:58:55.439: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 14.587053ms)
+Mar 19 14:58:55.439: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 14.541852ms)
+Mar 19 14:58:55.440: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 15.568956ms)
+Mar 19 14:58:55.440: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 15.080754ms)
+Mar 19 14:58:55.440: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 15.160555ms)
+Mar 19 14:58:55.440: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 15.357056ms)
+Mar 19 14:58:55.440: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 15.668856ms)
+Mar 19 14:58:55.441: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 15.931957ms)
+Mar 19 14:58:55.441: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 16.165158ms)
+Mar 19 14:58:55.441: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 16.66396ms)
+Mar 19 14:58:55.441: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 16.988861ms)
+Mar 19 14:58:55.441: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 16.126758ms)
+Mar 19 14:58:55.442: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 17.872765ms)
+Mar 19 14:58:55.442: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 17.695263ms)
+Mar 19 14:58:55.442: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 17.519463ms)
+Mar 19 14:58:55.442: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 17.809664ms)
+Mar 19 14:58:55.442: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 17.658663ms)
+Mar 19 14:58:55.442: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 17.783564ms)
+Mar 19 14:58:55.452: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 8.830331ms)
+Mar 19 14:58:55.458: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 15.320055ms)
+Mar 19 14:58:55.459: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 14.956154ms)
+Mar 19 14:58:55.459: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 15.951558ms)
+Mar 19 14:58:55.461: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 17.265962ms)
+Mar 19 14:58:55.461: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 17.445463ms)
+Mar 19 14:58:55.461: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 18.140365ms)
+Mar 19 14:58:55.461: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 17.613264ms)
+Mar 19 14:58:55.461: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 17.642964ms)
+Mar 19 14:58:55.462: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 17.871664ms)
+Mar 19 14:58:55.462: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 18.919268ms)
+Mar 19 14:58:55.463: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 19.055369ms)
+Mar 19 14:58:55.463: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 19.634571ms)
+Mar 19 14:58:55.463: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 19.249969ms)
+Mar 19 14:58:55.463: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 18.977969ms)
+Mar 19 14:58:55.463: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 19.271769ms)
+Mar 19 14:58:55.463: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 19.977372ms)
+Mar 19 14:58:55.463: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 19.646271ms)
+Mar 19 14:58:55.464: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 20.072472ms)
+Mar 19 14:58:55.464: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 20.286473ms)
+Mar 19 14:58:55.464: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 20.247573ms)
+Mar 19 14:58:55.464: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 20.551474ms)
+Mar 19 14:58:55.464: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 20.765875ms)
+Mar 19 14:58:55.469: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 24.918689ms)
+Mar 19 14:58:55.470: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 26.054794ms)
+Mar 19 14:58:55.470: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 25.794093ms)
+Mar 19 14:58:55.470: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 26.020894ms)
+Mar 19 14:58:55.471: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 26.852296ms)
+Mar 19 14:58:55.471: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 27.403898ms)
+Mar 19 14:58:55.471: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 27.8326ms)
+Mar 19 14:58:55.472: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 27.906ms)
+Mar 19 14:58:55.472: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 29.003504ms)
+Mar 19 14:58:55.474: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 30.239709ms)
+Mar 19 14:58:55.474: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 30.512309ms)
+Mar 19 14:58:55.484: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 9.579035ms)
+Mar 19 14:58:55.484: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 8.43053ms)
+Mar 19 14:58:55.484: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 8.860131ms)
+Mar 19 14:58:55.484: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 9.060632ms)
+Mar 19 14:58:55.485: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 9.977136ms)
+Mar 19 14:58:55.485: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 9.294834ms)
+Mar 19 14:58:55.485: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 10.456638ms)
+Mar 19 14:58:55.486: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 10.154437ms)
+Mar 19 14:58:55.487: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 12.021543ms)
+Mar 19 14:58:55.487: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 12.424645ms)
+Mar 19 14:58:55.487: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 12.820946ms)
+Mar 19 14:58:55.488: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 11.17584ms)
+Mar 19 14:58:55.488: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 13.092547ms)
+Mar 19 14:58:55.488: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 13.094447ms)
+Mar 19 14:58:58.583: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 3.106779187s)
+Mar 19 14:58:58.583: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 3.107246788s)
+Mar 19 14:58:58.583: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 3.107297789s)
+Mar 19 14:58:58.595: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 3.118500028s)
+Mar 19 14:58:58.620: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 3.145705027s)
+Mar 19 14:58:58.620: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 3.144587123s)
+Mar 19 14:58:58.621: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 3.144433723s)
+Mar 19 14:58:58.621: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 3.144917624s)
+Mar 19 14:58:58.621: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 3.145588426s)
+Mar 19 14:58:58.621: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 3.144639623s)
+Mar 19 14:58:58.621: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 3.144130021s)
+Mar 19 14:58:58.621: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 3.144818923s)
+Mar 19 14:58:58.621: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 3.144522722s)
+Mar 19 14:58:58.621: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 3.144125621s)
+Mar 19 14:58:58.621: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 3.146663631s)
+Mar 19 14:58:58.621: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 3.144454922s)
+Mar 19 14:58:58.621: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 3.144822224s)
+Mar 19 14:58:58.622: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 3.14659063s)
+Mar 19 14:58:58.622: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 3.146229528s)
+Mar 19 14:58:58.649: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 3.172939124s)
+Mar 19 14:58:58.656: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 7.366427ms)
+Mar 19 14:58:58.657: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 8.023228ms)
+Mar 19 14:58:58.657: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 7.530627ms)
+Mar 19 14:58:58.657: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 7.846028ms)
+Mar 19 14:58:58.657: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 8.20773ms)
+Mar 19 14:58:58.658: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 8.600731ms)
+Mar 19 14:58:58.658: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 9.015632ms)
+Mar 19 14:58:58.659: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 8.841631ms)
+Mar 19 14:58:58.660: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 10.068136ms)
+Mar 19 14:58:58.660: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 10.134436ms)
+Mar 19 14:58:58.663: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 13.579749ms)
+Mar 19 14:58:58.664: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 13.968151ms)
+Mar 19 14:58:58.665: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 14.996954ms)
+Mar 19 14:58:58.665: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 15.126854ms)
+Mar 19 14:58:58.665: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 16.116258ms)
+Mar 19 14:58:58.666: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 15.776857ms)
+Mar 19 14:58:58.666: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 15.832557ms)
+Mar 19 14:58:58.666: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 15.749756ms)
+Mar 19 14:58:58.666: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 16.44136ms)
+Mar 19 14:58:58.666: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 16.388459ms)
+Mar 19 14:58:58.666: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 15.910057ms)
+Mar 19 14:58:58.667: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 16.74876ms)
+Mar 19 14:58:58.667: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 17.329763ms)
+Mar 19 14:58:58.667: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 17.385862ms)
+Mar 19 14:58:58.667: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 17.392862ms)
+Mar 19 14:58:58.667: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 17.816864ms)
+Mar 19 14:58:58.667: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 18.113565ms)
+Mar 19 14:58:58.667: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 17.934964ms)
+Mar 19 14:58:58.668: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 18.509567ms)
+Mar 19 14:58:58.669: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 18.934868ms)
+Mar 19 14:58:58.669: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 19.28097ms)
+Mar 19 14:58:58.669: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 19.918271ms)
+Mar 19 14:58:58.669: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 19.922571ms)
+Mar 19 14:58:58.669: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 19.781972ms)
+Mar 19 14:58:58.678: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 7.979229ms)
+Mar 19 14:58:58.678: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 7.829328ms)
+Mar 19 14:58:58.678: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 7.311726ms)
+Mar 19 14:58:58.679: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 8.726732ms)
+Mar 19 14:58:58.679: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 9.372034ms)
+Mar 19 14:58:58.679: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 8.14913ms)
+Mar 19 14:58:58.679: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 8.296229ms)
+Mar 19 14:58:58.679: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 9.533234ms)
+Mar 19 14:58:58.680: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 7.494927ms)
+Mar 19 14:58:58.680: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 8.41483ms)
+Mar 19 14:58:58.680: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 9.825035ms)
+Mar 19 14:58:58.680: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 9.178133ms)
+Mar 19 14:58:58.680: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 8.284329ms)
+Mar 19 14:58:58.685: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 14.242651ms)
+Mar 19 14:58:58.685: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 14.747653ms)
+Mar 19 14:58:58.685: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 13.492748ms)
+Mar 19 14:58:58.686: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 16.925261ms)
+Mar 19 14:58:58.686: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 14.357952ms)
+Mar 19 14:58:58.686: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 14.599653ms)
+Mar 19 14:58:58.687: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 14.694553ms)
+Mar 19 14:58:58.687: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 15.255455ms)
+Mar 19 14:58:58.687: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 15.384055ms)
+Mar 19 14:58:58.687: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 15.739257ms)
+Mar 19 14:58:58.687: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 16.62286ms)
+Mar 19 14:58:58.687: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 15.057954ms)
+Mar 19 14:58:58.687: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 15.978958ms)
+Mar 19 14:58:58.687: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 16.75686ms)
+Mar 19 14:58:58.687: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 14.848653ms)
+Mar 19 14:58:58.687: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 15.101654ms)
+Mar 19 14:58:58.688: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 16.199858ms)
+Mar 19 14:58:58.688: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 17.213062ms)
+Mar 19 14:58:58.688: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 16.72006ms)
+Mar 19 14:58:58.690: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 18.065165ms)
+Mar 19 14:58:58.690: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 17.533764ms)
+Mar 19 14:58:58.699: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 9.075833ms)
+Mar 19 14:58:58.700: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 9.863835ms)
+Mar 19 14:58:58.700: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 10.518438ms)
+Mar 19 14:58:58.700: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 10.448337ms)
+Mar 19 14:58:58.701: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 11.238841ms)
+Mar 19 14:58:58.701: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 11.313041ms)
+Mar 19 14:58:58.702: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 11.018739ms)
+Mar 19 14:58:58.702: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 11.04954ms)
+Mar 19 14:58:58.702: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 11.182541ms)
+Mar 19 14:58:58.702: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 11.735142ms)
+Mar 19 14:58:58.702: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 11.539242ms)
+Mar 19 14:58:58.703: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 11.829443ms)
+Mar 19 14:58:58.710: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 20.093273ms)
+Mar 19 14:58:58.710: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 19.47107ms)
+Mar 19 14:58:58.710: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 19.938771ms)
+Mar 19 14:58:58.711: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 20.210773ms)
+Mar 19 14:58:58.711: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 20.324173ms)
+Mar 19 14:58:58.711: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 20.444373ms)
+Mar 19 14:58:58.711: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 20.465374ms)
+Mar 19 14:58:58.712: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 21.681178ms)
+Mar 19 14:58:58.713: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 22.19388ms)
+Mar 19 14:58:58.713: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 22.572181ms)
+Mar 19 14:58:58.713: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 21.726378ms)
+Mar 19 14:58:58.713: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 22.583782ms)
+Mar 19 14:58:58.713: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 22.13758ms)
+Mar 19 14:58:58.713: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 22.367881ms)
+Mar 19 14:58:58.713: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 22.911283ms)
+Mar 19 14:58:58.714: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 22.968383ms)
+Mar 19 14:58:58.714: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 23.352384ms)
+Mar 19 14:58:58.714: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 23.199583ms)
+Mar 19 14:58:58.714: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 23.526784ms)
+Mar 19 14:58:58.714: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 23.551585ms)
+Mar 19 14:58:58.714: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 24.260187ms)
+Mar 19 14:58:58.715: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 24.088587ms)
+Mar 19 14:58:58.722: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 7.430327ms)
+Mar 19 14:58:58.725: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 9.087033ms)
+Mar 19 14:58:58.725: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 10.082536ms)
+Mar 19 14:58:58.725: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 10.066837ms)
+Mar 19 14:58:58.726: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 10.412238ms)
+Mar 19 14:58:58.726: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 10.96924ms)
+Mar 19 14:58:58.727: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 10.99014ms)
+Mar 19 14:58:58.727: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 11.933443ms)
+Mar 19 14:58:58.727: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 11.16914ms)
+Mar 19 14:58:58.727: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 11.550042ms)
+Mar 19 14:58:58.727: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 11.261241ms)
+Mar 19 14:58:58.727: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 12.655946ms)
+Mar 19 14:58:58.727: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 12.538045ms)
+Mar 19 14:58:58.727: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 11.29134ms)
+Mar 19 14:58:58.728: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 11.622442ms)
+Mar 19 14:58:58.728: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 12.024244ms)
+Mar 19 14:58:58.728: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 11.689042ms)
+Mar 19 14:58:58.728: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 11.676742ms)
+Mar 19 14:58:58.728: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 11.658742ms)
+Mar 19 14:58:58.728: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 12.229944ms)
+Mar 19 14:58:58.728: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 11.870843ms)
+Mar 19 14:58:58.730: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 14.225751ms)
+Mar 19 14:58:58.730: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 15.001254ms)
+Mar 19 14:58:58.730: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 14.174251ms)
+Mar 19 14:58:58.730: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 14.415652ms)
+Mar 19 14:58:58.730: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 14.898254ms)
+Mar 19 14:58:58.730: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 14.293252ms)
+Mar 19 14:58:58.730: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 14.491352ms)
+Mar 19 14:58:58.730: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 14.477152ms)
+Mar 19 14:58:58.730: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 14.550252ms)
+Mar 19 14:58:58.730: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 14.486052ms)
+Mar 19 14:58:58.731: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 15.062755ms)
+Mar 19 14:58:58.731: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 15.574356ms)
+Mar 19 14:58:58.731: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 15.600856ms)
+Mar 19 14:58:58.737: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 4.575216ms)
+Mar 19 14:58:58.738: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 5.66172ms)
+Mar 19 14:58:58.738: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 5.744521ms)
+Mar 19 14:58:58.738: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 6.426123ms)
+Mar 19 14:58:58.739: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 7.228626ms)
+Mar 19 14:58:58.739: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 7.232826ms)
+Mar 19 14:58:58.741: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 8.47233ms)
+Mar 19 14:58:58.743: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 10.663738ms)
+Mar 19 14:58:58.750: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 17.032862ms)
+Mar 19 14:58:58.759: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 26.245394ms)
+Mar 19 14:58:58.759: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 26.044094ms)
+Mar 19 14:58:58.760: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 28.070001ms)
+Mar 19 14:58:58.760: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 26.942097ms)
+Mar 19 14:58:58.760: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 27.6799ms)
+Mar 19 14:58:58.760: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 28.119501ms)
+Mar 19 14:58:58.762: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 27.8379ms)
+Mar 19 14:58:58.762: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 27.964901ms)
+Mar 19 14:58:58.763: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 29.013605ms)
+Mar 19 14:58:58.764: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 30.64501ms)
+Mar 19 14:58:58.766: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 32.954919ms)
+Mar 19 14:58:58.768: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 33.919722ms)
+Mar 19 14:58:58.771: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 37.608735ms)
+Mar 19 14:58:58.774: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 41.92355ms)
+Mar 19 14:58:58.774: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 39.957344ms)
+Mar 19 14:58:58.774: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 40.805647ms)
+Mar 19 14:58:58.780: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 45.647964ms)
+Mar 19 14:58:58.780: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 45.968166ms)
+Mar 19 14:58:58.780: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 45.830365ms)
+Mar 19 14:58:58.780: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 45.900165ms)
+Mar 19 14:58:58.780: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 45.932965ms)
+Mar 19 14:58:58.780: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 46.003066ms)
+Mar 19 14:58:58.780: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 46.124166ms)
+Mar 19 14:58:58.780: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 45.950765ms)
+Mar 19 14:58:58.780: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 45.873265ms)
+Mar 19 14:58:58.786: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 5.209118ms)
+Mar 19 14:58:58.796: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 14.480352ms)
+Mar 19 14:58:58.799: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 17.455163ms)
+Mar 19 14:58:58.801: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 20.467874ms)
+Mar 19 14:58:58.802: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 20.307373ms)
+Mar 19 14:58:58.803: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 22.012879ms)
+Mar 19 14:58:58.803: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 21.820779ms)
+Mar 19 14:58:58.805: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 22.781382ms)
+Mar 19 14:59:05.212: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 6.429833241s)
+Mar 19 14:59:05.212: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 6.430281843s)
+Mar 19 14:59:05.212: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 6.430467143s)
+Mar 19 14:59:05.212: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 6.430353343s)
+Mar 19 14:59:05.212: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 6.430469244s)
+Mar 19 14:59:05.212: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 6.430576844s)
+Mar 19 14:59:05.212: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 6.431142246s)
+Mar 19 14:59:05.213: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 6.431594447s)
+Mar 19 14:59:05.214: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 6.433188853s)
+Mar 19 14:59:05.214: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 6.43239765s)
+Mar 19 14:59:05.214: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 6.432411351s)
+Mar 19 14:59:05.215: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 6.432825251s)
+Mar 19 14:59:05.215: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 6.432664052s)
+Mar 19 14:59:05.215: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 6.433092153s)
+Mar 19 14:59:05.216: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 6.434620058s)
+Mar 19 14:59:05.217: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 6.43517656s)
+Mar 19 14:59:05.217: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 6.435277361s)
+Mar 19 14:59:05.254: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 6.472257194s)
+Mar 19 14:59:05.276: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 6.494843075s)
+Mar 19 14:59:05.298: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 6.516389852s)
+Mar 19 14:59:05.298: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 6.516730554s)
+Mar 19 14:59:05.298: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 6.516341653s)
+Mar 19 14:59:05.299: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 6.516965354s)
+Mar 19 14:59:05.299: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 6.516653053s)
+Mar 19 14:59:05.299: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 6.517180355s)
+Mar 19 14:59:05.299: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 6.517036855s)
+Mar 19 14:59:05.304: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 5.061118ms)
+Mar 19 14:59:05.305: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 5.995721ms)
+Mar 19 14:59:05.306: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 6.285323ms)
+Mar 19 14:59:05.307: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 7.642127ms)
+Mar 19 14:59:05.307: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 7.276226ms)
+Mar 19 14:59:05.308: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 8.778832ms)
+Mar 19 14:59:05.308: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 8.32033ms)
+Mar 19 14:59:05.308: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 8.960332ms)
+Mar 19 14:59:05.309: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 9.296334ms)
+Mar 19 14:59:05.309: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 10.018936ms)
+Mar 19 14:59:05.313: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 12.737746ms)
+Mar 19 14:59:05.313: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 12.879046ms)
+Mar 19 14:59:05.313: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 12.888146ms)
+Mar 19 14:59:05.313: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 13.531249ms)
+Mar 19 14:59:05.313: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 13.599649ms)
+Mar 19 14:59:05.313: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 13.600749ms)
+Mar 19 14:59:05.313: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 13.303448ms)
+Mar 19 14:59:05.313: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 13.424549ms)
+Mar 19 14:59:05.313: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 13.97765ms)
+Mar 19 14:59:05.313: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 13.65105ms)
+Mar 19 14:59:05.314: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 15.189054ms)
+Mar 19 14:59:05.315: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 14.621453ms)
+Mar 19 14:59:05.315: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 14.706753ms)
+Mar 19 14:59:05.315: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 14.868954ms)
+Mar 19 14:59:05.315: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 14.779753ms)
+Mar 19 14:59:05.315: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 15.285155ms)
+Mar 19 14:59:05.316: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 15.918757ms)
+Mar 19 14:59:05.316: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 16.784461ms)
+Mar 19 14:59:05.316: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 16.713161ms)
+Mar 19 14:59:05.316: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 16.57716ms)
+Mar 19 14:59:05.316: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 16.69466ms)
+Mar 19 14:59:05.316: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 16.633459ms)
+Mar 19 14:59:05.317: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 17.281462ms)
+Mar 19 14:59:05.317: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 16.72206ms)
+Mar 19 14:59:05.325: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 7.034825ms)
+Mar 19 14:59:05.325: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 7.483427ms)
+Mar 19 14:59:05.325: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 7.644727ms)
+Mar 19 14:59:05.325: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 8.077729ms)
+Mar 19 14:59:05.326: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 8.41903ms)
+Mar 19 14:59:05.326: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 9.437034ms)
+Mar 19 14:59:05.327: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 8.32123ms)
+Mar 19 14:59:05.327: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 8.25373ms)
+Mar 19 14:59:05.327: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 9.263833ms)
+Mar 19 14:59:05.327: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 9.066432ms)
+Mar 19 14:59:05.328: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 9.435934ms)
+Mar 19 14:59:05.328: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 9.263934ms)
+Mar 19 14:59:05.330: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 11.827442ms)
+Mar 19 14:59:05.330: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 11.862143ms)
+Mar 19 14:59:05.330: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 11.852043ms)
+Mar 19 14:59:05.331: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 12.523645ms)
+Mar 19 14:59:05.331: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 12.903547ms)
+Mar 19 14:59:05.331: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 12.725246ms)
+Mar 19 14:59:05.331: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 12.737746ms)
+Mar 19 14:59:05.332: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 13.353648ms)
+Mar 19 14:59:05.333: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 14.830953ms)
+Mar 19 14:59:05.333: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 15.414755ms)
+Mar 19 14:59:05.333: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 14.997554ms)
+Mar 19 14:59:05.335: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 17.207062ms)
+Mar 19 14:59:05.335: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 16.77856ms)
+Mar 19 14:59:05.335: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 17.204061ms)
+Mar 19 14:59:05.335: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 17.266262ms)
+Mar 19 14:59:05.336: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 17.771664ms)
+Mar 19 14:59:05.336: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 18.255565ms)
+Mar 19 14:59:05.336: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 18.347666ms)
+Mar 19 14:59:05.337: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 18.195066ms)
+Mar 19 14:59:05.337: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 18.637967ms)
+Mar 19 14:59:05.337: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 18.235366ms)
+Mar 19 14:59:05.337: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 18.595067ms)
+Mar 19 14:59:05.343: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 5.706621ms)
+Mar 19 14:59:05.343: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 6.225323ms)
+Mar 19 14:59:05.348: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 10.765738ms)
+Mar 19 14:59:05.348: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 10.595939ms)
+Mar 19 14:59:05.348: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 11.33434ms)
+Mar 19 14:59:05.349: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 11.844142ms)
+Mar 19 14:59:05.352: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 15.313555ms)
+Mar 19 14:59:05.354: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 16.370859ms)
+Mar 19 14:59:05.354: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 16.71316ms)
+Mar 19 14:59:05.355: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 16.89246ms)
+Mar 19 14:59:05.355: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 17.660064ms)
+Mar 19 14:59:05.355: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 17.144162ms)
+Mar 19 14:59:05.355: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 17.762764ms)
+Mar 19 14:59:05.355: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 17.874965ms)
+Mar 19 14:59:05.356: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 18.119565ms)
+Mar 19 14:59:05.356: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 18.597467ms)
+Mar 19 14:59:05.356: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 17.664164ms)
+Mar 19 14:59:05.356: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 18.349266ms)
+Mar 19 14:59:05.356: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 17.588063ms)
+Mar 19 14:59:05.356: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 18.383666ms)
+Mar 19 14:59:05.356: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 18.496067ms)
+Mar 19 14:59:05.357: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 19.139869ms)
+Mar 19 14:59:05.357: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 18.552467ms)
+Mar 19 14:59:05.357: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 19.798571ms)
+Mar 19 14:59:05.358: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 19.188769ms)
+Mar 19 14:59:05.358: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 19.293769ms)
+Mar 19 14:59:05.358: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 19.48137ms)
+Mar 19 14:59:05.358: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 19.68037ms)
+Mar 19 14:59:05.358: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 19.777071ms)
+Mar 19 14:59:05.358: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 20.070972ms)
+Mar 19 14:59:05.358: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 19.771271ms)
+Mar 19 14:59:05.358: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 20.499074ms)
+Mar 19 14:59:05.359: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 20.671774ms)
+Mar 19 14:59:05.359: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 20.998976ms)
+Mar 19 14:59:05.368: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 8.560031ms)
+Mar 19 14:59:05.369: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 9.446134ms)
+Mar 19 14:59:05.369: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 9.388534ms)
+Mar 19 14:59:05.369: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 9.224733ms)
+Mar 19 14:59:05.369: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 9.295733ms)
+Mar 19 14:59:05.369: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 9.061333ms)
+Mar 19 14:59:05.369: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 9.586834ms)
+Mar 19 14:59:05.369: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 9.571034ms)
+Mar 19 14:59:05.371: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 11.807043ms)
+Mar 19 14:59:05.371: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 11.305441ms)
+Mar 19 14:59:05.371: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 11.540442ms)
+Mar 19 14:59:05.371: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 12.080144ms)
+Mar 19 14:59:05.372: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 11.934443ms)
+Mar 19 14:59:05.372: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 11.786443ms)
+Mar 19 14:59:05.372: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 12.657746ms)
+Mar 19 14:59:05.372: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 12.389945ms)
+Mar 19 14:59:05.372: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 12.292944ms)
+Mar 19 14:59:05.372: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 11.899543ms)
+Mar 19 14:59:05.372: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 12.502545ms)
+Mar 19 14:59:05.372: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 12.412544ms)
+Mar 19 14:59:05.372: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 12.412845ms)
+Mar 19 14:59:05.373: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 12.706945ms)
+Mar 19 14:59:05.373: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 12.596346ms)
+Mar 19 14:59:05.373: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 12.704646ms)
+Mar 19 14:59:05.373: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 13.241048ms)
+Mar 19 14:59:05.373: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 13.362448ms)
+Mar 19 14:59:05.376: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 15.932557ms)
+Mar 19 14:59:05.376: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 17.388762ms)
+Mar 19 14:59:05.377: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 17.142062ms)
+Mar 19 14:59:05.377: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 17.205462ms)
+Mar 19 14:59:05.377: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 16.877661ms)
+Mar 19 14:59:05.377: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 16.62666ms)
+Mar 19 14:59:05.377: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 16.855161ms)
+Mar 19 14:59:05.377: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 17.052161ms)
+Mar 19 14:59:05.384: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 7.020626ms)
+Mar 19 14:59:05.384: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 6.664624ms)
+Mar 19 14:59:05.385: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 6.519224ms)
+Mar 19 14:59:05.385: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 6.890425ms)
+Mar 19 14:59:05.385: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 7.512727ms)
+Mar 19 14:59:05.385: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 6.811125ms)
+Mar 19 14:59:05.385: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 6.560124ms)
+Mar 19 14:59:05.386: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 8.16053ms)
+Mar 19 14:59:05.386: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 7.129726ms)
+Mar 19 14:59:05.386: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 7.762928ms)
+Mar 19 14:59:05.387: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 8.35223ms)
+Mar 19 14:59:05.390: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 11.504441ms)
+Mar 19 14:59:05.391: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 11.624242ms)
+Mar 19 14:59:05.391: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 12.201544ms)
+Mar 19 14:59:05.391: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 11.900043ms)
+Mar 19 14:59:05.391: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 12.537545ms)
+Mar 19 14:59:05.392: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 12.631046ms)
+Mar 19 14:59:05.392: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 12.655746ms)
+Mar 19 14:59:05.393: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 13.95765ms)
+Mar 19 14:59:05.393: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 14.302851ms)
+Mar 19 14:59:05.393: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 14.099851ms)
+Mar 19 14:59:05.393: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 14.049351ms)
+Mar 19 14:59:05.393: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 14.522253ms)
+Mar 19 14:59:05.393: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 14.219651ms)
+Mar 19 14:59:05.394: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 15.008054ms)
+Mar 19 14:59:05.395: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 15.711356ms)
+Mar 19 14:59:05.395: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 15.853257ms)
+Mar 19 14:59:05.395: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 15.818857ms)
+Mar 19 14:59:05.395: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 15.788157ms)
+Mar 19 14:59:05.395: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 16.239659ms)
+Mar 19 14:59:05.395: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 16.204658ms)
+Mar 19 14:59:05.395: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 15.927457ms)
+Mar 19 14:59:05.395: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 17.238162ms)
+Mar 19 14:59:05.395: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 16.002758ms)
+Mar 19 14:59:05.405: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 9.388234ms)
+Mar 19 14:59:05.405: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 8.756631ms)
+Mar 19 14:59:05.405: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 8.952533ms)
+Mar 19 14:59:05.405: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 9.698235ms)
+Mar 19 14:59:05.406: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 9.952936ms)
+Mar 19 14:59:05.410: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 12.984847ms)
+Mar 19 14:59:05.410: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 14.612052ms)
+Mar 19 14:59:05.411: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 14.09735ms)
+Mar 19 14:59:05.411: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 15.140754ms)
+Mar 19 14:59:05.411: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 14.370752ms)
+Mar 19 14:59:05.411: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 14.760453ms)
+Mar 19 14:59:05.411: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 14.763553ms)
+Mar 19 14:59:05.412: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 15.556656ms)
+Mar 19 14:59:05.412: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 15.103155ms)
+Mar 19 14:59:05.412: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 16.245158ms)
+Mar 19 14:59:05.412: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 16.062157ms)
+Mar 19 14:59:05.413: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 16.251059ms)
+Mar 19 14:59:05.413: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 16.65966ms)
+Mar 19 14:59:05.413: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 17.005361ms)
+Mar 19 14:59:05.413: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 16.330659ms)
+Mar 19 14:59:05.413: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 17.556763ms)
+Mar 19 14:59:05.416: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 19.976072ms)
+Mar 19 14:59:05.416: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 20.123772ms)
+Mar 19 14:59:05.417: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 20.199772ms)
+Mar 19 14:59:05.417: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 20.425074ms)
+Mar 19 14:59:05.417: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 20.829275ms)
+Mar 19 14:59:05.417: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 20.412074ms)
+Mar 19 14:59:05.417: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 20.232772ms)
+Mar 19 14:59:05.417: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 20.577074ms)
+Mar 19 14:59:05.417: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 21.328276ms)
+Mar 19 14:59:05.417: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 21.377877ms)
+Mar 19 14:59:05.418: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 21.402177ms)
+Mar 19 14:59:05.418: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 21.208077ms)
+Mar 19 14:59:05.418: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 21.012175ms)
+Mar 19 14:59:05.430: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 11.841642ms)
+Mar 19 14:59:05.431: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 12.460345ms)
+Mar 19 14:59:05.431: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 12.243244ms)
+Mar 19 14:59:05.431: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 13.155147ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 12.646346ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 13.350048ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 13.279548ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 12.997947ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 13.577149ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 11.873543ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 13.193147ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 12.838746ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 11.779342ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 11.354441ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 12.431545ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 11.561541ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 12.942446ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 10.911739ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 12.343144ms)
+Mar 19 14:59:05.432: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 11.21874ms)
+Mar 19 14:59:05.433: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 12.519146ms)
+Mar 19 14:59:05.433: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 12.941147ms)
+Mar 19 14:59:05.434: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 13.154048ms)
+Mar 19 14:59:05.434: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 13.606149ms)
+Mar 19 14:59:05.434: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 13.73105ms)
+Mar 19 14:59:05.434: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 14.629453ms)
+Mar 19 14:59:05.434: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 15.008254ms)
+Mar 19 14:59:05.434: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 14.444552ms)
+Mar 19 14:59:05.434: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 14.629952ms)
+Mar 19 14:59:05.434: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 14.799753ms)
+Mar 19 14:59:05.434: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 14.878253ms)
+Mar 19 14:59:05.434: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 12.958846ms)
+Mar 19 14:59:05.434: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 12.720646ms)
+Mar 19 14:59:05.434: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 15.117154ms)
+Mar 19 14:59:05.452: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 15.249455ms)
+Mar 19 14:59:05.454: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 16.947761ms)
+Mar 19 14:59:05.454: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 16.60496ms)
+Mar 19 14:59:05.454: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 16.289858ms)
+Mar 19 14:59:05.454: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 17.182962ms)
+Mar 19 14:59:05.455: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 18.174065ms)
+Mar 19 14:59:05.455: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 17.549863ms)
+Mar 19 14:59:05.456: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 18.398966ms)
+Mar 19 14:59:05.456: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 19.338369ms)
+Mar 19 14:59:05.456: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 19.45707ms)
+Mar 19 14:59:05.456: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 19.61637ms)
+Mar 19 14:59:05.457: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 19.026868ms)
+Mar 19 14:59:05.458: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 20.236273ms)
+Mar 19 14:59:05.458: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 20.460173ms)
+Mar 19 14:59:05.458: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 20.802575ms)
+Mar 19 14:59:05.458: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 21.343977ms)
+Mar 19 14:59:05.458: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 20.748374ms)
+Mar 19 14:59:05.458: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 21.214376ms)
+Mar 19 14:59:05.458: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 20.821175ms)
+Mar 19 14:59:05.458: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 20.685775ms)
+Mar 19 14:59:05.458: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 21.270877ms)
+Mar 19 14:59:05.459: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 21.934679ms)
+Mar 19 14:59:05.459: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 21.312976ms)
+Mar 19 14:59:05.459: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 21.698079ms)
+Mar 19 14:59:05.459: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 21.842679ms)
+Mar 19 14:59:05.459: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 22.20858ms)
+Mar 19 14:59:05.460: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 23.188183ms)
+Mar 19 14:59:05.460: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 22.719082ms)
+Mar 19 14:59:05.460: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 22.770782ms)
+Mar 19 14:59:05.461: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 23.198884ms)
+Mar 19 14:59:05.461: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 23.059483ms)
+Mar 19 14:59:05.461: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 23.512685ms)
+Mar 19 14:59:05.461: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 23.844085ms)
+Mar 19 14:59:05.462: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 24.564888ms)
+Mar 19 14:59:05.467: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr/proxy/rewriteme"... (200; 4.754018ms)
+Mar 19 14:59:05.467: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/proxy/: foo (200; 5.111818ms)
+Mar 19 14:59:05.469: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/: bar (200; 6.751524ms)
+Mar 19 14:59:05.469: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/proxy/: foo (200; 6.820025ms)
+Mar 19 14:59:05.469: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/... (200; 6.840025ms)
+Mar 19 14:59:05.470: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/proxy/: foo (200; 7.607828ms)
+Mar 19 14:59:05.470: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/: tls qux (200; 6.717424ms)
+Mar 19 14:59:05.470: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname2/proxy/: tls qux (200; 7.013126ms)
+Mar 19 14:59:05.470: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/proxy/rewri... (200; 7.317226ms)
+Mar 19 14:59:05.470: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:443/proxy/... (200; 7.268627ms)
+Mar 19 14:59:05.471: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/: bar (200; 7.815128ms)
+Mar 19 14:59:05.471: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:80/: foo (200; 8.234929ms)
+Mar 19 14:59:05.471: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname1/: foo (200; 8.675432ms)
+Mar 19 14:59:05.474: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/: bar (200; 9.729835ms)
+Mar 19 14:59:05.474: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/: foo (200; 11.069039ms)
+Mar 19 14:59:05.475: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:1080/proxy/... (200; 10.630338ms)
+Mar 19 14:59:05.475: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/proxy/: tls baz (200; 11.657042ms)
+Mar 19 14:59:05.475: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:1080/rewri... (200; 10.984639ms)
+Mar 19 14:59:05.475: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:444/: tls qux (200; 12.429944ms)
+Mar 19 14:59:05.475: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:462/proxy/: tls qux (200; 11.614541ms)
+Mar 19 14:59:05.475: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/proxy/: bar (200; 10.91874ms)
+Mar 19 14:59:05.476: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:tlsportname1/: tls baz (200; 11.611041ms)
+Mar 19 14:59:05.476: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/https:proxy-service-54b9p-xlptr:460/proxy/: tls baz (200; 12.027844ms)
+Mar 19 14:59:05.476: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:160/: foo (200; 13.548049ms)
+Mar 19 14:59:05.476: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:portname2/proxy/: bar (200; 12.708145ms)
+Mar 19 14:59:05.476: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:81/: bar (200; 14.266951ms)
+Mar 19 14:59:05.477: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname1/proxy/: foo (200; 12.971646ms)
+Mar 19 14:59:05.477: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/pods/proxy-service-54b9p-xlptr:162/proxy/: bar (200; 13.214848ms)
+Mar 19 14:59:05.477: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:162/: bar (200; 15.134555ms)
+Mar 19 14:59:05.478: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:80/: foo (200; 13.511549ms)
+Mar 19 14:59:05.478: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/proxy-service-54b9p:81/: bar (200; 14.479852ms)
+Mar 19 14:59:05.478: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-nxlms/services/http:proxy-service-54b9p:portname2/proxy/: bar (200; 15.874958ms)
+Mar 19 14:59:05.478: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/services/https:proxy-service-54b9p:443/: tls baz (200; 14.997954ms)
+Mar 19 14:59:05.479: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-nxlms/pods/http:proxy-service-54b9p-xlptr:160/: foo (200; 15.933957ms)
+STEP: deleting { ReplicationController} proxy-service-54b9p in namespace e2e-tests-proxy-nxlms
+Mar 19 14:59:05.631: INFO: Deleting { ReplicationController} proxy-service-54b9p took: 47.850972ms
+Mar 19 14:59:05.631: INFO: Terminating { ReplicationController} proxy-service-54b9p pods took: 204.201µs
+Mar 19 14:59:15.036: INFO: Garbage collecting { ReplicationController} proxy-service-54b9p pods took: 9.453158736s
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:59:15.036: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-nxlms" for this suite.
+Mar 19 14:59:21.053: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:59:21.091: INFO: namespace: e2e-tests-proxy-nxlms, resource: bindings, ignored listing per whitelist
+Mar 19 14:59:21.190: INFO: namespace e2e-tests-proxy-nxlms deletion completed in 6.15040051s
+
+• [SLOW TEST:35.935 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:59:21.190: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 14:59:21.249: INFO: Waiting up to 5m0s for pod "downwardapi-volume-1af19038-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-bjk7b" to be "success or failure"
+Mar 19 14:59:21.269: INFO: Pod "downwardapi-volume-1af19038-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 19.42056ms
+Mar 19 14:59:23.273: INFO: Pod "downwardapi-volume-1af19038-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.02331949s
+STEP: Saw pod success
+Mar 19 14:59:23.273: INFO: Pod "downwardapi-volume-1af19038-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:59:23.287: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-1af19038-2b86-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 14:59:23.314: INFO: Waiting for pod downwardapi-volume-1af19038-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:59:23.321: INFO: Pod downwardapi-volume-1af19038-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:59:23.321: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-bjk7b" for this suite.
+Mar 19 14:59:29.370: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:59:29.492: INFO: namespace: e2e-tests-downward-api-bjk7b, resource: bindings, ignored listing per whitelist
+Mar 19 14:59:29.492: INFO: namespace e2e-tests-downward-api-bjk7b deletion completed in 6.1465994s
+
+• [SLOW TEST:8.301 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:59:29.492: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test override all
+Mar 19 14:59:29.548: INFO: Waiting up to 5m0s for pod "client-containers-1fe3c108-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-containers-4rfvg" to be "success or failure"
+Mar 19 14:59:29.552: INFO: Pod "client-containers-1fe3c108-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.736911ms
+Mar 19 14:59:31.556: INFO: Pod "client-containers-1fe3c108-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007877733s
+Mar 19 14:59:33.560: INFO: Pod "client-containers-1fe3c108-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011545658s
+STEP: Saw pod success
+Mar 19 14:59:33.560: INFO: Pod "client-containers-1fe3c108-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:59:33.562: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod client-containers-1fe3c108-2b86-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 14:59:33.608: INFO: Waiting for pod client-containers-1fe3c108-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:59:33.628: INFO: Pod client-containers-1fe3c108-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:59:33.634: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-4rfvg" for this suite.
+Mar 19 14:59:39.671: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:59:39.725: INFO: namespace: e2e-tests-containers-4rfvg, resource: bindings, ignored listing per whitelist
+Mar 19 14:59:39.807: INFO: namespace e2e-tests-containers-4rfvg deletion completed in 6.168765873s
+
+• [SLOW TEST:10.316 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:59:39.808: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 19 14:59:39.869: INFO: Waiting up to 5m0s for pod "downward-api-260a94b1-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-wt8xd" to be "success or failure"
+Mar 19 14:59:39.879: INFO: Pod "downward-api-260a94b1-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 10.615341ms
+Mar 19 14:59:41.883: INFO: Pod "downward-api-260a94b1-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.014087252s
+Mar 19 14:59:43.887: INFO: Pod "downward-api-260a94b1-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.018421538s
+STEP: Saw pod success
+Mar 19 14:59:43.887: INFO: Pod "downward-api-260a94b1-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:59:43.890: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downward-api-260a94b1-2b86-11e8-945a-764aeb95b32d container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 14:59:43.916: INFO: Waiting for pod downward-api-260a94b1-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:59:43.920: INFO: Pod downward-api-260a94b1-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:59:43.920: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-wt8xd" for this suite.
+Mar 19 14:59:50.009: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:59:50.140: INFO: namespace: e2e-tests-downward-api-wt8xd, resource: bindings, ignored listing per whitelist
+Mar 19 14:59:50.157: INFO: namespace e2e-tests-downward-api-wt8xd deletion completed in 6.21708361s
+
+• [SLOW TEST:10.349 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:59:50.157: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-map-2c351dcd-2b86-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 14:59:50.222: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-2c36323c-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-xzbfj" to be "success or failure"
+Mar 19 14:59:50.228: INFO: Pod "pod-projected-configmaps-2c36323c-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 5.293016ms
+Mar 19 14:59:52.232: INFO: Pod "pod-projected-configmaps-2c36323c-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009621878s
+STEP: Saw pod success
+Mar 19 14:59:52.232: INFO: Pod "pod-projected-configmaps-2c36323c-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 14:59:52.265: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-configmaps-2c36323c-2b86-11e8-945a-764aeb95b32d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 14:59:52.341: INFO: Waiting for pod pod-projected-configmaps-2c36323c-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 14:59:52.348: INFO: Pod pod-projected-configmaps-2c36323c-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 14:59:52.348: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xzbfj" for this suite.
+Mar 19 14:59:58.365: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 14:59:58.483: INFO: namespace: e2e-tests-projected-xzbfj, resource: bindings, ignored listing per whitelist
+Mar 19 14:59:58.492: INFO: namespace e2e-tests-projected-xzbfj deletion completed in 6.140307963s
+
+• [SLOW TEST:8.335 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 14:59:58.492: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-gl8ls
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 19 14:59:58.580: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 19 15:00:22.650: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.2.25 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-gl8ls PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:00:22.650: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:00:30.235: INFO: Found all expected endpoints: [netserver-0]
+Mar 19 15:00:30.238: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.0.51 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-gl8ls PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:00:30.238: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:00:31.232: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.0.51 8081 | grep -v '^\\s*$'": command terminated with exit code 137, stdout: "", stderr: ""
+Mar 19 15:00:31.232: INFO: Waiting for [netserver-1] endpoints (expected=[netserver-1], actual=[])
+Mar 19 15:00:33.236: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.0.51 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-gl8ls PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:00:33.236: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:00:34.430: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:00:34.430: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-gl8ls" for this suite.
+Mar 19 15:00:56.446: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:00:56.588: INFO: namespace: e2e-tests-pod-network-test-gl8ls, resource: bindings, ignored listing per whitelist
+Mar 19 15:00:56.592: INFO: namespace e2e-tests-pod-network-test-gl8ls deletion completed in 22.15813918s
+
+• [SLOW TEST:58.100 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:00:56.595: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:00:56.672: INFO: Waiting up to 5m0s for pod "downwardapi-volume-53d1aa2d-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-48nhp" to be "success or failure"
+Mar 19 15:00:56.681: INFO: Pod "downwardapi-volume-53d1aa2d-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 9.33653ms
+Mar 19 15:00:58.685: INFO: Pod "downwardapi-volume-53d1aa2d-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.013131608s
+STEP: Saw pod success
+Mar 19 15:00:58.685: INFO: Pod "downwardapi-volume-53d1aa2d-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:00:58.688: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-53d1aa2d-2b86-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:00:58.714: INFO: Waiting for pod downwardapi-volume-53d1aa2d-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:00:58.728: INFO: Pod downwardapi-volume-53d1aa2d-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:00:58.728: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-48nhp" for this suite.
+Mar 19 15:01:04.748: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:01:04.882: INFO: namespace: e2e-tests-projected-48nhp, resource: bindings, ignored listing per whitelist
+Mar 19 15:01:04.884: INFO: namespace e2e-tests-projected-48nhp deletion completed in 6.151598484s
+
+• [SLOW TEST:8.290 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:01:04.887: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:01:04.952: INFO: Waiting up to 5m0s for pod "downwardapi-volume-58c11c71-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-vmp8j" to be "success or failure"
+Mar 19 15:01:04.962: INFO: Pod "downwardapi-volume-58c11c71-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 9.812535ms
+Mar 19 15:01:06.965: INFO: Pod "downwardapi-volume-58c11c71-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.01305391s
+STEP: Saw pod success
+Mar 19 15:01:06.965: INFO: Pod "downwardapi-volume-58c11c71-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:01:06.968: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-58c11c71-2b86-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:01:07.025: INFO: Waiting for pod downwardapi-volume-58c11c71-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:01:07.032: INFO: Pod downwardapi-volume-58c11c71-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:01:07.032: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-vmp8j" for this suite.
+Mar 19 15:01:13.063: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:01:13.251: INFO: namespace: e2e-tests-projected-vmp8j, resource: bindings, ignored listing per whitelist
+Mar 19 15:01:13.260: INFO: namespace e2e-tests-projected-vmp8j deletion completed in 6.216127619s
+
+• [SLOW TEST:8.374 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:01:13.261: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap e2e-tests-configmap-z69fw/configmap-test-5dc111f3-2b86-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:01:13.345: INFO: Waiting up to 5m0s for pod "pod-configmaps-5dc196c0-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-configmap-z69fw" to be "success or failure"
+Mar 19 15:01:13.350: INFO: Pod "pod-configmaps-5dc196c0-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.013112ms
+Mar 19 15:01:15.353: INFO: Pod "pod-configmaps-5dc196c0-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007854663s
+Mar 19 15:01:17.402: INFO: Pod "pod-configmaps-5dc196c0-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.05664855s
+Mar 19 15:01:20.125: INFO: Pod "pod-configmaps-5dc196c0-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.77996594s
+STEP: Saw pod success
+Mar 19 15:01:20.126: INFO: Pod "pod-configmaps-5dc196c0-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:01:20.130: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-configmaps-5dc196c0-2b86-11e8-945a-764aeb95b32d container env-test: <nil>
+STEP: delete the pod
+Mar 19 15:01:20.281: INFO: Waiting for pod pod-configmaps-5dc196c0-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:01:20.297: INFO: Pod pod-configmaps-5dc196c0-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:01:20.297: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-z69fw" for this suite.
+Mar 19 15:01:26.312: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:01:26.386: INFO: namespace: e2e-tests-configmap-z69fw, resource: bindings, ignored listing per whitelist
+Mar 19 15:01:26.439: INFO: namespace e2e-tests-configmap-z69fw deletion completed in 6.138155163s
+
+• [SLOW TEST:13.178 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:01:26.440: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Mar 19 15:01:26.514: INFO: Waiting up to 5m0s for pod "pod-659b48e3-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-clckh" to be "success or failure"
+Mar 19 15:01:26.518: INFO: Pod "pod-659b48e3-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.995415ms
+Mar 19 15:01:28.521: INFO: Pod "pod-659b48e3-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006993365s
+Mar 19 15:01:30.524: INFO: Pod "pod-659b48e3-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010043032s
+STEP: Saw pod success
+Mar 19 15:01:30.524: INFO: Pod "pod-659b48e3-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:01:30.528: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-659b48e3-2b86-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:01:30.567: INFO: Waiting for pod pod-659b48e3-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:01:30.578: INFO: Pod pod-659b48e3-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:01:30.578: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-clckh" for this suite.
+Mar 19 15:01:36.625: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:01:36.737: INFO: namespace: e2e-tests-emptydir-clckh, resource: bindings, ignored listing per whitelist
+Mar 19 15:01:36.763: INFO: namespace e2e-tests-emptydir-clckh deletion completed in 6.173114452s
+
+• [SLOW TEST:10.323 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:01:36.763: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 15:01:36.829: INFO: (0) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 8.363723ms)
+Mar 19 15:01:36.845: INFO: (1) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 16.503346ms)
+Mar 19 15:01:36.850: INFO: (2) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.624012ms)
+Mar 19 15:01:36.855: INFO: (3) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.098714ms)
+Mar 19 15:01:36.860: INFO: (4) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.052214ms)
+Mar 19 15:01:36.865: INFO: (5) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.009414ms)
+Mar 19 15:01:36.870: INFO: (6) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.859814ms)
+Mar 19 15:01:36.875: INFO: (7) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.299515ms)
+Mar 19 15:01:36.881: INFO: (8) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.033014ms)
+Mar 19 15:01:36.885: INFO: (9) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.832213ms)
+Mar 19 15:01:36.892: INFO: (10) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 6.435718ms)
+Mar 19 15:01:36.903: INFO: (11) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 10.559329ms)
+Mar 19 15:01:36.909: INFO: (12) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.969917ms)
+Mar 19 15:01:36.913: INFO: (13) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.459713ms)
+Mar 19 15:01:36.918: INFO: (14) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.702013ms)
+Mar 19 15:01:36.923: INFO: (15) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.262615ms)
+Mar 19 15:01:36.929: INFO: (16) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.155014ms)
+Mar 19 15:01:36.934: INFO: (17) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.244615ms)
+Mar 19 15:01:36.939: INFO: (18) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.764713ms)
+Mar 19 15:01:36.944: INFO: (19) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.536212ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:01:36.944: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-wdqk5" for this suite.
+Mar 19 15:01:42.959: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:01:43.020: INFO: namespace: e2e-tests-proxy-wdqk5, resource: bindings, ignored listing per whitelist
+Mar 19 15:01:43.191: INFO: namespace e2e-tests-proxy-wdqk5 deletion completed in 6.243706495s
+
+• [SLOW TEST:6.428 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:01:43.191: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 19 15:01:43.260: INFO: Waiting up to 5m0s for pod "downward-api-6f9636ff-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-g2bd5" to be "success or failure"
+Mar 19 15:01:43.264: INFO: Pod "downward-api-6f9636ff-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.940811ms
+Mar 19 15:01:45.268: INFO: Pod "downward-api-6f9636ff-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007831413s
+Mar 19 15:01:47.273: INFO: Pod "downward-api-6f9636ff-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.013588515s
+Mar 19 15:01:49.277: INFO: Pod "downward-api-6f9636ff-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.017272752s
+STEP: Saw pod success
+Mar 19 15:01:49.277: INFO: Pod "downward-api-6f9636ff-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:01:49.280: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downward-api-6f9636ff-2b86-11e8-945a-764aeb95b32d container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 15:01:49.312: INFO: Waiting for pod downward-api-6f9636ff-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:01:49.327: INFO: Pod downward-api-6f9636ff-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:01:49.327: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-g2bd5" for this suite.
+Mar 19 15:01:55.342: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:01:55.386: INFO: namespace: e2e-tests-downward-api-g2bd5, resource: bindings, ignored listing per whitelist
+Mar 19 15:01:55.478: INFO: namespace e2e-tests-downward-api-g2bd5 deletion completed in 6.146646544s
+
+• [SLOW TEST:12.287 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:01:55.478: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 15:01:55.596: INFO: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:01:55.598: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-6cj6r" for this suite.
+Mar 19 15:02:01.616: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:02:01.724: INFO: namespace: e2e-tests-container-probe-6cj6r, resource: bindings, ignored listing per whitelist
+Mar 19 15:02:01.749: INFO: namespace e2e-tests-container-probe-6cj6r deletion completed in 6.147762858s
+
+S [SKIPPING] [6.271 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be restarted with a docker exec liveness probe with timeout  [Conformance] [It]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+
+  Mar 19 15:01:55.596: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:289
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:02:01.749: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-qxmxs
+Mar 19 15:02:05.815: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-qxmxs
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 19 15:02:05.817: INFO: Initial restart count of pod liveness-http is 0
+Mar 19 15:02:17.844: INFO: Restart count of pod e2e-tests-container-probe-qxmxs/liveness-http is now 1 (12.026586852s elapsed)
+Mar 19 15:02:35.883: INFO: Restart count of pod e2e-tests-container-probe-qxmxs/liveness-http is now 2 (30.066271541s elapsed)
+Mar 19 15:02:55.924: INFO: Restart count of pod e2e-tests-container-probe-qxmxs/liveness-http is now 3 (50.106764254s elapsed)
+Mar 19 15:03:15.968: INFO: Restart count of pod e2e-tests-container-probe-qxmxs/liveness-http is now 4 (1m10.15118333s elapsed)
+Mar 19 15:04:18.084: INFO: Restart count of pod e2e-tests-container-probe-qxmxs/liveness-http is now 5 (2m12.267297358s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:04:18.145: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-qxmxs" for this suite.
+Mar 19 15:04:24.168: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:04:24.236: INFO: namespace: e2e-tests-container-probe-qxmxs, resource: bindings, ignored listing per whitelist
+Mar 19 15:04:24.308: INFO: namespace e2e-tests-container-probe-qxmxs deletion completed in 6.155238571s
+
+• [SLOW TEST:142.559 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:04:24.308: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:04:24.393: INFO: Waiting up to 5m0s for pod "downwardapi-volume-cfa189b5-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-4b9pq" to be "success or failure"
+Mar 19 15:04:24.397: INFO: Pod "downwardapi-volume-cfa189b5-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.767413ms
+Mar 19 15:04:26.400: INFO: Pod "downwardapi-volume-cfa189b5-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007532037s
+STEP: Saw pod success
+Mar 19 15:04:26.400: INFO: Pod "downwardapi-volume-cfa189b5-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:04:26.405: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-cfa189b5-2b86-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:04:26.439: INFO: Waiting for pod downwardapi-volume-cfa189b5-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:04:26.444: INFO: Pod downwardapi-volume-cfa189b5-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:04:26.444: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4b9pq" for this suite.
+Mar 19 15:04:32.467: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:04:32.588: INFO: namespace: e2e-tests-projected-4b9pq, resource: bindings, ignored listing per whitelist
+Mar 19 15:04:32.602: INFO: namespace e2e-tests-projected-4b9pq deletion completed in 6.150610604s
+
+• [SLOW TEST:8.294 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:04:32.603: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:04:32.740: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-5kbp5" for this suite.
+Mar 19 15:04:54.766: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:04:54.815: INFO: namespace: e2e-tests-pods-5kbp5, resource: bindings, ignored listing per whitelist
+Mar 19 15:04:54.908: INFO: namespace e2e-tests-pods-5kbp5 deletion completed in 22.164388763s
+
+• [SLOW TEST:22.305 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:04:54.908: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating pod
+Mar 19 15:04:57.027: INFO: Pod pod-hostip-e1e1ed68-2b86-11e8-945a-764aeb95b32d has hostIP: 10.250.0.5
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:04:57.028: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-dzd75" for this suite.
+Mar 19 15:05:19.043: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:05:19.225: INFO: namespace: e2e-tests-pods-dzd75, resource: bindings, ignored listing per whitelist
+Mar 19 15:05:19.337: INFO: namespace e2e-tests-pods-dzd75 deletion completed in 22.305432374s
+
+• [SLOW TEST:24.428 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:05:19.338: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test use defaults
+Mar 19 15:05:19.408: INFO: Waiting up to 5m0s for pod "client-containers-f06bb343-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-containers-vjn6b" to be "success or failure"
+Mar 19 15:05:19.417: INFO: Pod "client-containers-f06bb343-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 9.225029ms
+Mar 19 15:05:21.421: INFO: Pod "client-containers-f06bb343-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.01274307s
+STEP: Saw pod success
+Mar 19 15:05:21.421: INFO: Pod "client-containers-f06bb343-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:05:21.424: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod client-containers-f06bb343-2b86-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:05:21.474: INFO: Waiting for pod client-containers-f06bb343-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:05:21.486: INFO: Pod client-containers-f06bb343-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:05:21.486: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-vjn6b" for this suite.
+Mar 19 15:05:27.509: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:05:27.633: INFO: namespace: e2e-tests-containers-vjn6b, resource: bindings, ignored listing per whitelist
+Mar 19 15:05:27.668: INFO: namespace e2e-tests-containers-vjn6b deletion completed in 6.178548746s
+
+• [SLOW TEST:8.330 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:05:27.668: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Mar 19 15:05:27.742: INFO: Waiting up to 5m0s for pod "pod-f563d655-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-6zdd8" to be "success or failure"
+Mar 19 15:05:27.746: INFO: Pod "pod-f563d655-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.891013ms
+Mar 19 15:05:29.749: INFO: Pod "pod-f563d655-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007205206s
+Mar 19 15:05:31.753: INFO: Pod "pod-f563d655-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011049346s
+STEP: Saw pod success
+Mar 19 15:05:31.753: INFO: Pod "pod-f563d655-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:05:31.756: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-f563d655-2b86-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:05:31.781: INFO: Waiting for pod pod-f563d655-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:05:31.786: INFO: Pod pod-f563d655-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:05:31.786: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-6zdd8" for this suite.
+Mar 19 15:05:37.820: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:05:37.901: INFO: namespace: e2e-tests-emptydir-6zdd8, resource: bindings, ignored listing per whitelist
+Mar 19 15:05:37.967: INFO: namespace e2e-tests-emptydir-6zdd8 deletion completed in 6.177592981s
+
+• [SLOW TEST:10.299 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:05:37.967: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Mar 19 15:05:38.040: INFO: Waiting up to 5m0s for pod "pod-fb871a51-2b86-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-mx8v8" to be "success or failure"
+Mar 19 15:05:38.043: INFO: Pod "pod-fb871a51-2b86-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.07761ms
+Mar 19 15:05:40.049: INFO: Pod "pod-fb871a51-2b86-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008323192s
+STEP: Saw pod success
+Mar 19 15:05:40.049: INFO: Pod "pod-fb871a51-2b86-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:05:40.051: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-fb871a51-2b86-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:05:40.074: INFO: Waiting for pod pod-fb871a51-2b86-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:05:40.080: INFO: Pod pod-fb871a51-2b86-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:05:40.080: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-mx8v8" for this suite.
+Mar 19 15:05:46.106: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:05:46.169: INFO: namespace: e2e-tests-emptydir-mx8v8, resource: bindings, ignored listing per whitelist
+Mar 19 15:05:46.238: INFO: namespace e2e-tests-emptydir-mx8v8 deletion completed in 6.151856681s
+
+• [SLOW TEST:8.271 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:05:46.240: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-00734cf6-2b87-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:05:46.317: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-0073dbc3-2b87-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-qp2sj" to be "success or failure"
+Mar 19 15:05:46.320: INFO: Pod "pod-projected-secrets-0073dbc3-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.135711ms
+Mar 19 15:05:48.323: INFO: Pod "pod-projected-secrets-0073dbc3-2b87-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006553928s
+STEP: Saw pod success
+Mar 19 15:05:48.323: INFO: Pod "pod-projected-secrets-0073dbc3-2b87-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:05:48.328: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-secrets-0073dbc3-2b87-11e8-945a-764aeb95b32d container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:05:48.719: INFO: Waiting for pod pod-projected-secrets-0073dbc3-2b87-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:05:48.722: INFO: Pod pod-projected-secrets-0073dbc3-2b87-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:05:48.722: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qp2sj" for this suite.
+Mar 19 15:05:54.770: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:05:54.845: INFO: namespace: e2e-tests-projected-qp2sj, resource: bindings, ignored listing per whitelist
+Mar 19 15:05:54.926: INFO: namespace e2e-tests-projected-qp2sj deletion completed in 6.201255392s
+
+• [SLOW TEST:8.687 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:05:54.927: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name cm-test-opt-del-05a38ccc-2b87-11e8-945a-764aeb95b32d
+STEP: Creating configMap with name cm-test-opt-upd-05a38d08-2b87-11e8-945a-764aeb95b32d
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-05a38ccc-2b87-11e8-945a-764aeb95b32d
+STEP: Updating configmap cm-test-opt-upd-05a38d08-2b87-11e8-945a-764aeb95b32d
+STEP: Creating configMap with name cm-test-opt-create-05a38d1c-2b87-11e8-945a-764aeb95b32d
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:07:06.214: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-cs2xq" for this suite.
+Mar 19 15:07:28.228: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:07:28.280: INFO: namespace: e2e-tests-projected-cs2xq, resource: bindings, ignored listing per whitelist
+Mar 19 15:07:28.364: INFO: namespace e2e-tests-projected-cs2xq deletion completed in 22.146877247s
+
+• [SLOW TEST:93.438 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:07:28.366: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Mar 19 15:07:28.467: INFO: Waiting up to 5m0s for pod "pod-3d58ebc6-2b87-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-l24gd" to be "success or failure"
+Mar 19 15:07:28.476: INFO: Pod "pod-3d58ebc6-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 9.804828ms
+Mar 19 15:07:30.480: INFO: Pod "pod-3d58ebc6-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01367964s
+Mar 19 15:07:32.484: INFO: Pod "pod-3d58ebc6-2b87-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017429159s
+STEP: Saw pod success
+Mar 19 15:07:32.484: INFO: Pod "pod-3d58ebc6-2b87-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:07:32.487: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-3d58ebc6-2b87-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:07:32.510: INFO: Waiting for pod pod-3d58ebc6-2b87-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:07:32.524: INFO: Pod pod-3d58ebc6-2b87-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:07:32.524: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-l24gd" for this suite.
+Mar 19 15:07:38.540: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:07:38.678: INFO: namespace: e2e-tests-emptydir-l24gd, resource: bindings, ignored listing per whitelist
+Mar 19 15:07:38.678: INFO: namespace e2e-tests-emptydir-l24gd deletion completed in 6.150391303s
+
+• [SLOW TEST:10.312 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:07:38.679: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 19 15:07:38.735: INFO: Waiting up to 5m0s for pod "downward-api-4377cebc-2b87-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-b5nsk" to be "success or failure"
+Mar 19 15:07:38.743: INFO: Pod "downward-api-4377cebc-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 7.452626ms
+Mar 19 15:07:40.747: INFO: Pod "downward-api-4377cebc-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011360785s
+Mar 19 15:07:42.750: INFO: Pod "downward-api-4377cebc-2b87-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015082184s
+STEP: Saw pod success
+Mar 19 15:07:42.750: INFO: Pod "downward-api-4377cebc-2b87-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:07:42.753: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downward-api-4377cebc-2b87-11e8-945a-764aeb95b32d container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 15:07:42.775: INFO: Waiting for pod downward-api-4377cebc-2b87-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:07:42.787: INFO: Pod downward-api-4377cebc-2b87-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:07:42.787: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-b5nsk" for this suite.
+Mar 19 15:07:48.817: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:07:48.891: INFO: namespace: e2e-tests-downward-api-b5nsk, resource: bindings, ignored listing per whitelist
+Mar 19 15:07:49.000: INFO: namespace e2e-tests-downward-api-b5nsk deletion completed in 6.208805189s
+
+• [SLOW TEST:10.322 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:07:49.001: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:07:49.074: INFO: Waiting up to 5m0s for pod "downwardapi-volume-49a13494-2b87-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-jnktf" to be "success or failure"
+Mar 19 15:07:49.085: INFO: Pod "downwardapi-volume-49a13494-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 11.221138ms
+Mar 19 15:07:51.089: INFO: Pod "downwardapi-volume-49a13494-2b87-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.015707609s
+STEP: Saw pod success
+Mar 19 15:07:51.089: INFO: Pod "downwardapi-volume-49a13494-2b87-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:07:51.092: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-49a13494-2b87-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:07:51.132: INFO: Waiting for pod downwardapi-volume-49a13494-2b87-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:07:51.138: INFO: Pod downwardapi-volume-49a13494-2b87-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:07:51.138: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jnktf" for this suite.
+Mar 19 15:07:57.168: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:07:57.221: INFO: namespace: e2e-tests-projected-jnktf, resource: bindings, ignored listing per whitelist
+Mar 19 15:07:57.315: INFO: namespace e2e-tests-projected-jnktf deletion completed in 6.165442715s
+
+• [SLOW TEST:8.314 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:07:57.316: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-4e94216b-2b87-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:07:57.379: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-4e94b0ba-2b87-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-bc72d" to be "success or failure"
+Mar 19 15:07:57.391: INFO: Pod "pod-projected-secrets-4e94b0ba-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 11.186733ms
+Mar 19 15:07:59.394: INFO: Pod "pod-projected-secrets-4e94b0ba-2b87-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.014741179s
+STEP: Saw pod success
+Mar 19 15:07:59.394: INFO: Pod "pod-projected-secrets-4e94b0ba-2b87-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:07:59.397: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-secrets-4e94b0ba-2b87-11e8-945a-764aeb95b32d container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:07:59.436: INFO: Waiting for pod pod-projected-secrets-4e94b0ba-2b87-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:07:59.444: INFO: Pod pod-projected-secrets-4e94b0ba-2b87-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:07:59.444: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-bc72d" for this suite.
+Mar 19 15:08:05.471: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:08:05.534: INFO: namespace: e2e-tests-projected-bc72d, resource: bindings, ignored listing per whitelist
+Mar 19 15:08:05.603: INFO: namespace e2e-tests-projected-bc72d deletion completed in 6.144340673s
+
+• [SLOW TEST:8.287 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:08:05.606: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 15:08:09.726: INFO: Waiting up to 5m0s for pod "client-envvars-55ee512d-2b87-11e8-945a-764aeb95b32d" in namespace "e2e-tests-pods-f4dfn" to be "success or failure"
+Mar 19 15:08:09.736: INFO: Pod "client-envvars-55ee512d-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 9.981637ms
+Mar 19 15:08:11.740: INFO: Pod "client-envvars-55ee512d-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013887701s
+Mar 19 15:08:13.744: INFO: Pod "client-envvars-55ee512d-2b87-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017085114s
+STEP: Saw pod success
+Mar 19 15:08:13.744: INFO: Pod "client-envvars-55ee512d-2b87-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:08:13.746: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod client-envvars-55ee512d-2b87-11e8-945a-764aeb95b32d container env3cont: <nil>
+STEP: delete the pod
+Mar 19 15:08:13.770: INFO: Waiting for pod client-envvars-55ee512d-2b87-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:08:13.784: INFO: Pod client-envvars-55ee512d-2b87-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:08:13.785: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-f4dfn" for this suite.
+Mar 19 15:08:35.816: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:08:35.897: INFO: namespace: e2e-tests-pods-f4dfn, resource: bindings, ignored listing per whitelist
+Mar 19 15:08:35.970: INFO: namespace e2e-tests-pods-f4dfn deletion completed in 22.178607826s
+
+• [SLOW TEST:30.364 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:08:35.978: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 15:08:36.051: INFO: (0) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 7.472292ms)
+Mar 19 15:08:36.056: INFO: (1) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.831994ms)
+Mar 19 15:08:36.062: INFO: (2) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.703594ms)
+Mar 19 15:08:36.068: INFO: (3) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 6.007693ms)
+Mar 19 15:08:36.074: INFO: (4) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 6.077294ms)
+Mar 19 15:08:36.091: INFO: (5) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 16.802181ms)
+Mar 19 15:08:36.097: INFO: (6) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.713894ms)
+Mar 19 15:08:36.102: INFO: (7) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.973694ms)
+Mar 19 15:08:36.107: INFO: (8) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.916194ms)
+Mar 19 15:08:36.113: INFO: (9) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 6.034994ms)
+Mar 19 15:08:36.119: INFO: (10) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.898394ms)
+Mar 19 15:08:36.129: INFO: (11) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 9.386789ms)
+Mar 19 15:08:36.134: INFO: (12) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.647994ms)
+Mar 19 15:08:36.140: INFO: (13) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.589793ms)
+Mar 19 15:08:36.145: INFO: (14) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.353294ms)
+Mar 19 15:08:36.151: INFO: (15) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 6.011193ms)
+Mar 19 15:08:36.157: INFO: (16) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.921093ms)
+Mar 19 15:08:36.163: INFO: (17) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.175094ms)
+Mar 19 15:08:36.168: INFO: (18) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.772694ms)
+Mar 19 15:08:36.173: INFO: (19) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.110194ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:08:36.174: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-hqpk6" for this suite.
+Mar 19 15:08:42.188: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:08:42.232: INFO: namespace: e2e-tests-proxy-hqpk6, resource: bindings, ignored listing per whitelist
+Mar 19 15:08:42.323: INFO: namespace e2e-tests-proxy-hqpk6 deletion completed in 6.145951571s
+
+• [SLOW TEST:6.345 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:08:42.324: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-6966ba20-2b87-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:08:42.390: INFO: Waiting up to 5m0s for pod "pod-secrets-69677944-2b87-11e8-945a-764aeb95b32d" in namespace "e2e-tests-secrets-sth4j" to be "success or failure"
+Mar 19 15:08:42.395: INFO: Pod "pod-secrets-69677944-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.870995ms
+Mar 19 15:08:44.399: INFO: Pod "pod-secrets-69677944-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008867276s
+Mar 19 15:08:46.403: INFO: Pod "pod-secrets-69677944-2b87-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01200736s
+STEP: Saw pod success
+Mar 19 15:08:46.403: INFO: Pod "pod-secrets-69677944-2b87-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:08:46.405: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-secrets-69677944-2b87-11e8-945a-764aeb95b32d container secret-env-test: <nil>
+STEP: delete the pod
+Mar 19 15:08:46.456: INFO: Waiting for pod pod-secrets-69677944-2b87-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:08:46.472: INFO: Pod pod-secrets-69677944-2b87-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:08:46.472: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-sth4j" for this suite.
+Mar 19 15:08:52.498: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:08:52.621: INFO: namespace: e2e-tests-secrets-sth4j, resource: bindings, ignored listing per whitelist
+Mar 19 15:08:52.632: INFO: namespace e2e-tests-secrets-sth4j deletion completed in 6.15499746s
+
+• [SLOW TEST:10.309 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:08:52.633: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test substitution in container's args
+Mar 19 15:08:52.694: INFO: Waiting up to 5m0s for pod "var-expansion-6f8cf50b-2b87-11e8-945a-764aeb95b32d" in namespace "e2e-tests-var-expansion-m595h" to be "success or failure"
+Mar 19 15:08:52.700: INFO: Pod "var-expansion-6f8cf50b-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 5.786422ms
+Mar 19 15:08:54.703: INFO: Pod "var-expansion-6f8cf50b-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009209823s
+Mar 19 15:08:56.706: INFO: Pod "var-expansion-6f8cf50b-2b87-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012585139s
+STEP: Saw pod success
+Mar 19 15:08:56.706: INFO: Pod "var-expansion-6f8cf50b-2b87-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:08:56.709: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod var-expansion-6f8cf50b-2b87-11e8-945a-764aeb95b32d container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 15:08:56.740: INFO: Waiting for pod var-expansion-6f8cf50b-2b87-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:08:56.749: INFO: Pod var-expansion-6f8cf50b-2b87-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:08:56.749: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-m595h" for this suite.
+Mar 19 15:09:02.767: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:09:02.866: INFO: namespace: e2e-tests-var-expansion-m595h, resource: bindings, ignored listing per whitelist
+Mar 19 15:09:02.898: INFO: namespace e2e-tests-var-expansion-m595h deletion completed in 6.143069584s
+
+• [SLOW TEST:10.265 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:09:02.898: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Mar 19 15:09:02.961: INFO: Waiting up to 5m0s for pod "pod-75ab7a1f-2b87-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-nm2pp" to be "success or failure"
+Mar 19 15:09:02.964: INFO: Pod "pod-75ab7a1f-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.238912ms
+Mar 19 15:09:04.967: INFO: Pod "pod-75ab7a1f-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006422307s
+Mar 19 15:09:06.972: INFO: Pod "pod-75ab7a1f-2b87-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010843514s
+STEP: Saw pod success
+Mar 19 15:09:06.972: INFO: Pod "pod-75ab7a1f-2b87-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:09:06.974: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-75ab7a1f-2b87-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:09:07.038: INFO: Waiting for pod pod-75ab7a1f-2b87-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:09:07.043: INFO: Pod pod-75ab7a1f-2b87-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:09:07.043: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-nm2pp" for this suite.
+Mar 19 15:09:13.059: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:09:13.204: INFO: namespace: e2e-tests-emptydir-nm2pp, resource: bindings, ignored listing per whitelist
+Mar 19 15:09:13.207: INFO: namespace e2e-tests-emptydir-nm2pp deletion completed in 6.161687897s
+
+• [SLOW TEST:10.309 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:09:13.208: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 19 15:09:13.302: INFO: Waiting up to 5m0s for pod "downward-api-7bd58380-2b87-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-6wpb9" to be "success or failure"
+Mar 19 15:09:13.310: INFO: Pod "downward-api-7bd58380-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 8.022728ms
+Mar 19 15:09:15.314: INFO: Pod "downward-api-7bd58380-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011687104s
+Mar 19 15:09:17.317: INFO: Pod "downward-api-7bd58380-2b87-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015184548s
+STEP: Saw pod success
+Mar 19 15:09:17.317: INFO: Pod "downward-api-7bd58380-2b87-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:09:17.320: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downward-api-7bd58380-2b87-11e8-945a-764aeb95b32d container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 15:09:17.371: INFO: Waiting for pod downward-api-7bd58380-2b87-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:09:17.374: INFO: Pod downward-api-7bd58380-2b87-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:09:17.374: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-6wpb9" for this suite.
+Mar 19 15:09:23.417: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:09:23.676: INFO: namespace: e2e-tests-downward-api-6wpb9, resource: bindings, ignored listing per whitelist
+Mar 19 15:09:23.691: INFO: namespace e2e-tests-downward-api-6wpb9 deletion completed in 6.296836109s
+
+• [SLOW TEST:10.483 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:09:23.691: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-w62c7
+Mar 19 15:09:25.792: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-w62c7
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 19 15:09:25.795: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:11:26.129: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-w62c7" for this suite.
+Mar 19 15:11:32.168: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:11:32.235: INFO: namespace: e2e-tests-container-probe-w62c7, resource: bindings, ignored listing per whitelist
+Mar 19 15:11:32.301: INFO: namespace e2e-tests-container-probe-w62c7 deletion completed in 6.143904173s
+
+• [SLOW TEST:128.610 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:11:32.301: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-ceba048d-2b87-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:11:32.377: INFO: Waiting up to 5m0s for pod "pod-configmaps-ceba92f5-2b87-11e8-945a-764aeb95b32d" in namespace "e2e-tests-configmap-wxxll" to be "success or failure"
+Mar 19 15:11:32.382: INFO: Pod "pod-configmaps-ceba92f5-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.529917ms
+Mar 19 15:11:34.386: INFO: Pod "pod-configmaps-ceba92f5-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008205858s
+Mar 19 15:11:36.390: INFO: Pod "pod-configmaps-ceba92f5-2b87-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012045053s
+STEP: Saw pod success
+Mar 19 15:11:36.390: INFO: Pod "pod-configmaps-ceba92f5-2b87-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:11:36.393: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-configmaps-ceba92f5-2b87-11e8-945a-764aeb95b32d container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:11:36.444: INFO: Waiting for pod pod-configmaps-ceba92f5-2b87-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:11:36.456: INFO: Pod pod-configmaps-ceba92f5-2b87-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:11:36.457: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-wxxll" for this suite.
+Mar 19 15:11:42.492: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:11:42.573: INFO: namespace: e2e-tests-configmap-wxxll, resource: bindings, ignored listing per whitelist
+Mar 19 15:11:42.622: INFO: namespace e2e-tests-configmap-wxxll deletion completed in 6.160765741s
+
+• [SLOW TEST:10.321 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:11:42.624: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-map-d4dfa010-2b87-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:11:42.690: INFO: Waiting up to 5m0s for pod "pod-configmaps-d4e02745-2b87-11e8-945a-764aeb95b32d" in namespace "e2e-tests-configmap-hl76z" to be "success or failure"
+Mar 19 15:11:42.708: INFO: Pod "pod-configmaps-d4e02745-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 18.758972ms
+Mar 19 15:11:44.712: INFO: Pod "pod-configmaps-d4e02745-2b87-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.0223793s
+Mar 19 15:11:46.715: INFO: Pod "pod-configmaps-d4e02745-2b87-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.025587906s
+STEP: Saw pod success
+Mar 19 15:11:46.715: INFO: Pod "pod-configmaps-d4e02745-2b87-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:11:46.721: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-configmaps-d4e02745-2b87-11e8-945a-764aeb95b32d container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:11:46.747: INFO: Waiting for pod pod-configmaps-d4e02745-2b87-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:11:46.753: INFO: Pod pod-configmaps-d4e02745-2b87-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:11:46.753: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-hl76z" for this suite.
+Mar 19 15:11:52.768: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:11:52.868: INFO: namespace: e2e-tests-configmap-hl76z, resource: bindings, ignored listing per whitelist
+Mar 19 15:11:52.894: INFO: namespace e2e-tests-configmap-hl76z deletion completed in 6.138429549s
+
+• [SLOW TEST:10.270 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:11:52.896: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-2q4xd
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 19 15:11:52.958: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 19 15:12:13.052: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.0.80:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-2q4xd PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:12:13.052: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:12:13.570: INFO: Found all expected endpoints: [netserver-0]
+Mar 19 15:12:13.574: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.2.26:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-2q4xd PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:12:13.574: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:12:13.775: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:12:13.776: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-2q4xd" for this suite.
+Mar 19 15:12:35.799: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:12:35.947: INFO: namespace: e2e-tests-pod-network-test-2q4xd, resource: bindings, ignored listing per whitelist
+Mar 19 15:12:35.963: INFO: namespace e2e-tests-pod-network-test-2q4xd deletion completed in 22.176647887s
+
+• [SLOW TEST:43.067 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:12:35.964: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-f4b0e5fe-2b87-11e8-945a-764aeb95b32d
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-f4b0e5fe-2b87-11e8-945a-764aeb95b32d
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:13:56.599: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fpjd5" for this suite.
+Mar 19 15:14:18.617: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:14:18.713: INFO: namespace: e2e-tests-projected-fpjd5, resource: bindings, ignored listing per whitelist
+Mar 19 15:14:18.754: INFO: namespace e2e-tests-projected-fpjd5 deletion completed in 22.151665846s
+
+• [SLOW TEST:102.790 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:14:18.754: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 15:14:18.888: INFO: (0) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 7.639525ms)
+Mar 19 15:14:18.894: INFO: (1) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.416017ms)
+Mar 19 15:14:18.907: INFO: (2) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 11.835838ms)
+Mar 19 15:14:18.925: INFO: (3) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 18.036558ms)
+Mar 19 15:14:18.951: INFO: (4) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 25.415083ms)
+Mar 19 15:14:18.964: INFO: (5) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 13.486844ms)
+Mar 19 15:14:18.991: INFO: (6) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 26.892288ms)
+Mar 19 15:14:19.010: INFO: (7) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 19.194163ms)
+Mar 19 15:14:19.024: INFO: (8) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 13.153243ms)
+Mar 19 15:14:19.048: INFO: (9) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 24.832981ms)
+Mar 19 15:14:19.061: INFO: (10) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 12.35994ms)
+Mar 19 15:14:19.077: INFO: (11) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 16.373553ms)
+Mar 19 15:14:19.096: INFO: (12) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 18.859062ms)
+Mar 19 15:14:19.118: INFO: (13) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 22.064372ms)
+Mar 19 15:14:19.133: INFO: (14) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 14.371147ms)
+Mar 19 15:14:19.158: INFO: (15) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 24.60308ms)
+Mar 19 15:14:19.170: INFO: (16) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 12.238039ms)
+Mar 19 15:14:19.184: INFO: (17) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 13.863545ms)
+Mar 19 15:14:19.197: INFO: (18) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 13.394344ms)
+Mar 19 15:14:19.211: INFO: (19) /api/v1/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 14.021846ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:14:19.212: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-lpv6r" for this suite.
+Mar 19 15:14:25.234: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:14:25.283: INFO: namespace: e2e-tests-proxy-lpv6r, resource: bindings, ignored listing per whitelist
+Mar 19 15:14:25.366: INFO: namespace e2e-tests-proxy-lpv6r deletion completed in 6.146692025s
+
+• [SLOW TEST:6.612 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:14:25.366: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir volume type on node default medium
+Mar 19 15:14:25.432: INFO: Waiting up to 5m0s for pod "pod-35e0dfa8-2b88-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-8xwhz" to be "success or failure"
+Mar 19 15:14:25.442: INFO: Pod "pod-35e0dfa8-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 9.685831ms
+Mar 19 15:14:27.446: INFO: Pod "pod-35e0dfa8-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013398568s
+Mar 19 15:14:29.450: INFO: Pod "pod-35e0dfa8-2b88-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017301553s
+STEP: Saw pod success
+Mar 19 15:14:29.450: INFO: Pod "pod-35e0dfa8-2b88-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:14:29.453: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-35e0dfa8-2b88-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:14:30.921: INFO: Waiting for pod pod-35e0dfa8-2b88-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:14:30.928: INFO: Pod pod-35e0dfa8-2b88-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:14:30.928: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-8xwhz" for this suite.
+Mar 19 15:14:36.948: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:14:37.091: INFO: namespace: e2e-tests-emptydir-8xwhz, resource: bindings, ignored listing per whitelist
+Mar 19 15:14:37.105: INFO: namespace e2e-tests-emptydir-8xwhz deletion completed in 6.172689302s
+
+• [SLOW TEST:11.739 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:14:37.105: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 19 15:14:39.725: INFO: Successfully updated pod "annotationupdate3ce1b183-2b88-11e8-945a-764aeb95b32d"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:14:43.756: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-s7tww" for this suite.
+Mar 19 15:15:05.770: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:15:05.836: INFO: namespace: e2e-tests-projected-s7tww, resource: bindings, ignored listing per whitelist
+Mar 19 15:15:05.908: INFO: namespace e2e-tests-projected-s7tww deletion completed in 22.148397186s
+
+• [SLOW TEST:28.803 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:15:05.908: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-v9zkk
+Mar 19 15:15:09.997: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-v9zkk
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 19 15:15:10.000: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:17:10.960: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-v9zkk" for this suite.
+Mar 19 15:17:16.991: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:17:17.097: INFO: namespace: e2e-tests-container-probe-v9zkk, resource: bindings, ignored listing per whitelist
+Mar 19 15:17:17.133: INFO: namespace e2e-tests-container-probe-v9zkk deletion completed in 6.161709471s
+
+• [SLOW TEST:131.225 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:17:17.134: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Mar 19 15:17:22.237: INFO: Successfully updated pod "pod-update-activedeadlineseconds-9c4284e7-2b88-11e8-945a-764aeb95b32d"
+Mar 19 15:17:22.237: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-9c4284e7-2b88-11e8-945a-764aeb95b32d" in namespace "e2e-tests-pods-nh69x" to be "terminated due to deadline exceeded"
+Mar 19 15:17:22.245: INFO: Pod "pod-update-activedeadlineseconds-9c4284e7-2b88-11e8-945a-764aeb95b32d": Phase="Running", Reason="", readiness=true. Elapsed: 8.217909ms
+Mar 19 15:17:24.346: INFO: Pod "pod-update-activedeadlineseconds-9c4284e7-2b88-11e8-945a-764aeb95b32d": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 2.108988088s
+Mar 19 15:17:24.346: INFO: Pod "pod-update-activedeadlineseconds-9c4284e7-2b88-11e8-945a-764aeb95b32d" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:17:24.346: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-nh69x" for this suite.
+Mar 19 15:17:30.367: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:17:30.443: INFO: namespace: e2e-tests-pods-nh69x, resource: bindings, ignored listing per whitelist
+Mar 19 15:17:30.512: INFO: namespace e2e-tests-pods-nh69x deletion completed in 6.161035369s
+
+• [SLOW TEST:13.378 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:17:30.513: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name s-test-opt-del-a43b80fe-2b88-11e8-945a-764aeb95b32d
+STEP: Creating secret with name s-test-opt-upd-a43b8153-2b88-11e8-945a-764aeb95b32d
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-a43b80fe-2b88-11e8-945a-764aeb95b32d
+STEP: Updating secret s-test-opt-upd-a43b8153-2b88-11e8-945a-764aeb95b32d
+STEP: Creating secret with name s-test-opt-create-a43b816d-2b88-11e8-945a-764aeb95b32d
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:17:34.875: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-hvr7r" for this suite.
+Mar 19 15:17:56.890: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:17:57.023: INFO: namespace: e2e-tests-secrets-hvr7r, resource: bindings, ignored listing per whitelist
+Mar 19 15:17:57.030: INFO: namespace e2e-tests-secrets-hvr7r deletion completed in 22.152364049s
+
+• [SLOW TEST:26.518 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:17:57.031: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-map-b40c2e41-2b88-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:17:57.132: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-b40fa8f6-2b88-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-4zbqz" to be "success or failure"
+Mar 19 15:17:57.141: INFO: Pod "pod-projected-configmaps-b40fa8f6-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 8.568329ms
+Mar 19 15:17:59.145: INFO: Pod "pod-projected-configmaps-b40fa8f6-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.012997696s
+Mar 19 15:18:01.151: INFO: Pod "pod-projected-configmaps-b40fa8f6-2b88-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.018541739s
+STEP: Saw pod success
+Mar 19 15:18:01.151: INFO: Pod "pod-projected-configmaps-b40fa8f6-2b88-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:18:01.155: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-configmaps-b40fa8f6-2b88-11e8-945a-764aeb95b32d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:18:01.224: INFO: Waiting for pod pod-projected-configmaps-b40fa8f6-2b88-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:18:01.227: INFO: Pod pod-projected-configmaps-b40fa8f6-2b88-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:18:01.228: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4zbqz" for this suite.
+Mar 19 15:18:07.244: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:18:07.347: INFO: namespace: e2e-tests-projected-4zbqz, resource: bindings, ignored listing per whitelist
+Mar 19 15:18:07.390: INFO: namespace e2e-tests-projected-4zbqz deletion completed in 6.159046616s
+
+• [SLOW TEST:10.359 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:18:07.391: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:18:07.454: INFO: Waiting up to 5m0s for pod "downwardapi-volume-ba36b69f-2b88-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-ztsnt" to be "success or failure"
+Mar 19 15:18:07.515: INFO: Pod "downwardapi-volume-ba36b69f-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 60.801324ms
+Mar 19 15:18:09.568: INFO: Pod "downwardapi-volume-ba36b69f-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.114026614s
+Mar 19 15:18:11.572: INFO: Pod "downwardapi-volume-ba36b69f-2b88-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.117458689s
+STEP: Saw pod success
+Mar 19 15:18:11.572: INFO: Pod "downwardapi-volume-ba36b69f-2b88-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:18:11.574: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-ba36b69f-2b88-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:18:11.619: INFO: Waiting for pod downwardapi-volume-ba36b69f-2b88-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:18:11.642: INFO: Pod downwardapi-volume-ba36b69f-2b88-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:18:11.643: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-ztsnt" for this suite.
+Mar 19 15:18:17.685: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:18:17.810: INFO: namespace: e2e-tests-downward-api-ztsnt, resource: bindings, ignored listing per whitelist
+Mar 19 15:18:17.829: INFO: namespace e2e-tests-downward-api-ztsnt deletion completed in 6.158013571s
+
+• [SLOW TEST:10.438 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:18:17.831: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-c06ee93a-2b88-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:18:17.893: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-c06f712a-2b88-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-qqdkw" to be "success or failure"
+Mar 19 15:18:17.899: INFO: Pod "pod-projected-configmaps-c06f712a-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 5.842719ms
+Mar 19 15:18:19.907: INFO: Pod "pod-projected-configmaps-c06f712a-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013718175s
+Mar 19 15:18:21.910: INFO: Pod "pod-projected-configmaps-c06f712a-2b88-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017311875s
+STEP: Saw pod success
+Mar 19 15:18:21.910: INFO: Pod "pod-projected-configmaps-c06f712a-2b88-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:18:21.913: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-configmaps-c06f712a-2b88-11e8-945a-764aeb95b32d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:18:21.956: INFO: Waiting for pod pod-projected-configmaps-c06f712a-2b88-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:18:22.014: INFO: Pod pod-projected-configmaps-c06f712a-2b88-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:18:22.014: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qqdkw" for this suite.
+Mar 19 15:18:28.032: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:18:28.078: INFO: namespace: e2e-tests-projected-qqdkw, resource: bindings, ignored listing per whitelist
+Mar 19 15:18:28.182: INFO: namespace e2e-tests-projected-qqdkw deletion completed in 6.163792553s
+
+• [SLOW TEST:10.351 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:18:28.184: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-bq7bk
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 19 15:18:28.280: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 19 15:18:48.353: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.92:8080/dial?request=hostName&protocol=udp&host=100.96.0.91&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-bq7bk PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:18:48.353: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:18:48.550: INFO: Waiting for endpoints: map[]
+Mar 19 15:18:48.554: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.92:8080/dial?request=hostName&protocol=udp&host=100.96.2.27&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-bq7bk PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:18:48.554: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:18:48.690: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:18:48.690: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-bq7bk" for this suite.
+Mar 19 15:19:10.707: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:19:10.813: INFO: namespace: e2e-tests-pod-network-test-bq7bk, resource: bindings, ignored listing per whitelist
+Mar 19 15:19:10.839: INFO: namespace e2e-tests-pod-network-test-bq7bk deletion completed in 22.145923184s
+
+• [SLOW TEST:42.656 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:19:10.840: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:19:10.913: INFO: Waiting up to 5m0s for pod "downwardapi-volume-e009c085-2b88-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-jdbj5" to be "success or failure"
+Mar 19 15:19:10.920: INFO: Pod "downwardapi-volume-e009c085-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 7.512323ms
+Mar 19 15:19:12.932: INFO: Pod "downwardapi-volume-e009c085-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.019104729s
+Mar 19 15:19:14.936: INFO: Pod "downwardapi-volume-e009c085-2b88-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.023079302s
+STEP: Saw pod success
+Mar 19 15:19:14.936: INFO: Pod "downwardapi-volume-e009c085-2b88-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:19:14.939: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-e009c085-2b88-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:19:14.967: INFO: Waiting for pod downwardapi-volume-e009c085-2b88-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:19:14.973: INFO: Pod downwardapi-volume-e009c085-2b88-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:19:14.973: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-jdbj5" for this suite.
+Mar 19 15:19:20.996: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:19:21.062: INFO: namespace: e2e-tests-downward-api-jdbj5, resource: bindings, ignored listing per whitelist
+Mar 19 15:19:21.136: INFO: namespace e2e-tests-downward-api-jdbj5 deletion completed in 6.152365356s
+
+• [SLOW TEST:10.296 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:19:21.137: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-map-e64ab043-2b88-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:19:21.409: INFO: Waiting up to 5m0s for pod "pod-secrets-e64b4ff6-2b88-11e8-945a-764aeb95b32d" in namespace "e2e-tests-secrets-ctsnc" to be "success or failure"
+Mar 19 15:19:21.414: INFO: Pod "pod-secrets-e64b4ff6-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.799414ms
+Mar 19 15:19:23.436: INFO: Pod "pod-secrets-e64b4ff6-2b88-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.026634358s
+STEP: Saw pod success
+Mar 19 15:19:23.436: INFO: Pod "pod-secrets-e64b4ff6-2b88-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:19:23.449: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-secrets-e64b4ff6-2b88-11e8-945a-764aeb95b32d container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:19:23.496: INFO: Waiting for pod pod-secrets-e64b4ff6-2b88-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:19:23.506: INFO: Pod pod-secrets-e64b4ff6-2b88-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:19:23.506: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-ctsnc" for this suite.
+Mar 19 15:19:29.562: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:19:29.606: INFO: namespace: e2e-tests-secrets-ctsnc, resource: bindings, ignored listing per whitelist
+Mar 19 15:19:29.702: INFO: namespace e2e-tests-secrets-ctsnc deletion completed in 6.159807281s
+
+• [SLOW TEST:8.565 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:19:29.702: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 15:19:29.761: INFO: Creating ReplicaSet my-hostname-basic-eb469bd8-2b88-11e8-945a-764aeb95b32d
+Mar 19 15:19:29.769: INFO: Pod name my-hostname-basic-eb469bd8-2b88-11e8-945a-764aeb95b32d: Found 0 pods out of 1
+Mar 19 15:19:34.773: INFO: Pod name my-hostname-basic-eb469bd8-2b88-11e8-945a-764aeb95b32d: Found 1 pods out of 1
+Mar 19 15:19:34.773: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-eb469bd8-2b88-11e8-945a-764aeb95b32d" is running
+Mar 19 15:19:34.776: INFO: Pod "my-hostname-basic-eb469bd8-2b88-11e8-945a-764aeb95b32d-6cwsf" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-19 15:19:29 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-19 15:19:31 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-19 15:19:29 +0000 UTC Reason: Message:}])
+Mar 19 15:19:34.776: INFO: Trying to dial the pod
+Mar 19 15:19:39.830: INFO: Controller my-hostname-basic-eb469bd8-2b88-11e8-945a-764aeb95b32d: Got expected result from replica 1 [my-hostname-basic-eb469bd8-2b88-11e8-945a-764aeb95b32d-6cwsf]: "my-hostname-basic-eb469bd8-2b88-11e8-945a-764aeb95b32d-6cwsf", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:19:39.831: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-ddt5d" for this suite.
+Mar 19 15:19:45.850: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:19:45.904: INFO: namespace: e2e-tests-replicaset-ddt5d, resource: bindings, ignored listing per whitelist
+Mar 19 15:19:45.986: INFO: namespace e2e-tests-replicaset-ddt5d deletion completed in 6.152698481s
+
+• [SLOW TEST:16.285 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:19:45.991: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap e2e-tests-configmap-9vljv/configmap-test-f4fcea73-2b88-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:19:46.067: INFO: Waiting up to 5m0s for pod "pod-configmaps-f4fd83c5-2b88-11e8-945a-764aeb95b32d" in namespace "e2e-tests-configmap-9vljv" to be "success or failure"
+Mar 19 15:19:46.072: INFO: Pod "pod-configmaps-f4fd83c5-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 5.101517ms
+Mar 19 15:19:48.075: INFO: Pod "pod-configmaps-f4fd83c5-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008826755s
+Mar 19 15:19:50.079: INFO: Pod "pod-configmaps-f4fd83c5-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.012180018s
+Mar 19 15:19:52.082: INFO: Pod "pod-configmaps-f4fd83c5-2b88-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.015661175s
+STEP: Saw pod success
+Mar 19 15:19:52.082: INFO: Pod "pod-configmaps-f4fd83c5-2b88-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:19:52.086: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-configmaps-f4fd83c5-2b88-11e8-945a-764aeb95b32d container env-test: <nil>
+STEP: delete the pod
+Mar 19 15:19:52.105: INFO: Waiting for pod pod-configmaps-f4fd83c5-2b88-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:19:52.115: INFO: Pod pod-configmaps-f4fd83c5-2b88-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:19:52.115: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-9vljv" for this suite.
+Mar 19 15:19:58.135: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:19:58.226: INFO: namespace: e2e-tests-configmap-9vljv, resource: bindings, ignored listing per whitelist
+Mar 19 15:19:58.287: INFO: namespace e2e-tests-configmap-9vljv deletion completed in 6.166464142s
+
+• [SLOW TEST:12.296 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:19:58.290: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:19:58.360: INFO: Waiting up to 5m0s for pod "downwardapi-volume-fc518455-2b88-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-rjpjt" to be "success or failure"
+Mar 19 15:19:58.369: INFO: Pod "downwardapi-volume-fc518455-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 8.730226ms
+Mar 19 15:20:00.372: INFO: Pod "downwardapi-volume-fc518455-2b88-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.012107635s
+Mar 19 15:20:02.376: INFO: Pod "downwardapi-volume-fc518455-2b88-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016153589s
+STEP: Saw pod success
+Mar 19 15:20:02.376: INFO: Pod "downwardapi-volume-fc518455-2b88-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:20:02.379: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-fc518455-2b88-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:20:02.418: INFO: Waiting for pod downwardapi-volume-fc518455-2b88-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:20:02.435: INFO: Pod downwardapi-volume-fc518455-2b88-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:20:02.438: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-rjpjt" for this suite.
+Mar 19 15:20:08.455: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:20:08.595: INFO: namespace: e2e-tests-downward-api-rjpjt, resource: bindings, ignored listing per whitelist
+Mar 19 15:20:08.595: INFO: namespace e2e-tests-downward-api-rjpjt deletion completed in 6.150372689s
+
+• [SLOW TEST:10.305 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:20:08.596: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-0274585e-2b89-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:20:08.668: INFO: Waiting up to 5m0s for pod "pod-configmaps-02764bd9-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-configmap-4b6lg" to be "success or failure"
+Mar 19 15:20:08.671: INFO: Pod "pod-configmaps-02764bd9-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.403209ms
+Mar 19 15:20:10.675: INFO: Pod "pod-configmaps-02764bd9-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006795911s
+STEP: Saw pod success
+Mar 19 15:20:10.675: INFO: Pod "pod-configmaps-02764bd9-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:20:10.677: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-configmaps-02764bd9-2b89-11e8-945a-764aeb95b32d container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:20:10.701: INFO: Waiting for pod pod-configmaps-02764bd9-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:20:10.705: INFO: Pod pod-configmaps-02764bd9-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:20:10.706: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-4b6lg" for this suite.
+Mar 19 15:20:16.741: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:20:16.880: INFO: namespace: e2e-tests-configmap-4b6lg, resource: bindings, ignored listing per whitelist
+Mar 19 15:20:16.880: INFO: namespace e2e-tests-configmap-4b6lg deletion completed in 6.171182995s
+
+• [SLOW TEST:8.285 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:20:16.881: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-map-07659e75-2b89-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:20:16.950: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-07660f79-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-2tw8v" to be "success or failure"
+Mar 19 15:20:16.964: INFO: Pod "pod-projected-configmaps-07660f79-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 14.059646ms
+Mar 19 15:20:18.971: INFO: Pod "pod-projected-configmaps-07660f79-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.021176675s
+Mar 19 15:20:20.974: INFO: Pod "pod-projected-configmaps-07660f79-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.024125521s
+STEP: Saw pod success
+Mar 19 15:20:20.974: INFO: Pod "pod-projected-configmaps-07660f79-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:20:20.976: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-configmaps-07660f79-2b89-11e8-945a-764aeb95b32d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:20:21.014: INFO: Waiting for pod pod-projected-configmaps-07660f79-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:20:21.030: INFO: Pod pod-projected-configmaps-07660f79-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:20:21.030: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2tw8v" for this suite.
+Mar 19 15:20:27.048: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:20:27.117: INFO: namespace: e2e-tests-projected-2tw8v, resource: bindings, ignored listing per whitelist
+Mar 19 15:20:27.210: INFO: namespace e2e-tests-projected-2tw8v deletion completed in 6.17646729s
+
+• [SLOW TEST:10.329 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:20:27.211: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 15:20:27.307: INFO: (0) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 9.765025ms)
+Mar 19 15:20:27.312: INFO: (1) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.533214ms)
+Mar 19 15:20:27.319: INFO: (2) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 6.182016ms)
+Mar 19 15:20:27.324: INFO: (3) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.007213ms)
+Mar 19 15:20:27.329: INFO: (4) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.683014ms)
+Mar 19 15:20:27.335: INFO: (5) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.647214ms)
+Mar 19 15:20:27.341: INFO: (6) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.519714ms)
+Mar 19 15:20:27.346: INFO: (7) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.138214ms)
+Mar 19 15:20:27.352: INFO: (8) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.627514ms)
+Mar 19 15:20:27.356: INFO: (9) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.356212ms)
+Mar 19 15:20:27.361: INFO: (10) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.843712ms)
+Mar 19 15:20:27.366: INFO: (11) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.841813ms)
+Mar 19 15:20:27.371: INFO: (12) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.827212ms)
+Mar 19 15:20:27.376: INFO: (13) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.256514ms)
+Mar 19 15:20:27.382: INFO: (14) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.514414ms)
+Mar 19 15:20:27.387: INFO: (15) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.635114ms)
+Mar 19 15:20:27.393: INFO: (16) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.195013ms)
+Mar 19 15:20:27.399: INFO: (17) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.811615ms)
+Mar 19 15:20:27.408: INFO: (18) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 9.749325ms)
+Mar 19 15:20:27.415: INFO: (19) /api/v1/proxy/nodes/shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd:10250/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 6.147916ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:20:27.415: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-8pfnb" for this suite.
+Mar 19 15:20:33.429: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:20:33.546: INFO: namespace: e2e-tests-proxy-8pfnb, resource: bindings, ignored listing per whitelist
+Mar 19 15:20:33.565: INFO: namespace e2e-tests-proxy-8pfnb deletion completed in 6.147216737s
+
+• [SLOW TEST:6.354 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node with explicit kubelet port  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:20:33.571: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-map-115a94d5-2b89-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:20:33.658: INFO: Waiting up to 5m0s for pod "pod-configmaps-115b06b8-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-configmap-qrm9f" to be "success or failure"
+Mar 19 15:20:33.663: INFO: Pod "pod-configmaps-115b06b8-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.765613ms
+Mar 19 15:20:35.666: INFO: Pod "pod-configmaps-115b06b8-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007954694s
+STEP: Saw pod success
+Mar 19 15:20:35.666: INFO: Pod "pod-configmaps-115b06b8-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:20:35.669: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-configmaps-115b06b8-2b89-11e8-945a-764aeb95b32d container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:20:35.705: INFO: Waiting for pod pod-configmaps-115b06b8-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:20:35.712: INFO: Pod pod-configmaps-115b06b8-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:20:35.712: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-qrm9f" for this suite.
+Mar 19 15:20:41.734: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:20:41.855: INFO: namespace: e2e-tests-configmap-qrm9f, resource: bindings, ignored listing per whitelist
+Mar 19 15:20:41.869: INFO: namespace e2e-tests-configmap-qrm9f deletion completed in 6.147919745s
+
+• [SLOW TEST:8.299 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:20:41.870: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-16584a01-2b89-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:20:42.028: INFO: Waiting up to 5m0s for pod "pod-secrets-1658ba59-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-secrets-xwqn9" to be "success or failure"
+Mar 19 15:20:42.036: INFO: Pod "pod-secrets-1658ba59-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 7.465925ms
+Mar 19 15:20:44.041: INFO: Pod "pod-secrets-1658ba59-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012582858s
+STEP: Saw pod success
+Mar 19 15:20:44.041: INFO: Pod "pod-secrets-1658ba59-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:20:44.044: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-secrets-1658ba59-2b89-11e8-945a-764aeb95b32d container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:20:44.066: INFO: Waiting for pod pod-secrets-1658ba59-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:20:44.076: INFO: Pod pod-secrets-1658ba59-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:20:44.079: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-xwqn9" for this suite.
+Mar 19 15:20:50.103: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:20:50.160: INFO: namespace: e2e-tests-secrets-xwqn9, resource: bindings, ignored listing per whitelist
+Mar 19 15:20:50.251: INFO: namespace e2e-tests-secrets-xwqn9 deletion completed in 6.167090938s
+
+• [SLOW TEST:8.381 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:20:50.255: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Mar 19 15:20:52.882: INFO: Successfully updated pod "pod-update-1b4f4d11-2b89-11e8-945a-764aeb95b32d"
+STEP: verifying the updated pod is in kubernetes
+Mar 19 15:20:52.900: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:20:52.900: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-57f4t" for this suite.
+Mar 19 15:21:14.924: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:21:15.050: INFO: namespace: e2e-tests-pods-57f4t, resource: bindings, ignored listing per whitelist
+Mar 19 15:21:15.057: INFO: namespace e2e-tests-pods-57f4t deletion completed in 22.153407934s
+
+• [SLOW TEST:24.803 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:21:15.058: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name projected-secret-test-2a16722f-2b89-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:21:15.151: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-2a16fe8e-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-rk9jd" to be "success or failure"
+Mar 19 15:21:15.163: INFO: Pod "pod-projected-secrets-2a16fe8e-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 11.183532ms
+Mar 19 15:21:17.167: INFO: Pod "pod-projected-secrets-2a16fe8e-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.015239996s
+Mar 19 15:21:19.183: INFO: Pod "pod-projected-secrets-2a16fe8e-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.031964105s
+STEP: Saw pod success
+Mar 19 15:21:19.184: INFO: Pod "pod-projected-secrets-2a16fe8e-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:21:19.192: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-secrets-2a16fe8e-2b89-11e8-945a-764aeb95b32d container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:21:19.249: INFO: Waiting for pod pod-projected-secrets-2a16fe8e-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:21:19.261: INFO: Pod pod-projected-secrets-2a16fe8e-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:21:19.261: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rk9jd" for this suite.
+Mar 19 15:21:25.290: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:21:25.394: INFO: namespace: e2e-tests-projected-rk9jd, resource: bindings, ignored listing per whitelist
+Mar 19 15:21:25.421: INFO: namespace e2e-tests-projected-rk9jd deletion completed in 6.14977014s
+
+• [SLOW TEST:10.363 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:21:25.422: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-czrhr.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-czrhr.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-czrhr.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-czrhr.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-czrhr.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-czrhr.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Mar 19 15:21:53.519: INFO: DNS probes using dns-test-303e8a24-2b89-11e8-945a-764aeb95b32d succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:21:53.545: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-czrhr" for this suite.
+Mar 19 15:21:59.570: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:21:59.699: INFO: namespace: e2e-tests-dns-czrhr, resource: bindings, ignored listing per whitelist
+Mar 19 15:21:59.707: INFO: namespace e2e-tests-dns-czrhr deletion completed in 6.158815711s
+
+• [SLOW TEST:34.285 seconds]
+[sig-network] DNS
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:21:59.708: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Mar 19 15:21:59.790: INFO: Waiting up to 1m0s for all nodes to be ready
+Mar 19 15:22:59.816: INFO: Waiting for terminating namespaces to be deleted...
+Mar 19 15:22:59.822: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 19 15:22:59.842: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 19 15:22:59.842: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 19 15:22:59.846: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 19 15:22:59.846: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd before test
+Mar 19 15:22:59.861: INFO: addons-nginx-ingress-controller-ddcb6d7fc-gz8ht from kube-system started at 2018-03-19 14:04:28 +0000 UTC (1 container statuses recorded)
+Mar 19 15:22:59.861: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: addons-heapster-e3b0c-b9ff79bbd-mbg6f from kube-system started at 2018-03-19 14:04:28 +0000 UTC (2 container statuses recorded)
+Mar 19 15:22:59.861: INFO: 	Container heapster ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: 	Container heapster-nanny ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: addons-kubernetes-dashboard-7fc5877997-29c2m from kube-system started at 2018-03-19 14:04:28 +0000 UTC (1 container statuses recorded)
+Mar 19 15:22:59.861: INFO: 	Container main ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: kube-dns-858cbcf6ff-gbf2s from kube-system started at 2018-03-19 14:04:28 +0000 UTC (3 container statuses recorded)
+Mar 19 15:22:59.861: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: 	Container kubedns ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: 	Container sidecar ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: kube-dns-autoscaler-6966fd6fb6-tj5wc from kube-system started at 2018-03-19 14:04:29 +0000 UTC (1 container statuses recorded)
+Mar 19 15:22:59.861: INFO: 	Container autoscaler ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: kube-proxy-tv4sn from kube-system started at 2018-03-19 12:40:27 +0000 UTC (1 container statuses recorded)
+Mar 19 15:22:59.861: INFO: 	Container kube-proxy ready: true, restart count 1
+Mar 19 15:22:59.861: INFO: calico-node-2284r from kube-system started at 2018-03-19 12:40:27 +0000 UTC (2 container statuses recorded)
+Mar 19 15:22:59.861: INFO: 	Container calico-node ready: true, restart count 1
+Mar 19 15:22:59.861: INFO: 	Container install-cni ready: true, restart count 1
+Mar 19 15:22:59.861: INFO: vpn-shoot-56558cd489-2q8hr from kube-system started at 2018-03-19 14:04:29 +0000 UTC (1 container statuses recorded)
+Mar 19 15:22:59.861: INFO: 	Container vpn-shoot ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: kube-dns-858cbcf6ff-52ttw from kube-system started at 2018-03-19 14:04:29 +0000 UTC (3 container statuses recorded)
+Mar 19 15:22:59.861: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: 	Container kubedns ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: 	Container sidecar ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: node-exporter-cfkn7 from kube-system started at 2018-03-19 12:40:27 +0000 UTC (1 container statuses recorded)
+Mar 19 15:22:59.861: INFO: 	Container node-exporter ready: true, restart count 1
+Mar 19 15:22:59.861: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-rwfhz from kube-system started at 2018-03-19 14:04:28 +0000 UTC (1 container statuses recorded)
+Mar 19 15:22:59.861: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Mar 19 15:22:59.861: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs before test
+Mar 19 15:22:59.873: INFO: node-exporter-hctwh from kube-system started at 2018-03-18 14:29:49 +0000 UTC (1 container statuses recorded)
+Mar 19 15:22:59.874: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 19 15:22:59.874: INFO: kube-proxy-zqcn8 from kube-system started at 2018-03-18 14:29:49 +0000 UTC (1 container statuses recorded)
+Mar 19 15:22:59.874: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 19 15:22:59.874: INFO: sonobuoy from sonobuoy started at 2018-03-19 14:50:46 +0000 UTC (1 container statuses recorded)
+Mar 19 15:22:59.874: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Mar 19 15:22:59.874: INFO: calico-node-9nl8j from kube-system started at 2018-03-18 14:29:49 +0000 UTC (2 container statuses recorded)
+Mar 19 15:22:59.874: INFO: 	Container calico-node ready: true, restart count 0
+Mar 19 15:22:59.874: INFO: 	Container install-cni ready: true, restart count 0
+Mar 19 15:22:59.874: INFO: sonobuoy-e2e-job-839773c704254943 from sonobuoy started at 2018-03-19 14:51:02 +0000 UTC (2 container statuses recorded)
+Mar 19 15:22:59.874: INFO: 	Container e2e ready: true, restart count 0
+Mar 19 15:22:59.875: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-69bb5f5a-2b89-11e8-945a-764aeb95b32d 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-69bb5f5a-2b89-11e8-945a-764aeb95b32d off the node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-69bb5f5a-2b89-11e8-945a-764aeb95b32d
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:23:03.971: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-tzdfh" for this suite.
+Mar 19 15:23:26.017: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:23:26.089: INFO: namespace: e2e-tests-sched-pred-tzdfh, resource: bindings, ignored listing per whitelist
+Mar 19 15:23:26.177: INFO: namespace e2e-tests-sched-pred-tzdfh deletion completed in 22.202266086s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:86.469 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:23:26.178: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 19 15:23:28.830: INFO: Successfully updated pod "annotationupdate783e005c-2b89-11e8-945a-764aeb95b32d"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:23:32.872: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-f5s2s" for this suite.
+Mar 19 15:23:54.888: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:23:55.016: INFO: namespace: e2e-tests-downward-api-f5s2s, resource: bindings, ignored listing per whitelist
+Mar 19 15:23:55.024: INFO: namespace e2e-tests-downward-api-f5s2s deletion completed in 22.149101497s
+
+• [SLOW TEST:28.846 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:23:55.024: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-8981c98a-2b89-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:23:55.244: INFO: Waiting up to 5m0s for pod "pod-secrets-8982e5ea-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-secrets-nbnc4" to be "success or failure"
+Mar 19 15:23:55.259: INFO: Pod "pod-secrets-8982e5ea-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 14.548149ms
+Mar 19 15:23:57.262: INFO: Pod "pod-secrets-8982e5ea-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.018347754s
+Mar 19 15:23:59.266: INFO: Pod "pod-secrets-8982e5ea-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.021613681s
+STEP: Saw pod success
+Mar 19 15:23:59.266: INFO: Pod "pod-secrets-8982e5ea-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:23:59.268: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-secrets-8982e5ea-2b89-11e8-945a-764aeb95b32d container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:23:59.290: INFO: Waiting for pod pod-secrets-8982e5ea-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:23:59.298: INFO: Pod pod-secrets-8982e5ea-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:23:59.302: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-nbnc4" for this suite.
+Mar 19 15:24:05.332: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:24:05.546: INFO: namespace: e2e-tests-secrets-nbnc4, resource: bindings, ignored listing per whitelist
+Mar 19 15:24:05.557: INFO: namespace e2e-tests-secrets-nbnc4 deletion completed in 6.236804343s
+
+• [SLOW TEST:10.533 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:24:05.558: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-map-8fb1bf42-2b89-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:24:05.620: INFO: Waiting up to 5m0s for pod "pod-configmaps-8fb24366-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-configmap-zx5gn" to be "success or failure"
+Mar 19 15:24:05.627: INFO: Pod "pod-configmaps-8fb24366-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 7.010617ms
+Mar 19 15:24:07.630: INFO: Pod "pod-configmaps-8fb24366-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010459578s
+Mar 19 15:24:09.633: INFO: Pod "pod-configmaps-8fb24366-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013881987s
+STEP: Saw pod success
+Mar 19 15:24:09.634: INFO: Pod "pod-configmaps-8fb24366-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:24:09.636: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-configmaps-8fb24366-2b89-11e8-945a-764aeb95b32d container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:24:09.655: INFO: Waiting for pod pod-configmaps-8fb24366-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:24:09.661: INFO: Pod pod-configmaps-8fb24366-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:24:09.661: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-zx5gn" for this suite.
+Mar 19 15:24:15.684: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:24:15.757: INFO: namespace: e2e-tests-configmap-zx5gn, resource: bindings, ignored listing per whitelist
+Mar 19 15:24:15.820: INFO: namespace e2e-tests-configmap-zx5gn deletion completed in 6.145597778s
+
+• [SLOW TEST:10.262 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:24:15.820: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-kc9wp
+Mar 19 15:24:20.192: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-kc9wp
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 19 15:24:20.195: INFO: Initial restart count of pod liveness-exec is 0
+Mar 19 15:25:12.294: INFO: Restart count of pod e2e-tests-container-probe-kc9wp/liveness-exec is now 1 (52.099271837s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:25:12.317: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-kc9wp" for this suite.
+Mar 19 15:25:18.368: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:25:18.442: INFO: namespace: e2e-tests-container-probe-kc9wp, resource: bindings, ignored listing per whitelist
+Mar 19 15:25:18.543: INFO: namespace e2e-tests-container-probe-kc9wp deletion completed in 6.210456501s
+
+• [SLOW TEST:62.724 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:25:18.545: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: getting the auto-created API token
+Mar 19 15:25:19.147: INFO: created pod pod-service-account-defaultsa
+Mar 19 15:25:19.148: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Mar 19 15:25:19.168: INFO: created pod pod-service-account-mountsa
+Mar 19 15:25:19.169: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Mar 19 15:25:19.190: INFO: created pod pod-service-account-nomountsa
+Mar 19 15:25:19.190: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Mar 19 15:25:19.200: INFO: created pod pod-service-account-defaultsa-mountspec
+Mar 19 15:25:19.200: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Mar 19 15:25:19.211: INFO: created pod pod-service-account-mountsa-mountspec
+Mar 19 15:25:19.211: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Mar 19 15:25:19.222: INFO: created pod pod-service-account-nomountsa-mountspec
+Mar 19 15:25:19.222: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Mar 19 15:25:19.240: INFO: created pod pod-service-account-defaultsa-nomountspec
+Mar 19 15:25:19.240: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Mar 19 15:25:19.255: INFO: created pod pod-service-account-mountsa-nomountspec
+Mar 19 15:25:19.255: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Mar 19 15:25:19.261: INFO: created pod pod-service-account-nomountsa-nomountspec
+Mar 19 15:25:19.261: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:25:19.261: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-lkgx2" for this suite.
+Mar 19 15:25:41.342: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:25:41.380: INFO: namespace: e2e-tests-svcaccounts-lkgx2, resource: bindings, ignored listing per whitelist
+Mar 19 15:25:41.470: INFO: namespace e2e-tests-svcaccounts-lkgx2 deletion completed in 22.180528948s
+
+• [SLOW TEST:22.925 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:25:41.471: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:37
+[It] should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test hostPath mode
+Mar 19 15:25:41.580: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-qnphn" to be "success or failure"
+Mar 19 15:25:41.585: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 4.789314ms
+Mar 19 15:25:43.588: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008250237s
+Mar 19 15:25:45.592: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012188989s
+STEP: Saw pod success
+Mar 19 15:25:45.592: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Mar 19 15:25:45.595: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Mar 19 15:25:45.630: INFO: Waiting for pod pod-host-path-test to disappear
+Mar 19 15:25:45.637: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:25:45.637: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-qnphn" for this suite.
+Mar 19 15:25:51.654: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:25:51.725: INFO: namespace: e2e-tests-hostpath-qnphn, resource: bindings, ignored listing per whitelist
+Mar 19 15:25:51.787: INFO: namespace e2e-tests-hostpath-qnphn deletion completed in 6.146347074s
+
+• [SLOW TEST:10.316 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:34
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:25:51.787: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:25:51.886: INFO: Waiting up to 5m0s for pod "downwardapi-volume-cf095b23-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-8f7nt" to be "success or failure"
+Mar 19 15:25:51.899: INFO: Pod "downwardapi-volume-cf095b23-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 12.456138ms
+Mar 19 15:25:53.903: INFO: Pod "downwardapi-volume-cf095b23-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.016620315s
+Mar 19 15:25:55.910: INFO: Pod "downwardapi-volume-cf095b23-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.023628782s
+STEP: Saw pod success
+Mar 19 15:25:55.910: INFO: Pod "downwardapi-volume-cf095b23-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:25:55.916: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-cf095b23-2b89-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:25:55.941: INFO: Waiting for pod downwardapi-volume-cf095b23-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:25:55.944: INFO: Pod downwardapi-volume-cf095b23-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:25:55.944: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-8f7nt" for this suite.
+Mar 19 15:26:02.025: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:26:02.137: INFO: namespace: e2e-tests-downward-api-8f7nt, resource: bindings, ignored listing per whitelist
+Mar 19 15:26:02.163: INFO: namespace e2e-tests-downward-api-8f7nt deletion completed in 6.215198364s
+
+• [SLOW TEST:10.376 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:26:02.163: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Mar 19 15:26:02.234: INFO: Waiting up to 5m0s for pod "pod-d5345117-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-shn7s" to be "success or failure"
+Mar 19 15:26:02.243: INFO: Pod "pod-d5345117-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 8.733129ms
+Mar 19 15:26:04.246: INFO: Pod "pod-d5345117-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012386612s
+STEP: Saw pod success
+Mar 19 15:26:04.246: INFO: Pod "pod-d5345117-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:26:04.249: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-d5345117-2b89-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:26:04.294: INFO: Waiting for pod pod-d5345117-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:26:04.298: INFO: Pod pod-d5345117-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:26:04.298: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-shn7s" for this suite.
+Mar 19 15:26:10.319: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:26:10.429: INFO: namespace: e2e-tests-emptydir-shn7s, resource: bindings, ignored listing per whitelist
+Mar 19 15:26:10.459: INFO: namespace e2e-tests-emptydir-shn7s deletion completed in 6.157485379s
+
+• [SLOW TEST:8.297 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:26:10.461: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-da317ac3-2b89-11e8-945a-764aeb95b32d,GenerateName:,Namespace:e2e-tests-events-bxpq9,SelfLink:/api/v1/namespaces/e2e-tests-events-bxpq9/pods/send-events-da317ac3-2b89-11e8-945a-764aeb95b32d,UID:da31f8dd-2b89-11e8-a078-ea46dfd82876,ResourceVersion:126832,Generation:0,CreationTimestamp:2018-03-19 15:26:10 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 599003274,},Annotations:map[string]string{cni.projectcalico.org/podIP: 100.96.0.123/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-lbjxs {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-lbjxs,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-lbjxs true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc4217a4990} {node.kubernetes.io/unreachable Exists  NoExecute 0xc4217a49b0}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-03-19 15:26:10 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-03-19 15:26:12 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-03-19 15:26:10 +0000 UTC  }],Message:,Reason:,HostIP:10.250.0.5,PodIP:100.96.0.123,StartTime:2018-03-19 15:26:10 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-03-19 15:26:11 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://487b258b51cf9069ff4fac24336ec20812d516d5f5678ef0d433a15f281ed26a}],QOSClass:BestEffort,InitContainerStatuses:[],},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:26:18.630: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-bxpq9" for this suite.
+Mar 19 15:26:24.676: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:26:24.815: INFO: namespace: e2e-tests-events-bxpq9, resource: bindings, ignored listing per whitelist
+Mar 19 15:26:24.824: INFO: namespace e2e-tests-events-bxpq9 deletion completed in 6.182219041s
+
+• [SLOW TEST:14.363 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:26:24.827: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Mar 19 15:26:26.969: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-e2baddf9-2b89-11e8-945a-764aeb95b32d", GenerateName:"", Namespace:"e2e-tests-pods-6xppg", SelfLink:"/api/v1/namespaces/e2e-tests-pods-6xppg/pods/pod-submit-remove-e2baddf9-2b89-11e8-945a-764aeb95b32d", UID:"e2bc2636-2b89-11e8-a078-ea46dfd82876", ResourceVersion:"126870", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63657069984, loc:(*time.Location)(0x619f460)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"921142998"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"100.96.0.124/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-c25nz", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc421cd3cc0), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"gcr.io/google-containers/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-c25nz", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc42163b5f8), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs", HostNetwork:false, HostPID:false, HostIPC:false, SecurityContext:(*v1.PodSecurityContext)(0xc421cd3d40), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc42163b630)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc42163b650)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63657069984, loc:(*time.Location)(0x619f460)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63657069986, loc:(*time.Location)(0x619f460)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63657069984, loc:(*time.Location)(0x619f460)}}, Reason:"", Message:""}}, Message:"", Reason:"", HostIP:"10.250.0.5", PodIP:"100.96.0.124", StartTime:(*v1.Time)(0xc421913920), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc421913940), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"gcr.io/google-containers/nginx-slim-amd64:0.20", ImageID:"docker-pullable://gcr.io/google-containers/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://aa930eb8bc3fb90fadf8e49e407acf4a8f24e62c4897bf7b6bbf55091d4cf6b4"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:26:34.976: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-6xppg" for this suite.
+Mar 19 15:26:40.991: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:26:41.030: INFO: namespace: e2e-tests-pods-6xppg, resource: bindings, ignored listing per whitelist
+Mar 19 15:26:41.122: INFO: namespace e2e-tests-pods-6xppg deletion completed in 6.142116194s
+
+• [SLOW TEST:16.296 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:26:41.125: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:26:41.191: INFO: Waiting up to 5m0s for pod "downwardapi-volume-ec6c2149-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-x8hdj" to be "success or failure"
+Mar 19 15:26:41.196: INFO: Pod "downwardapi-volume-ec6c2149-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.952717ms
+Mar 19 15:26:43.199: INFO: Pod "downwardapi-volume-ec6c2149-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007969564s
+STEP: Saw pod success
+Mar 19 15:26:43.199: INFO: Pod "downwardapi-volume-ec6c2149-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:26:43.202: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-ec6c2149-2b89-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:26:43.248: INFO: Waiting for pod downwardapi-volume-ec6c2149-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:26:43.257: INFO: Pod downwardapi-volume-ec6c2149-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:26:43.257: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-x8hdj" for this suite.
+Mar 19 15:26:49.279: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:26:49.425: INFO: namespace: e2e-tests-projected-x8hdj, resource: bindings, ignored listing per whitelist
+Mar 19 15:26:49.425: INFO: namespace e2e-tests-projected-x8hdj deletion completed in 6.15801115s
+
+• [SLOW TEST:8.300 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:26:49.425: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Mar 19 15:26:49.580: INFO: Waiting up to 5m0s for pod "pod-f16cd401-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-j57g4" to be "success or failure"
+Mar 19 15:26:49.584: INFO: Pod "pod-f16cd401-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.192311ms
+Mar 19 15:26:51.588: INFO: Pod "pod-f16cd401-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007781218s
+Mar 19 15:26:53.591: INFO: Pod "pod-f16cd401-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010863698s
+STEP: Saw pod success
+Mar 19 15:26:53.591: INFO: Pod "pod-f16cd401-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:26:53.594: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-f16cd401-2b89-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:26:53.616: INFO: Waiting for pod pod-f16cd401-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:26:53.622: INFO: Pod pod-f16cd401-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:26:53.622: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-j57g4" for this suite.
+Mar 19 15:26:59.663: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:26:59.720: INFO: namespace: e2e-tests-emptydir-j57g4, resource: bindings, ignored listing per whitelist
+Mar 19 15:26:59.795: INFO: namespace e2e-tests-emptydir-j57g4 deletion completed in 6.169252588s
+
+• [SLOW TEST:10.369 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:26:59.795: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Mar 19 15:26:59.865: INFO: Waiting up to 5m0s for pod "pod-f78c69d9-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-26swv" to be "success or failure"
+Mar 19 15:26:59.905: INFO: Pod "pod-f78c69d9-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 40.54493ms
+Mar 19 15:27:01.909: INFO: Pod "pod-f78c69d9-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.044353426s
+STEP: Saw pod success
+Mar 19 15:27:01.909: INFO: Pod "pod-f78c69d9-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:27:01.913: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-f78c69d9-2b89-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:27:01.996: INFO: Waiting for pod pod-f78c69d9-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:27:02.005: INFO: Pod pod-f78c69d9-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:27:02.005: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-26swv" for this suite.
+Mar 19 15:27:08.055: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:27:08.183: INFO: namespace: e2e-tests-emptydir-26swv, resource: bindings, ignored listing per whitelist
+Mar 19 15:27:08.190: INFO: namespace e2e-tests-emptydir-26swv deletion completed in 6.181698267s
+
+• [SLOW TEST:8.395 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:27:08.190: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-fc8d0fe6-2b89-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:27:08.256: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-fc8dd7dc-2b89-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-x542q" to be "success or failure"
+Mar 19 15:27:08.283: INFO: Pod "pod-projected-configmaps-fc8dd7dc-2b89-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 27.236774ms
+Mar 19 15:27:10.288: INFO: Pod "pod-projected-configmaps-fc8dd7dc-2b89-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.032001279s
+STEP: Saw pod success
+Mar 19 15:27:10.288: INFO: Pod "pod-projected-configmaps-fc8dd7dc-2b89-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:27:10.291: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-configmaps-fc8dd7dc-2b89-11e8-945a-764aeb95b32d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:27:10.315: INFO: Waiting for pod pod-projected-configmaps-fc8dd7dc-2b89-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:27:10.319: INFO: Pod pod-projected-configmaps-fc8dd7dc-2b89-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:27:10.323: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-x542q" for this suite.
+Mar 19 15:27:16.363: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:27:16.421: INFO: namespace: e2e-tests-projected-x542q, resource: bindings, ignored listing per whitelist
+Mar 19 15:27:16.493: INFO: namespace e2e-tests-projected-x542q deletion completed in 6.158303722s
+
+• [SLOW TEST:8.302 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:27:16.493: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating replication controller my-hostname-basic-01823209-2b8a-11e8-945a-764aeb95b32d
+Mar 19 15:27:16.570: INFO: Pod name my-hostname-basic-01823209-2b8a-11e8-945a-764aeb95b32d: Found 0 pods out of 1
+Mar 19 15:27:21.574: INFO: Pod name my-hostname-basic-01823209-2b8a-11e8-945a-764aeb95b32d: Found 1 pods out of 1
+Mar 19 15:27:21.574: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-01823209-2b8a-11e8-945a-764aeb95b32d" are running
+Mar 19 15:27:21.577: INFO: Pod "my-hostname-basic-01823209-2b8a-11e8-945a-764aeb95b32d-4xkrq" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-19 15:27:16 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-19 15:27:18 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-19 15:27:16 +0000 UTC Reason: Message:}])
+Mar 19 15:27:21.577: INFO: Trying to dial the pod
+Mar 19 15:27:26.634: INFO: Controller my-hostname-basic-01823209-2b8a-11e8-945a-764aeb95b32d: Got expected result from replica 1 [my-hostname-basic-01823209-2b8a-11e8-945a-764aeb95b32d-4xkrq]: "my-hostname-basic-01823209-2b8a-11e8-945a-764aeb95b32d-4xkrq", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:27:26.634: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-hfgs7" for this suite.
+Mar 19 15:27:32.653: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:27:32.726: INFO: namespace: e2e-tests-replication-controller-hfgs7, resource: bindings, ignored listing per whitelist
+Mar 19 15:27:32.783: INFO: namespace e2e-tests-replication-controller-hfgs7 deletion completed in 6.145952078s
+
+• [SLOW TEST:16.291 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:27:32.786: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 19 15:27:32.854: INFO: Waiting up to 5m0s for pod "downward-api-0b368899-2b8a-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-28sxr" to be "success or failure"
+Mar 19 15:27:32.861: INFO: Pod "downward-api-0b368899-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 7.188724ms
+Mar 19 15:27:34.864: INFO: Pod "downward-api-0b368899-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010682754s
+Mar 19 15:27:36.868: INFO: Pod "downward-api-0b368899-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.014458348s
+Mar 19 15:27:38.872: INFO: Pod "downward-api-0b368899-2b8a-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.018495411s
+STEP: Saw pod success
+Mar 19 15:27:38.873: INFO: Pod "downward-api-0b368899-2b8a-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:27:38.876: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downward-api-0b368899-2b8a-11e8-945a-764aeb95b32d container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 15:27:38.911: INFO: Waiting for pod downward-api-0b368899-2b8a-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:27:38.914: INFO: Pod downward-api-0b368899-2b8a-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:27:38.914: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-28sxr" for this suite.
+Mar 19 15:27:44.930: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:27:45.062: INFO: namespace: e2e-tests-downward-api-28sxr, resource: bindings, ignored listing per whitelist
+Mar 19 15:27:45.065: INFO: namespace e2e-tests-downward-api-28sxr deletion completed in 6.146486328s
+
+• [SLOW TEST:12.279 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:27:45.066: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:28:45.142: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-5dmwj" for this suite.
+Mar 19 15:29:07.162: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:29:07.210: INFO: namespace: e2e-tests-container-probe-5dmwj, resource: bindings, ignored listing per whitelist
+Mar 19 15:29:07.292: INFO: namespace e2e-tests-container-probe-5dmwj deletion completed in 22.143765449s
+
+• [SLOW TEST:82.226 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default commmand (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:29:07.294: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default commmand (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test override command
+Mar 19 15:29:07.354: INFO: Waiting up to 5m0s for pod "client-containers-438b60f6-2b8a-11e8-945a-764aeb95b32d" in namespace "e2e-tests-containers-v9knk" to be "success or failure"
+Mar 19 15:29:07.362: INFO: Pod "client-containers-438b60f6-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 7.559225ms
+Mar 19 15:29:09.365: INFO: Pod "client-containers-438b60f6-2b8a-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011096699s
+STEP: Saw pod success
+Mar 19 15:29:09.365: INFO: Pod "client-containers-438b60f6-2b8a-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:29:09.368: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod client-containers-438b60f6-2b8a-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:29:09.410: INFO: Waiting for pod client-containers-438b60f6-2b8a-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:29:09.413: INFO: Pod client-containers-438b60f6-2b8a-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:29:09.413: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-v9knk" for this suite.
+Mar 19 15:29:15.428: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:29:15.521: INFO: namespace: e2e-tests-containers-v9knk, resource: bindings, ignored listing per whitelist
+Mar 19 15:29:15.563: INFO: namespace e2e-tests-containers-v9knk deletion completed in 6.146899799s
+
+• [SLOW TEST:8.270 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be able to override the image's default commmand (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:29:15.565: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-projected-all-test-volume-4886e601-2b8a-11e8-945a-764aeb95b32d
+STEP: Creating secret with name secret-projected-all-test-volume-4886e5f0-2b8a-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Mar 19 15:29:15.721: INFO: Waiting up to 5m0s for pod "projected-volume-4886e59d-2b8a-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-brsv8" to be "success or failure"
+Mar 19 15:29:15.726: INFO: Pod "projected-volume-4886e59d-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.189412ms
+Mar 19 15:29:17.729: INFO: Pod "projected-volume-4886e59d-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008095094s
+Mar 19 15:29:20.279: INFO: Pod "projected-volume-4886e59d-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.557426812s
+Mar 19 15:29:22.282: INFO: Pod "projected-volume-4886e59d-2b8a-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.560342079s
+STEP: Saw pod success
+Mar 19 15:29:22.282: INFO: Pod "projected-volume-4886e59d-2b8a-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:29:22.284: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod projected-volume-4886e59d-2b8a-11e8-945a-764aeb95b32d container projected-all-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:29:22.313: INFO: Waiting for pod projected-volume-4886e59d-2b8a-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:29:22.331: INFO: Pod projected-volume-4886e59d-2b8a-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:29:22.331: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-brsv8" for this suite.
+Mar 19 15:29:28.351: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:29:28.443: INFO: namespace: e2e-tests-projected-brsv8, resource: bindings, ignored listing per whitelist
+Mar 19 15:29:28.485: INFO: namespace e2e-tests-projected-brsv8 deletion completed in 6.150391449s
+
+• [SLOW TEST:12.921 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:29:28.486: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-upd-502d60d2-2b8a-11e8-945a-764aeb95b32d
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-502d60d2-2b8a-11e8-945a-764aeb95b32d
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:30:33.997: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-jjg99" for this suite.
+Mar 19 15:30:56.015: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:30:56.140: INFO: namespace: e2e-tests-configmap-jjg99, resource: bindings, ignored listing per whitelist
+Mar 19 15:30:56.143: INFO: namespace e2e-tests-configmap-jjg99 deletion completed in 22.143709507s
+
+• [SLOW TEST:87.657 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:30:56.144: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-846e3129-2b8a-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:30:56.244: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-8471ef7d-2b8a-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-6j7l9" to be "success or failure"
+Mar 19 15:30:56.249: INFO: Pod "pod-projected-secrets-8471ef7d-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.655516ms
+Mar 19 15:30:58.252: INFO: Pod "pod-projected-secrets-8471ef7d-2b8a-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007687623s
+STEP: Saw pod success
+Mar 19 15:30:58.252: INFO: Pod "pod-projected-secrets-8471ef7d-2b8a-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:30:58.256: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-secrets-8471ef7d-2b8a-11e8-945a-764aeb95b32d container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:30:58.280: INFO: Waiting for pod pod-projected-secrets-8471ef7d-2b8a-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:30:58.320: INFO: Pod pod-projected-secrets-8471ef7d-2b8a-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:30:58.321: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6j7l9" for this suite.
+Mar 19 15:31:04.335: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:31:04.393: INFO: namespace: e2e-tests-projected-6j7l9, resource: bindings, ignored listing per whitelist
+Mar 19 15:31:04.540: INFO: namespace e2e-tests-projected-6j7l9 deletion completed in 6.215548656s
+
+• [SLOW TEST:8.396 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:31:04.541: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:51
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:31:04.619: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-5sqvv" for this suite.
+Mar 19 15:31:10.633: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:31:10.799: INFO: namespace: e2e-tests-services-5sqvv, resource: bindings, ignored listing per whitelist
+Mar 19 15:31:10.802: INFO: namespace e2e-tests-services-5sqvv deletion completed in 6.179799321s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:56
+
+• [SLOW TEST:6.261 seconds]
+[sig-network] Services
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:31:10.802: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-8d2aabfa-2b8a-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:31:10.886: INFO: Waiting up to 5m0s for pod "pod-configmaps-8d2b1858-2b8a-11e8-945a-764aeb95b32d" in namespace "e2e-tests-configmap-jvvrp" to be "success or failure"
+Mar 19 15:31:10.888: INFO: Pod "pod-configmaps-8d2b1858-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.370909ms
+Mar 19 15:31:12.896: INFO: Pod "pod-configmaps-8d2b1858-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009623936s
+Mar 19 15:31:14.900: INFO: Pod "pod-configmaps-8d2b1858-2b8a-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014038938s
+STEP: Saw pod success
+Mar 19 15:31:14.900: INFO: Pod "pod-configmaps-8d2b1858-2b8a-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:31:14.903: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-configmaps-8d2b1858-2b8a-11e8-945a-764aeb95b32d container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:31:14.929: INFO: Waiting for pod pod-configmaps-8d2b1858-2b8a-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:31:14.950: INFO: Pod pod-configmaps-8d2b1858-2b8a-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:31:14.950: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-jvvrp" for this suite.
+Mar 19 15:31:20.968: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:31:21.204: INFO: namespace: e2e-tests-configmap-jvvrp, resource: bindings, ignored listing per whitelist
+Mar 19 15:31:21.300: INFO: namespace e2e-tests-configmap-jvvrp deletion completed in 6.345648143s
+
+• [SLOW TEST:10.498 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:31:21.303: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name s-test-opt-del-93731b0f-2b8a-11e8-945a-764aeb95b32d
+STEP: Creating secret with name s-test-opt-upd-93731b63-2b8a-11e8-945a-764aeb95b32d
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-93731b0f-2b8a-11e8-945a-764aeb95b32d
+STEP: Updating secret s-test-opt-upd-93731b63-2b8a-11e8-945a-764aeb95b32d
+STEP: Creating secret with name s-test-opt-create-93731b86-2b8a-11e8-945a-764aeb95b32d
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:31:29.876: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xg9ww" for this suite.
+Mar 19 15:31:51.951: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:31:52.012: INFO: namespace: e2e-tests-projected-xg9ww, resource: bindings, ignored listing per whitelist
+Mar 19 15:31:52.079: INFO: namespace e2e-tests-projected-xg9ww deletion completed in 22.199565825s
+
+• [SLOW TEST:30.777 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:31:52.081: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:31:52.146: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a5c4932b-2b8a-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-k5dsk" to be "success or failure"
+Mar 19 15:31:52.172: INFO: Pod "downwardapi-volume-a5c4932b-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 26.280585ms
+Mar 19 15:31:54.176: INFO: Pod "downwardapi-volume-a5c4932b-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.02991787s
+Mar 19 15:31:56.179: INFO: Pod "downwardapi-volume-a5c4932b-2b8a-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.03352936s
+STEP: Saw pod success
+Mar 19 15:31:56.179: INFO: Pod "downwardapi-volume-a5c4932b-2b8a-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:31:56.182: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-a5c4932b-2b8a-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:31:56.270: INFO: Waiting for pod downwardapi-volume-a5c4932b-2b8a-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:31:56.278: INFO: Pod downwardapi-volume-a5c4932b-2b8a-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:31:56.278: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-k5dsk" for this suite.
+Mar 19 15:32:02.295: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:32:02.393: INFO: namespace: e2e-tests-downward-api-k5dsk, resource: bindings, ignored listing per whitelist
+Mar 19 15:32:02.448: INFO: namespace e2e-tests-downward-api-k5dsk deletion completed in 6.166675128s
+
+• [SLOW TEST:10.367 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:32:02.452: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Mar 19 15:32:03.053: INFO: Waiting up to 5m0s for pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-kpcqd" in namespace "e2e-tests-svcaccounts-x8nck" to be "success or failure"
+Mar 19 15:32:03.064: INFO: Pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-kpcqd": Phase="Pending", Reason="", readiness=false. Elapsed: 11.670333ms
+Mar 19 15:32:05.070: INFO: Pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-kpcqd": Phase="Pending", Reason="", readiness=false. Elapsed: 2.017327776s
+Mar 19 15:32:07.074: INFO: Pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-kpcqd": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.021037871s
+STEP: Saw pod success
+Mar 19 15:32:07.074: INFO: Pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-kpcqd" satisfied condition "success or failure"
+Mar 19 15:32:07.076: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-kpcqd container token-test: <nil>
+STEP: delete the pod
+Mar 19 15:32:13.214: INFO: Waiting for pod pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-kpcqd to disappear
+Mar 19 15:32:13.218: INFO: Pod pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-kpcqd no longer exists
+STEP: Creating a pod to test consume service account root CA
+Mar 19 15:32:13.228: INFO: Waiting up to 5m0s for pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-t72cq" in namespace "e2e-tests-svcaccounts-x8nck" to be "success or failure"
+Mar 19 15:32:13.237: INFO: Pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-t72cq": Phase="Pending", Reason="", readiness=false. Elapsed: 8.603726ms
+Mar 19 15:32:15.247: INFO: Pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-t72cq": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.018168436s
+STEP: Saw pod success
+Mar 19 15:32:15.247: INFO: Pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-t72cq" satisfied condition "success or failure"
+Mar 19 15:32:15.255: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-t72cq container root-ca-test: <nil>
+STEP: delete the pod
+Mar 19 15:32:15.285: INFO: Waiting for pod pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-t72cq to disappear
+Mar 19 15:32:15.311: INFO: Pod pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-t72cq no longer exists
+STEP: Creating a pod to test consume service account namespace
+Mar 19 15:32:15.319: INFO: Waiting up to 5m0s for pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-jtnsg" in namespace "e2e-tests-svcaccounts-x8nck" to be "success or failure"
+Mar 19 15:32:15.337: INFO: Pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-jtnsg": Phase="Pending", Reason="", readiness=false. Elapsed: 18.049052ms
+Mar 19 15:32:17.344: INFO: Pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-jtnsg": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.025761632s
+STEP: Saw pod success
+Mar 19 15:32:17.344: INFO: Pod "pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-jtnsg" satisfied condition "success or failure"
+Mar 19 15:32:17.351: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-jtnsg container namespace-test: <nil>
+STEP: delete the pod
+Mar 19 15:32:17.379: INFO: Waiting for pod pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-jtnsg to disappear
+Mar 19 15:32:17.394: INFO: Pod pod-service-account-ac44a87f-2b8a-11e8-945a-764aeb95b32d-jtnsg no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:32:17.398: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-x8nck" for this suite.
+Mar 19 15:32:23.416: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:32:23.677: INFO: namespace: e2e-tests-svcaccounts-x8nck, resource: bindings, ignored listing per whitelist
+Mar 19 15:32:23.757: INFO: namespace e2e-tests-svcaccounts-x8nck deletion completed in 6.354560187s
+
+• [SLOW TEST:21.306 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:32:23.759: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-mkpfn A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-mkpfn;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-mkpfn A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-mkpfn;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-mkpfn.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-mkpfn.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-mkpfn.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-mkpfn.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-mkpfn.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-mkpfn.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-mkpfn.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-mkpfn.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-mkpfn.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-mkpfn.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-mkpfn.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-mkpfn.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-mkpfn.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 143.106.65.100.in-addr.arpa. PTR)" && echo OK > /results/100.65.106.143_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 143.106.65.100.in-addr.arpa. PTR)" && echo OK > /results/100.65.106.143_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-mkpfn A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-mkpfn;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-mkpfn A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-mkpfn;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-mkpfn.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-mkpfn.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-mkpfn.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-mkpfn.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-mkpfn.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-mkpfn.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-mkpfn.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-mkpfn.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-mkpfn.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-mkpfn.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-mkpfn.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-mkpfn.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-mkpfn.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 143.106.65.100.in-addr.arpa. PTR)" && echo OK > /results/100.65.106.143_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 143.106.65.100.in-addr.arpa. PTR)" && echo OK > /results/100.65.106.143_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Mar 19 15:32:39.160: INFO: DNS probes using dns-test-b8abd254-2b8a-11e8-945a-764aeb95b32d succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:32:39.280: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-mkpfn" for this suite.
+Mar 19 15:32:45.305: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:32:45.412: INFO: namespace: e2e-tests-dns-mkpfn, resource: bindings, ignored listing per whitelist
+Mar 19 15:32:45.432: INFO: namespace e2e-tests-dns-mkpfn deletion completed in 6.144650101s
+
+• [SLOW TEST:21.673 seconds]
+[sig-network] DNS
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:32:45.432: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Mar 19 15:32:45.512: INFO: Waiting up to 5m0s for pod "pod-c59347f4-2b8a-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-dgkvd" to be "success or failure"
+Mar 19 15:32:45.518: INFO: Pod "pod-c59347f4-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 6.844722ms
+Mar 19 15:32:47.522: INFO: Pod "pod-c59347f4-2b8a-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010214741s
+STEP: Saw pod success
+Mar 19 15:32:47.522: INFO: Pod "pod-c59347f4-2b8a-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:32:47.524: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-c59347f4-2b8a-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:32:47.542: INFO: Waiting for pod pod-c59347f4-2b8a-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:32:47.564: INFO: Pod pod-c59347f4-2b8a-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:32:47.564: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-dgkvd" for this suite.
+Mar 19 15:32:53.584: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:32:53.653: INFO: namespace: e2e-tests-emptydir-dgkvd, resource: bindings, ignored listing per whitelist
+Mar 19 15:32:53.723: INFO: namespace e2e-tests-emptydir-dgkvd deletion completed in 6.14924581s
+
+• [SLOW TEST:8.291 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:32:53.723: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Mar 19 15:32:53.776: INFO: Waiting up to 5m0s for pod "pod-ca80bcc6-2b8a-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-d5s7s" to be "success or failure"
+Mar 19 15:32:53.783: INFO: Pod "pod-ca80bcc6-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 7.620125ms
+Mar 19 15:32:55.789: INFO: Pod "pod-ca80bcc6-2b8a-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012827959s
+STEP: Saw pod success
+Mar 19 15:32:55.789: INFO: Pod "pod-ca80bcc6-2b8a-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:32:55.791: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-ca80bcc6-2b8a-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:32:55.810: INFO: Waiting for pod pod-ca80bcc6-2b8a-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:32:55.851: INFO: Pod pod-ca80bcc6-2b8a-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:32:55.851: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-d5s7s" for this suite.
+Mar 19 15:33:01.873: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:33:01.977: INFO: namespace: e2e-tests-emptydir-d5s7s, resource: bindings, ignored listing per whitelist
+Mar 19 15:33:02.013: INFO: namespace e2e-tests-emptydir-d5s7s deletion completed in 6.15868962s
+
+• [SLOW TEST:8.290 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:33:02.015: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:33:02.093: INFO: Waiting up to 5m0s for pod "downwardapi-volume-cf75a015-2b8a-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-79mgd" to be "success or failure"
+Mar 19 15:33:02.096: INFO: Pod "downwardapi-volume-cf75a015-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.681908ms
+Mar 19 15:33:04.099: INFO: Pod "downwardapi-volume-cf75a015-2b8a-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005858099s
+STEP: Saw pod success
+Mar 19 15:33:04.099: INFO: Pod "downwardapi-volume-cf75a015-2b8a-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:33:04.104: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-cf75a015-2b8a-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:33:04.125: INFO: Waiting for pod downwardapi-volume-cf75a015-2b8a-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:33:04.136: INFO: Pod downwardapi-volume-cf75a015-2b8a-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:33:04.136: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-79mgd" for this suite.
+Mar 19 15:33:10.159: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:33:10.283: INFO: namespace: e2e-tests-downward-api-79mgd, resource: bindings, ignored listing per whitelist
+Mar 19 15:33:10.294: INFO: namespace e2e-tests-downward-api-79mgd deletion completed in 6.147606879s
+
+• [SLOW TEST:8.279 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:33:10.294: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-tbl5n
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 19 15:33:10.390: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 19 15:33:34.470: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.147:8080/dial?request=hostName&protocol=http&host=100.96.0.146&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-tbl5n PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:33:34.470: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:33:34.658: INFO: Waiting for endpoints: map[]
+Mar 19 15:33:34.662: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.147:8080/dial?request=hostName&protocol=http&host=100.96.2.28&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-tbl5n PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:33:34.662: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:33:34.786: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:33:34.786: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-tbl5n" for this suite.
+Mar 19 15:33:56.804: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:33:56.879: INFO: namespace: e2e-tests-pod-network-test-tbl5n, resource: bindings, ignored listing per whitelist
+Mar 19 15:33:56.933: INFO: namespace e2e-tests-pod-network-test-tbl5n deletion completed in 22.143230898s
+
+• [SLOW TEST:46.639 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:33:56.934: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-f0340b86-2b8a-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:33:57.030: INFO: Waiting up to 5m0s for pod "pod-secrets-f034825b-2b8a-11e8-945a-764aeb95b32d" in namespace "e2e-tests-secrets-mggpb" to be "success or failure"
+Mar 19 15:33:57.038: INFO: Pod "pod-secrets-f034825b-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 7.141025ms
+Mar 19 15:33:59.043: INFO: Pod "pod-secrets-f034825b-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.012309857s
+Mar 19 15:34:01.046: INFO: Pod "pod-secrets-f034825b-2b8a-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015993069s
+STEP: Saw pod success
+Mar 19 15:34:01.046: INFO: Pod "pod-secrets-f034825b-2b8a-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:34:01.048: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-secrets-f034825b-2b8a-11e8-945a-764aeb95b32d container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:34:01.076: INFO: Waiting for pod pod-secrets-f034825b-2b8a-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:34:01.105: INFO: Pod pod-secrets-f034825b-2b8a-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:34:01.105: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-mggpb" for this suite.
+Mar 19 15:34:07.134: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:34:07.234: INFO: namespace: e2e-tests-secrets-mggpb, resource: bindings, ignored listing per whitelist
+Mar 19 15:34:07.261: INFO: namespace e2e-tests-secrets-mggpb deletion completed in 6.146395595s
+
+• [SLOW TEST:10.328 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:34:07.262: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Mar 19 15:34:07.391: INFO: Waiting up to 5m0s for pod "pod-f66165fa-2b8a-11e8-945a-764aeb95b32d" in namespace "e2e-tests-emptydir-2bh2q" to be "success or failure"
+Mar 19 15:34:07.396: INFO: Pod "pod-f66165fa-2b8a-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.110812ms
+Mar 19 15:34:09.400: INFO: Pod "pod-f66165fa-2b8a-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00815931s
+STEP: Saw pod success
+Mar 19 15:34:09.400: INFO: Pod "pod-f66165fa-2b8a-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:34:09.406: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-f66165fa-2b8a-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:34:09.438: INFO: Waiting for pod pod-f66165fa-2b8a-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:34:09.454: INFO: Pod pod-f66165fa-2b8a-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:34:09.454: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-2bh2q" for this suite.
+Mar 19 15:34:15.481: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:34:15.548: INFO: namespace: e2e-tests-emptydir-2bh2q, resource: bindings, ignored listing per whitelist
+Mar 19 15:34:15.607: INFO: namespace e2e-tests-emptydir-2bh2q deletion completed in 6.149920028s
+
+• [SLOW TEST:8.346 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:34:15.608: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 19 15:34:18.209: INFO: Successfully updated pod "labelsupdatefb4f7236-2b8a-11e8-945a-764aeb95b32d"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:34:20.234: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-5d6xh" for this suite.
+Mar 19 15:34:42.249: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:34:42.346: INFO: namespace: e2e-tests-downward-api-5d6xh, resource: bindings, ignored listing per whitelist
+Mar 19 15:34:42.387: INFO: namespace e2e-tests-downward-api-5d6xh deletion completed in 22.149643246s
+
+• [SLOW TEST:26.779 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:34:42.387: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Mar 19 15:34:42.444: INFO: Waiting up to 1m0s for all nodes to be ready
+Mar 19 15:35:42.465: INFO: Waiting for terminating namespaces to be deleted...
+Mar 19 15:35:42.470: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 19 15:35:42.487: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 19 15:35:42.487: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 19 15:35:42.492: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 19 15:35:42.492: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd before test
+Mar 19 15:35:42.501: INFO: node-exporter-cfkn7 from kube-system started at 2018-03-19 12:40:27 +0000 UTC (1 container statuses recorded)
+Mar 19 15:35:42.501: INFO: 	Container node-exporter ready: true, restart count 1
+Mar 19 15:35:42.501: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-rwfhz from kube-system started at 2018-03-19 14:04:28 +0000 UTC (1 container statuses recorded)
+Mar 19 15:35:42.501: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Mar 19 15:35:42.501: INFO: addons-nginx-ingress-controller-ddcb6d7fc-gz8ht from kube-system started at 2018-03-19 14:04:28 +0000 UTC (1 container statuses recorded)
+Mar 19 15:35:42.501: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Mar 19 15:35:42.501: INFO: addons-heapster-e3b0c-b9ff79bbd-mbg6f from kube-system started at 2018-03-19 14:04:28 +0000 UTC (2 container statuses recorded)
+Mar 19 15:35:42.501: INFO: 	Container heapster ready: true, restart count 0
+Mar 19 15:35:42.501: INFO: 	Container heapster-nanny ready: true, restart count 0
+Mar 19 15:35:42.501: INFO: addons-kubernetes-dashboard-7fc5877997-29c2m from kube-system started at 2018-03-19 14:04:28 +0000 UTC (1 container statuses recorded)
+Mar 19 15:35:42.501: INFO: 	Container main ready: true, restart count 0
+Mar 19 15:35:42.501: INFO: kube-dns-858cbcf6ff-gbf2s from kube-system started at 2018-03-19 14:04:28 +0000 UTC (3 container statuses recorded)
+Mar 19 15:35:42.501: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 19 15:35:42.501: INFO: 	Container kubedns ready: true, restart count 0
+Mar 19 15:35:42.502: INFO: 	Container sidecar ready: true, restart count 0
+Mar 19 15:35:42.502: INFO: kube-dns-autoscaler-6966fd6fb6-tj5wc from kube-system started at 2018-03-19 14:04:29 +0000 UTC (1 container statuses recorded)
+Mar 19 15:35:42.502: INFO: 	Container autoscaler ready: true, restart count 0
+Mar 19 15:35:42.502: INFO: kube-proxy-tv4sn from kube-system started at 2018-03-19 12:40:27 +0000 UTC (1 container statuses recorded)
+Mar 19 15:35:42.502: INFO: 	Container kube-proxy ready: true, restart count 1
+Mar 19 15:35:42.502: INFO: calico-node-2284r from kube-system started at 2018-03-19 12:40:27 +0000 UTC (2 container statuses recorded)
+Mar 19 15:35:42.502: INFO: 	Container calico-node ready: true, restart count 1
+Mar 19 15:35:42.502: INFO: 	Container install-cni ready: true, restart count 1
+Mar 19 15:35:42.502: INFO: vpn-shoot-56558cd489-2q8hr from kube-system started at 2018-03-19 14:04:29 +0000 UTC (1 container statuses recorded)
+Mar 19 15:35:42.502: INFO: 	Container vpn-shoot ready: true, restart count 1
+Mar 19 15:35:42.502: INFO: kube-dns-858cbcf6ff-52ttw from kube-system started at 2018-03-19 14:04:29 +0000 UTC (3 container statuses recorded)
+Mar 19 15:35:42.502: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 19 15:35:42.502: INFO: 	Container kubedns ready: true, restart count 0
+Mar 19 15:35:42.502: INFO: 	Container sidecar ready: true, restart count 0
+Mar 19 15:35:42.502: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs before test
+Mar 19 15:35:42.514: INFO: sonobuoy from sonobuoy started at 2018-03-19 14:50:46 +0000 UTC (1 container statuses recorded)
+Mar 19 15:35:42.514: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Mar 19 15:35:42.514: INFO: calico-node-9nl8j from kube-system started at 2018-03-18 14:29:49 +0000 UTC (2 container statuses recorded)
+Mar 19 15:35:42.514: INFO: 	Container calico-node ready: true, restart count 0
+Mar 19 15:35:42.514: INFO: 	Container install-cni ready: true, restart count 0
+Mar 19 15:35:42.514: INFO: sonobuoy-e2e-job-839773c704254943 from sonobuoy started at 2018-03-19 14:51:02 +0000 UTC (2 container statuses recorded)
+Mar 19 15:35:42.514: INFO: 	Container e2e ready: true, restart count 0
+Mar 19 15:35:42.514: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Mar 19 15:35:42.514: INFO: node-exporter-hctwh from kube-system started at 2018-03-18 14:29:49 +0000 UTC (1 container statuses recorded)
+Mar 19 15:35:42.514: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 19 15:35:42.514: INFO: kube-proxy-zqcn8 from kube-system started at 2018-03-18 14:29:49 +0000 UTC (1 container statuses recorded)
+Mar 19 15:35:42.514: INFO: 	Container kube-proxy ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: verifying the node has the label node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+STEP: verifying the node has the label node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs
+Mar 19 15:35:42.557: INFO: Pod addons-heapster-e3b0c-b9ff79bbd-mbg6f requesting resource cpu=50m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+Mar 19 15:35:42.557: INFO: Pod addons-kubernetes-dashboard-7fc5877997-29c2m requesting resource cpu=100m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+Mar 19 15:35:42.557: INFO: Pod addons-nginx-ingress-controller-ddcb6d7fc-gz8ht requesting resource cpu=0m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+Mar 19 15:35:42.557: INFO: Pod addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-rwfhz requesting resource cpu=0m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+Mar 19 15:35:42.557: INFO: Pod calico-node-2284r requesting resource cpu=250m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+Mar 19 15:35:42.557: INFO: Pod calico-node-9nl8j requesting resource cpu=250m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs
+Mar 19 15:35:42.557: INFO: Pod kube-dns-858cbcf6ff-52ttw requesting resource cpu=260m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+Mar 19 15:35:42.557: INFO: Pod kube-dns-858cbcf6ff-gbf2s requesting resource cpu=260m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+Mar 19 15:35:42.557: INFO: Pod kube-dns-autoscaler-6966fd6fb6-tj5wc requesting resource cpu=20m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+Mar 19 15:35:42.557: INFO: Pod kube-proxy-tv4sn requesting resource cpu=100m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+Mar 19 15:35:42.557: INFO: Pod kube-proxy-zqcn8 requesting resource cpu=100m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs
+Mar 19 15:35:42.557: INFO: Pod node-exporter-cfkn7 requesting resource cpu=100m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+Mar 19 15:35:42.557: INFO: Pod node-exporter-hctwh requesting resource cpu=100m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs
+Mar 19 15:35:42.557: INFO: Pod vpn-shoot-56558cd489-2q8hr requesting resource cpu=100m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+Mar 19 15:35:42.557: INFO: Pod sonobuoy requesting resource cpu=0m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs
+Mar 19 15:35:42.557: INFO: Pod sonobuoy-e2e-job-839773c704254943 requesting resource cpu=0m on Node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2f1b7dd3-2b8b-11e8-945a-764aeb95b32d.151d5c4ec8fb1fe1], Reason = [Scheduled], Message = [Successfully assigned filler-pod-2f1b7dd3-2b8b-11e8-945a-764aeb95b32d to shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2f1b7dd3-2b8b-11e8-945a-764aeb95b32d.151d5c4ed2acf712], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-jm2bw" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2f1b7dd3-2b8b-11e8-945a-764aeb95b32d.151d5c4f0c876ef2], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2f1b7dd3-2b8b-11e8-945a-764aeb95b32d.151d5c4f16a84c9c], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2f1b7dd3-2b8b-11e8-945a-764aeb95b32d.151d5c4f2036479e], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2f1cbe54-2b8b-11e8-945a-764aeb95b32d.151d5c4eca6bbfd2], Reason = [Scheduled], Message = [Successfully assigned filler-pod-2f1cbe54-2b8b-11e8-945a-764aeb95b32d to shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2f1cbe54-2b8b-11e8-945a-764aeb95b32d.151d5c4ed87f9ea2], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-jm2bw" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2f1cbe54-2b8b-11e8-945a-764aeb95b32d.151d5c4f0b9616d5], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2f1cbe54-2b8b-11e8-945a-764aeb95b32d.151d5c4f129b0f16], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2f1cbe54-2b8b-11e8-945a-764aeb95b32d.151d5c4f1d84a316], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.151d5c4f42a721bc], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 Insufficient cpu.]
+STEP: removing the label node off the node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:35:45.653: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-wrj5j" for this suite.
+Mar 19 15:36:07.677: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:36:07.766: INFO: namespace: e2e-tests-sched-pred-wrj5j, resource: bindings, ignored listing per whitelist
+Mar 19 15:36:07.825: INFO: namespace e2e-tests-sched-pred-wrj5j deletion completed in 22.163403398s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:85.438 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:36:07.827: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-3e36025e-2b8b-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume configMaps
+Mar 19 15:36:07.907: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-3e369729-2b8b-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-hfb9l" to be "success or failure"
+Mar 19 15:36:07.936: INFO: Pod "pod-projected-configmaps-3e369729-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 28.862297ms
+Mar 19 15:36:09.941: INFO: Pod "pod-projected-configmaps-3e369729-2b8b-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.033495807s
+STEP: Saw pod success
+Mar 19 15:36:09.941: INFO: Pod "pod-projected-configmaps-3e369729-2b8b-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:36:09.945: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-configmaps-3e369729-2b8b-11e8-945a-764aeb95b32d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:36:10.011: INFO: Waiting for pod pod-projected-configmaps-3e369729-2b8b-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:36:10.017: INFO: Pod pod-projected-configmaps-3e369729-2b8b-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:36:10.017: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hfb9l" for this suite.
+Mar 19 15:36:16.054: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:36:16.142: INFO: namespace: e2e-tests-projected-hfb9l, resource: bindings, ignored listing per whitelist
+Mar 19 15:36:16.183: INFO: namespace e2e-tests-projected-hfb9l deletion completed in 6.145016617s
+
+• [SLOW TEST:8.356 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:36:16.183: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating secret e2e-tests-secrets-xkg44/secret-test-432e5ac6-2b8b-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:36:16.249: INFO: Waiting up to 5m0s for pod "pod-configmaps-432ed1c2-2b8b-11e8-945a-764aeb95b32d" in namespace "e2e-tests-secrets-xkg44" to be "success or failure"
+Mar 19 15:36:16.253: INFO: Pod "pod-configmaps-432ed1c2-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.502611ms
+Mar 19 15:36:18.257: INFO: Pod "pod-configmaps-432ed1c2-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007364712s
+Mar 19 15:36:20.263: INFO: Pod "pod-configmaps-432ed1c2-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.013452239s
+Mar 19 15:36:22.267: INFO: Pod "pod-configmaps-432ed1c2-2b8b-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.017507151s
+STEP: Saw pod success
+Mar 19 15:36:22.267: INFO: Pod "pod-configmaps-432ed1c2-2b8b-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:36:22.270: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-configmaps-432ed1c2-2b8b-11e8-945a-764aeb95b32d container env-test: <nil>
+STEP: delete the pod
+Mar 19 15:36:22.298: INFO: Waiting for pod pod-configmaps-432ed1c2-2b8b-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:36:22.312: INFO: Pod pod-configmaps-432ed1c2-2b8b-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:36:22.312: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-xkg44" for this suite.
+Mar 19 15:36:28.339: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:36:28.480: INFO: namespace: e2e-tests-secrets-xkg44, resource: bindings, ignored listing per whitelist
+Mar 19 15:36:28.481: INFO: namespace e2e-tests-secrets-xkg44 deletion completed in 6.158276862s
+
+• [SLOW TEST:12.297 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:36:28.481: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test env composition
+Mar 19 15:36:28.543: INFO: Waiting up to 5m0s for pod "var-expansion-4a82dc9b-2b8b-11e8-945a-764aeb95b32d" in namespace "e2e-tests-var-expansion-5jwv4" to be "success or failure"
+Mar 19 15:36:28.553: INFO: Pod "var-expansion-4a82dc9b-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 9.635527ms
+Mar 19 15:36:30.557: INFO: Pod "var-expansion-4a82dc9b-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013593151s
+Mar 19 15:36:32.560: INFO: Pod "var-expansion-4a82dc9b-2b8b-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016964564s
+STEP: Saw pod success
+Mar 19 15:36:32.560: INFO: Pod "var-expansion-4a82dc9b-2b8b-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:36:32.562: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod var-expansion-4a82dc9b-2b8b-11e8-945a-764aeb95b32d container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 15:36:32.583: INFO: Waiting for pod var-expansion-4a82dc9b-2b8b-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:36:32.593: INFO: Pod var-expansion-4a82dc9b-2b8b-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:36:32.593: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-5jwv4" for this suite.
+Mar 19 15:36:38.617: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:36:38.679: INFO: namespace: e2e-tests-var-expansion-5jwv4, resource: bindings, ignored listing per whitelist
+Mar 19 15:36:38.755: INFO: namespace e2e-tests-var-expansion-5jwv4 deletion completed in 6.158300141s
+
+• [SLOW TEST:10.274 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:36:38.756: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-50a54ca6-2b8b-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:36:38.838: INFO: Waiting up to 5m0s for pod "pod-secrets-50a5e48b-2b8b-11e8-945a-764aeb95b32d" in namespace "e2e-tests-secrets-zwhwr" to be "success or failure"
+Mar 19 15:36:38.848: INFO: Pod "pod-secrets-50a5e48b-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 10.049037ms
+Mar 19 15:36:40.852: INFO: Pod "pod-secrets-50a5e48b-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013657467s
+Mar 19 15:36:42.855: INFO: Pod "pod-secrets-50a5e48b-2b8b-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017017836s
+STEP: Saw pod success
+Mar 19 15:36:42.855: INFO: Pod "pod-secrets-50a5e48b-2b8b-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:36:42.858: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-secrets-50a5e48b-2b8b-11e8-945a-764aeb95b32d container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:36:42.907: INFO: Waiting for pod pod-secrets-50a5e48b-2b8b-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:36:42.910: INFO: Pod pod-secrets-50a5e48b-2b8b-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:36:42.911: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-zwhwr" for this suite.
+Mar 19 15:36:48.927: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:36:48.977: INFO: namespace: e2e-tests-secrets-zwhwr, resource: bindings, ignored listing per whitelist
+Mar 19 15:36:49.047: INFO: namespace e2e-tests-secrets-zwhwr deletion completed in 6.132896125s
+
+• [SLOW TEST:10.292 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:36:49.047: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-map-56c5b46d-2b8b-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:36:49.115: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-56c629db-2b8b-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-b5szf" to be "success or failure"
+Mar 19 15:36:49.125: INFO: Pod "pod-projected-secrets-56c629db-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 9.490928ms
+Mar 19 15:36:51.128: INFO: Pod "pod-projected-secrets-56c629db-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013405189s
+Mar 19 15:36:53.132: INFO: Pod "pod-projected-secrets-56c629db-2b8b-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016878426s
+STEP: Saw pod success
+Mar 19 15:36:53.132: INFO: Pod "pod-projected-secrets-56c629db-2b8b-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:36:53.135: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-projected-secrets-56c629db-2b8b-11e8-945a-764aeb95b32d container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:36:53.155: INFO: Waiting for pod pod-projected-secrets-56c629db-2b8b-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:36:53.163: INFO: Pod pod-projected-secrets-56c629db-2b8b-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:36:53.163: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-b5szf" for this suite.
+Mar 19 15:36:59.186: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:36:59.318: INFO: namespace: e2e-tests-projected-b5szf, resource: bindings, ignored listing per whitelist
+Mar 19 15:36:59.318: INFO: namespace e2e-tests-projected-b5szf deletion completed in 6.149331754s
+
+• [SLOW TEST:10.271 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:36:59.319: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Mar 19 15:37:07.422: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-5djzc PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:37:07.422: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:37:07.624: INFO: Exec stderr: ""
+Mar 19 15:37:07.624: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-5djzc PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:37:07.624: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:37:07.752: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Mar 19 15:37:07.752: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-5djzc PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:37:07.752: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:37:07.894: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Mar 19 15:37:07.894: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-5djzc PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:37:07.894: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:37:08.060: INFO: Exec stderr: ""
+Mar 19 15:37:08.060: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-5djzc PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 15:37:08.060: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+Mar 19 15:37:08.217: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:37:08.217: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-5djzc" for this suite.
+Mar 19 15:37:46.238: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:37:46.347: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-5djzc, resource: bindings, ignored listing per whitelist
+Mar 19 15:37:46.366: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-5djzc deletion completed in 38.144954504s
+
+• [SLOW TEST:47.047 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:37:46.366: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-map-78eebbf5-2b8b-11e8-945a-764aeb95b32d
+STEP: Creating a pod to test consume secrets
+Mar 19 15:37:46.431: INFO: Waiting up to 5m0s for pod "pod-secrets-78efe255-2b8b-11e8-945a-764aeb95b32d" in namespace "e2e-tests-secrets-64n5t" to be "success or failure"
+Mar 19 15:37:46.470: INFO: Pod "pod-secrets-78efe255-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 39.261734ms
+Mar 19 15:37:48.500: INFO: Pod "pod-secrets-78efe255-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.06955427s
+Mar 19 15:37:50.504: INFO: Pod "pod-secrets-78efe255-2b8b-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.073313145s
+STEP: Saw pod success
+Mar 19 15:37:50.504: INFO: Pod "pod-secrets-78efe255-2b8b-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:37:50.507: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod pod-secrets-78efe255-2b8b-11e8-945a-764aeb95b32d container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 15:37:50.532: INFO: Waiting for pod pod-secrets-78efe255-2b8b-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:37:50.539: INFO: Pod pod-secrets-78efe255-2b8b-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:37:50.539: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-64n5t" for this suite.
+Mar 19 15:37:56.566: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:37:56.644: INFO: namespace: e2e-tests-secrets-64n5t, resource: bindings, ignored listing per whitelist
+Mar 19 15:37:56.693: INFO: namespace e2e-tests-secrets-64n5t deletion completed in 6.149974208s
+
+• [SLOW TEST:10.327 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:37:56.693: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:51
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-mxfr2
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-mxfr2 to expose endpoints map[]
+Mar 19 15:37:56.777: INFO: Get endpoints failed (2.339007ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Mar 19 15:37:57.781: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-mxfr2 exposes endpoints map[] (1.00607009s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-mxfr2
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-mxfr2 to expose endpoints map[pod1:[80]]
+Mar 19 15:38:00.813: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-mxfr2 exposes endpoints map[pod1:[80]] (3.025275954s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-mxfr2
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-mxfr2 to expose endpoints map[pod1:[80] pod2:[80]]
+Mar 19 15:38:02.870: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-mxfr2 exposes endpoints map[pod2:[80] pod1:[80]] (2.051821678s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-mxfr2
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-mxfr2 to expose endpoints map[pod2:[80]]
+Mar 19 15:38:02.917: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-mxfr2 exposes endpoints map[pod2:[80]] (39.727236ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-mxfr2
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-mxfr2 to expose endpoints map[]
+Mar 19 15:38:02.928: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-mxfr2 exposes endpoints map[] (3.401312ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:38:02.947: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-mxfr2" for this suite.
+Mar 19 15:38:24.982: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:38:25.041: INFO: namespace: e2e-tests-services-mxfr2, resource: bindings, ignored listing per whitelist
+Mar 19 15:38:25.114: INFO: namespace e2e-tests-services-mxfr2 deletion completed in 22.15844578s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:56
+
+• [SLOW TEST:28.421 seconds]
+[sig-network] Services
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:38:25.114: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:38:25.182: INFO: Waiting up to 5m0s for pod "downwardapi-volume-90078ae0-2b8b-11e8-945a-764aeb95b32d" in namespace "e2e-tests-downward-api-z6jg8" to be "success or failure"
+Mar 19 15:38:25.197: INFO: Pod "downwardapi-volume-90078ae0-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 15.612857ms
+Mar 19 15:38:27.201: INFO: Pod "downwardapi-volume-90078ae0-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.019598167s
+Mar 19 15:38:29.205: INFO: Pod "downwardapi-volume-90078ae0-2b8b-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.023629229s
+STEP: Saw pod success
+Mar 19 15:38:29.205: INFO: Pod "downwardapi-volume-90078ae0-2b8b-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:38:29.209: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-90078ae0-2b8b-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:38:30.964: INFO: Waiting for pod downwardapi-volume-90078ae0-2b8b-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:38:30.980: INFO: Pod downwardapi-volume-90078ae0-2b8b-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:38:30.981: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-z6jg8" for this suite.
+Mar 19 15:38:37.000: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:38:37.123: INFO: namespace: e2e-tests-downward-api-z6jg8, resource: bindings, ignored listing per whitelist
+Mar 19 15:38:37.123: INFO: namespace e2e-tests-downward-api-z6jg8 deletion completed in 6.137825575s
+
+• [SLOW TEST:12.009 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:38:37.123: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:51
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-b2tzk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-b2tzk to expose endpoints map[]
+Mar 19 15:38:37.206: INFO: Get endpoints failed (4.446114ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Mar 19 15:38:38.209: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-b2tzk exposes endpoints map[] (1.007584027s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-b2tzk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-b2tzk to expose endpoints map[pod1:[100]]
+Mar 19 15:38:40.238: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-b2tzk exposes endpoints map[pod1:[100]] (2.021431841s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-b2tzk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-b2tzk to expose endpoints map[pod1:[100] pod2:[101]]
+Mar 19 15:38:43.287: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-b2tzk exposes endpoints map[pod2:[101] pod1:[100]] (3.043060772s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-b2tzk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-b2tzk to expose endpoints map[pod2:[101]]
+Mar 19 15:38:43.307: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-b2tzk exposes endpoints map[pod2:[101]] (9.720628ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-b2tzk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-b2tzk to expose endpoints map[]
+Mar 19 15:38:43.323: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-b2tzk exposes endpoints map[] (3.071409ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:38:43.347: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-b2tzk" for this suite.
+Mar 19 15:38:49.385: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:38:49.451: INFO: namespace: e2e-tests-services-b2tzk, resource: bindings, ignored listing per whitelist
+Mar 19 15:38:49.509: INFO: namespace e2e-tests-services-b2tzk deletion completed in 6.151657926s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:56
+
+• [SLOW TEST:12.386 seconds]
+[sig-network] Services
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:38:49.509: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test substitution in container's command
+Mar 19 15:38:49.605: INFO: Waiting up to 5m0s for pod "var-expansion-9e931a18-2b8b-11e8-945a-764aeb95b32d" in namespace "e2e-tests-var-expansion-6hzkw" to be "success or failure"
+Mar 19 15:38:49.617: INFO: Pod "var-expansion-9e931a18-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 11.851139ms
+Mar 19 15:38:51.620: INFO: Pod "var-expansion-9e931a18-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.015425515s
+Mar 19 15:38:53.655: INFO: Pod "var-expansion-9e931a18-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.050422362s
+Mar 19 15:38:55.775: INFO: Pod "var-expansion-9e931a18-2b8b-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.170519368s
+STEP: Saw pod success
+Mar 19 15:38:55.775: INFO: Pod "var-expansion-9e931a18-2b8b-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:38:55.778: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod var-expansion-9e931a18-2b8b-11e8-945a-764aeb95b32d container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 15:38:56.993: INFO: Waiting for pod var-expansion-9e931a18-2b8b-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:38:56.998: INFO: Pod var-expansion-9e931a18-2b8b-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:38:56.998: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-6hzkw" for this suite.
+Mar 19 15:39:03.017: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:39:03.115: INFO: namespace: e2e-tests-var-expansion-6hzkw, resource: bindings, ignored listing per whitelist
+Mar 19 15:39:03.158: INFO: namespace e2e-tests-var-expansion-6hzkw deletion completed in 6.155904662s
+
+• [SLOW TEST:13.649 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:39:03.158: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 15:39:03.224: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a6b5e094-2b8b-11e8-945a-764aeb95b32d" in namespace "e2e-tests-projected-bb2l6" to be "success or failure"
+Mar 19 15:39:03.272: INFO: Pod "downwardapi-volume-a6b5e094-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 48.519348ms
+Mar 19 15:39:05.275: INFO: Pod "downwardapi-volume-a6b5e094-2b8b-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.051673773s
+STEP: Saw pod success
+Mar 19 15:39:05.276: INFO: Pod "downwardapi-volume-a6b5e094-2b8b-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:39:05.278: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod downwardapi-volume-a6b5e094-2b8b-11e8-945a-764aeb95b32d container client-container: <nil>
+STEP: delete the pod
+Mar 19 15:39:05.297: INFO: Waiting for pod downwardapi-volume-a6b5e094-2b8b-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:39:05.302: INFO: Pod downwardapi-volume-a6b5e094-2b8b-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:39:05.302: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-bb2l6" for this suite.
+Mar 19 15:39:11.330: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:39:11.453: INFO: namespace: e2e-tests-projected-bb2l6, resource: bindings, ignored listing per whitelist
+Mar 19 15:39:11.483: INFO: namespace e2e-tests-projected-bb2l6 deletion completed in 6.177570004s
+
+• [SLOW TEST:8.325 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:39:11.483: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test override arguments
+Mar 19 15:39:11.562: INFO: Waiting up to 5m0s for pod "client-containers-abae426b-2b8b-11e8-945a-764aeb95b32d" in namespace "e2e-tests-containers-zqxpw" to be "success or failure"
+Mar 19 15:39:11.567: INFO: Pod "client-containers-abae426b-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.712413ms
+Mar 19 15:39:13.570: INFO: Pod "client-containers-abae426b-2b8b-11e8-945a-764aeb95b32d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008247577s
+Mar 19 15:39:15.574: INFO: Pod "client-containers-abae426b-2b8b-11e8-945a-764aeb95b32d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012068785s
+STEP: Saw pod success
+Mar 19 15:39:15.574: INFO: Pod "client-containers-abae426b-2b8b-11e8-945a-764aeb95b32d" satisfied condition "success or failure"
+Mar 19 15:39:15.577: INFO: Trying to get logs from node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs pod client-containers-abae426b-2b8b-11e8-945a-764aeb95b32d container test-container: <nil>
+STEP: delete the pod
+Mar 19 15:39:15.638: INFO: Waiting for pod client-containers-abae426b-2b8b-11e8-945a-764aeb95b32d to disappear
+Mar 19 15:39:15.642: INFO: Pod client-containers-abae426b-2b8b-11e8-945a-764aeb95b32d no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:39:15.642: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-zqxpw" for this suite.
+Mar 19 15:39:21.659: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:39:21.759: INFO: namespace: e2e-tests-containers-zqxpw, resource: bindings, ignored listing per whitelist
+Mar 19 15:39:21.806: INFO: namespace e2e-tests-containers-zqxpw deletion completed in 6.159435031s
+
+• [SLOW TEST:10.323 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:39:21.807: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Mar 19 15:39:21.862: INFO: Waiting up to 1m0s for all nodes to be ready
+Mar 19 15:40:21.887: INFO: Waiting for terminating namespaces to be deleted...
+Mar 19 15:40:21.892: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 19 15:40:21.904: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 19 15:40:21.904: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 19 15:40:21.908: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 19 15:40:21.908: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-az194-worker-ct5tc-7fb5554856-dhspd before test
+Mar 19 15:40:21.920: INFO: kube-dns-858cbcf6ff-gbf2s from kube-system started at 2018-03-19 14:04:28 +0000 UTC (3 container statuses recorded)
+Mar 19 15:40:21.920: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 19 15:40:21.920: INFO: 	Container kubedns ready: true, restart count 0
+Mar 19 15:40:21.920: INFO: 	Container sidecar ready: true, restart count 0
+Mar 19 15:40:21.920: INFO: kube-dns-autoscaler-6966fd6fb6-tj5wc from kube-system started at 2018-03-19 14:04:29 +0000 UTC (1 container statuses recorded)
+Mar 19 15:40:21.921: INFO: 	Container autoscaler ready: true, restart count 0
+Mar 19 15:40:21.921: INFO: kube-proxy-tv4sn from kube-system started at 2018-03-19 12:40:27 +0000 UTC (1 container statuses recorded)
+Mar 19 15:40:21.921: INFO: 	Container kube-proxy ready: true, restart count 1
+Mar 19 15:40:21.921: INFO: calico-node-2284r from kube-system started at 2018-03-19 12:40:27 +0000 UTC (2 container statuses recorded)
+Mar 19 15:40:21.921: INFO: 	Container calico-node ready: true, restart count 1
+Mar 19 15:40:21.921: INFO: 	Container install-cni ready: true, restart count 1
+Mar 19 15:40:21.921: INFO: addons-nginx-ingress-controller-ddcb6d7fc-gz8ht from kube-system started at 2018-03-19 14:04:28 +0000 UTC (1 container statuses recorded)
+Mar 19 15:40:21.921: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Mar 19 15:40:21.921: INFO: addons-heapster-e3b0c-b9ff79bbd-mbg6f from kube-system started at 2018-03-19 14:04:28 +0000 UTC (2 container statuses recorded)
+Mar 19 15:40:21.921: INFO: 	Container heapster ready: true, restart count 0
+Mar 19 15:40:21.921: INFO: 	Container heapster-nanny ready: true, restart count 0
+Mar 19 15:40:21.921: INFO: addons-kubernetes-dashboard-7fc5877997-29c2m from kube-system started at 2018-03-19 14:04:28 +0000 UTC (1 container statuses recorded)
+Mar 19 15:40:21.921: INFO: 	Container main ready: true, restart count 0
+Mar 19 15:40:21.921: INFO: vpn-shoot-56558cd489-2q8hr from kube-system started at 2018-03-19 14:04:29 +0000 UTC (1 container statuses recorded)
+Mar 19 15:40:21.922: INFO: 	Container vpn-shoot ready: true, restart count 1
+Mar 19 15:40:21.922: INFO: kube-dns-858cbcf6ff-52ttw from kube-system started at 2018-03-19 14:04:29 +0000 UTC (3 container statuses recorded)
+Mar 19 15:40:21.922: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 19 15:40:21.922: INFO: 	Container kubedns ready: true, restart count 0
+Mar 19 15:40:21.922: INFO: 	Container sidecar ready: true, restart count 0
+Mar 19 15:40:21.922: INFO: node-exporter-cfkn7 from kube-system started at 2018-03-19 12:40:27 +0000 UTC (1 container statuses recorded)
+Mar 19 15:40:21.922: INFO: 	Container node-exporter ready: true, restart count 1
+Mar 19 15:40:21.922: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-rwfhz from kube-system started at 2018-03-19 14:04:28 +0000 UTC (1 container statuses recorded)
+Mar 19 15:40:21.922: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Mar 19 15:40:21.922: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-az194-worker-ct5tc-7fb5554856-j7zrs before test
+Mar 19 15:40:21.938: INFO: node-exporter-hctwh from kube-system started at 2018-03-18 14:29:49 +0000 UTC (1 container statuses recorded)
+Mar 19 15:40:21.938: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 19 15:40:21.938: INFO: kube-proxy-zqcn8 from kube-system started at 2018-03-18 14:29:49 +0000 UTC (1 container statuses recorded)
+Mar 19 15:40:21.938: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 19 15:40:21.938: INFO: sonobuoy from sonobuoy started at 2018-03-19 14:50:46 +0000 UTC (1 container statuses recorded)
+Mar 19 15:40:21.938: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Mar 19 15:40:21.938: INFO: calico-node-9nl8j from kube-system started at 2018-03-18 14:29:49 +0000 UTC (2 container statuses recorded)
+Mar 19 15:40:21.938: INFO: 	Container calico-node ready: true, restart count 0
+Mar 19 15:40:21.938: INFO: 	Container install-cni ready: true, restart count 0
+Mar 19 15:40:21.938: INFO: sonobuoy-e2e-job-839773c704254943 from sonobuoy started at 2018-03-19 14:51:02 +0000 UTC (2 container statuses recorded)
+Mar 19 15:40:21.938: INFO: 	Container e2e ready: true, restart count 0
+Mar 19 15:40:21.938: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.151d5c8fd5c40ee1], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 MatchNodeSelector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:40:22.962: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-2z46d" for this suite.
+Mar 19 15:40:44.998: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:40:45.048: INFO: namespace: e2e-tests-sched-pred-2z46d, resource: bindings, ignored listing per whitelist
+Mar 19 15:40:45.133: INFO: namespace e2e-tests-sched-pred-2z46d deletion completed in 22.159774172s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.326 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 15:40:45.133: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 15:40:45.190: INFO: >>> kubeConfig: /tmp/kubeconfig-881496793
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 15:40:45.749: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-mqlkk" for this suite.
+Mar 19 15:40:51.765: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 15:40:51.883: INFO: namespace: e2e-tests-custom-resource-definition-mqlkk, resource: bindings, ignored listing per whitelist
+Mar 19 15:40:51.905: INFO: namespace e2e-tests-custom-resource-definition-mqlkk deletion completed in 6.153392561s
+
+• [SLOW TEST:6.772 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSMar 19 15:40:51.906: INFO: Running AfterSuite actions on all node
+Mar 19 15:40:51.906: INFO: Running AfterSuite actions on node 1
+Mar 19 15:40:51.906: INFO: Skipping dumping logs from cluster
+
+Ran 125 of 782 Specs in 2986.292 seconds
+SUCCESS! -- 125 Passed | 0 Failed | 0 Pending | 657 Skipped PASS
+
+Ginkgo ran 1 suite in 49m46.793379254s
+Test Suite Passed

--- a/v1.9/sap-cp-azure/junit_01.xml
+++ b/v1.9/sap-cp-azure/junit_01.xml
@@ -1,0 +1,2099 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="125" failures="0" time="2986.292127343">
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="51.421933508"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [Conformance]" classname="Kubernetes e2e suite" time="10.314416644"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [Conformance]" classname="Kubernetes e2e suite" time="10.390530408"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="10.332345512"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [Conformance]" classname="Kubernetes e2e suite" time="10.33058207"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod using local volume with non-existant path should not be able to mount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart  [Conformance]" classname="Kubernetes e2e suite" time="46.241247144"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [Conformance]" classname="Kubernetes e2e suite" time="10.357028038"></testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="10.292367654"></testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="10.544655716"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod using local volume with non-existant path should not be able to mount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod&#39;s node is different from PV&#39;s NodeName should not be able to mount due to different NodeName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="32.308246134"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files  [Conformance]" classname="Kubernetes e2e suite" time="10.260894052"></testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should autoscale with Custom Metrics from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [Conformance]" classname="Kubernetes e2e suite" time="101.515285218"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod using local volume with non-existant path should not be able to mount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="26.247180979"></testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="107.105557738"></testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="11.298817242"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="35.935177219"></testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.301354899"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments  [Conformance]" classname="Kubernetes e2e suite" time="10.31552219"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.348782636"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.334740399"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="58.100120595"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [Conformance]" classname="Kubernetes e2e suite" time="8.290221799"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.373570047"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="13.178159842"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="10.32302285"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.427935708"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var  [Conformance]" classname="Kubernetes e2e suite" time="12.286804564"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout  [Conformance]" classname="Kubernetes e2e suite" time="6.270607561">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation [Feature:MountPropagation] should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count  [Slow] [Conformance]" classname="Kubernetes e2e suite" time="142.558849424"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [Conformance]" classname="Kubernetes e2e suite" time="8.293934498"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.305089811"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should rollback without unnecessary restarts" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP  [Conformance]" classname="Kubernetes e2e suite" time="24.428377288"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank  [Conformance]" classname="Kubernetes e2e suite" time="8.330007167"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="10.298975801"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.270986735"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]" classname="Kubernetes e2e suite" time="8.686874519"></testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="93.437757775"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when using local volume provisioner should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha docker/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="10.312445405"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.321531403"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.314287553"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.287424335"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existent secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services  [Conformance]" classname="Kubernetes e2e suite" time="30.36446836"></testcase>
+      <testcase name="[k8s.io] Sysctls should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node  [Conformance]" classname="Kubernetes e2e suite" time="6.345342545"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.308909038"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate crd" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args  [Conformance]" classname="Kubernetes e2e suite" time="10.265034335"></testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="10.309036896"></testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable  [Conformance]" classname="Kubernetes e2e suite" time="10.482688933"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="128.609848605"></testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should have a working scale subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root  [Conformance]" classname="Kubernetes e2e suite" time="10.320566461"></testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root  [Conformance]" classname="Kubernetes e2e suite" time="10.270490338"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="43.067338398"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="102.789873487"></testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.611553039"></testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="11.738865686"></testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when StatefulSet has pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [Conformance]" classname="Kubernetes e2e suite" time="28.803095557"></testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="131.224960008"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated  [Conformance]" classname="Kubernetes e2e suite" time="13.378361782"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.51763473"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [Conformance]" classname="Kubernetes e2e suite" time="10.3593729"></testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="10.438486447"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [Conformance]" classname="Kubernetes e2e suite" time="10.351180461"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor using proxy subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPU] run Nvidia GPU tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that a pod with an invalid NodeAffinity is rejected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="42.655937549"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file  [Conformance]" classname="Kubernetes e2e suite" time="10.296303224"></testcase>
+      <testcase name="[k8s.io] Sysctls should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set  [Conformance]" classname="Kubernetes e2e suite" time="8.565097251"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.284781611"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should schedule pods in the same zones as statically provisioned PVs [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable  [Conformance]" classname="Kubernetes e2e suite" time="12.296238297"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only  [Conformance]" classname="Kubernetes e2e suite" time="10.305121774"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod  [Conformance]" classname="Kubernetes e2e suite" time="8.284949619"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="10.329195195"></testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port  [Conformance]" classname="Kubernetes e2e suite" time="6.353989268"></testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.298996957"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod  [Conformance]" classname="Kubernetes e2e suite" time="8.380919351"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should adopt existing pods when creating a RollingUpdate DaemonSet regardless of templateGeneration" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated  [Conformance]" classname="Kubernetes e2e suite" time="24.803417312"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [Conformance]" classname="Kubernetes e2e suite" time="10.363477057"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="34.285435117"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="86.469301181"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification  [Conformance]" classname="Kubernetes e2e suite" time="28.846257759"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.OrphanDependents is true" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="10.533300702"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="10.261966543"></testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="62.72378041"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="22.925343734"></testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [Conformance]" classname="Kubernetes e2e suite" time="10.31619635"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request  [Conformance]" classname="Kubernetes e2e suite" time="10.375510975"></testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.296607036"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="14.363285328"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [DisabledForLargeClusters] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="16.296071102"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Node Auto Repairs [Slow] [Disruptive] should repair node [Feature:NodeAutoRepairs]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [Conformance]" classname="Kubernetes e2e suite" time="8.300217873"></testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="10.369470823"></testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.395084597"></testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] LimitRange should create a LimitRange with default ephemeral storage and ensure pod has the default applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [Conformance]" classname="Kubernetes e2e suite" time="8.302289134"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.290787494"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]" classname="Kubernetes e2e suite" time="12.279325404"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart  [Conformance]" classname="Kubernetes e2e suite" time="82.225979893"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default commmand (docker entrypoint)  [Conformance]" classname="Kubernetes e2e suite" time="8.269669564"></testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection] [Conformance]" classname="Kubernetes e2e suite" time="12.920579447"></testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="87.65722393"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.395910084"></testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.261229608"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="10.497686774"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="30.776735402"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit  [Conformance]" classname="Kubernetes e2e suite" time="10.367230984"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="21.305778587"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="21.672860043"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should update pod when spec was updated and update strategy is RollingUpdate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.290862458"></testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="8.29016464"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit  [Conformance]" classname="Kubernetes e2e suite" time="8.279151002"></testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="46.639426631"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="10.327576794"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.345937598"></testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification  [Conformance]" classname="Kubernetes e2e suite" time="26.778958018"></testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="85.438491696"></testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.356257477"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="12.297292587"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.274388615"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]" classname="Kubernetes e2e suite" time="10.291562738"></testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="10.27096389"></testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file  [Conformance]" classname="Kubernetes e2e suite" time="47.046869889"></testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="10.327318802"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="28.420644004"></testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request  [Conformance]" classname="Kubernetes e2e suite" time="12.008618508"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="12.385888762"></testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command  [Conformance]" classname="Kubernetes e2e suite" time="13.648647497"></testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [Conformance]" classname="Kubernetes e2e suite" time="8.324647158"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd)  [Conformance]" classname="Kubernetes e2e suite" time="10.323347377"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.326228416"></testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [DisabledForLargeClusters] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod&#39;s node is different from PV&#39;s NodeName should not be able to mount due to different NodeName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="6.771882178"></testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod&#39;s node is different from PV&#39;s NodeName should not be able to mount due to different NodeName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.9/sap-cp-azure/version.txt
+++ b/v1.9/sap-cp-azure/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.4", GitCommit:"bee2d1505c4fe820744d26d41ecd3fdd4a3d6546", GitTreeState:"clean", BuildDate:"2018-03-12T16:29:47Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.4", GitCommit:"bee2d1505c4fe820744d26d41ecd3fdd4a3d6546", GitTreeState:"clean", BuildDate:"2018-03-12T16:21:35Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}

--- a/v1.9/sap-cp-gcp/PRODUCT.yaml
+++ b/v1.9/sap-cp-gcp/PRODUCT.yaml
@@ -1,0 +1,6 @@
+vendor: SAP
+name: Cloud Platform - Gardener (https://github.com/gardener/gardener) shoot cluster deployed on Google Cloud Platform
+version: 0.1.0 (changed with Open Source shipment)
+website_url: https://cloudplatform.sap.com/index.html
+documentation_url: https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/
+product_logo_url: https://www.sap.com/dam/application/shared/logos/sap-logo-svg.svg

--- a/v1.9/sap-cp-gcp/README.md
+++ b/v1.9/sap-cp-gcp/README.md
@@ -1,0 +1,43 @@
+# To reproduce:
+
+## Create Kubernetes Cluster
+
+Login to SAP Gardener Dashboard to create a Kubernetes Clusters on Amazon Web Services, Microsoft Azure, Google Cloud Platform, or OpenStack cloud provider.
+
+After the creation completed, copy the cluster's kubeconfig, which is provided by the Gardener Dashboard in the cluster's detail view, to ~/.kube/config and launch the Kubernetes E2E conformance tests.
+
+## Launch E2E Conformance Tests
+1. Launch e2e pod and sonobuoy master under namespace `sonobuoy`   
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+    ```
+
+2. Check logs of `sonobuoy` pod to see when test can be finished   
+Run
+
+    ```shell
+    kubectl logs -f -n sonobuoy sonobuoy
+    ```
+    and wait for line `no-exit was specified, sonobuoy is now blocking`.
+
+3. Use `kubectl cp` to copy the results to the client   
+Get the name of the <result archive> from the log output in step 2.
+
+    ```shell
+    kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy/<result archive> /home/result
+    ```
+
+4. Delete the conformance test resources
+
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl delete -f -
+    ```
+
+5. Untar the tarball
+
+    ```shell
+    cd /home/result
+    tar -xzf *_sonobuoy_*.tar.gz
+    ```
+
+    The result files `e2e.log` and `junit_01.xml` are located in the in the directory `plugins/e2e/results/`.

--- a/v1.9/sap-cp-gcp/e2e.log
+++ b/v1.9/sap-cp-gcp/e2e.log
@@ -1,0 +1,6323 @@
+Mar 20 08:24:50.795: INFO: Overriding default scale value of zero to 1
+Mar 20 08:24:50.795: INFO: Overriding default milliseconds value of zero to 5000
+I0320 08:24:50.913242      18 test_context.go:349] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-163837168
+I0320 08:24:50.913365      18 e2e.go:331] Starting e2e run "289f73e6-2c18-11e8-bd77-b6fcf399588c" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1521534290 - Will randomize all specs
+Will run 126 of 782 specs
+
+Mar 20 08:24:50.970: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:24:50.972: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
+Mar 20 08:24:51.001: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 20 08:24:51.089: INFO: 20 / 20 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 20 08:24:51.089: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 20 08:24:51.094: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 20 08:24:51.094: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Mar 20 08:24:51.097: INFO: e2e test version: v1.9.4
+Mar 20 08:24:51.099: INFO: kube-apiserver version: v1.9.4
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:24:51.099: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+Mar 20 08:24:51.140: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Mar 20 08:24:51.147: INFO: Waiting up to 5m0s for pod "pod-28e04ce4-2c18-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-jf528" to be "success or failure"
+Mar 20 08:24:51.149: INFO: Pod "pod-28e04ce4-2c18-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.243774ms
+Mar 20 08:24:53.153: INFO: Pod "pod-28e04ce4-2c18-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005601822s
+STEP: Saw pod success
+Mar 20 08:24:53.153: INFO: Pod "pod-28e04ce4-2c18-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:24:53.155: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-28e04ce4-2c18-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:24:53.169: INFO: Waiting for pod pod-28e04ce4-2c18-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:24:53.171: INFO: Pod pod-28e04ce4-2c18-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:24:53.171: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-jf528" for this suite.
+Mar 20 08:24:59.182: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:24:59.286: INFO: namespace: e2e-tests-emptydir-jf528, resource: bindings, ignored listing per whitelist
+Mar 20 08:24:59.288: INFO: namespace e2e-tests-emptydir-jf528 deletion completed in 6.114328295s
+
+• [SLOW TEST:8.189 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:24:59.288: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-4qmxd
+Mar 20 08:25:07.335: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-4qmxd
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 20 08:25:07.338: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:27:07.553: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-4qmxd" for this suite.
+Mar 20 08:27:13.564: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:27:13.636: INFO: namespace: e2e-tests-container-probe-4qmxd, resource: bindings, ignored listing per whitelist
+Mar 20 08:27:13.658: INFO: namespace e2e-tests-container-probe-4qmxd deletion completed in 6.101984043s
+
+• [SLOW TEST:134.370 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:27:13.659: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name s-test-opt-del-7dd8d3e3-2c18-11e8-bd77-b6fcf399588c
+STEP: Creating secret with name s-test-opt-upd-7dd8d431-2c18-11e8-bd77-b6fcf399588c
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-7dd8d3e3-2c18-11e8-bd77-b6fcf399588c
+STEP: Updating secret s-test-opt-upd-7dd8d431-2c18-11e8-bd77-b6fcf399588c
+STEP: Creating secret with name s-test-opt-create-7dd8d448-2c18-11e8-bd77-b6fcf399588c
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:28:22.206: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-vznf4" for this suite.
+Mar 20 08:28:44.218: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:28:44.289: INFO: namespace: e2e-tests-projected-vznf4, resource: bindings, ignored listing per whitelist
+Mar 20 08:28:44.311: INFO: namespace e2e-tests-projected-vznf4 deletion completed in 22.100830504s
+
+• [SLOW TEST:90.652 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:28:44.311: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-b3e0a9b5-2c18-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:28:44.355: INFO: Waiting up to 5m0s for pod "pod-secrets-b3e11217-2c18-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-secrets-5rr5s" to be "success or failure"
+Mar 20 08:28:44.357: INFO: Pod "pod-secrets-b3e11217-2c18-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.040669ms
+Mar 20 08:28:46.360: INFO: Pod "pod-secrets-b3e11217-2c18-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004988472s
+STEP: Saw pod success
+Mar 20 08:28:46.360: INFO: Pod "pod-secrets-b3e11217-2c18-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:28:46.362: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-secrets-b3e11217-2c18-11e8-bd77-b6fcf399588c container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:28:46.426: INFO: Waiting for pod pod-secrets-b3e11217-2c18-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:28:46.429: INFO: Pod pod-secrets-b3e11217-2c18-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:28:46.429: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-5rr5s" for this suite.
+Mar 20 08:28:52.440: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:28:52.532: INFO: namespace: e2e-tests-secrets-5rr5s, resource: bindings, ignored listing per whitelist
+Mar 20 08:28:52.542: INFO: namespace e2e-tests-secrets-5rr5s deletion completed in 6.110348163s
+
+• [SLOW TEST:8.231 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:28:52.542: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:28:52.582: INFO: Waiting up to 5m0s for pod "downwardapi-volume-b8c87ce4-2c18-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-v4dq6" to be "success or failure"
+Mar 20 08:28:52.584: INFO: Pod "downwardapi-volume-b8c87ce4-2c18-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.935287ms
+Mar 20 08:28:54.588: INFO: Pod "downwardapi-volume-b8c87ce4-2c18-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005696947s
+STEP: Saw pod success
+Mar 20 08:28:54.588: INFO: Pod "downwardapi-volume-b8c87ce4-2c18-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:28:54.590: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downwardapi-volume-b8c87ce4-2c18-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:28:54.608: INFO: Waiting for pod downwardapi-volume-b8c87ce4-2c18-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:28:54.610: INFO: Pod downwardapi-volume-b8c87ce4-2c18-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:28:54.610: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-v4dq6" for this suite.
+Mar 20 08:29:00.622: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:29:00.663: INFO: namespace: e2e-tests-projected-v4dq6, resource: bindings, ignored listing per whitelist
+Mar 20 08:29:00.715: INFO: namespace e2e-tests-projected-v4dq6 deletion completed in 6.101405278s
+
+• [SLOW TEST:8.173 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:29:00.715: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-bda7ee17-2c18-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:29:00.761: INFO: Waiting up to 5m0s for pod "pod-configmaps-bda8787c-2c18-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-configmap-jfzqp" to be "success or failure"
+Mar 20 08:29:00.763: INFO: Pod "pod-configmaps-bda8787c-2c18-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004466ms
+Mar 20 08:29:02.766: INFO: Pod "pod-configmaps-bda8787c-2c18-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005183806s
+STEP: Saw pod success
+Mar 20 08:29:02.766: INFO: Pod "pod-configmaps-bda8787c-2c18-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:29:02.769: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-configmaps-bda8787c-2c18-11e8-bd77-b6fcf399588c container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:29:02.782: INFO: Waiting for pod pod-configmaps-bda8787c-2c18-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:29:02.784: INFO: Pod pod-configmaps-bda8787c-2c18-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:29:02.784: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-jfzqp" for this suite.
+Mar 20 08:29:08.795: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:29:08.870: INFO: namespace: e2e-tests-configmap-jfzqp, resource: bindings, ignored listing per whitelist
+Mar 20 08:29:08.904: INFO: namespace e2e-tests-configmap-jfzqp deletion completed in 6.117516513s
+
+• [SLOW TEST:8.189 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:29:08.904: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 20 08:29:08.946: INFO: Waiting up to 5m0s for pod "downward-api-c2894899-2c18-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-mr76s" to be "success or failure"
+Mar 20 08:29:08.949: INFO: Pod "downward-api-c2894899-2c18-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 3.50117ms
+Mar 20 08:29:10.954: INFO: Pod "downward-api-c2894899-2c18-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008384386s
+Mar 20 08:29:12.958: INFO: Pod "downward-api-c2894899-2c18-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 4.011941308s
+Mar 20 08:29:14.961: INFO: Pod "downward-api-c2894899-2c18-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.015395505s
+STEP: Saw pod success
+Mar 20 08:29:14.961: INFO: Pod "downward-api-c2894899-2c18-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:29:14.963: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downward-api-c2894899-2c18-11e8-bd77-b6fcf399588c container dapi-container: <nil>
+STEP: delete the pod
+Mar 20 08:29:14.978: INFO: Waiting for pod downward-api-c2894899-2c18-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:29:14.979: INFO: Pod downward-api-c2894899-2c18-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:29:14.979: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-mr76s" for this suite.
+Mar 20 08:29:20.990: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:29:21.084: INFO: namespace: e2e-tests-downward-api-mr76s, resource: bindings, ignored listing per whitelist
+Mar 20 08:29:21.086: INFO: namespace e2e-tests-downward-api-mr76s deletion completed in 6.103811358s
+
+• [SLOW TEST:12.182 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:29:21.086: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-c9cc104e-2c18-11e8-bd77-b6fcf399588c,GenerateName:,Namespace:e2e-tests-events-pkp9r,SelfLink:/api/v1/namespaces/e2e-tests-events-pkp9r/pods/send-events-c9cc104e-2c18-11e8-bd77-b6fcf399588c,UID:c9c00ea1-2c18-11e8-a4e7-d6a5b4815c86,ResourceVersion:563284,Generation:0,CreationTimestamp:2018-03-20 08:29:21 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 123134508,},Annotations:map[string]string{cni.projectcalico.org/podIP: 100.96.4.10/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-drbxb {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-drbxb,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-drbxb true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc420d736b0} {node.kubernetes.io/unreachable Exists  NoExecute 0xc420d736d0}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-03-20 08:29:21 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-03-20 08:29:23 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-03-20 08:29:21 +0000 UTC  }],Message:,Reason:,HostIP:10.250.0.6,PodIP:100.96.4.10,StartTime:2018-03-20 08:29:21 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-03-20 08:29:22 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://443902f664f460d97aa1573fd8e1f2249c4d59f47a015812ac63e5146f864915}],QOSClass:BestEffort,InitContainerStatuses:[],},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:29:29.149: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-pkp9r" for this suite.
+Mar 20 08:29:51.162: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:29:51.201: INFO: namespace: e2e-tests-events-pkp9r, resource: bindings, ignored listing per whitelist
+Mar 20 08:29:51.255: INFO: namespace e2e-tests-events-pkp9r deletion completed in 22.101266528s
+
+• [SLOW TEST:30.169 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:29:51.255: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 20 08:29:51.294: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:29:51.827: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-r798d" for this suite.
+Mar 20 08:29:57.839: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:29:57.931: INFO: namespace: e2e-tests-custom-resource-definition-r798d, resource: bindings, ignored listing per whitelist
+Mar 20 08:29:57.933: INFO: namespace e2e-tests-custom-resource-definition-r798d deletion completed in 6.102255043s
+
+• [SLOW TEST:6.678 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:29:57.933: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Mar 20 08:29:57.973: INFO: Waiting up to 5m0s for pod "pod-dfc245b2-2c18-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-b9649" to be "success or failure"
+Mar 20 08:29:57.975: INFO: Pod "pod-dfc245b2-2c18-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.183614ms
+Mar 20 08:29:59.978: INFO: Pod "pod-dfc245b2-2c18-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005284365s
+STEP: Saw pod success
+Mar 20 08:29:59.978: INFO: Pod "pod-dfc245b2-2c18-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:29:59.980: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-dfc245b2-2c18-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:29:59.996: INFO: Waiting for pod pod-dfc245b2-2c18-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:29:59.998: INFO: Pod pod-dfc245b2-2c18-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:29:59.998: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-b9649" for this suite.
+Mar 20 08:30:06.009: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:30:06.099: INFO: namespace: e2e-tests-emptydir-b9649, resource: bindings, ignored listing per whitelist
+Mar 20 08:30:06.100: INFO: namespace e2e-tests-emptydir-b9649 deletion completed in 6.0992394s
+
+• [SLOW TEST:8.167 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:30:06.101: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: getting the auto-created API token
+Mar 20 08:30:06.650: INFO: created pod pod-service-account-defaultsa
+Mar 20 08:30:06.650: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Mar 20 08:30:06.653: INFO: created pod pod-service-account-mountsa
+Mar 20 08:30:06.653: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Mar 20 08:30:06.656: INFO: created pod pod-service-account-nomountsa
+Mar 20 08:30:06.656: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Mar 20 08:30:06.659: INFO: created pod pod-service-account-defaultsa-mountspec
+Mar 20 08:30:06.659: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Mar 20 08:30:06.662: INFO: created pod pod-service-account-mountsa-mountspec
+Mar 20 08:30:06.662: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Mar 20 08:30:06.667: INFO: created pod pod-service-account-nomountsa-mountspec
+Mar 20 08:30:06.667: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Mar 20 08:30:06.672: INFO: created pod pod-service-account-defaultsa-nomountspec
+Mar 20 08:30:06.672: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Mar 20 08:30:06.675: INFO: created pod pod-service-account-mountsa-nomountspec
+Mar 20 08:30:06.675: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Mar 20 08:30:06.678: INFO: created pod pod-service-account-nomountsa-nomountspec
+Mar 20 08:30:06.678: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:30:06.678: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-9hmvz" for this suite.
+Mar 20 08:30:12.692: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:30:12.772: INFO: namespace: e2e-tests-svcaccounts-9hmvz, resource: bindings, ignored listing per whitelist
+Mar 20 08:30:12.782: INFO: namespace e2e-tests-svcaccounts-9hmvz deletion completed in 6.09829773s
+
+• [SLOW TEST:6.682 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:30:12.783: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:51
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-fxtgv
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-fxtgv to expose endpoints map[]
+Mar 20 08:30:12.830: INFO: Get endpoints failed (1.800999ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Mar 20 08:30:13.834: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-fxtgv exposes endpoints map[] (1.00485732s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-fxtgv
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-fxtgv to expose endpoints map[pod1:[80]]
+Mar 20 08:30:15.852: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-fxtgv exposes endpoints map[pod1:[80]] (2.013454658s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-fxtgv
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-fxtgv to expose endpoints map[pod1:[80] pod2:[80]]
+Mar 20 08:30:17.877: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-fxtgv exposes endpoints map[pod1:[80] pod2:[80]] (2.020380219s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-fxtgv
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-fxtgv to expose endpoints map[pod2:[80]]
+Mar 20 08:30:18.891: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-fxtgv exposes endpoints map[pod2:[80]] (1.011108677s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-fxtgv
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-fxtgv to expose endpoints map[]
+Mar 20 08:30:19.899: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-fxtgv exposes endpoints map[] (1.005113097s elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:30:19.911: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-fxtgv" for this suite.
+Mar 20 08:30:25.922: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:30:26.001: INFO: namespace: e2e-tests-services-fxtgv, resource: bindings, ignored listing per whitelist
+Mar 20 08:30:26.020: INFO: namespace e2e-tests-services-fxtgv deletion completed in 6.106081646s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:56
+
+• [SLOW TEST:13.237 seconds]
+[sig-network] Services
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] Pods 
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:30:26.020: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating pod
+Mar 20 08:30:28.071: INFO: Pod pod-hostip-f0800b06-2c18-11e8-bd77-b6fcf399588c has hostIP: 10.250.0.7
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:30:28.071: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-f46gf" for this suite.
+Mar 20 08:30:50.081: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:30:50.167: INFO: namespace: e2e-tests-pods-f46gf, resource: bindings, ignored listing per whitelist
+Mar 20 08:30:50.175: INFO: namespace e2e-tests-pods-f46gf deletion completed in 22.101480765s
+
+• [SLOW TEST:24.155 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:30:50.175: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-map-fee6fba4-2c18-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:30:50.225: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-fee76b82-2c18-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-5gt22" to be "success or failure"
+Mar 20 08:30:50.227: INFO: Pod "pod-projected-secrets-fee76b82-2c18-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.847951ms
+Mar 20 08:30:52.230: INFO: Pod "pod-projected-secrets-fee76b82-2c18-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005156744s
+STEP: Saw pod success
+Mar 20 08:30:52.230: INFO: Pod "pod-projected-secrets-fee76b82-2c18-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:30:52.232: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-projected-secrets-fee76b82-2c18-11e8-bd77-b6fcf399588c container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:30:52.246: INFO: Waiting for pod pod-projected-secrets-fee76b82-2c18-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:30:52.249: INFO: Pod pod-projected-secrets-fee76b82-2c18-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:30:52.249: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5gt22" for this suite.
+Mar 20 08:30:58.263: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:30:58.339: INFO: namespace: e2e-tests-projected-5gt22, resource: bindings, ignored listing per whitelist
+Mar 20 08:30:58.367: INFO: namespace e2e-tests-projected-5gt22 deletion completed in 6.111932121s
+
+• [SLOW TEST:8.192 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:30:58.367: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-wng8f A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-wng8f;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-wng8f A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-wng8f;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-wng8f.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-wng8f.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-wng8f.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-wng8f.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-wng8f.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-wng8f.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-wng8f.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-wng8f.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-wng8f.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-wng8f.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-wng8f.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-wng8f.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-wng8f.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 234.83.67.100.in-addr.arpa. PTR)" && echo OK > /results/100.67.83.234_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 234.83.67.100.in-addr.arpa. PTR)" && echo OK > /results/100.67.83.234_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-wng8f A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-wng8f;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-wng8f A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-wng8f;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-wng8f.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-wng8f.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-wng8f.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-wng8f.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-wng8f.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-wng8f.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-wng8f.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-wng8f.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-wng8f.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-wng8f.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-wng8f.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-wng8f.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-wng8f.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 234.83.67.100.in-addr.arpa. PTR)" && echo OK > /results/100.67.83.234_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 234.83.67.100.in-addr.arpa. PTR)" && echo OK > /results/100.67.83.234_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Mar 20 08:31:19.697: INFO: DNS probes using dns-test-03c9c259-2c19-11e8-bd77-b6fcf399588c succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:31:19.721: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-wng8f" for this suite.
+Mar 20 08:31:25.732: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:31:25.820: INFO: namespace: e2e-tests-dns-wng8f, resource: bindings, ignored listing per whitelist
+Mar 20 08:31:25.828: INFO: namespace e2e-tests-dns-wng8f deletion completed in 6.103980758s
+
+• [SLOW TEST:27.461 seconds]
+[sig-network] DNS
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:31:25.828: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Mar 20 08:31:32.387: INFO: Successfully updated pod "pod-update-activedeadlineseconds-14266ed7-2c19-11e8-bd77-b6fcf399588c"
+Mar 20 08:31:32.387: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-14266ed7-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-pods-tzhkj" to be "terminated due to deadline exceeded"
+Mar 20 08:31:32.389: INFO: Pod "pod-update-activedeadlineseconds-14266ed7-2c19-11e8-bd77-b6fcf399588c": Phase="Running", Reason="", readiness=true. Elapsed: 1.730987ms
+Mar 20 08:31:34.392: INFO: Pod "pod-update-activedeadlineseconds-14266ed7-2c19-11e8-bd77-b6fcf399588c": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 2.004999204s
+Mar 20 08:31:34.392: INFO: Pod "pod-update-activedeadlineseconds-14266ed7-2c19-11e8-bd77-b6fcf399588c" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:31:34.392: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-tzhkj" for this suite.
+Mar 20 08:31:40.404: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:31:40.438: INFO: namespace: e2e-tests-pods-tzhkj, resource: bindings, ignored listing per whitelist
+Mar 20 08:31:40.494: INFO: namespace e2e-tests-pods-tzhkj deletion completed in 6.099126786s
+
+• [SLOW TEST:14.666 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:31:40.495: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test override arguments
+Mar 20 08:31:40.537: INFO: Waiting up to 5m0s for pod "client-containers-1ce46637-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-containers-zdj2f" to be "success or failure"
+Mar 20 08:31:40.539: INFO: Pod "client-containers-1ce46637-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.038809ms
+Mar 20 08:31:42.542: INFO: Pod "client-containers-1ce46637-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00564839s
+Mar 20 08:31:44.546: INFO: Pod "client-containers-1ce46637-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008888662s
+STEP: Saw pod success
+Mar 20 08:31:44.546: INFO: Pod "client-containers-1ce46637-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:31:44.548: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod client-containers-1ce46637-2c19-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:31:44.562: INFO: Waiting for pod client-containers-1ce46637-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:31:44.564: INFO: Pod client-containers-1ce46637-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:31:44.564: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-zdj2f" for this suite.
+Mar 20 08:31:50.575: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:31:50.643: INFO: namespace: e2e-tests-containers-zdj2f, resource: bindings, ignored listing per whitelist
+Mar 20 08:31:50.670: INFO: namespace e2e-tests-containers-zdj2f deletion completed in 6.103490681s
+
+• [SLOW TEST:10.176 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:31:50.671: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 20 08:31:50.712: INFO: Waiting up to 5m0s for pod "downward-api-22f4dfb6-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-5l2b9" to be "success or failure"
+Mar 20 08:31:50.714: INFO: Pod "downward-api-22f4dfb6-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.981063ms
+Mar 20 08:31:52.717: INFO: Pod "downward-api-22f4dfb6-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005172851s
+Mar 20 08:31:54.721: INFO: Pod "downward-api-22f4dfb6-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008715294s
+STEP: Saw pod success
+Mar 20 08:31:54.721: INFO: Pod "downward-api-22f4dfb6-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:31:54.723: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod downward-api-22f4dfb6-2c19-11e8-bd77-b6fcf399588c container dapi-container: <nil>
+STEP: delete the pod
+Mar 20 08:31:54.742: INFO: Waiting for pod downward-api-22f4dfb6-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:31:54.745: INFO: Pod downward-api-22f4dfb6-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:31:54.745: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-5l2b9" for this suite.
+Mar 20 08:32:00.757: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:32:00.835: INFO: namespace: e2e-tests-downward-api-5l2b9, resource: bindings, ignored listing per whitelist
+Mar 20 08:32:00.854: INFO: namespace e2e-tests-downward-api-5l2b9 deletion completed in 6.105612851s
+
+• [SLOW TEST:10.183 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:32:00.854: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:32:00.897: INFO: Waiting up to 5m0s for pod "downwardapi-volume-2906ddcb-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-p4wg6" to be "success or failure"
+Mar 20 08:32:00.900: INFO: Pod "downwardapi-volume-2906ddcb-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.282271ms
+Mar 20 08:32:02.904: INFO: Pod "downwardapi-volume-2906ddcb-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006080826s
+STEP: Saw pod success
+Mar 20 08:32:02.904: INFO: Pod "downwardapi-volume-2906ddcb-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:32:02.906: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downwardapi-volume-2906ddcb-2c19-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:32:02.922: INFO: Waiting for pod downwardapi-volume-2906ddcb-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:32:02.924: INFO: Pod downwardapi-volume-2906ddcb-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:32:02.924: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-p4wg6" for this suite.
+Mar 20 08:32:08.936: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:32:09.024: INFO: namespace: e2e-tests-downward-api-p4wg6, resource: bindings, ignored listing per whitelist
+Mar 20 08:32:09.036: INFO: namespace e2e-tests-downward-api-p4wg6 deletion completed in 6.108324799s
+
+• [SLOW TEST:8.182 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:32:09.036: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-2de71b47-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:32:09.080: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-2de793af-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-l8zzt" to be "success or failure"
+Mar 20 08:32:09.082: INFO: Pod "pod-projected-configmaps-2de793af-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.003821ms
+Mar 20 08:32:11.085: INFO: Pod "pod-projected-configmaps-2de793af-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005549783s
+STEP: Saw pod success
+Mar 20 08:32:11.085: INFO: Pod "pod-projected-configmaps-2de793af-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:32:11.088: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-projected-configmaps-2de793af-2c19-11e8-bd77-b6fcf399588c container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:32:11.104: INFO: Waiting for pod pod-projected-configmaps-2de793af-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:32:11.106: INFO: Pod pod-projected-configmaps-2de793af-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:32:11.106: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-l8zzt" for this suite.
+Mar 20 08:32:17.118: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:32:17.211: INFO: namespace: e2e-tests-projected-l8zzt, resource: bindings, ignored listing per whitelist
+Mar 20 08:32:17.213: INFO: namespace e2e-tests-projected-l8zzt deletion completed in 6.103456271s
+
+• [SLOW TEST:8.176 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:32:17.213: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 20 08:32:17.249: INFO: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:32:17.249: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-qf6mp" for this suite.
+Mar 20 08:32:23.260: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:32:23.354: INFO: namespace: e2e-tests-container-probe-qf6mp, resource: bindings, ignored listing per whitelist
+Mar 20 08:32:23.358: INFO: namespace e2e-tests-container-probe-qf6mp deletion completed in 6.105937115s
+
+S [SKIPPING] [6.146 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be restarted with a docker exec liveness probe with timeout  [Conformance] [It]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+
+  Mar 20 08:32:17.249: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:289
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:32:23.358: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-projected-all-test-volume-36702cbe-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating secret with name secret-projected-all-test-volume-36702cad-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Mar 20 08:32:23.401: INFO: Waiting up to 5m0s for pod "projected-volume-36702c81-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-6pwf2" to be "success or failure"
+Mar 20 08:32:23.402: INFO: Pod "projected-volume-36702c81-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.611393ms
+Mar 20 08:32:25.405: INFO: Pod "projected-volume-36702c81-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004920475s
+Mar 20 08:32:27.409: INFO: Pod "projected-volume-36702c81-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008534082s
+STEP: Saw pod success
+Mar 20 08:32:27.409: INFO: Pod "projected-volume-36702c81-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:32:27.412: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod projected-volume-36702c81-2c19-11e8-bd77-b6fcf399588c container projected-all-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:32:27.430: INFO: Waiting for pod projected-volume-36702c81-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:32:27.432: INFO: Pod projected-volume-36702c81-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:32:27.432: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6pwf2" for this suite.
+Mar 20 08:32:33.444: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:32:33.515: INFO: namespace: e2e-tests-projected-6pwf2, resource: bindings, ignored listing per whitelist
+Mar 20 08:32:33.541: INFO: namespace e2e-tests-projected-6pwf2 deletion completed in 6.105813444s
+
+• [SLOW TEST:10.183 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:32:33.541: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating server pod server in namespace e2e-tests-prestop-xplbv
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-xplbv
+STEP: Deleting pre-stop pod
+Mar 20 08:32:46.653: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:32:46.657: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-xplbv" for this suite.
+Mar 20 08:33:24.672: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:33:24.768: INFO: namespace: e2e-tests-prestop-xplbv, resource: bindings, ignored listing per whitelist
+Mar 20 08:33:24.770: INFO: namespace e2e-tests-prestop-xplbv deletion completed in 38.108107871s
+
+• [SLOW TEST:51.229 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:33:24.770: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-5b0b84b4-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:33:24.815: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-5b0beeef-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-488kn" to be "success or failure"
+Mar 20 08:33:24.817: INFO: Pod "pod-projected-configmaps-5b0beeef-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.719358ms
+Mar 20 08:33:26.819: INFO: Pod "pod-projected-configmaps-5b0beeef-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00452639s
+STEP: Saw pod success
+Mar 20 08:33:26.820: INFO: Pod "pod-projected-configmaps-5b0beeef-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:33:26.822: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-projected-configmaps-5b0beeef-2c19-11e8-bd77-b6fcf399588c container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:33:26.838: INFO: Waiting for pod pod-projected-configmaps-5b0beeef-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:33:26.840: INFO: Pod pod-projected-configmaps-5b0beeef-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:33:26.841: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-488kn" for this suite.
+Mar 20 08:33:32.855: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:33:32.927: INFO: namespace: e2e-tests-projected-488kn, resource: bindings, ignored listing per whitelist
+Mar 20 08:33:32.955: INFO: namespace e2e-tests-projected-488kn deletion completed in 6.109536842s
+
+• [SLOW TEST:8.185 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:33:32.955: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-map-5fec5caa-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:33:33.000: INFO: Waiting up to 5m0s for pod "pod-secrets-5fecc920-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-secrets-cx9l5" to be "success or failure"
+Mar 20 08:33:33.001: INFO: Pod "pod-secrets-5fecc920-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.832227ms
+Mar 20 08:33:35.005: INFO: Pod "pod-secrets-5fecc920-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005340215s
+STEP: Saw pod success
+Mar 20 08:33:35.005: INFO: Pod "pod-secrets-5fecc920-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:33:35.007: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-secrets-5fecc920-2c19-11e8-bd77-b6fcf399588c container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:33:35.024: INFO: Waiting for pod pod-secrets-5fecc920-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:33:35.026: INFO: Pod pod-secrets-5fecc920-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:33:35.026: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-cx9l5" for this suite.
+Mar 20 08:33:41.043: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:33:41.140: INFO: namespace: e2e-tests-secrets-cx9l5, resource: bindings, ignored listing per whitelist
+Mar 20 08:33:41.140: INFO: namespace e2e-tests-secrets-cx9l5 deletion completed in 6.10493579s
+
+• [SLOW TEST:8.185 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:33:41.140: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap e2e-tests-configmap-vgcsb/configmap-test-64cd45d4-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:33:41.184: INFO: Waiting up to 5m0s for pod "pod-configmaps-64cda987-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-configmap-vgcsb" to be "success or failure"
+Mar 20 08:33:41.188: INFO: Pod "pod-configmaps-64cda987-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 3.245426ms
+Mar 20 08:33:43.191: INFO: Pod "pod-configmaps-64cda987-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006689259s
+Mar 20 08:33:45.194: INFO: Pod "pod-configmaps-64cda987-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009703115s
+STEP: Saw pod success
+Mar 20 08:33:45.194: INFO: Pod "pod-configmaps-64cda987-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:33:45.196: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-configmaps-64cda987-2c19-11e8-bd77-b6fcf399588c container env-test: <nil>
+STEP: delete the pod
+Mar 20 08:33:45.214: INFO: Waiting for pod pod-configmaps-64cda987-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:33:45.217: INFO: Pod pod-configmaps-64cda987-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:33:45.217: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-vgcsb" for this suite.
+Mar 20 08:33:51.228: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:33:51.321: INFO: namespace: e2e-tests-configmap-vgcsb, resource: bindings, ignored listing per whitelist
+Mar 20 08:33:51.325: INFO: namespace e2e-tests-configmap-vgcsb deletion completed in 6.104930668s
+
+• [SLOW TEST:10.185 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:33:51.325: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Mar 20 08:33:51.379: INFO: Waiting up to 5m0s for pod "pod-6ae13009-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-49d9s" to be "success or failure"
+Mar 20 08:33:51.381: INFO: Pod "pod-6ae13009-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.254892ms
+Mar 20 08:33:53.385: INFO: Pod "pod-6ae13009-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005654015s
+STEP: Saw pod success
+Mar 20 08:33:53.385: INFO: Pod "pod-6ae13009-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:33:53.387: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-6ae13009-2c19-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:33:53.402: INFO: Waiting for pod pod-6ae13009-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:33:53.404: INFO: Pod pod-6ae13009-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:33:53.404: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-49d9s" for this suite.
+Mar 20 08:33:59.414: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:33:59.518: INFO: namespace: e2e-tests-emptydir-49d9s, resource: bindings, ignored listing per whitelist
+Mar 20 08:33:59.522: INFO: namespace e2e-tests-emptydir-49d9s deletion completed in 6.114464806s
+
+• [SLOW TEST:8.197 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:33:59.522: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating secret e2e-tests-secrets-psvvk/secret-test-6fc1c901-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:33:59.564: INFO: Waiting up to 5m0s for pod "pod-configmaps-6fc23926-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-secrets-psvvk" to be "success or failure"
+Mar 20 08:33:59.566: INFO: Pod "pod-configmaps-6fc23926-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.945137ms
+Mar 20 08:34:01.569: INFO: Pod "pod-configmaps-6fc23926-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00516268s
+Mar 20 08:34:03.573: INFO: Pod "pod-configmaps-6fc23926-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 4.00872525s
+Mar 20 08:34:05.576: INFO: Pod "pod-configmaps-6fc23926-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.012122276s
+STEP: Saw pod success
+Mar 20 08:34:05.576: INFO: Pod "pod-configmaps-6fc23926-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:34:05.578: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-configmaps-6fc23926-2c19-11e8-bd77-b6fcf399588c container env-test: <nil>
+STEP: delete the pod
+Mar 20 08:34:05.596: INFO: Waiting for pod pod-configmaps-6fc23926-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:34:05.598: INFO: Pod pod-configmaps-6fc23926-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:34:05.598: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-psvvk" for this suite.
+Mar 20 08:34:11.609: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:34:11.656: INFO: namespace: e2e-tests-secrets-psvvk, resource: bindings, ignored listing per whitelist
+Mar 20 08:34:11.706: INFO: namespace e2e-tests-secrets-psvvk deletion completed in 6.104512891s
+
+• [SLOW TEST:12.184 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:34:11.706: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test env composition
+Mar 20 08:34:11.749: INFO: Waiting up to 5m0s for pod "var-expansion-770535b7-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-var-expansion-7bd7m" to be "success or failure"
+Mar 20 08:34:11.751: INFO: Pod "var-expansion-770535b7-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.550925ms
+Mar 20 08:34:13.754: INFO: Pod "var-expansion-770535b7-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005805554s
+Mar 20 08:34:15.758: INFO: Pod "var-expansion-770535b7-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009344656s
+STEP: Saw pod success
+Mar 20 08:34:15.758: INFO: Pod "var-expansion-770535b7-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:34:15.760: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod var-expansion-770535b7-2c19-11e8-bd77-b6fcf399588c container dapi-container: <nil>
+STEP: delete the pod
+Mar 20 08:34:15.775: INFO: Waiting for pod var-expansion-770535b7-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:34:15.777: INFO: Pod var-expansion-770535b7-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:34:15.777: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-7bd7m" for this suite.
+Mar 20 08:34:21.788: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:34:21.820: INFO: namespace: e2e-tests-var-expansion-7bd7m, resource: bindings, ignored listing per whitelist
+Mar 20 08:34:21.886: INFO: namespace e2e-tests-var-expansion-7bd7m deletion completed in 6.105455759s
+
+• [SLOW TEST:10.180 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:34:21.886: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Mar 20 08:34:21.928: INFO: Waiting up to 5m0s for pod "pod-7d168d59-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-wdbtp" to be "success or failure"
+Mar 20 08:34:21.929: INFO: Pod "pod-7d168d59-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.74362ms
+Mar 20 08:34:23.933: INFO: Pod "pod-7d168d59-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00553763s
+STEP: Saw pod success
+Mar 20 08:34:23.933: INFO: Pod "pod-7d168d59-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:34:23.936: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-7d168d59-2c19-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:34:23.952: INFO: Waiting for pod pod-7d168d59-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:34:23.954: INFO: Pod pod-7d168d59-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:34:23.954: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-wdbtp" for this suite.
+Mar 20 08:34:29.972: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:34:30.022: INFO: namespace: e2e-tests-emptydir-wdbtp, resource: bindings, ignored listing per whitelist
+Mar 20 08:34:30.067: INFO: namespace e2e-tests-emptydir-wdbtp deletion completed in 6.103521923s
+
+• [SLOW TEST:8.181 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:34:30.067: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-81f6ea98-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:34:30.111: INFO: Waiting up to 5m0s for pod "pod-secrets-81f748b8-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-secrets-g7chf" to be "success or failure"
+Mar 20 08:34:30.113: INFO: Pod "pod-secrets-81f748b8-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.057736ms
+Mar 20 08:34:32.116: INFO: Pod "pod-secrets-81f748b8-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005450287s
+STEP: Saw pod success
+Mar 20 08:34:32.116: INFO: Pod "pod-secrets-81f748b8-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:34:32.118: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-secrets-81f748b8-2c19-11e8-bd77-b6fcf399588c container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:34:32.132: INFO: Waiting for pod pod-secrets-81f748b8-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:34:32.134: INFO: Pod pod-secrets-81f748b8-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:34:32.134: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-g7chf" for this suite.
+Mar 20 08:34:38.144: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:34:38.230: INFO: namespace: e2e-tests-secrets-g7chf, resource: bindings, ignored listing per whitelist
+Mar 20 08:34:38.239: INFO: namespace e2e-tests-secrets-g7chf deletion completed in 6.102735867s
+
+• [SLOW TEST:8.172 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:34:38.239: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-86d59166-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:34:38.281: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-86d5f1ff-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-wc9js" to be "success or failure"
+Mar 20 08:34:38.282: INFO: Pod "pod-projected-secrets-86d5f1ff-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.81145ms
+Mar 20 08:34:40.286: INFO: Pod "pod-projected-secrets-86d5f1ff-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00518322s
+STEP: Saw pod success
+Mar 20 08:34:40.286: INFO: Pod "pod-projected-secrets-86d5f1ff-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:34:40.288: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-projected-secrets-86d5f1ff-2c19-11e8-bd77-b6fcf399588c container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:34:40.302: INFO: Waiting for pod pod-projected-secrets-86d5f1ff-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:34:40.303: INFO: Pod pod-projected-secrets-86d5f1ff-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:34:40.303: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wc9js" for this suite.
+Mar 20 08:34:46.314: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:34:46.370: INFO: namespace: e2e-tests-projected-wc9js, resource: bindings, ignored listing per whitelist
+Mar 20 08:34:46.406: INFO: namespace e2e-tests-projected-wc9js deletion completed in 6.099634766s
+
+• [SLOW TEST:8.166 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:34:46.406: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-map-8bb392d8-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:34:46.447: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-8bb3f9df-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-zggrg" to be "success or failure"
+Mar 20 08:34:46.449: INFO: Pod "pod-projected-configmaps-8bb3f9df-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.869997ms
+Mar 20 08:34:48.452: INFO: Pod "pod-projected-configmaps-8bb3f9df-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00505295s
+STEP: Saw pod success
+Mar 20 08:34:48.452: INFO: Pod "pod-projected-configmaps-8bb3f9df-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:34:48.454: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-projected-configmaps-8bb3f9df-2c19-11e8-bd77-b6fcf399588c container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:34:48.469: INFO: Waiting for pod pod-projected-configmaps-8bb3f9df-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:34:48.471: INFO: Pod pod-projected-configmaps-8bb3f9df-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:34:48.471: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-zggrg" for this suite.
+Mar 20 08:34:54.482: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:34:54.566: INFO: namespace: e2e-tests-projected-zggrg, resource: bindings, ignored listing per whitelist
+Mar 20 08:34:54.580: INFO: namespace e2e-tests-projected-zggrg deletion completed in 6.10659823s
+
+• [SLOW TEST:8.174 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:34:54.580: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-tgps4 in namespace e2e-tests-proxy-6wr79
+I0320 08:34:54.630380      18 runners.go:178] Created replication controller with name: proxy-service-tgps4, namespace: e2e-tests-proxy-6wr79, replica count: 1
+I0320 08:34:55.630652      18 runners.go:178] proxy-service-tgps4 Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0320 08:34:56.630904      18 runners.go:178] proxy-service-tgps4 Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0320 08:34:57.631119      18 runners.go:178] proxy-service-tgps4 Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0320 08:34:58.631316      18 runners.go:178] proxy-service-tgps4 Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Mar 20 08:34:58.634: INFO: setup took 4.015884947s, starting test cases
+STEP: running 34 cases, 20 attempts per case, 680 total attempts
+Mar 20 08:34:58.644: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 10.181482ms)
+Mar 20 08:34:58.644: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 9.998621ms)
+Mar 20 08:34:58.645: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 10.431351ms)
+Mar 20 08:34:58.645: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 10.635907ms)
+Mar 20 08:34:58.645: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 10.67722ms)
+Mar 20 08:34:58.650: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 15.903932ms)
+Mar 20 08:34:58.650: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 16.198086ms)
+Mar 20 08:34:58.650: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 15.971029ms)
+Mar 20 08:34:58.650: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 15.923175ms)
+Mar 20 08:34:58.650: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 16.26658ms)
+Mar 20 08:34:58.650: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 16.117777ms)
+Mar 20 08:34:58.650: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 16.082638ms)
+Mar 20 08:34:58.651: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 16.142645ms)
+Mar 20 08:34:58.651: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 16.090393ms)
+Mar 20 08:34:58.651: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 16.252706ms)
+Mar 20 08:34:58.651: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 16.539134ms)
+Mar 20 08:34:58.651: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 16.492886ms)
+Mar 20 08:34:58.653: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 18.703148ms)
+Mar 20 08:34:58.654: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 19.875639ms)
+Mar 20 08:34:58.656: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 21.568479ms)
+Mar 20 08:34:58.656: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 22.027788ms)
+Mar 20 08:34:58.656: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 21.770982ms)
+Mar 20 08:34:58.656: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 21.695473ms)
+Mar 20 08:34:58.656: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 21.619506ms)
+Mar 20 08:34:58.656: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 22.01282ms)
+Mar 20 08:34:58.656: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 21.716215ms)
+Mar 20 08:34:58.656: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 21.748412ms)
+Mar 20 08:34:58.656: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 22.192044ms)
+Mar 20 08:34:58.656: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 21.956754ms)
+Mar 20 08:34:58.657: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 22.846467ms)
+Mar 20 08:34:58.658: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 24.295204ms)
+Mar 20 08:34:58.660: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 26.033181ms)
+Mar 20 08:34:58.661: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 26.429291ms)
+Mar 20 08:34:58.663: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 29.237361ms)
+Mar 20 08:34:58.669: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 4.954785ms)
+Mar 20 08:34:58.671: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 7.142783ms)
+Mar 20 08:34:58.671: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 7.323046ms)
+Mar 20 08:34:58.671: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 7.183267ms)
+Mar 20 08:34:58.671: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 7.251153ms)
+Mar 20 08:34:58.671: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 7.663614ms)
+Mar 20 08:34:58.671: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 7.189823ms)
+Mar 20 08:34:58.672: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 7.672833ms)
+Mar 20 08:34:58.672: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 7.896764ms)
+Mar 20 08:34:58.672: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 7.974659ms)
+Mar 20 08:34:58.673: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 8.411883ms)
+Mar 20 08:34:58.673: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 8.601341ms)
+Mar 20 08:34:58.674: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 10.015004ms)
+Mar 20 08:34:58.674: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 9.8857ms)
+Mar 20 08:34:58.674: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 10.162632ms)
+Mar 20 08:34:58.674: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 9.834132ms)
+Mar 20 08:34:58.674: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 9.966872ms)
+Mar 20 08:34:58.674: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 10.572201ms)
+Mar 20 08:34:58.674: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 10.2838ms)
+Mar 20 08:34:58.674: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 9.864474ms)
+Mar 20 08:34:58.674: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 10.531404ms)
+Mar 20 08:34:58.674: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 10.070859ms)
+Mar 20 08:34:58.674: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 9.911227ms)
+Mar 20 08:34:58.674: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 10.483535ms)
+Mar 20 08:34:58.675: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 11.214533ms)
+Mar 20 08:34:58.676: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 11.714378ms)
+Mar 20 08:34:58.676: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 12.277462ms)
+Mar 20 08:34:58.676: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 12.023308ms)
+Mar 20 08:34:58.676: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 11.606168ms)
+Mar 20 08:34:58.676: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 12.029017ms)
+Mar 20 08:34:58.676: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 11.774101ms)
+Mar 20 08:34:58.676: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 11.645035ms)
+Mar 20 08:34:58.676: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 12.050499ms)
+Mar 20 08:34:58.676: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 12.580204ms)
+Mar 20 08:34:58.693: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 16.042931ms)
+Mar 20 08:34:58.693: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 16.479488ms)
+Mar 20 08:34:58.693: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 15.959749ms)
+Mar 20 08:34:58.693: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 15.762766ms)
+Mar 20 08:34:58.693: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 16.262175ms)
+Mar 20 08:34:58.693: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 16.414221ms)
+Mar 20 08:34:58.693: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 16.801965ms)
+Mar 20 08:34:58.693: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 16.967787ms)
+Mar 20 08:34:58.693: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 16.871023ms)
+Mar 20 08:34:58.693: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 17.037423ms)
+Mar 20 08:34:58.694: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 16.714603ms)
+Mar 20 08:34:58.694: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 16.473208ms)
+Mar 20 08:34:58.694: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 16.991549ms)
+Mar 20 08:34:58.694: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 17.267534ms)
+Mar 20 08:34:58.694: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 16.609969ms)
+Mar 20 08:34:58.694: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 16.972854ms)
+Mar 20 08:34:58.694: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 17.001082ms)
+Mar 20 08:34:58.694: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 18.198799ms)
+Mar 20 08:34:58.694: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 17.614395ms)
+Mar 20 08:34:58.695: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 18.192146ms)
+Mar 20 08:34:58.695: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 18.58984ms)
+Mar 20 08:34:58.695: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 18.431567ms)
+Mar 20 08:34:58.695: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 18.524924ms)
+Mar 20 08:34:58.695: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 18.734128ms)
+Mar 20 08:34:58.696: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 19.346982ms)
+Mar 20 08:35:01.844: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 3.167345057s)
+Mar 20 08:35:01.844: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 3.167987983s)
+Mar 20 08:35:01.844: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 3.167356165s)
+Mar 20 08:35:01.845: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 3.168348471s)
+Mar 20 08:35:01.845: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 3.167994758s)
+Mar 20 08:35:01.845: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 3.168349692s)
+Mar 20 08:35:01.850: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 3.172890264s)
+Mar 20 08:35:01.850: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 3.172984802s)
+Mar 20 08:35:01.850: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 3.173513605s)
+Mar 20 08:35:01.875: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 25.076283ms)
+Mar 20 08:35:01.880: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 29.743041ms)
+Mar 20 08:35:01.881: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 30.408119ms)
+Mar 20 08:35:01.881: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 29.988573ms)
+Mar 20 08:35:01.881: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 30.776835ms)
+Mar 20 08:35:01.881: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 30.10919ms)
+Mar 20 08:35:01.895: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 44.039906ms)
+Mar 20 08:35:01.895: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 44.691181ms)
+Mar 20 08:35:01.896: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 45.08971ms)
+Mar 20 08:35:01.896: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 44.867063ms)
+Mar 20 08:35:01.896: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 45.295519ms)
+Mar 20 08:35:01.896: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 45.073976ms)
+Mar 20 08:35:01.897: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 45.848181ms)
+Mar 20 08:35:01.897: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 46.286476ms)
+Mar 20 08:35:01.897: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 46.02929ms)
+Mar 20 08:35:01.897: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 46.427824ms)
+Mar 20 08:35:01.898: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 46.825608ms)
+Mar 20 08:35:01.898: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 46.632714ms)
+Mar 20 08:35:01.898: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 47.048209ms)
+Mar 20 08:35:01.898: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 46.761344ms)
+Mar 20 08:35:01.898: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 47.65655ms)
+Mar 20 08:35:01.898: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 46.913067ms)
+Mar 20 08:35:01.898: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 46.872359ms)
+Mar 20 08:35:01.899: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 48.205218ms)
+Mar 20 08:35:01.899: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 48.113082ms)
+Mar 20 08:35:01.899: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 47.53411ms)
+Mar 20 08:35:01.899: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 47.892837ms)
+Mar 20 08:35:01.899: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 47.970613ms)
+Mar 20 08:35:01.899: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 47.921965ms)
+Mar 20 08:35:01.899: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 47.899696ms)
+Mar 20 08:35:01.899: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 48.469029ms)
+Mar 20 08:35:01.899: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 48.575366ms)
+Mar 20 08:35:01.899: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 48.104091ms)
+Mar 20 08:35:01.899: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 48.734546ms)
+Mar 20 08:35:01.919: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 19.881129ms)
+Mar 20 08:35:01.919: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 19.539784ms)
+Mar 20 08:35:01.919: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 20.076446ms)
+Mar 20 08:35:01.920: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 19.917561ms)
+Mar 20 08:35:01.920: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 20.55736ms)
+Mar 20 08:35:01.920: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 20.334874ms)
+Mar 20 08:35:01.920: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 20.571685ms)
+Mar 20 08:35:01.920: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 21.062088ms)
+Mar 20 08:35:01.920: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 20.653841ms)
+Mar 20 08:35:01.920: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 20.87856ms)
+Mar 20 08:35:01.921: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 21.466994ms)
+Mar 20 08:35:01.921: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 21.586712ms)
+Mar 20 08:35:01.921: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 21.679073ms)
+Mar 20 08:35:01.921: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 21.71556ms)
+Mar 20 08:35:01.921: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 21.653164ms)
+Mar 20 08:35:01.923: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 23.344994ms)
+Mar 20 08:35:01.924: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 23.884821ms)
+Mar 20 08:35:01.924: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 23.6377ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 24.763965ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 25.529369ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 25.519929ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 25.5128ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 25.185979ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 25.222131ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 25.318276ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 25.398173ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 25.585248ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 25.517659ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 25.511993ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 25.281898ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 25.426193ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 25.63735ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 25.67895ms)
+Mar 20 08:35:01.925: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 25.653162ms)
+Mar 20 08:35:01.931: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 5.52821ms)
+Mar 20 08:35:01.932: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 5.788104ms)
+Mar 20 08:35:01.932: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 6.866148ms)
+Mar 20 08:35:01.932: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 6.358463ms)
+Mar 20 08:35:01.933: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 7.138315ms)
+Mar 20 08:35:01.933: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 6.599469ms)
+Mar 20 08:35:01.933: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 7.714385ms)
+Mar 20 08:35:01.933: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 7.89693ms)
+Mar 20 08:35:01.934: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 8.036319ms)
+Mar 20 08:35:01.934: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 7.945323ms)
+Mar 20 08:35:01.934: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 8.085036ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 9.536771ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 9.468578ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 9.858158ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 9.552589ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 8.507885ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 8.788532ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 9.274989ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 8.857392ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 8.7595ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 9.017928ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 9.204168ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 9.765477ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 10.091943ms)
+Mar 20 08:35:01.936: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 9.632905ms)
+Mar 20 08:35:01.937: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 10.131712ms)
+Mar 20 08:35:01.937: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 10.624686ms)
+Mar 20 08:35:01.937: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 11.285749ms)
+Mar 20 08:35:01.941: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 14.685188ms)
+Mar 20 08:35:01.941: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 14.814978ms)
+Mar 20 08:35:01.941: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 14.67862ms)
+Mar 20 08:35:01.941: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 15.236791ms)
+Mar 20 08:35:01.942: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 15.175106ms)
+Mar 20 08:35:01.942: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 15.898315ms)
+Mar 20 08:35:01.950: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 7.843895ms)
+Mar 20 08:35:01.950: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 7.7496ms)
+Mar 20 08:35:01.950: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 7.985399ms)
+Mar 20 08:35:01.950: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 8.10107ms)
+Mar 20 08:35:01.951: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 8.112906ms)
+Mar 20 08:35:01.951: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 7.97304ms)
+Mar 20 08:35:01.951: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 8.04071ms)
+Mar 20 08:35:01.951: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 8.341469ms)
+Mar 20 08:35:01.951: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 8.317839ms)
+Mar 20 08:35:01.951: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 8.567008ms)
+Mar 20 08:35:01.951: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 8.181382ms)
+Mar 20 08:35:01.951: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 8.541481ms)
+Mar 20 08:35:01.951: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 8.640633ms)
+Mar 20 08:35:01.951: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 8.495076ms)
+Mar 20 08:35:01.952: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 9.229313ms)
+Mar 20 08:35:01.952: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 9.336425ms)
+Mar 20 08:35:01.952: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 9.306595ms)
+Mar 20 08:35:01.952: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 9.582524ms)
+Mar 20 08:35:01.952: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 10.123369ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 12.06163ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 12.114291ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 12.281209ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 12.287688ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 12.234904ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 12.477612ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 12.400232ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 12.353367ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 12.427178ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 12.276195ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 12.682146ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 12.435665ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 12.648025ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 12.671986ms)
+Mar 20 08:35:01.955: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 12.62996ms)
+Mar 20 08:35:01.963: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 7.334838ms)
+Mar 20 08:35:01.963: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 7.770818ms)
+Mar 20 08:35:01.963: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 7.932188ms)
+Mar 20 08:35:01.963: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 7.937594ms)
+Mar 20 08:35:01.963: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 7.876844ms)
+Mar 20 08:35:01.964: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 8.950129ms)
+Mar 20 08:35:01.964: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 8.969517ms)
+Mar 20 08:35:01.964: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 8.459317ms)
+Mar 20 08:35:01.964: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 9.081655ms)
+Mar 20 08:35:01.965: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 8.875114ms)
+Mar 20 08:35:01.965: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 9.268713ms)
+Mar 20 08:35:01.965: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 9.010187ms)
+Mar 20 08:35:01.965: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 9.455284ms)
+Mar 20 08:35:01.965: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 9.575486ms)
+Mar 20 08:35:01.965: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 9.338544ms)
+Mar 20 08:35:01.965: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 9.17471ms)
+Mar 20 08:35:01.965: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 9.61399ms)
+Mar 20 08:35:01.965: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 9.551052ms)
+Mar 20 08:35:01.965: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 9.409095ms)
+Mar 20 08:35:01.965: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 10.055191ms)
+Mar 20 08:35:01.965: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 9.686526ms)
+Mar 20 08:35:01.966: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 9.845189ms)
+Mar 20 08:35:01.966: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 10.174012ms)
+Mar 20 08:35:01.966: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 10.668016ms)
+Mar 20 08:35:01.966: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 10.576447ms)
+Mar 20 08:35:01.966: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 10.219265ms)
+Mar 20 08:35:01.966: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 10.401221ms)
+Mar 20 08:35:01.966: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 10.434582ms)
+Mar 20 08:35:01.966: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 10.702668ms)
+Mar 20 08:35:01.966: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 10.438788ms)
+Mar 20 08:35:01.966: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 10.52382ms)
+Mar 20 08:35:01.966: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 11.03807ms)
+Mar 20 08:35:01.966: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 10.792638ms)
+Mar 20 08:35:01.967: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 11.000868ms)
+Mar 20 08:35:01.971: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 3.888552ms)
+Mar 20 08:35:01.971: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 4.303222ms)
+Mar 20 08:35:01.972: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 4.573894ms)
+Mar 20 08:35:01.972: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 5.238766ms)
+Mar 20 08:35:01.975: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 7.859853ms)
+Mar 20 08:35:01.975: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 7.831804ms)
+Mar 20 08:35:01.975: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 8.336756ms)
+Mar 20 08:35:01.976: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 8.70227ms)
+Mar 20 08:35:01.976: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 8.254944ms)
+Mar 20 08:35:01.976: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 8.536908ms)
+Mar 20 08:35:01.976: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 8.73823ms)
+Mar 20 08:35:01.976: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 8.778869ms)
+Mar 20 08:35:01.976: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 8.4905ms)
+Mar 20 08:35:01.977: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 8.809335ms)
+Mar 20 08:35:01.977: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 8.907594ms)
+Mar 20 08:35:01.977: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 9.363349ms)
+Mar 20 08:35:01.977: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 9.033648ms)
+Mar 20 08:35:01.977: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 9.975611ms)
+Mar 20 08:35:01.978: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 9.819156ms)
+Mar 20 08:35:01.978: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 10.991706ms)
+Mar 20 08:35:01.978: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 10.075674ms)
+Mar 20 08:35:01.978: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 10.080267ms)
+Mar 20 08:35:01.978: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 10.350894ms)
+Mar 20 08:35:01.978: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 10.843032ms)
+Mar 20 08:35:01.978: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 10.178633ms)
+Mar 20 08:35:01.978: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 10.925117ms)
+Mar 20 08:35:01.978: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 11.02119ms)
+Mar 20 08:35:01.978: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 10.401163ms)
+Mar 20 08:35:01.978: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 10.495869ms)
+Mar 20 08:35:01.979: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 10.588241ms)
+Mar 20 08:35:01.979: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 11.003902ms)
+Mar 20 08:35:01.979: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 11.192741ms)
+Mar 20 08:35:01.979: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 11.039208ms)
+Mar 20 08:35:01.979: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 11.380511ms)
+Mar 20 08:35:01.986: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 6.127501ms)
+Mar 20 08:35:01.986: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 6.692247ms)
+Mar 20 08:35:01.986: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 6.755879ms)
+Mar 20 08:35:01.986: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 6.38876ms)
+Mar 20 08:35:01.986: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 6.600782ms)
+Mar 20 08:35:01.986: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 6.593689ms)
+Mar 20 08:35:01.986: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 7.047082ms)
+Mar 20 08:35:01.987: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 7.114523ms)
+Mar 20 08:35:01.987: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 7.552364ms)
+Mar 20 08:35:01.987: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 7.598918ms)
+Mar 20 08:35:01.988: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 7.685809ms)
+Mar 20 08:35:01.988: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 7.911897ms)
+Mar 20 08:35:01.988: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 7.85452ms)
+Mar 20 08:35:01.988: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 8.31072ms)
+Mar 20 08:35:01.988: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 8.741831ms)
+Mar 20 08:35:01.988: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 8.565403ms)
+Mar 20 08:35:01.989: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 9.098432ms)
+Mar 20 08:35:01.989: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 9.182619ms)
+Mar 20 08:35:01.989: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 9.068221ms)
+Mar 20 08:35:01.989: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 9.65378ms)
+Mar 20 08:35:01.990: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 10.193001ms)
+Mar 20 08:35:01.990: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 10.360275ms)
+Mar 20 08:35:01.990: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 10.358448ms)
+Mar 20 08:35:01.990: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 10.427905ms)
+Mar 20 08:35:01.990: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 10.42863ms)
+Mar 20 08:35:01.990: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 10.566878ms)
+Mar 20 08:35:01.991: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 10.825035ms)
+Mar 20 08:35:01.991: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 10.958813ms)
+Mar 20 08:35:01.991: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 10.825143ms)
+Mar 20 08:35:01.991: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 11.100813ms)
+Mar 20 08:35:01.991: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 11.140417ms)
+Mar 20 08:35:01.991: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 11.271455ms)
+Mar 20 08:35:01.991: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 10.908029ms)
+Mar 20 08:35:01.991: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 11.73226ms)
+Mar 20 08:35:01.998: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 6.540166ms)
+Mar 20 08:35:01.999: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 7.214414ms)
+Mar 20 08:35:01.999: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 7.204674ms)
+Mar 20 08:35:02.000: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 7.778918ms)
+Mar 20 08:35:02.000: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 7.597165ms)
+Mar 20 08:35:02.000: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 7.961231ms)
+Mar 20 08:35:02.000: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 8.17345ms)
+Mar 20 08:35:02.000: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 8.186411ms)
+Mar 20 08:35:02.000: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 8.17151ms)
+Mar 20 08:35:02.000: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 8.342281ms)
+Mar 20 08:35:02.000: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 8.406535ms)
+Mar 20 08:35:02.000: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 8.594461ms)
+Mar 20 08:35:02.000: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 8.271723ms)
+Mar 20 08:35:02.001: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 8.78912ms)
+Mar 20 08:35:02.001: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 8.961381ms)
+Mar 20 08:35:02.001: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 9.404995ms)
+Mar 20 08:35:02.001: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 8.693263ms)
+Mar 20 08:35:02.001: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 9.029252ms)
+Mar 20 08:35:02.001: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 9.499541ms)
+Mar 20 08:35:02.002: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 9.356252ms)
+Mar 20 08:35:02.002: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 9.598994ms)
+Mar 20 08:35:02.002: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 9.872135ms)
+Mar 20 08:35:02.002: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 9.806653ms)
+Mar 20 08:35:02.002: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 10.039315ms)
+Mar 20 08:35:02.002: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 10.107639ms)
+Mar 20 08:35:02.002: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 10.080387ms)
+Mar 20 08:35:02.003: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 10.787428ms)
+Mar 20 08:35:02.003: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 11.211152ms)
+Mar 20 08:35:02.003: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 10.788097ms)
+Mar 20 08:35:02.003: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 11.175551ms)
+Mar 20 08:35:02.004: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 11.220169ms)
+Mar 20 08:35:02.004: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 11.304822ms)
+Mar 20 08:35:02.004: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 11.061375ms)
+Mar 20 08:35:02.004: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 11.356908ms)
+Mar 20 08:35:02.010: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 6.391213ms)
+Mar 20 08:35:02.011: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 6.86112ms)
+Mar 20 08:35:02.012: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 7.110438ms)
+Mar 20 08:35:02.012: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 7.185308ms)
+Mar 20 08:35:02.012: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 7.058433ms)
+Mar 20 08:35:02.012: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 7.493658ms)
+Mar 20 08:35:02.012: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 7.465598ms)
+Mar 20 08:35:02.012: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 7.614546ms)
+Mar 20 08:35:02.012: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 8.3209ms)
+Mar 20 08:35:02.012: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 7.862522ms)
+Mar 20 08:35:02.013: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 8.055677ms)
+Mar 20 08:35:02.013: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 8.409013ms)
+Mar 20 08:35:02.013: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 8.77531ms)
+Mar 20 08:35:02.014: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 10.177582ms)
+Mar 20 08:35:02.014: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 9.778936ms)
+Mar 20 08:35:02.015: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 10.970974ms)
+Mar 20 08:35:02.015: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 11.166011ms)
+Mar 20 08:35:02.015: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 11.1498ms)
+Mar 20 08:35:02.015: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 10.628731ms)
+Mar 20 08:35:02.015: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 11.325819ms)
+Mar 20 08:35:02.015: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 10.813515ms)
+Mar 20 08:35:02.015: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 11.175171ms)
+Mar 20 08:35:02.015: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 10.795986ms)
+Mar 20 08:35:02.015: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 10.903218ms)
+Mar 20 08:35:02.015: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 11.0241ms)
+Mar 20 08:35:02.015: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 10.930026ms)
+Mar 20 08:35:02.016: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 11.82173ms)
+Mar 20 08:35:02.016: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 11.870972ms)
+Mar 20 08:35:02.016: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 12.291348ms)
+Mar 20 08:35:02.016: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 12.128475ms)
+Mar 20 08:35:02.016: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 12.192836ms)
+Mar 20 08:35:02.017: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 13.241571ms)
+Mar 20 08:35:02.017: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 13.267169ms)
+Mar 20 08:35:02.017: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 12.629784ms)
+Mar 20 08:35:02.024: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 5.79796ms)
+Mar 20 08:35:02.024: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 6.07326ms)
+Mar 20 08:35:02.024: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 6.065259ms)
+Mar 20 08:35:02.024: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 6.17912ms)
+Mar 20 08:35:02.024: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 6.42088ms)
+Mar 20 08:35:02.024: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 6.803537ms)
+Mar 20 08:35:02.024: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 6.408419ms)
+Mar 20 08:35:02.024: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 6.74376ms)
+Mar 20 08:35:02.025: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 7.561442ms)
+Mar 20 08:35:02.025: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 7.624535ms)
+Mar 20 08:35:02.026: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 8.112127ms)
+Mar 20 08:35:02.026: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 8.420573ms)
+Mar 20 08:35:02.026: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 8.703677ms)
+Mar 20 08:35:02.027: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 9.425207ms)
+Mar 20 08:35:02.028: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 9.939441ms)
+Mar 20 08:35:02.028: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 9.899621ms)
+Mar 20 08:35:02.028: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 9.903868ms)
+Mar 20 08:35:02.028: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 10.015255ms)
+Mar 20 08:35:02.028: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 9.967978ms)
+Mar 20 08:35:02.028: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 9.969099ms)
+Mar 20 08:35:02.029: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 10.761096ms)
+Mar 20 08:35:02.029: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 10.837746ms)
+Mar 20 08:35:02.029: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 11.031998ms)
+Mar 20 08:35:02.029: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 11.614954ms)
+Mar 20 08:35:02.030: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 11.76948ms)
+Mar 20 08:35:02.030: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 11.895072ms)
+Mar 20 08:35:02.030: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 11.835143ms)
+Mar 20 08:35:02.030: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 11.834537ms)
+Mar 20 08:35:02.030: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 12.017847ms)
+Mar 20 08:35:02.030: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 12.144653ms)
+Mar 20 08:35:02.030: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 12.091058ms)
+Mar 20 08:35:02.030: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 12.098285ms)
+Mar 20 08:35:02.030: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 12.285425ms)
+Mar 20 08:35:02.030: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 11.94594ms)
+Mar 20 08:35:02.034: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 3.661268ms)
+Mar 20 08:35:02.036: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 5.559459ms)
+Mar 20 08:35:02.037: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 6.52852ms)
+Mar 20 08:35:02.037: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 6.589522ms)
+Mar 20 08:35:02.037: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 6.101771ms)
+Mar 20 08:35:02.037: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 6.993309ms)
+Mar 20 08:35:02.037: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 6.965926ms)
+Mar 20 08:35:02.037: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 6.74254ms)
+Mar 20 08:35:02.038: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 7.223719ms)
+Mar 20 08:35:02.040: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 9.349902ms)
+Mar 20 08:35:02.040: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 9.692603ms)
+Mar 20 08:35:02.040: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 9.295613ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 14.809006ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 14.171294ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 14.41441ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 14.844039ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 14.839572ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 14.564634ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 14.994286ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 14.404127ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 14.364853ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 14.688023ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 14.538212ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 14.656947ms)
+Mar 20 08:35:02.045: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 14.887996ms)
+Mar 20 08:35:08.437: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 6.406942855s)
+Mar 20 08:35:08.437: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 6.406929224s)
+Mar 20 08:35:08.437: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 6.407095412s)
+Mar 20 08:35:08.437: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 6.406608396s)
+Mar 20 08:35:08.437: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 6.406649961s)
+Mar 20 08:35:08.542: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 6.511209381s)
+Mar 20 08:35:08.542: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 6.511343791s)
+Mar 20 08:35:08.626: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 6.595511393s)
+Mar 20 08:35:08.626: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 6.595846425s)
+Mar 20 08:35:08.634: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 7.474779ms)
+Mar 20 08:35:08.634: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 7.708874ms)
+Mar 20 08:35:08.634: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 7.899823ms)
+Mar 20 08:35:08.635: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 8.128703ms)
+Mar 20 08:35:08.635: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 8.047881ms)
+Mar 20 08:35:08.635: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 8.076534ms)
+Mar 20 08:35:08.635: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 8.500184ms)
+Mar 20 08:35:08.636: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 9.119532ms)
+Mar 20 08:35:08.636: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 8.997511ms)
+Mar 20 08:35:08.636: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 8.931967ms)
+Mar 20 08:35:08.636: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 9.101292ms)
+Mar 20 08:35:08.636: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 9.306775ms)
+Mar 20 08:35:08.636: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 9.356306ms)
+Mar 20 08:35:08.636: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 9.25521ms)
+Mar 20 08:35:08.637: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 9.958844ms)
+Mar 20 08:35:08.637: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 10.080062ms)
+Mar 20 08:35:08.637: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 10.266112ms)
+Mar 20 08:35:08.637: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 9.87558ms)
+Mar 20 08:35:08.637: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 9.880723ms)
+Mar 20 08:35:08.637: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 10.542549ms)
+Mar 20 08:35:08.637: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 10.530833ms)
+Mar 20 08:35:08.638: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 11.251106ms)
+Mar 20 08:35:08.638: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 11.664176ms)
+Mar 20 08:35:08.638: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 11.641467ms)
+Mar 20 08:35:08.638: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 11.16976ms)
+Mar 20 08:35:08.638: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 12.006258ms)
+Mar 20 08:35:08.638: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 11.599886ms)
+Mar 20 08:35:08.639: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 11.457695ms)
+Mar 20 08:35:08.638: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 11.793634ms)
+Mar 20 08:35:08.639: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 11.762123ms)
+Mar 20 08:35:08.639: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 12.445503ms)
+Mar 20 08:35:08.639: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 12.360011ms)
+Mar 20 08:35:08.639: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 12.510841ms)
+Mar 20 08:35:08.639: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 12.609389ms)
+Mar 20 08:35:08.644: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 4.81065ms)
+Mar 20 08:35:08.648: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 7.52825ms)
+Mar 20 08:35:08.648: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 8.170576ms)
+Mar 20 08:35:08.648: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 8.532157ms)
+Mar 20 08:35:08.648: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 8.69512ms)
+Mar 20 08:35:08.649: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 8.403879ms)
+Mar 20 08:35:08.649: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 9.030051ms)
+Mar 20 08:35:08.649: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 8.564121ms)
+Mar 20 08:35:08.649: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 9.572523ms)
+Mar 20 08:35:08.650: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 10.389431ms)
+Mar 20 08:35:08.650: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 9.045722ms)
+Mar 20 08:35:08.650: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 9.86963ms)
+Mar 20 08:35:08.650: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 10.306951ms)
+Mar 20 08:35:08.650: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 10.274817ms)
+Mar 20 08:35:08.650: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 10.393705ms)
+Mar 20 08:35:08.650: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 10.759999ms)
+Mar 20 08:35:08.650: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 10.92861ms)
+Mar 20 08:35:08.650: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 9.525335ms)
+Mar 20 08:35:08.651: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 10.002924ms)
+Mar 20 08:35:08.651: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 10.020613ms)
+Mar 20 08:35:08.651: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 10.126379ms)
+Mar 20 08:35:08.651: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 10.240758ms)
+Mar 20 08:35:08.651: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 11.459615ms)
+Mar 20 08:35:08.651: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 11.028857ms)
+Mar 20 08:35:08.651: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 10.986808ms)
+Mar 20 08:35:08.652: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 10.679351ms)
+Mar 20 08:35:08.652: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 10.547565ms)
+Mar 20 08:35:08.652: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 11.356278ms)
+Mar 20 08:35:08.652: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 11.984721ms)
+Mar 20 08:35:08.652: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 11.358316ms)
+Mar 20 08:35:08.652: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 11.277274ms)
+Mar 20 08:35:08.652: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 11.567295ms)
+Mar 20 08:35:08.652: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 11.960357ms)
+Mar 20 08:35:08.652: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 12.008548ms)
+Mar 20 08:35:08.661: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 7.505094ms)
+Mar 20 08:35:08.661: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 7.882581ms)
+Mar 20 08:35:08.661: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 7.830358ms)
+Mar 20 08:35:08.661: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 8.624461ms)
+Mar 20 08:35:08.662: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 9.017259ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 9.081323ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 9.314337ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 10.245931ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 8.645498ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 9.071816ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 8.445ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 8.654564ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 8.897873ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 9.822119ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 10.017622ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 10.275372ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 9.478284ms)
+Mar 20 08:35:08.663: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 10.605077ms)
+Mar 20 08:35:08.664: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 10.581224ms)
+Mar 20 08:35:08.664: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 10.518397ms)
+Mar 20 08:35:08.664: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 9.785198ms)
+Mar 20 08:35:08.664: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 10.481283ms)
+Mar 20 08:35:08.664: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 9.881572ms)
+Mar 20 08:35:08.664: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 10.861759ms)
+Mar 20 08:35:08.664: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 10.259704ms)
+Mar 20 08:35:08.665: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 10.253166ms)
+Mar 20 08:35:08.665: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 12.089678ms)
+Mar 20 08:35:08.665: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 11.02858ms)
+Mar 20 08:35:08.665: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 10.946439ms)
+Mar 20 08:35:08.665: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 10.561248ms)
+Mar 20 08:35:08.665: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 10.827605ms)
+Mar 20 08:35:08.665: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 10.364772ms)
+Mar 20 08:35:08.665: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 10.204505ms)
+Mar 20 08:35:08.665: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 11.098202ms)
+Mar 20 08:35:08.671: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 5.853047ms)
+Mar 20 08:35:08.671: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 5.544119ms)
+Mar 20 08:35:08.671: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 5.922437ms)
+Mar 20 08:35:08.672: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 6.372941ms)
+Mar 20 08:35:08.672: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 6.23336ms)
+Mar 20 08:35:08.672: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 6.812664ms)
+Mar 20 08:35:08.672: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 6.179675ms)
+Mar 20 08:35:08.672: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 6.815602ms)
+Mar 20 08:35:08.672: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 6.532862ms)
+Mar 20 08:35:08.673: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 7.468936ms)
+Mar 20 08:35:08.673: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 7.308745ms)
+Mar 20 08:35:08.674: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 8.45798ms)
+Mar 20 08:35:08.674: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 7.668921ms)
+Mar 20 08:35:08.674: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 7.808483ms)
+Mar 20 08:35:08.674: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 8.547258ms)
+Mar 20 08:35:08.674: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 8.650854ms)
+Mar 20 08:35:08.674: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 8.831144ms)
+Mar 20 08:35:08.674: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 8.639234ms)
+Mar 20 08:35:08.675: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 9.165027ms)
+Mar 20 08:35:08.675: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 9.214642ms)
+Mar 20 08:35:08.675: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 9.314762ms)
+Mar 20 08:35:08.676: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 10.054144ms)
+Mar 20 08:35:08.676: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 10.125009ms)
+Mar 20 08:35:08.676: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 10.311322ms)
+Mar 20 08:35:08.676: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 10.397053ms)
+Mar 20 08:35:08.677: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 10.977801ms)
+Mar 20 08:35:08.677: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 10.77436ms)
+Mar 20 08:35:08.677: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 10.837205ms)
+Mar 20 08:35:08.677: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 11.488156ms)
+Mar 20 08:35:08.677: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 10.954822ms)
+Mar 20 08:35:08.677: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 11.02369ms)
+Mar 20 08:35:08.677: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 11.567444ms)
+Mar 20 08:35:08.677: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 11.188965ms)
+Mar 20 08:35:08.677: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 11.882514ms)
+Mar 20 08:35:08.686: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 8.523478ms)
+Mar 20 08:35:08.686: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 8.75495ms)
+Mar 20 08:35:08.687: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 9.303993ms)
+Mar 20 08:35:08.688: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 10.041389ms)
+Mar 20 08:35:08.688: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 10.443288ms)
+Mar 20 08:35:08.688: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 10.855694ms)
+Mar 20 08:35:08.689: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 10.900816ms)
+Mar 20 08:35:08.689: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 11.174654ms)
+Mar 20 08:35:08.689: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 11.260183ms)
+Mar 20 08:35:08.689: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 11.277718ms)
+Mar 20 08:35:08.689: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 11.295043ms)
+Mar 20 08:35:08.691: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 12.729953ms)
+Mar 20 08:35:08.691: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 12.873001ms)
+Mar 20 08:35:08.691: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 12.970211ms)
+Mar 20 08:35:08.691: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 12.817865ms)
+Mar 20 08:35:08.691: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 13.527658ms)
+Mar 20 08:35:08.691: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 13.506837ms)
+Mar 20 08:35:08.691: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 13.502829ms)
+Mar 20 08:35:08.691: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 13.485564ms)
+Mar 20 08:35:08.692: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 13.900807ms)
+Mar 20 08:35:08.692: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 14.030995ms)
+Mar 20 08:35:08.692: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 14.665389ms)
+Mar 20 08:35:08.692: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 14.59506ms)
+Mar 20 08:35:08.692: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 14.815545ms)
+Mar 20 08:35:08.693: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 15.418045ms)
+Mar 20 08:35:08.693: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 15.481997ms)
+Mar 20 08:35:08.693: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 15.620991ms)
+Mar 20 08:35:08.693: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 15.612598ms)
+Mar 20 08:35:08.694: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 15.809818ms)
+Mar 20 08:35:08.694: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 15.834518ms)
+Mar 20 08:35:08.694: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 16.126372ms)
+Mar 20 08:35:08.694: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 16.087449ms)
+Mar 20 08:35:08.694: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 16.164141ms)
+Mar 20 08:35:08.694: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 16.518678ms)
+Mar 20 08:35:08.703: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/: bar (200; 8.984888ms)
+Mar 20 08:35:08.703: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql/proxy/rewriteme"... (200; 8.899194ms)
+Mar 20 08:35:08.706: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:460/proxy/: tls baz (200; 11.810041ms)
+Mar 20 08:35:08.706: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/: foo (200; 11.785184ms)
+Mar 20 08:35:08.706: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/proxy/: tls baz (200; 11.403264ms)
+Mar 20 08:35:08.706: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 11.738752ms)
+Mar 20 08:35:08.706: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/: foo (200; 11.708514ms)
+Mar 20 08:35:08.706: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:81/: bar (200; 11.936603ms)
+Mar 20 08:35:08.706: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:444/: tls qux (200; 11.627016ms)
+Mar 20 08:35:08.706: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:443/proxy/... (200; 11.790957ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/: tls qux (200; 12.174014ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/https:proxy-service-tgps4-nr5ql:462/proxy/: tls qux (200; 12.070883ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname2/proxy/: tls qux (200; 12.190734ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 12.457422ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/proxy/: bar (200; 12.094787ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:tlsportname1/: tls baz (200; 11.70489ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/proxy/: foo (200; 12.546651ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/proxy/: bar (200; 11.964746ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname1/: foo (200; 12.142948ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:162/proxy/: bar (200; 12.509104ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/... (200; 12.556138ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:160/proxy/: foo (200; 12.661406ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/proxy/: foo (200; 12.343712ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:80/: foo (200; 12.249151ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/proxy/rewri... (200; 12.73723ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/https:proxy-service-tgps4:443/: tls baz (200; 12.524498ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:portname2/: bar (200; 12.57854ms)
+Mar 20 08:35:08.707: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:1080/proxy/... (200; 12.686695ms)
+Mar 20 08:35:08.708: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname1/: foo (200; 13.033366ms)
+Mar 20 08:35:08.708: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/http:proxy-service-tgps4:80/: foo (200; 13.141192ms)
+Mar 20 08:35:08.708: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/http:proxy-service-tgps4-nr5ql:162/: bar (200; 12.781202ms)
+Mar 20 08:35:08.708: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:81/: bar (200; 12.963486ms)
+Mar 20 08:35:08.708: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/pods/proxy-service-tgps4-nr5ql:1080/rewri... (200; 13.805266ms)
+Mar 20 08:35:08.708: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-6wr79/services/proxy-service-tgps4:portname2/: bar (200; 13.758584ms)
+STEP: deleting { ReplicationController} proxy-service-tgps4 in namespace e2e-tests-proxy-6wr79
+Mar 20 08:35:08.843: INFO: Deleting { ReplicationController} proxy-service-tgps4 took: 32.545215ms
+Mar 20 08:35:08.843: INFO: Terminating { ReplicationController} proxy-service-tgps4 pods took: 36.748µs
+Mar 20 08:35:20.744: INFO: Garbage collecting { ReplicationController} proxy-service-tgps4 pods took: 11.932732243s
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:35:20.744: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-6wr79" for this suite.
+Mar 20 08:35:26.755: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:35:26.814: INFO: namespace: e2e-tests-proxy-6wr79, resource: bindings, ignored listing per whitelist
+Mar 20 08:35:26.846: INFO: namespace e2e-tests-proxy-6wr79 deletion completed in 6.098425323s
+
+• [SLOW TEST:32.266 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:35:26.846: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 20 08:35:28.906: INFO: Waiting up to 5m0s for pod "client-envvars-a5028beb-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-pods-9vnqw" to be "success or failure"
+Mar 20 08:35:28.908: INFO: Pod "client-envvars-a5028beb-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.060151ms
+Mar 20 08:35:30.911: INFO: Pod "client-envvars-a5028beb-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005026792s
+Mar 20 08:35:32.914: INFO: Pod "client-envvars-a5028beb-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008197656s
+STEP: Saw pod success
+Mar 20 08:35:32.914: INFO: Pod "client-envvars-a5028beb-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:35:32.916: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod client-envvars-a5028beb-2c19-11e8-bd77-b6fcf399588c container env3cont: <nil>
+STEP: delete the pod
+Mar 20 08:35:32.930: INFO: Waiting for pod client-envvars-a5028beb-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:35:32.932: INFO: Pod client-envvars-a5028beb-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:35:32.932: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-9vnqw" for this suite.
+Mar 20 08:35:54.944: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:35:55.011: INFO: namespace: e2e-tests-pods-9vnqw, resource: bindings, ignored listing per whitelist
+Mar 20 08:35:55.045: INFO: namespace e2e-tests-pods-9vnqw deletion completed in 22.108002503s
+
+• [SLOW TEST:28.199 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:35:55.045: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-b49db77f-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:35:55.091: INFO: Waiting up to 5m0s for pod "pod-configmaps-b49e2925-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-configmap-2xw4q" to be "success or failure"
+Mar 20 08:35:55.093: INFO: Pod "pod-configmaps-b49e2925-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.992298ms
+Mar 20 08:35:57.096: INFO: Pod "pod-configmaps-b49e2925-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005362766s
+STEP: Saw pod success
+Mar 20 08:35:57.097: INFO: Pod "pod-configmaps-b49e2925-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:35:57.099: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-configmaps-b49e2925-2c19-11e8-bd77-b6fcf399588c container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:35:57.114: INFO: Waiting for pod pod-configmaps-b49e2925-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:35:57.116: INFO: Pod pod-configmaps-b49e2925-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:35:57.116: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-2xw4q" for this suite.
+Mar 20 08:36:03.131: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:36:03.175: INFO: namespace: e2e-tests-configmap-2xw4q, resource: bindings, ignored listing per whitelist
+Mar 20 08:36:03.225: INFO: namespace e2e-tests-configmap-2xw4q deletion completed in 6.101013858s
+
+• [SLOW TEST:8.180 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:36:03.225: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-b97d6f10-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:36:03.267: INFO: Waiting up to 5m0s for pod "pod-secrets-b97dd258-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-secrets-ljzxn" to be "success or failure"
+Mar 20 08:36:03.269: INFO: Pod "pod-secrets-b97dd258-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.861744ms
+Mar 20 08:36:05.273: INFO: Pod "pod-secrets-b97dd258-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00587216s
+Mar 20 08:36:07.276: INFO: Pod "pod-secrets-b97dd258-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008887897s
+STEP: Saw pod success
+Mar 20 08:36:07.276: INFO: Pod "pod-secrets-b97dd258-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:36:07.279: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-secrets-b97dd258-2c19-11e8-bd77-b6fcf399588c container secret-env-test: <nil>
+STEP: delete the pod
+Mar 20 08:36:07.295: INFO: Waiting for pod pod-secrets-b97dd258-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:36:07.297: INFO: Pod pod-secrets-b97dd258-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:36:07.298: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-ljzxn" for this suite.
+Mar 20 08:36:13.312: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:36:13.391: INFO: namespace: e2e-tests-secrets-ljzxn, resource: bindings, ignored listing per whitelist
+Mar 20 08:36:13.409: INFO: namespace e2e-tests-secrets-ljzxn deletion completed in 6.104340992s
+
+• [SLOW TEST:10.184 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:36:13.409: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-map-bf8fc72f-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:36:13.454: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-bf9026e5-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-rzsmk" to be "success or failure"
+Mar 20 08:36:13.456: INFO: Pod "pod-projected-configmaps-bf9026e5-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.825249ms
+Mar 20 08:36:15.459: INFO: Pod "pod-projected-configmaps-bf9026e5-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005220115s
+STEP: Saw pod success
+Mar 20 08:36:15.459: INFO: Pod "pod-projected-configmaps-bf9026e5-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:36:15.461: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-projected-configmaps-bf9026e5-2c19-11e8-bd77-b6fcf399588c container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:36:15.475: INFO: Waiting for pod pod-projected-configmaps-bf9026e5-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:36:15.477: INFO: Pod pod-projected-configmaps-bf9026e5-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:36:15.477: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rzsmk" for this suite.
+Mar 20 08:36:21.488: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:36:21.566: INFO: namespace: e2e-tests-projected-rzsmk, resource: bindings, ignored listing per whitelist
+Mar 20 08:36:21.592: INFO: namespace e2e-tests-projected-rzsmk deletion completed in 6.112729728s
+
+• [SLOW TEST:8.184 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:36:21.593: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Mar 20 08:36:21.628: INFO: Waiting up to 1m0s for all nodes to be ready
+Mar 20 08:37:21.648: INFO: Waiting for terminating namespaces to be deleted...
+Mar 20 08:37:21.652: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 20 08:37:21.663: INFO: 20 / 20 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 20 08:37:21.663: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 20 08:37:21.666: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 20 08:37:21.666: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb before test
+Mar 20 08:37:21.677: INFO: node-exporter-82hj9 from kube-system started at 2018-03-20 07:13:26 +0000 UTC (1 container statuses recorded)
+Mar 20 08:37:21.677: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 20 08:37:21.677: INFO: calico-node-j7bpr from kube-system started at 2018-03-20 07:13:26 +0000 UTC (2 container statuses recorded)
+Mar 20 08:37:21.677: INFO: 	Container calico-node ready: true, restart count 0
+Mar 20 08:37:21.677: INFO: 	Container install-cni ready: true, restart count 0
+Mar 20 08:37:21.677: INFO: addons-nginx-ingress-controller-cb447d457-6k6qt from kube-system started at 2018-03-20 07:13:51 +0000 UTC (1 container statuses recorded)
+Mar 20 08:37:21.677: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Mar 20 08:37:21.677: INFO: vpn-shoot-67c4cbdfdf-q9qpk from kube-system started at 2018-03-20 07:13:52 +0000 UTC (1 container statuses recorded)
+Mar 20 08:37:21.677: INFO: 	Container vpn-shoot ready: true, restart count 1
+Mar 20 08:37:21.677: INFO: kube-dns-858cbcf6ff-v9lzv from kube-system started at 2018-03-20 07:15:45 +0000 UTC (3 container statuses recorded)
+Mar 20 08:37:21.677: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 20 08:37:21.677: INFO: 	Container kubedns ready: true, restart count 0
+Mar 20 08:37:21.677: INFO: 	Container sidecar ready: true, restart count 0
+Mar 20 08:37:21.677: INFO: sonobuoy-e2e-job-f715eaa3bda849d5 from sonobuoy started at 2018-03-20 08:24:36 +0000 UTC (2 container statuses recorded)
+Mar 20 08:37:21.677: INFO: 	Container e2e ready: true, restart count 0
+Mar 20 08:37:21.677: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Mar 20 08:37:21.677: INFO: kube-proxy-msxf5 from kube-system started at 2018-03-20 07:13:26 +0000 UTC (1 container statuses recorded)
+Mar 20 08:37:21.677: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 20 08:37:21.677: INFO: addons-heapster-e3b0c-b9ff79bbd-pq8mw from kube-system started at 2018-03-20 07:15:05 +0000 UTC (2 container statuses recorded)
+Mar 20 08:37:21.677: INFO: 	Container heapster ready: true, restart count 0
+Mar 20 08:37:21.677: INFO: 	Container heapster-nanny ready: true, restart count 0
+Mar 20 08:37:21.677: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 before test
+Mar 20 08:37:21.688: INFO: kube-proxy-xgwsm from kube-system started at 2018-03-20 07:13:26 +0000 UTC (1 container statuses recorded)
+Mar 20 08:37:21.688: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 20 08:37:21.688: INFO: calico-node-h25k8 from kube-system started at 2018-03-20 07:13:26 +0000 UTC (2 container statuses recorded)
+Mar 20 08:37:21.688: INFO: 	Container calico-node ready: true, restart count 0
+Mar 20 08:37:21.688: INFO: 	Container install-cni ready: true, restart count 0
+Mar 20 08:37:21.688: INFO: kube-dns-858cbcf6ff-5frzh from kube-system started at 2018-03-20 07:13:52 +0000 UTC (3 container statuses recorded)
+Mar 20 08:37:21.688: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 20 08:37:21.688: INFO: 	Container kubedns ready: true, restart count 0
+Mar 20 08:37:21.688: INFO: 	Container sidecar ready: true, restart count 0
+Mar 20 08:37:21.688: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-dccwt from kube-system started at 2018-03-20 07:15:05 +0000 UTC (1 container statuses recorded)
+Mar 20 08:37:21.688: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Mar 20 08:37:21.688: INFO: sonobuoy from sonobuoy started at 2018-03-20 08:24:21 +0000 UTC (1 container statuses recorded)
+Mar 20 08:37:21.688: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Mar 20 08:37:21.688: INFO: node-exporter-vpz2p from kube-system started at 2018-03-20 07:13:26 +0000 UTC (1 container statuses recorded)
+Mar 20 08:37:21.688: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 20 08:37:21.688: INFO: kube-dns-autoscaler-6966fd6fb6-28zlr from kube-system started at 2018-03-20 07:13:52 +0000 UTC (1 container statuses recorded)
+Mar 20 08:37:21.688: INFO: 	Container autoscaler ready: true, restart count 0
+Mar 20 08:37:21.688: INFO: addons-kubernetes-dashboard-7fc5877997-j6s5j from kube-system started at 2018-03-20 07:15:45 +0000 UTC (1 container statuses recorded)
+Mar 20 08:37:21.688: INFO: 	Container main ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: verifying the node has the label node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb
+STEP: verifying the node has the label node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2
+Mar 20 08:37:21.718: INFO: Pod addons-heapster-e3b0c-b9ff79bbd-pq8mw requesting resource cpu=50m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb
+Mar 20 08:37:21.718: INFO: Pod addons-kubernetes-dashboard-7fc5877997-j6s5j requesting resource cpu=100m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2
+Mar 20 08:37:21.718: INFO: Pod addons-nginx-ingress-controller-cb447d457-6k6qt requesting resource cpu=0m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb
+Mar 20 08:37:21.718: INFO: Pod addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-dccwt requesting resource cpu=0m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2
+Mar 20 08:37:21.718: INFO: Pod calico-node-h25k8 requesting resource cpu=250m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2
+Mar 20 08:37:21.718: INFO: Pod calico-node-j7bpr requesting resource cpu=250m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb
+Mar 20 08:37:21.718: INFO: Pod kube-dns-858cbcf6ff-5frzh requesting resource cpu=260m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2
+Mar 20 08:37:21.718: INFO: Pod kube-dns-858cbcf6ff-v9lzv requesting resource cpu=260m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb
+Mar 20 08:37:21.719: INFO: Pod kube-dns-autoscaler-6966fd6fb6-28zlr requesting resource cpu=20m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2
+Mar 20 08:37:21.719: INFO: Pod kube-proxy-msxf5 requesting resource cpu=100m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb
+Mar 20 08:37:21.719: INFO: Pod kube-proxy-xgwsm requesting resource cpu=100m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2
+Mar 20 08:37:21.719: INFO: Pod node-exporter-82hj9 requesting resource cpu=100m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb
+Mar 20 08:37:21.719: INFO: Pod node-exporter-vpz2p requesting resource cpu=100m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2
+Mar 20 08:37:21.719: INFO: Pod vpn-shoot-67c4cbdfdf-q9qpk requesting resource cpu=100m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb
+Mar 20 08:37:21.719: INFO: Pod sonobuoy requesting resource cpu=0m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2
+Mar 20 08:37:21.719: INFO: Pod sonobuoy-e2e-job-f715eaa3bda849d5 requesting resource cpu=0m on Node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8412e38-2c19-11e8-bd77-b6fcf399588c.151d940f1845de4b], Reason = [Scheduled], Message = [Successfully assigned filler-pod-e8412e38-2c19-11e8-bd77-b6fcf399588c to shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8412e38-2c19-11e8-bd77-b6fcf399588c.151d940f26d0283b], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-mbrzv" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8412e38-2c19-11e8-bd77-b6fcf399588c.151d940f5078d945], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8412e38-2c19-11e8-bd77-b6fcf399588c.151d940f5375a33e], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8412e38-2c19-11e8-bd77-b6fcf399588c.151d940f5bec06d6], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8423edd-2c19-11e8-bd77-b6fcf399588c.151d940f1874439c], Reason = [Scheduled], Message = [Successfully assigned filler-pod-e8423edd-2c19-11e8-bd77-b6fcf399588c to shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8423edd-2c19-11e8-bd77-b6fcf399588c.151d940f1ffca8f7], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-mbrzv" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8423edd-2c19-11e8-bd77-b6fcf399588c.151d940f48b0d199], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8423edd-2c19-11e8-bd77-b6fcf399588c.151d940f4be88ff0], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8423edd-2c19-11e8-bd77-b6fcf399588c.151d940f50e98f0e], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.151d940f90b5411f], Reason = [FailedScheduling], Message = [0/4 nodes are available: 2 Insufficient cpu, 2 NodeUnschedulable.]
+STEP: removing the label node off the node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:37:24.768: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-n56j9" for this suite.
+Mar 20 08:37:46.782: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:37:46.849: INFO: namespace: e2e-tests-sched-pred-n56j9, resource: bindings, ignored listing per whitelist
+Mar 20 08:37:46.893: INFO: namespace e2e-tests-sched-pred-n56j9 deletion completed in 22.12175913s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:85.301 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:37:46.893: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:37:46.939: INFO: Waiting up to 5m0s for pod "downwardapi-volume-f748dbb8-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-qbzmk" to be "success or failure"
+Mar 20 08:37:46.943: INFO: Pod "downwardapi-volume-f748dbb8-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 3.805198ms
+Mar 20 08:37:48.946: INFO: Pod "downwardapi-volume-f748dbb8-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007250248s
+STEP: Saw pod success
+Mar 20 08:37:48.946: INFO: Pod "downwardapi-volume-f748dbb8-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:37:48.948: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod downwardapi-volume-f748dbb8-2c19-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:37:48.966: INFO: Waiting for pod downwardapi-volume-f748dbb8-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:37:48.968: INFO: Pod downwardapi-volume-f748dbb8-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:37:48.968: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qbzmk" for this suite.
+Mar 20 08:37:54.978: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:37:55.055: INFO: namespace: e2e-tests-projected-qbzmk, resource: bindings, ignored listing per whitelist
+Mar 20 08:37:55.070: INFO: namespace e2e-tests-projected-qbzmk deletion completed in 6.099242199s
+
+• [SLOW TEST:8.177 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:37:55.070: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-fc27a7ff-2c19-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:37:55.112: INFO: Waiting up to 5m0s for pod "pod-configmaps-fc281159-2c19-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-configmap-h4w49" to be "success or failure"
+Mar 20 08:37:55.114: INFO: Pod "pod-configmaps-fc281159-2c19-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.938256ms
+Mar 20 08:37:57.117: INFO: Pod "pod-configmaps-fc281159-2c19-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005130581s
+STEP: Saw pod success
+Mar 20 08:37:57.117: INFO: Pod "pod-configmaps-fc281159-2c19-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:37:57.120: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-configmaps-fc281159-2c19-11e8-bd77-b6fcf399588c container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:37:57.133: INFO: Waiting for pod pod-configmaps-fc281159-2c19-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:37:57.134: INFO: Pod pod-configmaps-fc281159-2c19-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:37:57.134: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-h4w49" for this suite.
+Mar 20 08:38:03.145: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:38:03.224: INFO: namespace: e2e-tests-configmap-h4w49, resource: bindings, ignored listing per whitelist
+Mar 20 08:38:03.239: INFO: namespace e2e-tests-configmap-h4w49 deletion completed in 6.101307544s
+
+• [SLOW TEST:8.168 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:38:03.239: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-01065cc2-2c1a-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:38:03.284: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-0106e442-2c1a-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-ml5gs" to be "success or failure"
+Mar 20 08:38:03.286: INFO: Pod "pod-projected-secrets-0106e442-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.150731ms
+Mar 20 08:38:05.289: INFO: Pod "pod-projected-secrets-0106e442-2c1a-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005326457s
+STEP: Saw pod success
+Mar 20 08:38:05.289: INFO: Pod "pod-projected-secrets-0106e442-2c1a-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:38:05.291: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-projected-secrets-0106e442-2c1a-11e8-bd77-b6fcf399588c container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:38:05.308: INFO: Waiting for pod pod-projected-secrets-0106e442-2c1a-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:38:05.312: INFO: Pod pod-projected-secrets-0106e442-2c1a-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:38:05.312: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-ml5gs" for this suite.
+Mar 20 08:38:11.329: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:38:11.376: INFO: namespace: e2e-tests-projected-ml5gs, resource: bindings, ignored listing per whitelist
+Mar 20 08:38:11.424: INFO: namespace e2e-tests-projected-ml5gs deletion completed in 6.105656089s
+
+• [SLOW TEST:8.185 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:38:11.424: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Mar 20 08:38:11.465: INFO: Waiting up to 5m0s for pod "pod-05e7455d-2c1a-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-hm5fq" to be "success or failure"
+Mar 20 08:38:11.467: INFO: Pod "pod-05e7455d-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.0299ms
+Mar 20 08:38:13.471: INFO: Pod "pod-05e7455d-2c1a-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005768922s
+STEP: Saw pod success
+Mar 20 08:38:13.471: INFO: Pod "pod-05e7455d-2c1a-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:38:13.473: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-05e7455d-2c1a-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:38:13.486: INFO: Waiting for pod pod-05e7455d-2c1a-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:38:13.488: INFO: Pod pod-05e7455d-2c1a-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:38:13.488: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-hm5fq" for this suite.
+Mar 20 08:38:19.499: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:38:19.580: INFO: namespace: e2e-tests-emptydir-hm5fq, resource: bindings, ignored listing per whitelist
+Mar 20 08:38:19.595: INFO: namespace e2e-tests-emptydir-hm5fq deletion completed in 6.104261095s
+
+• [SLOW TEST:8.171 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:38:19.596: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-0ac638c2-2c1a-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:38:19.639: INFO: Waiting up to 5m0s for pod "pod-secrets-0ac69e54-2c1a-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-secrets-6878g" to be "success or failure"
+Mar 20 08:38:19.641: INFO: Pod "pod-secrets-0ac69e54-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.764478ms
+Mar 20 08:38:21.645: INFO: Pod "pod-secrets-0ac69e54-2c1a-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.0052494s
+STEP: Saw pod success
+Mar 20 08:38:21.645: INFO: Pod "pod-secrets-0ac69e54-2c1a-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:38:21.648: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-secrets-0ac69e54-2c1a-11e8-bd77-b6fcf399588c container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:38:21.661: INFO: Waiting for pod pod-secrets-0ac69e54-2c1a-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:38:21.666: INFO: Pod pod-secrets-0ac69e54-2c1a-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:38:21.666: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-6878g" for this suite.
+Mar 20 08:38:27.678: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:38:27.711: INFO: namespace: e2e-tests-secrets-6878g, resource: bindings, ignored listing per whitelist
+Mar 20 08:38:27.773: INFO: namespace e2e-tests-secrets-6878g deletion completed in 6.102431054s
+
+• [SLOW TEST:8.178 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:38:27.773: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-0fa685fb-2c1a-11e8-bd77-b6fcf399588c
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-0fa685fb-2c1a-11e8-bd77-b6fcf399588c
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:38:31.896: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lplvj" for this suite.
+Mar 20 08:38:53.907: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:38:53.988: INFO: namespace: e2e-tests-projected-lplvj, resource: bindings, ignored listing per whitelist
+Mar 20 08:38:53.992: INFO: namespace e2e-tests-projected-lplvj deletion completed in 22.093246364s
+
+• [SLOW TEST:26.219 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:38:53.992: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:38:54.032: INFO: Waiting up to 5m0s for pod "downwardapi-volume-1f467a35-2c1a-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-v6kkq" to be "success or failure"
+Mar 20 08:38:54.034: INFO: Pod "downwardapi-volume-1f467a35-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.76501ms
+Mar 20 08:38:56.037: INFO: Pod "downwardapi-volume-1f467a35-2c1a-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004725005s
+STEP: Saw pod success
+Mar 20 08:38:56.037: INFO: Pod "downwardapi-volume-1f467a35-2c1a-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:38:56.039: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod downwardapi-volume-1f467a35-2c1a-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:38:56.053: INFO: Waiting for pod downwardapi-volume-1f467a35-2c1a-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:38:56.055: INFO: Pod downwardapi-volume-1f467a35-2c1a-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:38:56.055: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-v6kkq" for this suite.
+Mar 20 08:39:02.068: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:39:02.153: INFO: namespace: e2e-tests-downward-api-v6kkq, resource: bindings, ignored listing per whitelist
+Mar 20 08:39:02.159: INFO: namespace e2e-tests-downward-api-v6kkq deletion completed in 6.099932643s
+
+• [SLOW TEST:8.167 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:39:02.159: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap e2e-tests-configmap-j7hps/configmap-test-242473f8-2c1a-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:39:02.200: INFO: Waiting up to 5m0s for pod "pod-configmaps-2424d5e3-2c1a-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-configmap-j7hps" to be "success or failure"
+Mar 20 08:39:02.201: INFO: Pod "pod-configmaps-2424d5e3-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.730142ms
+Mar 20 08:39:04.204: INFO: Pod "pod-configmaps-2424d5e3-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004741305s
+Mar 20 08:39:06.210: INFO: Pod "pod-configmaps-2424d5e3-2c1a-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010192119s
+STEP: Saw pod success
+Mar 20 08:39:06.210: INFO: Pod "pod-configmaps-2424d5e3-2c1a-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:39:06.212: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-configmaps-2424d5e3-2c1a-11e8-bd77-b6fcf399588c container env-test: <nil>
+STEP: delete the pod
+Mar 20 08:39:06.226: INFO: Waiting for pod pod-configmaps-2424d5e3-2c1a-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:39:06.228: INFO: Pod pod-configmaps-2424d5e3-2c1a-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:39:06.228: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-j7hps" for this suite.
+Mar 20 08:39:12.240: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:39:12.302: INFO: namespace: e2e-tests-configmap-j7hps, resource: bindings, ignored listing per whitelist
+Mar 20 08:39:12.333: INFO: namespace e2e-tests-configmap-j7hps deletion completed in 6.101993068s
+
+• [SLOW TEST:10.174 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:39:12.333: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Mar 20 08:39:12.372: INFO: Waiting up to 1m0s for all nodes to be ready
+Mar 20 08:40:12.393: INFO: Waiting for terminating namespaces to be deleted...
+Mar 20 08:40:12.397: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 20 08:40:12.406: INFO: 20 / 20 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 20 08:40:12.407: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 20 08:40:12.410: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 20 08:40:12.410: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb before test
+Mar 20 08:40:12.419: INFO: sonobuoy-e2e-job-f715eaa3bda849d5 from sonobuoy started at 2018-03-20 08:24:36 +0000 UTC (2 container statuses recorded)
+Mar 20 08:40:12.419: INFO: 	Container e2e ready: true, restart count 0
+Mar 20 08:40:12.419: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Mar 20 08:40:12.419: INFO: node-exporter-82hj9 from kube-system started at 2018-03-20 07:13:26 +0000 UTC (1 container statuses recorded)
+Mar 20 08:40:12.419: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 20 08:40:12.419: INFO: calico-node-j7bpr from kube-system started at 2018-03-20 07:13:26 +0000 UTC (2 container statuses recorded)
+Mar 20 08:40:12.419: INFO: 	Container calico-node ready: true, restart count 0
+Mar 20 08:40:12.419: INFO: 	Container install-cni ready: true, restart count 0
+Mar 20 08:40:12.419: INFO: addons-nginx-ingress-controller-cb447d457-6k6qt from kube-system started at 2018-03-20 07:13:51 +0000 UTC (1 container statuses recorded)
+Mar 20 08:40:12.419: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Mar 20 08:40:12.419: INFO: vpn-shoot-67c4cbdfdf-q9qpk from kube-system started at 2018-03-20 07:13:52 +0000 UTC (1 container statuses recorded)
+Mar 20 08:40:12.419: INFO: 	Container vpn-shoot ready: true, restart count 1
+Mar 20 08:40:12.419: INFO: kube-dns-858cbcf6ff-v9lzv from kube-system started at 2018-03-20 07:15:45 +0000 UTC (3 container statuses recorded)
+Mar 20 08:40:12.419: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 20 08:40:12.419: INFO: 	Container kubedns ready: true, restart count 0
+Mar 20 08:40:12.419: INFO: 	Container sidecar ready: true, restart count 0
+Mar 20 08:40:12.419: INFO: kube-proxy-msxf5 from kube-system started at 2018-03-20 07:13:26 +0000 UTC (1 container statuses recorded)
+Mar 20 08:40:12.419: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 20 08:40:12.419: INFO: addons-heapster-e3b0c-b9ff79bbd-pq8mw from kube-system started at 2018-03-20 07:15:05 +0000 UTC (2 container statuses recorded)
+Mar 20 08:40:12.419: INFO: 	Container heapster ready: true, restart count 0
+Mar 20 08:40:12.420: INFO: 	Container heapster-nanny ready: true, restart count 0
+Mar 20 08:40:12.420: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 before test
+Mar 20 08:40:12.429: INFO: kube-proxy-xgwsm from kube-system started at 2018-03-20 07:13:26 +0000 UTC (1 container statuses recorded)
+Mar 20 08:40:12.429: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 20 08:40:12.429: INFO: calico-node-h25k8 from kube-system started at 2018-03-20 07:13:26 +0000 UTC (2 container statuses recorded)
+Mar 20 08:40:12.429: INFO: 	Container calico-node ready: true, restart count 0
+Mar 20 08:40:12.429: INFO: 	Container install-cni ready: true, restart count 0
+Mar 20 08:40:12.429: INFO: kube-dns-858cbcf6ff-5frzh from kube-system started at 2018-03-20 07:13:52 +0000 UTC (3 container statuses recorded)
+Mar 20 08:40:12.429: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 20 08:40:12.429: INFO: 	Container kubedns ready: true, restart count 0
+Mar 20 08:40:12.429: INFO: 	Container sidecar ready: true, restart count 0
+Mar 20 08:40:12.429: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-dccwt from kube-system started at 2018-03-20 07:15:05 +0000 UTC (1 container statuses recorded)
+Mar 20 08:40:12.429: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Mar 20 08:40:12.429: INFO: sonobuoy from sonobuoy started at 2018-03-20 08:24:21 +0000 UTC (1 container statuses recorded)
+Mar 20 08:40:12.429: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Mar 20 08:40:12.429: INFO: node-exporter-vpz2p from kube-system started at 2018-03-20 07:13:26 +0000 UTC (1 container statuses recorded)
+Mar 20 08:40:12.429: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 20 08:40:12.429: INFO: kube-dns-autoscaler-6966fd6fb6-28zlr from kube-system started at 2018-03-20 07:13:52 +0000 UTC (1 container statuses recorded)
+Mar 20 08:40:12.429: INFO: 	Container autoscaler ready: true, restart count 0
+Mar 20 08:40:12.429: INFO: addons-kubernetes-dashboard-7fc5877997-j6s5j from kube-system started at 2018-03-20 07:15:45 +0000 UTC (1 container statuses recorded)
+Mar 20 08:40:12.429: INFO: 	Container main ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.151d9436d7a692a5], Reason = [FailedScheduling], Message = [0/4 nodes are available: 2 NodeUnschedulable, 4 MatchNodeSelector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:40:13.448: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-r8gdz" for this suite.
+Mar 20 08:40:35.459: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:40:35.541: INFO: namespace: e2e-tests-sched-pred-r8gdz, resource: bindings, ignored listing per whitelist
+Mar 20 08:40:35.558: INFO: namespace e2e-tests-sched-pred-r8gdz deletion completed in 22.107088399s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.225 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:40:35.558: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Mar 20 08:40:35.599: INFO: Waiting up to 5m0s for pod "pod-5bd05017-2c1a-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-lj99q" to be "success or failure"
+Mar 20 08:40:35.601: INFO: Pod "pod-5bd05017-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.059124ms
+Mar 20 08:40:37.604: INFO: Pod "pod-5bd05017-2c1a-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005172985s
+STEP: Saw pod success
+Mar 20 08:40:37.604: INFO: Pod "pod-5bd05017-2c1a-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:40:37.606: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-5bd05017-2c1a-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:40:37.623: INFO: Waiting for pod pod-5bd05017-2c1a-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:40:37.625: INFO: Pod pod-5bd05017-2c1a-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:40:37.625: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-lj99q" for this suite.
+Mar 20 08:40:43.636: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:40:43.671: INFO: namespace: e2e-tests-emptydir-lj99q, resource: bindings, ignored listing per whitelist
+Mar 20 08:40:43.725: INFO: namespace e2e-tests-emptydir-lj99q deletion completed in 6.096995852s
+
+• [SLOW TEST:8.167 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:40:43.725: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Mar 20 08:40:43.765: INFO: Waiting up to 5m0s for pod "pod-60ae66e6-2c1a-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-2t485" to be "success or failure"
+Mar 20 08:40:43.767: INFO: Pod "pod-60ae66e6-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.019475ms
+Mar 20 08:40:45.770: INFO: Pod "pod-60ae66e6-2c1a-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004770127s
+STEP: Saw pod success
+Mar 20 08:40:45.770: INFO: Pod "pod-60ae66e6-2c1a-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:40:45.772: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-60ae66e6-2c1a-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:40:45.785: INFO: Waiting for pod pod-60ae66e6-2c1a-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:40:45.787: INFO: Pod pod-60ae66e6-2c1a-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:40:45.787: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-2t485" for this suite.
+Mar 20 08:40:51.797: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:40:51.880: INFO: namespace: e2e-tests-emptydir-2t485, resource: bindings, ignored listing per whitelist
+Mar 20 08:40:51.890: INFO: namespace e2e-tests-emptydir-2t485 deletion completed in 6.099894496s
+
+• [SLOW TEST:8.164 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:40:51.890: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-map-658c5eb8-2c1a-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:40:51.933: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-658cbc8f-2c1a-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-rzggv" to be "success or failure"
+Mar 20 08:40:51.935: INFO: Pod "pod-projected-secrets-658cbc8f-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.643547ms
+Mar 20 08:40:53.938: INFO: Pod "pod-projected-secrets-658cbc8f-2c1a-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005220983s
+STEP: Saw pod success
+Mar 20 08:40:53.939: INFO: Pod "pod-projected-secrets-658cbc8f-2c1a-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:40:53.940: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-projected-secrets-658cbc8f-2c1a-11e8-bd77-b6fcf399588c container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:40:53.957: INFO: Waiting for pod pod-projected-secrets-658cbc8f-2c1a-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:40:53.965: INFO: Pod pod-projected-secrets-658cbc8f-2c1a-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:40:53.965: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rzggv" for this suite.
+Mar 20 08:40:59.976: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:41:00.034: INFO: namespace: e2e-tests-projected-rzggv, resource: bindings, ignored listing per whitelist
+Mar 20 08:41:00.075: INFO: namespace e2e-tests-projected-rzggv deletion completed in 6.106514248s
+
+• [SLOW TEST:8.185 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:41:00.075: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 20 08:41:00.113: INFO: Waiting up to 5m0s for pod "downward-api-6a6cedbf-2c1a-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-98vj7" to be "success or failure"
+Mar 20 08:41:00.115: INFO: Pod "downward-api-6a6cedbf-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.205182ms
+Mar 20 08:41:02.119: INFO: Pod "downward-api-6a6cedbf-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.0056733s
+Mar 20 08:41:04.123: INFO: Pod "downward-api-6a6cedbf-2c1a-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009290537s
+STEP: Saw pod success
+Mar 20 08:41:04.123: INFO: Pod "downward-api-6a6cedbf-2c1a-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:41:04.125: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downward-api-6a6cedbf-2c1a-11e8-bd77-b6fcf399588c container dapi-container: <nil>
+STEP: delete the pod
+Mar 20 08:41:04.141: INFO: Waiting for pod downward-api-6a6cedbf-2c1a-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:41:04.145: INFO: Pod downward-api-6a6cedbf-2c1a-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:41:04.145: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-98vj7" for this suite.
+Mar 20 08:41:10.157: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:41:10.207: INFO: namespace: e2e-tests-downward-api-98vj7, resource: bindings, ignored listing per whitelist
+Mar 20 08:41:10.277: INFO: namespace e2e-tests-downward-api-98vj7 deletion completed in 6.129032673s
+
+• [SLOW TEST:10.202 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:41:10.277: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:41:10.322: INFO: Waiting up to 5m0s for pod "downwardapi-volume-70825e92-2c1a-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-jvctz" to be "success or failure"
+Mar 20 08:41:10.324: INFO: Pod "downwardapi-volume-70825e92-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.932306ms
+Mar 20 08:41:12.328: INFO: Pod "downwardapi-volume-70825e92-2c1a-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00578272s
+STEP: Saw pod success
+Mar 20 08:41:12.328: INFO: Pod "downwardapi-volume-70825e92-2c1a-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:41:12.331: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod downwardapi-volume-70825e92-2c1a-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:41:12.348: INFO: Waiting for pod downwardapi-volume-70825e92-2c1a-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:41:12.351: INFO: Pod downwardapi-volume-70825e92-2c1a-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:41:12.351: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jvctz" for this suite.
+Mar 20 08:41:18.364: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:41:18.400: INFO: namespace: e2e-tests-projected-jvctz, resource: bindings, ignored listing per whitelist
+Mar 20 08:41:18.455: INFO: namespace e2e-tests-projected-jvctz deletion completed in 6.100409645s
+
+• [SLOW TEST:8.177 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:41:18.455: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-666p9.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-666p9.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-666p9.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-666p9.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-666p9.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-666p9.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Mar 20 08:41:31.408: INFO: DNS probes using dns-test-7561ece7-2c1a-11e8-bd77-b6fcf399588c succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:41:31.416: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-666p9" for this suite.
+Mar 20 08:41:37.427: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:41:37.499: INFO: namespace: e2e-tests-dns-666p9, resource: bindings, ignored listing per whitelist
+Mar 20 08:41:37.517: INFO: namespace e2e-tests-dns-666p9 deletion completed in 6.098055581s
+
+• [SLOW TEST:19.062 seconds]
+[sig-network] DNS
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:41:37.517: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test substitution in container's args
+Mar 20 08:41:37.559: INFO: Waiting up to 5m0s for pod "var-expansion-80bec527-2c1a-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-var-expansion-xj88f" to be "success or failure"
+Mar 20 08:41:37.561: INFO: Pod "var-expansion-80bec527-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.816618ms
+Mar 20 08:41:39.564: INFO: Pod "var-expansion-80bec527-2c1a-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004827029s
+Mar 20 08:41:41.567: INFO: Pod "var-expansion-80bec527-2c1a-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008075618s
+STEP: Saw pod success
+Mar 20 08:41:41.567: INFO: Pod "var-expansion-80bec527-2c1a-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:41:41.570: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod var-expansion-80bec527-2c1a-11e8-bd77-b6fcf399588c container dapi-container: <nil>
+STEP: delete the pod
+Mar 20 08:41:41.584: INFO: Waiting for pod var-expansion-80bec527-2c1a-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:41:41.586: INFO: Pod var-expansion-80bec527-2c1a-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:41:41.586: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-xj88f" for this suite.
+Mar 20 08:41:47.598: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:41:47.683: INFO: namespace: e2e-tests-var-expansion-xj88f, resource: bindings, ignored listing per whitelist
+Mar 20 08:41:47.689: INFO: namespace e2e-tests-var-expansion-xj88f deletion completed in 6.100173096s
+
+• [SLOW TEST:10.172 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:41:47.689: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:41:47.733: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-df84x" for this suite.
+Mar 20 08:45:11.743: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:45:11.798: INFO: namespace: e2e-tests-pods-df84x, resource: bindings, ignored listing per whitelist
+Mar 20 08:45:11.837: INFO: namespace e2e-tests-pods-df84x deletion completed in 3m24.101186618s
+
+• [SLOW TEST:204.148 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:45:11.837: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:45:11.879: INFO: Waiting up to 5m0s for pod "downwardapi-volume-007d3a32-2c1b-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-f696h" to be "success or failure"
+Mar 20 08:45:11.881: INFO: Pod "downwardapi-volume-007d3a32-2c1b-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.437966ms
+Mar 20 08:45:13.885: INFO: Pod "downwardapi-volume-007d3a32-2c1b-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006182038s
+STEP: Saw pod success
+Mar 20 08:45:13.885: INFO: Pod "downwardapi-volume-007d3a32-2c1b-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:45:13.888: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downwardapi-volume-007d3a32-2c1b-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:45:13.907: INFO: Waiting for pod downwardapi-volume-007d3a32-2c1b-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:45:13.909: INFO: Pod downwardapi-volume-007d3a32-2c1b-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:45:13.909: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-f696h" for this suite.
+Mar 20 08:45:19.921: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:45:19.965: INFO: namespace: e2e-tests-projected-f696h, resource: bindings, ignored listing per whitelist
+Mar 20 08:45:20.020: INFO: namespace e2e-tests-projected-f696h deletion completed in 6.107252615s
+
+• [SLOW TEST:8.182 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:45:20.020: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Mar 20 08:45:22.075: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-055db9c9-2c1b-11e8-bd77-b6fcf399588c", GenerateName:"", Namespace:"e2e-tests-pods-2zk57", SelfLink:"/api/v1/namespaces/e2e-tests-pods-2zk57/pods/pod-submit-remove-055db9c9-2c1b-11e8-bd77-b6fcf399588c", UID:"055666db-2c1b-11e8-a4e7-d6a5b4815c86", ResourceVersion:"565669", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63657132320, loc:(*time.Location)(0x619f460)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"56780085"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"100.96.5.42/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-f8clz", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc4212d47c0), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"gcr.io/google-containers/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-f8clz", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc420eec478), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2", HostNetwork:false, HostPID:false, HostIPC:false, SecurityContext:(*v1.PodSecurityContext)(0xc4212d4840), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc420eec4b0)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc420eec4d0)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63657132320, loc:(*time.Location)(0x619f460)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63657132321, loc:(*time.Location)(0x619f460)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63657132320, loc:(*time.Location)(0x619f460)}}, Reason:"", Message:""}}, Message:"", Reason:"", HostIP:"10.250.0.7", PodIP:"100.96.5.42", StartTime:(*v1.Time)(0xc421589d60), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc421589d80), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"gcr.io/google-containers/nginx-slim-amd64:0.20", ImageID:"docker-pullable://gcr.io/google-containers/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://a0a7de6fbf30d129b97fd4f4d7fc9357e7d0dadc6fa4716c097c7bb641bdfa48"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:45:32.871: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-2zk57" for this suite.
+Mar 20 08:45:38.881: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:45:38.933: INFO: namespace: e2e-tests-pods-2zk57, resource: bindings, ignored listing per whitelist
+Mar 20 08:45:38.984: INFO: namespace e2e-tests-pods-2zk57 deletion completed in 6.110049454s
+
+• [SLOW TEST:18.964 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:45:38.984: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Mar 20 08:45:39.027: INFO: Waiting up to 5m0s for pod "pod-10abbfac-2c1b-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-tdppw" to be "success or failure"
+Mar 20 08:45:39.029: INFO: Pod "pod-10abbfac-2c1b-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.156883ms
+Mar 20 08:45:41.033: INFO: Pod "pod-10abbfac-2c1b-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005860042s
+STEP: Saw pod success
+Mar 20 08:45:41.033: INFO: Pod "pod-10abbfac-2c1b-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:45:41.035: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-10abbfac-2c1b-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:45:41.055: INFO: Waiting for pod pod-10abbfac-2c1b-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:45:41.063: INFO: Pod pod-10abbfac-2c1b-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:45:41.063: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-tdppw" for this suite.
+Mar 20 08:45:47.083: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:45:47.162: INFO: namespace: e2e-tests-emptydir-tdppw, resource: bindings, ignored listing per whitelist
+Mar 20 08:45:47.180: INFO: namespace e2e-tests-emptydir-tdppw deletion completed in 6.108674867s
+
+• [SLOW TEST:8.196 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:45:47.180: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-9bfrq
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 20 08:45:47.216: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 20 08:46:05.259: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.5.44:8080/dial?request=hostName&protocol=http&host=100.96.4.39&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-9bfrq PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 08:46:05.259: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:46:05.371: INFO: Waiting for endpoints: map[]
+Mar 20 08:46:05.374: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.5.44:8080/dial?request=hostName&protocol=http&host=100.96.5.43&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-9bfrq PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 08:46:05.374: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:46:05.526: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:46:05.526: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-9bfrq" for this suite.
+Mar 20 08:46:27.541: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:46:27.624: INFO: namespace: e2e-tests-pod-network-test-9bfrq, resource: bindings, ignored listing per whitelist
+Mar 20 08:46:27.640: INFO: namespace e2e-tests-pod-network-test-9bfrq deletion completed in 22.108437918s
+
+• [SLOW TEST:40.460 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:46:27.641: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:51
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:46:27.681: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-fqn4l" for this suite.
+Mar 20 08:46:33.693: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:46:33.790: INFO: namespace: e2e-tests-services-fqn4l, resource: bindings, ignored listing per whitelist
+Mar 20 08:46:33.790: INFO: namespace e2e-tests-services-fqn4l deletion completed in 6.105432148s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:56
+
+• [SLOW TEST:6.149 seconds]
+[sig-network] Services
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:46:33.790: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Mar 20 08:46:37.852: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-ml5dh PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 08:46:37.852: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:46:37.970: INFO: Exec stderr: ""
+Mar 20 08:46:37.971: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-ml5dh PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 08:46:37.971: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:46:38.135: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Mar 20 08:46:38.135: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-ml5dh PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 08:46:38.135: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:46:45.356: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Mar 20 08:46:45.356: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-ml5dh PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 08:46:45.356: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:46:45.515: INFO: Exec stderr: ""
+Mar 20 08:46:45.515: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-ml5dh PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 08:46:45.515: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:46:45.623: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:46:45.623: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-ml5dh" for this suite.
+Mar 20 08:47:35.636: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:47:35.724: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-ml5dh, resource: bindings, ignored listing per whitelist
+Mar 20 08:47:35.732: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-ml5dh deletion completed in 50.104266355s
+
+• [SLOW TEST:61.942 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:47:35.732: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Mar 20 08:47:35.773: INFO: Waiting up to 5m0s for pod "pod-5641e06a-2c1b-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-g98bq" to be "success or failure"
+Mar 20 08:47:35.775: INFO: Pod "pod-5641e06a-2c1b-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.902579ms
+Mar 20 08:47:37.779: INFO: Pod "pod-5641e06a-2c1b-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005495638s
+STEP: Saw pod success
+Mar 20 08:47:37.779: INFO: Pod "pod-5641e06a-2c1b-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:47:37.782: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-5641e06a-2c1b-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:47:37.799: INFO: Waiting for pod pod-5641e06a-2c1b-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:47:37.801: INFO: Pod pod-5641e06a-2c1b-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:47:37.801: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-g98bq" for this suite.
+Mar 20 08:47:43.812: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:47:43.896: INFO: namespace: e2e-tests-emptydir-g98bq, resource: bindings, ignored listing per whitelist
+Mar 20 08:47:43.912: INFO: namespace e2e-tests-emptydir-g98bq deletion completed in 6.10765179s
+
+• [SLOW TEST:8.180 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:47:43.912: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:47:43.952: INFO: Waiting up to 5m0s for pod "downwardapi-volume-5b21cc6e-2c1b-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-72p4b" to be "success or failure"
+Mar 20 08:47:43.954: INFO: Pod "downwardapi-volume-5b21cc6e-2c1b-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.92404ms
+Mar 20 08:47:45.957: INFO: Pod "downwardapi-volume-5b21cc6e-2c1b-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005073743s
+STEP: Saw pod success
+Mar 20 08:47:45.957: INFO: Pod "downwardapi-volume-5b21cc6e-2c1b-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:47:45.959: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod downwardapi-volume-5b21cc6e-2c1b-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:47:45.973: INFO: Waiting for pod downwardapi-volume-5b21cc6e-2c1b-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:47:45.975: INFO: Pod downwardapi-volume-5b21cc6e-2c1b-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:47:45.975: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-72p4b" for this suite.
+Mar 20 08:47:51.987: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:47:52.053: INFO: namespace: e2e-tests-downward-api-72p4b, resource: bindings, ignored listing per whitelist
+Mar 20 08:47:52.084: INFO: namespace e2e-tests-downward-api-72p4b deletion completed in 6.106045675s
+
+• [SLOW TEST:8.172 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:47:52.084: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test substitution in container's command
+Mar 20 08:47:52.125: INFO: Waiting up to 5m0s for pod "var-expansion-6000f398-2c1b-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-var-expansion-8qs5j" to be "success or failure"
+Mar 20 08:47:52.127: INFO: Pod "var-expansion-6000f398-2c1b-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.910545ms
+Mar 20 08:47:54.130: INFO: Pod "var-expansion-6000f398-2c1b-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004704046s
+Mar 20 08:47:56.134: INFO: Pod "var-expansion-6000f398-2c1b-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008438165s
+STEP: Saw pod success
+Mar 20 08:47:56.134: INFO: Pod "var-expansion-6000f398-2c1b-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:47:56.136: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod var-expansion-6000f398-2c1b-11e8-bd77-b6fcf399588c container dapi-container: <nil>
+STEP: delete the pod
+Mar 20 08:47:56.153: INFO: Waiting for pod var-expansion-6000f398-2c1b-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:47:56.155: INFO: Pod var-expansion-6000f398-2c1b-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:47:56.155: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-8qs5j" for this suite.
+Mar 20 08:48:02.166: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:48:02.263: INFO: namespace: e2e-tests-var-expansion-8qs5j, resource: bindings, ignored listing per whitelist
+Mar 20 08:48:02.288: INFO: namespace e2e-tests-var-expansion-8qs5j deletion completed in 6.130069526s
+
+• [SLOW TEST:10.204 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:48:02.288: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-map-6617337a-2c1b-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:48:02.342: INFO: Waiting up to 5m0s for pod "pod-configmaps-6617e5ae-2c1b-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-configmap-42jjr" to be "success or failure"
+Mar 20 08:48:02.344: INFO: Pod "pod-configmaps-6617e5ae-2c1b-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.915275ms
+Mar 20 08:48:04.351: INFO: Pod "pod-configmaps-6617e5ae-2c1b-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008622558s
+STEP: Saw pod success
+Mar 20 08:48:04.351: INFO: Pod "pod-configmaps-6617e5ae-2c1b-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:48:04.357: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-configmaps-6617e5ae-2c1b-11e8-bd77-b6fcf399588c container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:48:04.374: INFO: Waiting for pod pod-configmaps-6617e5ae-2c1b-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:48:04.376: INFO: Pod pod-configmaps-6617e5ae-2c1b-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:48:04.376: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-42jjr" for this suite.
+Mar 20 08:48:10.394: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:48:10.469: INFO: namespace: e2e-tests-configmap-42jjr, resource: bindings, ignored listing per whitelist
+Mar 20 08:48:10.498: INFO: namespace e2e-tests-configmap-42jjr deletion completed in 6.117862829s
+
+• [SLOW TEST:8.210 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:48:10.498: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 20 08:48:10.544: INFO: (0) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.773431ms)
+Mar 20 08:48:10.548: INFO: (1) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.056371ms)
+Mar 20 08:48:10.552: INFO: (2) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.670431ms)
+Mar 20 08:48:10.556: INFO: (3) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.664222ms)
+Mar 20 08:48:10.560: INFO: (4) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.799618ms)
+Mar 20 08:48:10.563: INFO: (5) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.58379ms)
+Mar 20 08:48:10.567: INFO: (6) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.521246ms)
+Mar 20 08:48:10.571: INFO: (7) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.00536ms)
+Mar 20 08:48:10.575: INFO: (8) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.828207ms)
+Mar 20 08:48:10.579: INFO: (9) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.353899ms)
+Mar 20 08:48:10.583: INFO: (10) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.603848ms)
+Mar 20 08:48:10.586: INFO: (11) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.705591ms)
+Mar 20 08:48:10.590: INFO: (12) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.423482ms)
+Mar 20 08:48:10.593: INFO: (13) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.644151ms)
+Mar 20 08:48:10.597: INFO: (14) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.527685ms)
+Mar 20 08:48:10.601: INFO: (15) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.593148ms)
+Mar 20 08:48:10.604: INFO: (16) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.601057ms)
+Mar 20 08:48:10.608: INFO: (17) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.452664ms)
+Mar 20 08:48:10.612: INFO: (18) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.831618ms)
+Mar 20 08:48:10.615: INFO: (19) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.684375ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:48:10.615: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-9qnh6" for this suite.
+Mar 20 08:48:16.626: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:48:16.715: INFO: namespace: e2e-tests-proxy-9qnh6, resource: bindings, ignored listing per whitelist
+Mar 20 08:48:16.721: INFO: namespace e2e-tests-proxy-9qnh6 deletion completed in 6.102954388s
+
+• [SLOW TEST:6.223 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:48:16.721: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name s-test-opt-del-6eb104ea-2c1b-11e8-bd77-b6fcf399588c
+STEP: Creating secret with name s-test-opt-upd-6eb10532-2c1b-11e8-bd77-b6fcf399588c
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-6eb104ea-2c1b-11e8-bd77-b6fcf399588c
+STEP: Updating secret s-test-opt-upd-6eb10532-2c1b-11e8-bd77-b6fcf399588c
+STEP: Creating secret with name s-test-opt-create-6eb10548-2c1b-11e8-bd77-b6fcf399588c
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:48:21.051: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-cnj72" for this suite.
+Mar 20 08:48:43.063: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:48:43.139: INFO: namespace: e2e-tests-secrets-cnj72, resource: bindings, ignored listing per whitelist
+Mar 20 08:48:43.164: INFO: namespace e2e-tests-secrets-cnj72 deletion completed in 22.109195415s
+
+• [SLOW TEST:26.443 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:48:43.164: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 20 08:48:45.734: INFO: Successfully updated pod "labelsupdate7e7387cf-2c1b-11e8-bd77-b6fcf399588c"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:48:47.752: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-ph97v" for this suite.
+Mar 20 08:49:09.763: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:49:09.804: INFO: namespace: e2e-tests-projected-ph97v, resource: bindings, ignored listing per whitelist
+Mar 20 08:49:09.859: INFO: namespace e2e-tests-projected-ph97v deletion completed in 22.104327408s
+
+• [SLOW TEST:26.695 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:49:09.859: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 20 08:49:27.910: INFO: Container started at 2018-03-20 08:49:10 +0000 UTC, pod became ready at 2018-03-20 08:49:27 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:49:27.910: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-rthbg" for this suite.
+Mar 20 08:49:49.921: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:49:49.997: INFO: namespace: e2e-tests-container-probe-rthbg, resource: bindings, ignored listing per whitelist
+Mar 20 08:49:50.013: INFO: namespace e2e-tests-container-probe-rthbg deletion completed in 22.099888886s
+
+• [SLOW TEST:40.154 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:49:50.013: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 20 08:49:50.059: INFO: (0) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.497384ms)
+Mar 20 08:49:50.063: INFO: (1) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.895122ms)
+Mar 20 08:49:50.067: INFO: (2) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.959768ms)
+Mar 20 08:49:50.071: INFO: (3) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.972754ms)
+Mar 20 08:49:50.075: INFO: (4) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.660179ms)
+Mar 20 08:49:50.078: INFO: (5) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.565277ms)
+Mar 20 08:49:50.082: INFO: (6) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.13377ms)
+Mar 20 08:49:50.086: INFO: (7) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.883054ms)
+Mar 20 08:49:50.090: INFO: (8) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.64647ms)
+Mar 20 08:49:50.093: INFO: (9) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.503427ms)
+Mar 20 08:49:53.224: INFO: (10) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.130446909s)
+Mar 20 08:49:53.228: INFO: (11) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.312607ms)
+Mar 20 08:49:53.232: INFO: (12) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.069277ms)
+Mar 20 08:49:53.237: INFO: (13) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.12302ms)
+Mar 20 08:49:53.241: INFO: (14) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.979699ms)
+Mar 20 08:49:53.245: INFO: (15) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.106498ms)
+Mar 20 08:49:53.249: INFO: (16) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.895783ms)
+Mar 20 08:49:53.252: INFO: (17) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.659759ms)
+Mar 20 08:49:53.256: INFO: (18) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.994991ms)
+Mar 20 08:49:53.260: INFO: (19) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.873772ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:49:53.260: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-5lzk5" for this suite.
+Mar 20 08:49:59.271: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:49:59.315: INFO: namespace: e2e-tests-proxy-5lzk5, resource: bindings, ignored listing per whitelist
+Mar 20 08:49:59.368: INFO: namespace e2e-tests-proxy-5lzk5 deletion completed in 6.105248658s
+
+• [SLOW TEST:9.355 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:49:59.369: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:49:59.410: INFO: Waiting up to 5m0s for pod "downwardapi-volume-abdf11b7-2c1b-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-tk7lz" to be "success or failure"
+Mar 20 08:49:59.412: INFO: Pod "downwardapi-volume-abdf11b7-2c1b-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.863299ms
+Mar 20 08:50:01.415: INFO: Pod "downwardapi-volume-abdf11b7-2c1b-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005249875s
+STEP: Saw pod success
+Mar 20 08:50:01.415: INFO: Pod "downwardapi-volume-abdf11b7-2c1b-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:50:01.417: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downwardapi-volume-abdf11b7-2c1b-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:50:01.433: INFO: Waiting for pod downwardapi-volume-abdf11b7-2c1b-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:50:01.435: INFO: Pod downwardapi-volume-abdf11b7-2c1b-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:50:01.435: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-tk7lz" for this suite.
+Mar 20 08:50:07.446: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:50:07.540: INFO: namespace: e2e-tests-projected-tk7lz, resource: bindings, ignored listing per whitelist
+Mar 20 08:50:07.542: INFO: namespace e2e-tests-projected-tk7lz deletion completed in 6.1039616s
+
+• [SLOW TEST:8.173 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:50:07.542: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-map-b0be366f-2c1b-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:50:07.585: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-b0be9a10-2c1b-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-chrlh" to be "success or failure"
+Mar 20 08:50:07.588: INFO: Pod "pod-projected-configmaps-b0be9a10-2c1b-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.138762ms
+Mar 20 08:50:09.591: INFO: Pod "pod-projected-configmaps-b0be9a10-2c1b-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005392577s
+STEP: Saw pod success
+Mar 20 08:50:09.591: INFO: Pod "pod-projected-configmaps-b0be9a10-2c1b-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:50:09.593: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-projected-configmaps-b0be9a10-2c1b-11e8-bd77-b6fcf399588c container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:50:09.608: INFO: Waiting for pod pod-projected-configmaps-b0be9a10-2c1b-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:50:09.611: INFO: Pod pod-projected-configmaps-b0be9a10-2c1b-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:50:09.611: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-chrlh" for this suite.
+Mar 20 08:50:15.621: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:50:15.653: INFO: namespace: e2e-tests-projected-chrlh, resource: bindings, ignored listing per whitelist
+Mar 20 08:50:15.714: INFO: namespace e2e-tests-projected-chrlh deletion completed in 6.100940369s
+
+• [SLOW TEST:8.172 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:50:15.714: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-r4bm5
+Mar 20 08:50:19.760: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-r4bm5
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 20 08:50:19.763: INFO: Initial restart count of pod liveness-http is 0
+Mar 20 08:50:41.800: INFO: Restart count of pod e2e-tests-container-probe-r4bm5/liveness-http is now 1 (22.037888821s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:50:41.808: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-r4bm5" for this suite.
+Mar 20 08:50:47.824: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:50:47.884: INFO: namespace: e2e-tests-container-probe-r4bm5, resource: bindings, ignored listing per whitelist
+Mar 20 08:50:47.917: INFO: namespace e2e-tests-container-probe-r4bm5 deletion completed in 6.10586907s
+
+• [SLOW TEST:32.203 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:50:47.918: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Mar 20 08:50:47.958: INFO: Waiting up to 5m0s for pod "pod-c8cf0514-2c1b-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-hsqqb" to be "success or failure"
+Mar 20 08:50:47.960: INFO: Pod "pod-c8cf0514-2c1b-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.756949ms
+Mar 20 08:50:49.963: INFO: Pod "pod-c8cf0514-2c1b-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004859945s
+STEP: Saw pod success
+Mar 20 08:50:49.963: INFO: Pod "pod-c8cf0514-2c1b-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:50:49.965: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-c8cf0514-2c1b-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:50:49.980: INFO: Waiting for pod pod-c8cf0514-2c1b-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:50:49.982: INFO: Pod pod-c8cf0514-2c1b-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:50:49.982: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-hsqqb" for this suite.
+Mar 20 08:50:55.993: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:50:56.024: INFO: namespace: e2e-tests-emptydir-hsqqb, resource: bindings, ignored listing per whitelist
+Mar 20 08:50:56.089: INFO: namespace e2e-tests-emptydir-hsqqb deletion completed in 6.10414765s
+
+• [SLOW TEST:8.172 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:50:56.090: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name cm-test-opt-del-cdae1362-2c1b-11e8-bd77-b6fcf399588c
+STEP: Creating configMap with name cm-test-opt-upd-cdae1397-2c1b-11e8-bd77-b6fcf399588c
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-cdae1362-2c1b-11e8-bd77-b6fcf399588c
+STEP: Updating configmap cm-test-opt-upd-cdae1397-2c1b-11e8-bd77-b6fcf399588c
+STEP: Creating configMap with name cm-test-opt-create-cdae13ae-2c1b-11e8-bd77-b6fcf399588c
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:51:00.405: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-4fv8k" for this suite.
+Mar 20 08:51:22.419: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:51:22.471: INFO: namespace: e2e-tests-configmap-4fv8k, resource: bindings, ignored listing per whitelist
+Mar 20 08:51:22.512: INFO: namespace e2e-tests-configmap-4fv8k deletion completed in 22.104168034s
+
+• [SLOW TEST:26.423 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:51:22.513: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-qwtmz
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 20 08:51:22.549: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 20 08:51:40.591: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.5.54 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-qwtmz PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 08:51:40.591: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:51:41.688: INFO: Found all expected endpoints: [netserver-0]
+Mar 20 08:51:41.690: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.4.44 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-qwtmz PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 08:51:41.690: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:51:42.690: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.4.44 8081 | grep -v '^\\s*$'": command terminated with exit code 137, stdout: "", stderr: ""
+Mar 20 08:51:42.690: INFO: Waiting for [netserver-1] endpoints (expected=[netserver-1], actual=[])
+Mar 20 08:51:44.693: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.4.44 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-qwtmz PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 08:51:44.693: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:51:45.788: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:51:45.788: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-qwtmz" for this suite.
+Mar 20 08:52:07.798: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:52:07.833: INFO: namespace: e2e-tests-pod-network-test-qwtmz, resource: bindings, ignored listing per whitelist
+Mar 20 08:52:07.891: INFO: namespace e2e-tests-pod-network-test-qwtmz deletion completed in 22.09992214s
+
+• [SLOW TEST:45.379 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:52:07.891: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name projected-secret-test-f879e7ec-2c1b-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:52:07.934: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-f87a477e-2c1b-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-8qnrt" to be "success or failure"
+Mar 20 08:52:07.936: INFO: Pod "pod-projected-secrets-f87a477e-2c1b-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.801573ms
+Mar 20 08:52:09.939: INFO: Pod "pod-projected-secrets-f87a477e-2c1b-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004890229s
+STEP: Saw pod success
+Mar 20 08:52:09.939: INFO: Pod "pod-projected-secrets-f87a477e-2c1b-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:52:09.941: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-projected-secrets-f87a477e-2c1b-11e8-bd77-b6fcf399588c container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:52:09.955: INFO: Waiting for pod pod-projected-secrets-f87a477e-2c1b-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:52:09.957: INFO: Pod pod-projected-secrets-f87a477e-2c1b-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:52:09.957: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8qnrt" for this suite.
+Mar 20 08:52:15.967: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:52:16.043: INFO: namespace: e2e-tests-projected-8qnrt, resource: bindings, ignored listing per whitelist
+Mar 20 08:52:16.059: INFO: namespace e2e-tests-projected-8qnrt deletion completed in 6.099500514s
+
+• [SLOW TEST:8.168 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:52:16.059: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 20 08:52:18.623: INFO: Successfully updated pod "annotationupdatefd584f1c-2c1b-11e8-bd77-b6fcf399588c"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:53:44.802: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-rbmb4" for this suite.
+Mar 20 08:54:06.814: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:54:06.900: INFO: namespace: e2e-tests-downward-api-rbmb4, resource: bindings, ignored listing per whitelist
+Mar 20 08:54:06.904: INFO: namespace e2e-tests-downward-api-rbmb4 deletion completed in 22.098332993s
+
+• [SLOW TEST:110.845 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:54:06.904: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-3f69c973-2c1c-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:54:06.947: INFO: Waiting up to 5m0s for pod "pod-configmaps-3f6a2ef8-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-configmap-tkblv" to be "success or failure"
+Mar 20 08:54:06.949: INFO: Pod "pod-configmaps-3f6a2ef8-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.030794ms
+Mar 20 08:54:08.952: INFO: Pod "pod-configmaps-3f6a2ef8-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005672297s
+STEP: Saw pod success
+Mar 20 08:54:08.953: INFO: Pod "pod-configmaps-3f6a2ef8-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:54:08.955: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-configmaps-3f6a2ef8-2c1c-11e8-bd77-b6fcf399588c container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:54:08.969: INFO: Waiting for pod pod-configmaps-3f6a2ef8-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:54:08.972: INFO: Pod pod-configmaps-3f6a2ef8-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:54:08.972: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-tkblv" for this suite.
+Mar 20 08:54:14.982: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:54:15.055: INFO: namespace: e2e-tests-configmap-tkblv, resource: bindings, ignored listing per whitelist
+Mar 20 08:54:15.079: INFO: namespace e2e-tests-configmap-tkblv deletion completed in 6.103981588s
+
+• [SLOW TEST:8.175 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:54:15.079: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:54:15.118: INFO: Waiting up to 5m0s for pod "downwardapi-volume-444910eb-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-tk7tn" to be "success or failure"
+Mar 20 08:54:15.121: INFO: Pod "downwardapi-volume-444910eb-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.29589ms
+Mar 20 08:54:17.124: INFO: Pod "downwardapi-volume-444910eb-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00531034s
+STEP: Saw pod success
+Mar 20 08:54:17.124: INFO: Pod "downwardapi-volume-444910eb-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:54:17.126: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod downwardapi-volume-444910eb-2c1c-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:54:17.140: INFO: Waiting for pod downwardapi-volume-444910eb-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:54:17.142: INFO: Pod downwardapi-volume-444910eb-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:54:17.142: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-tk7tn" for this suite.
+Mar 20 08:54:23.157: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:54:23.235: INFO: namespace: e2e-tests-projected-tk7tn, resource: bindings, ignored listing per whitelist
+Mar 20 08:54:23.248: INFO: namespace e2e-tests-projected-tk7tn deletion completed in 6.101903377s
+
+• [SLOW TEST:8.169 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:54:23.248: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-gqqdq
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 20 08:54:23.284: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 20 08:54:37.325: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.5.58:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-gqqdq PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 08:54:37.325: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:54:37.434: INFO: Found all expected endpoints: [netserver-0]
+Mar 20 08:54:37.442: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.4.47:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-gqqdq PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 08:54:37.442: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 08:54:37.586: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:54:37.586: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-gqqdq" for this suite.
+Mar 20 08:54:59.600: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:54:59.646: INFO: namespace: e2e-tests-pod-network-test-gqqdq, resource: bindings, ignored listing per whitelist
+Mar 20 08:54:59.692: INFO: namespace e2e-tests-pod-network-test-gqqdq deletion completed in 22.101828607s
+
+• [SLOW TEST:36.444 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:54:59.692: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Mar 20 08:54:59.732: INFO: Waiting up to 5m0s for pod "pod-5ee0aa67-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-lv68b" to be "success or failure"
+Mar 20 08:54:59.734: INFO: Pod "pod-5ee0aa67-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.767353ms
+Mar 20 08:55:01.737: INFO: Pod "pod-5ee0aa67-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004862424s
+STEP: Saw pod success
+Mar 20 08:55:01.737: INFO: Pod "pod-5ee0aa67-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:55:01.740: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-5ee0aa67-2c1c-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:55:03.602: INFO: Waiting for pod pod-5ee0aa67-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:55:03.604: INFO: Pod pod-5ee0aa67-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:55:03.604: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-lv68b" for this suite.
+Mar 20 08:55:09.614: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:55:09.648: INFO: namespace: e2e-tests-emptydir-lv68b, resource: bindings, ignored listing per whitelist
+Mar 20 08:55:09.705: INFO: namespace e2e-tests-emptydir-lv68b deletion completed in 6.098301851s
+
+• [SLOW TEST:10.013 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:55:09.705: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Mar 20 08:55:09.746: INFO: Waiting up to 5m0s for pod "pod-64d8ae89-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-flkww" to be "success or failure"
+Mar 20 08:55:09.748: INFO: Pod "pod-64d8ae89-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.130584ms
+Mar 20 08:55:11.751: INFO: Pod "pod-64d8ae89-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005043692s
+STEP: Saw pod success
+Mar 20 08:55:11.751: INFO: Pod "pod-64d8ae89-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:55:11.753: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-64d8ae89-2c1c-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:55:11.770: INFO: Waiting for pod pod-64d8ae89-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:55:11.772: INFO: Pod pod-64d8ae89-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:55:11.772: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-flkww" for this suite.
+Mar 20 08:55:17.784: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:55:17.839: INFO: namespace: e2e-tests-emptydir-flkww, resource: bindings, ignored listing per whitelist
+Mar 20 08:55:17.877: INFO: namespace e2e-tests-emptydir-flkww deletion completed in 6.10168738s
+
+• [SLOW TEST:8.172 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:55:17.877: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Mar 20 08:55:17.915: INFO: Waiting up to 5m0s for pod "pod-69b734a1-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-4xv9h" to be "success or failure"
+Mar 20 08:55:17.917: INFO: Pod "pod-69b734a1-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.739511ms
+Mar 20 08:55:19.920: INFO: Pod "pod-69b734a1-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005087357s
+STEP: Saw pod success
+Mar 20 08:55:19.920: INFO: Pod "pod-69b734a1-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:55:19.923: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-69b734a1-2c1c-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:55:19.936: INFO: Waiting for pod pod-69b734a1-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:55:19.938: INFO: Pod pod-69b734a1-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:55:19.938: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-4xv9h" for this suite.
+Mar 20 08:55:25.949: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:55:26.032: INFO: namespace: e2e-tests-emptydir-4xv9h, resource: bindings, ignored listing per whitelist
+Mar 20 08:55:26.037: INFO: namespace e2e-tests-emptydir-4xv9h deletion completed in 6.096655913s
+
+• [SLOW TEST:8.160 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:55:26.038: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-6e94b76e-2c1c-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:55:26.083: INFO: Waiting up to 5m0s for pod "pod-secrets-6e95170e-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-secrets-86jql" to be "success or failure"
+Mar 20 08:55:26.085: INFO: Pod "pod-secrets-6e95170e-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.496969ms
+Mar 20 08:55:28.088: INFO: Pod "pod-secrets-6e95170e-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005796738s
+STEP: Saw pod success
+Mar 20 08:55:28.088: INFO: Pod "pod-secrets-6e95170e-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:55:28.090: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-secrets-6e95170e-2c1c-11e8-bd77-b6fcf399588c container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:55:28.105: INFO: Waiting for pod pod-secrets-6e95170e-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:55:28.117: INFO: Pod pod-secrets-6e95170e-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:55:28.117: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-86jql" for this suite.
+Mar 20 08:55:34.130: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:55:34.172: INFO: namespace: e2e-tests-secrets-86jql, resource: bindings, ignored listing per whitelist
+Mar 20 08:55:34.234: INFO: namespace e2e-tests-secrets-86jql deletion completed in 6.114425402s
+
+• [SLOW TEST:8.197 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:55:34.235: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 20 08:55:34.272: INFO: Creating ReplicaSet my-hostname-basic-7377a1ca-2c1c-11e8-bd77-b6fcf399588c
+Mar 20 08:55:34.277: INFO: Pod name my-hostname-basic-7377a1ca-2c1c-11e8-bd77-b6fcf399588c: Found 0 pods out of 1
+Mar 20 08:55:39.281: INFO: Pod name my-hostname-basic-7377a1ca-2c1c-11e8-bd77-b6fcf399588c: Found 1 pods out of 1
+Mar 20 08:55:39.281: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-7377a1ca-2c1c-11e8-bd77-b6fcf399588c" is running
+Mar 20 08:55:39.283: INFO: Pod "my-hostname-basic-7377a1ca-2c1c-11e8-bd77-b6fcf399588c-lcqvc" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-20 08:55:34 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-20 08:55:36 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-20 08:55:34 +0000 UTC Reason: Message:}])
+Mar 20 08:55:39.283: INFO: Trying to dial the pod
+Mar 20 08:55:44.337: INFO: Controller my-hostname-basic-7377a1ca-2c1c-11e8-bd77-b6fcf399588c: Got expected result from replica 1 [my-hostname-basic-7377a1ca-2c1c-11e8-bd77-b6fcf399588c-lcqvc]: "my-hostname-basic-7377a1ca-2c1c-11e8-bd77-b6fcf399588c-lcqvc", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:55:44.337: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-j5fkr" for this suite.
+Mar 20 08:55:50.348: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:55:50.397: INFO: namespace: e2e-tests-replicaset-j5fkr, resource: bindings, ignored listing per whitelist
+Mar 20 08:55:50.443: INFO: namespace e2e-tests-replicaset-j5fkr deletion completed in 6.103108444s
+
+• [SLOW TEST:16.208 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:55:50.443: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-map-7d20ece8-2c1c-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 08:55:50.490: INFO: Waiting up to 5m0s for pod "pod-secrets-7d21b83e-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-secrets-6kv9k" to be "success or failure"
+Mar 20 08:55:50.492: INFO: Pod "pod-secrets-7d21b83e-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.526534ms
+Mar 20 08:55:52.495: INFO: Pod "pod-secrets-7d21b83e-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004897421s
+STEP: Saw pod success
+Mar 20 08:55:52.495: INFO: Pod "pod-secrets-7d21b83e-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:55:52.497: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-secrets-7d21b83e-2c1c-11e8-bd77-b6fcf399588c container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:55:52.512: INFO: Waiting for pod pod-secrets-7d21b83e-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:55:52.515: INFO: Pod pod-secrets-7d21b83e-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:55:52.515: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-6kv9k" for this suite.
+Mar 20 08:55:58.526: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:55:58.563: INFO: namespace: e2e-tests-secrets-6kv9k, resource: bindings, ignored listing per whitelist
+Mar 20 08:55:58.625: INFO: namespace e2e-tests-secrets-6kv9k deletion completed in 6.106670983s
+
+• [SLOW TEST:8.182 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:55:58.625: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:55:58.668: INFO: Waiting up to 5m0s for pod "downwardapi-volume-82014612-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-jj2ld" to be "success or failure"
+Mar 20 08:55:58.671: INFO: Pod "downwardapi-volume-82014612-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.548381ms
+Mar 20 08:56:00.679: INFO: Pod "downwardapi-volume-82014612-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010693373s
+STEP: Saw pod success
+Mar 20 08:56:00.679: INFO: Pod "downwardapi-volume-82014612-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:56:00.681: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downwardapi-volume-82014612-2c1c-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:56:00.697: INFO: Waiting for pod downwardapi-volume-82014612-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:56:00.699: INFO: Pod downwardapi-volume-82014612-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:56:00.699: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jj2ld" for this suite.
+Mar 20 08:56:06.710: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:56:06.797: INFO: namespace: e2e-tests-projected-jj2ld, resource: bindings, ignored listing per whitelist
+Mar 20 08:56:06.809: INFO: namespace e2e-tests-projected-jj2ld deletion completed in 6.106397361s
+
+• [SLOW TEST:8.184 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:56:06.809: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name cm-test-opt-del-86e2bfbb-2c1c-11e8-bd77-b6fcf399588c
+STEP: Creating configMap with name cm-test-opt-upd-86e2bff7-2c1c-11e8-bd77-b6fcf399588c
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-86e2bfbb-2c1c-11e8-bd77-b6fcf399588c
+STEP: Updating configmap cm-test-opt-upd-86e2bff7-2c1c-11e8-bd77-b6fcf399588c
+STEP: Creating configMap with name cm-test-opt-create-86e2c00d-2c1c-11e8-bd77-b6fcf399588c
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:56:11.137: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-swzxr" for this suite.
+Mar 20 08:56:33.149: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:56:33.227: INFO: namespace: e2e-tests-projected-swzxr, resource: bindings, ignored listing per whitelist
+Mar 20 08:56:33.238: INFO: namespace e2e-tests-projected-swzxr deletion completed in 22.098062194s
+
+• [SLOW TEST:26.429 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:56:33.238: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-96a29888-2c1c-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:56:33.280: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-96a2f91e-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-jvph2" to be "success or failure"
+Mar 20 08:56:33.282: INFO: Pod "pod-projected-configmaps-96a2f91e-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.652692ms
+Mar 20 08:56:35.286: INFO: Pod "pod-projected-configmaps-96a2f91e-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005323621s
+STEP: Saw pod success
+Mar 20 08:56:35.286: INFO: Pod "pod-projected-configmaps-96a2f91e-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:56:35.288: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-projected-configmaps-96a2f91e-2c1c-11e8-bd77-b6fcf399588c container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:56:35.303: INFO: Waiting for pod pod-projected-configmaps-96a2f91e-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:56:35.305: INFO: Pod pod-projected-configmaps-96a2f91e-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:56:35.305: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jvph2" for this suite.
+Mar 20 08:56:41.316: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:56:41.359: INFO: namespace: e2e-tests-projected-jvph2, resource: bindings, ignored listing per whitelist
+Mar 20 08:56:41.415: INFO: namespace e2e-tests-projected-jvph2 deletion completed in 6.107308687s
+
+• [SLOW TEST:8.177 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:56:41.415: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 20 08:56:41.464: INFO: Waiting up to 5m0s for pod "downward-api-9b83941d-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-hsrcq" to be "success or failure"
+Mar 20 08:56:41.466: INFO: Pod "downward-api-9b83941d-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.16303ms
+Mar 20 08:56:43.470: INFO: Pod "downward-api-9b83941d-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005553223s
+Mar 20 08:56:45.473: INFO: Pod "downward-api-9b83941d-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009045901s
+STEP: Saw pod success
+Mar 20 08:56:45.473: INFO: Pod "downward-api-9b83941d-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:56:45.476: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downward-api-9b83941d-2c1c-11e8-bd77-b6fcf399588c container dapi-container: <nil>
+STEP: delete the pod
+Mar 20 08:56:45.492: INFO: Waiting for pod downward-api-9b83941d-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:56:45.494: INFO: Pod downward-api-9b83941d-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:56:45.494: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-hsrcq" for this suite.
+Mar 20 08:56:51.505: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:56:51.587: INFO: namespace: e2e-tests-downward-api-hsrcq, resource: bindings, ignored listing per whitelist
+Mar 20 08:56:51.603: INFO: namespace e2e-tests-downward-api-hsrcq deletion completed in 6.105988477s
+
+• [SLOW TEST:10.188 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:56:51.603: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir volume type on node default medium
+Mar 20 08:56:51.645: INFO: Waiting up to 5m0s for pod "pod-a1951abe-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-emptydir-kblr6" to be "success or failure"
+Mar 20 08:56:51.647: INFO: Pod "pod-a1951abe-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.157706ms
+Mar 20 08:56:53.650: INFO: Pod "pod-a1951abe-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005488475s
+STEP: Saw pod success
+Mar 20 08:56:53.650: INFO: Pod "pod-a1951abe-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:56:53.652: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-a1951abe-2c1c-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:56:53.665: INFO: Waiting for pod pod-a1951abe-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:56:53.667: INFO: Pod pod-a1951abe-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:56:53.667: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-kblr6" for this suite.
+Mar 20 08:56:59.678: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:56:59.761: INFO: namespace: e2e-tests-emptydir-kblr6, resource: bindings, ignored listing per whitelist
+Mar 20 08:56:59.768: INFO: namespace e2e-tests-emptydir-kblr6 deletion completed in 6.097682636s
+
+• [SLOW TEST:8.165 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:56:59.768: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test override all
+Mar 20 08:56:59.807: INFO: Waiting up to 5m0s for pod "client-containers-a672a2ac-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-containers-fbtrs" to be "success or failure"
+Mar 20 08:56:59.808: INFO: Pod "client-containers-a672a2ac-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.539815ms
+Mar 20 08:57:01.811: INFO: Pod "client-containers-a672a2ac-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004618784s
+Mar 20 08:57:03.815: INFO: Pod "client-containers-a672a2ac-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.007931327s
+STEP: Saw pod success
+Mar 20 08:57:03.815: INFO: Pod "client-containers-a672a2ac-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:57:03.817: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod client-containers-a672a2ac-2c1c-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 08:57:03.835: INFO: Waiting for pod client-containers-a672a2ac-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:57:03.837: INFO: Pod client-containers-a672a2ac-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:57:03.839: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-fbtrs" for this suite.
+Mar 20 08:57:09.849: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:57:09.882: INFO: namespace: e2e-tests-containers-fbtrs, resource: bindings, ignored listing per whitelist
+Mar 20 08:57:09.943: INFO: namespace e2e-tests-containers-fbtrs deletion completed in 6.101747087s
+
+• [SLOW TEST:10.175 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:57:09.943: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-m5vsp
+I0320 08:57:09.983217      18 runners.go:178] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-m5vsp, replica count: 1
+I0320 08:57:10.983504      18 runners.go:178] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0320 08:57:11.983744      18 runners.go:178] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Mar 20 08:57:12.092: INFO: Created: latency-svc-xdhs5
+Mar 20 08:57:12.096: INFO: Got endpoints: latency-svc-xdhs5 [12.58882ms]
+Mar 20 08:57:12.104: INFO: Created: latency-svc-j2h88
+Mar 20 08:57:12.110: INFO: Got endpoints: latency-svc-j2h88 [13.385595ms]
+Mar 20 08:57:12.110: INFO: Created: latency-svc-wtwg8
+Mar 20 08:57:12.114: INFO: Got endpoints: latency-svc-wtwg8 [17.670819ms]
+Mar 20 08:57:12.114: INFO: Created: latency-svc-jgkqc
+Mar 20 08:57:12.118: INFO: Got endpoints: latency-svc-jgkqc [21.810176ms]
+Mar 20 08:57:12.119: INFO: Created: latency-svc-dtcqh
+Mar 20 08:57:12.122: INFO: Got endpoints: latency-svc-dtcqh [26.160904ms]
+Mar 20 08:57:12.123: INFO: Created: latency-svc-xg9dc
+Mar 20 08:57:12.140: INFO: Got endpoints: latency-svc-xg9dc [43.880625ms]
+Mar 20 08:57:12.142: INFO: Created: latency-svc-l7rtq
+Mar 20 08:57:12.144: INFO: Got endpoints: latency-svc-l7rtq [47.434294ms]
+Mar 20 08:57:12.147: INFO: Created: latency-svc-v99hg
+Mar 20 08:57:12.149: INFO: Got endpoints: latency-svc-v99hg [53.066219ms]
+Mar 20 08:57:12.152: INFO: Created: latency-svc-67glg
+Mar 20 08:57:12.160: INFO: Got endpoints: latency-svc-67glg [63.596557ms]
+Mar 20 08:57:12.162: INFO: Created: latency-svc-qd2nf
+Mar 20 08:57:12.164: INFO: Got endpoints: latency-svc-qd2nf [67.747757ms]
+Mar 20 08:57:12.167: INFO: Created: latency-svc-bps9k
+Mar 20 08:57:12.176: INFO: Got endpoints: latency-svc-bps9k [79.194823ms]
+Mar 20 08:57:12.178: INFO: Created: latency-svc-z29zb
+Mar 20 08:57:12.180: INFO: Got endpoints: latency-svc-z29zb [83.534898ms]
+Mar 20 08:57:12.192: INFO: Created: latency-svc-f5tpb
+Mar 20 08:57:12.201: INFO: Got endpoints: latency-svc-f5tpb [104.825734ms]
+Mar 20 08:57:12.211: INFO: Created: latency-svc-5xcsq
+Mar 20 08:57:12.223: INFO: Got endpoints: latency-svc-5xcsq [126.731395ms]
+Mar 20 08:57:12.224: INFO: Created: latency-svc-5mjll
+Mar 20 08:57:12.232: INFO: Got endpoints: latency-svc-5mjll [135.802804ms]
+Mar 20 08:57:12.258: INFO: Created: latency-svc-sf877
+Mar 20 08:57:12.263: INFO: Got endpoints: latency-svc-sf877 [166.567217ms]
+Mar 20 08:57:12.265: INFO: Created: latency-svc-mm62x
+Mar 20 08:57:12.265: INFO: Got endpoints: latency-svc-mm62x [155.149997ms]
+Mar 20 08:57:12.268: INFO: Created: latency-svc-mjhr5
+Mar 20 08:57:12.270: INFO: Got endpoints: latency-svc-mjhr5 [156.142478ms]
+Mar 20 08:57:12.274: INFO: Created: latency-svc-7xprg
+Mar 20 08:57:12.279: INFO: Got endpoints: latency-svc-7xprg [160.915353ms]
+Mar 20 08:57:12.279: INFO: Created: latency-svc-dr2fs
+Mar 20 08:57:12.287: INFO: Got endpoints: latency-svc-dr2fs [164.80229ms]
+Mar 20 08:57:12.289: INFO: Created: latency-svc-8hdqq
+Mar 20 08:57:12.298: INFO: Got endpoints: latency-svc-8hdqq [157.189011ms]
+Mar 20 08:57:12.300: INFO: Created: latency-svc-kv7c8
+Mar 20 08:57:12.306: INFO: Created: latency-svc-842vt
+Mar 20 08:57:12.306: INFO: Got endpoints: latency-svc-kv7c8 [162.049359ms]
+Mar 20 08:57:12.313: INFO: Got endpoints: latency-svc-842vt [164.010495ms]
+Mar 20 08:57:12.316: INFO: Created: latency-svc-mzkrg
+Mar 20 08:57:12.318: INFO: Got endpoints: latency-svc-mzkrg [157.827242ms]
+Mar 20 08:57:12.329: INFO: Created: latency-svc-dxcch
+Mar 20 08:57:12.336: INFO: Got endpoints: latency-svc-dxcch [172.194872ms]
+Mar 20 08:57:12.339: INFO: Created: latency-svc-2qb9v
+Mar 20 08:57:12.341: INFO: Got endpoints: latency-svc-2qb9v [165.297266ms]
+Mar 20 08:57:12.344: INFO: Created: latency-svc-mlqfp
+Mar 20 08:57:12.354: INFO: Got endpoints: latency-svc-mlqfp [173.733661ms]
+Mar 20 08:57:12.369: INFO: Created: latency-svc-kwpqn
+Mar 20 08:57:12.371: INFO: Got endpoints: latency-svc-kwpqn [169.43788ms]
+Mar 20 08:57:12.375: INFO: Created: latency-svc-6p9t5
+Mar 20 08:57:12.376: INFO: Got endpoints: latency-svc-6p9t5 [152.953644ms]
+Mar 20 08:57:12.380: INFO: Created: latency-svc-hv42r
+Mar 20 08:57:12.388: INFO: Got endpoints: latency-svc-hv42r [155.860581ms]
+Mar 20 08:57:12.390: INFO: Created: latency-svc-mqkvl
+Mar 20 08:57:12.392: INFO: Got endpoints: latency-svc-mqkvl [129.137629ms]
+Mar 20 08:57:12.397: INFO: Created: latency-svc-rmplk
+Mar 20 08:57:12.404: INFO: Got endpoints: latency-svc-rmplk [139.578257ms]
+Mar 20 08:57:12.407: INFO: Created: latency-svc-czl2n
+Mar 20 08:57:12.409: INFO: Got endpoints: latency-svc-czl2n [138.237043ms]
+Mar 20 08:57:12.421: INFO: Created: latency-svc-4wptc
+Mar 20 08:57:12.429: INFO: Got endpoints: latency-svc-4wptc [149.799701ms]
+Mar 20 08:57:12.431: INFO: Created: latency-svc-m59dl
+Mar 20 08:57:12.433: INFO: Got endpoints: latency-svc-m59dl [146.058592ms]
+Mar 20 08:57:12.438: INFO: Created: latency-svc-fxgjb
+Mar 20 08:57:12.445: INFO: Got endpoints: latency-svc-fxgjb [147.322749ms]
+Mar 20 08:57:12.448: INFO: Created: latency-svc-lkgm8
+Mar 20 08:57:12.450: INFO: Got endpoints: latency-svc-lkgm8 [143.626167ms]
+Mar 20 08:57:12.454: INFO: Created: latency-svc-stgwm
+Mar 20 08:57:12.461: INFO: Got endpoints: latency-svc-stgwm [147.605302ms]
+Mar 20 08:57:12.464: INFO: Created: latency-svc-2qpdp
+Mar 20 08:57:12.487: INFO: Created: latency-svc-jrl7p
+Mar 20 08:57:12.493: INFO: Created: latency-svc-ldjr7
+Mar 20 08:57:12.503: INFO: Got endpoints: latency-svc-2qpdp [185.303091ms]
+Mar 20 08:57:12.506: INFO: Created: latency-svc-mf8gb
+Mar 20 08:57:12.519: INFO: Created: latency-svc-rd6ww
+Mar 20 08:57:12.530: INFO: Created: latency-svc-5vmk7
+Mar 20 08:57:12.542: INFO: Created: latency-svc-nkpgg
+Mar 20 08:57:12.547: INFO: Got endpoints: latency-svc-jrl7p [210.572731ms]
+Mar 20 08:57:12.557: INFO: Created: latency-svc-cmrxn
+Mar 20 08:57:12.563: INFO: Created: latency-svc-lnrw9
+Mar 20 08:57:12.567: INFO: Created: latency-svc-74hk8
+Mar 20 08:57:12.571: INFO: Created: latency-svc-npxb7
+Mar 20 08:57:12.585: INFO: Created: latency-svc-zddjr
+Mar 20 08:57:12.604: INFO: Got endpoints: latency-svc-ldjr7 [263.18166ms]
+Mar 20 08:57:12.605: INFO: Created: latency-svc-fmxhj
+Mar 20 08:57:12.610: INFO: Created: latency-svc-5fjhf
+Mar 20 08:57:12.616: INFO: Created: latency-svc-9659m
+Mar 20 08:57:12.622: INFO: Created: latency-svc-7ktp4
+Mar 20 08:57:12.641: INFO: Created: latency-svc-h4h7c
+Mar 20 08:57:12.647: INFO: Created: latency-svc-2j55q
+Mar 20 08:57:12.654: INFO: Got endpoints: latency-svc-mf8gb [300.437129ms]
+Mar 20 08:57:12.662: INFO: Created: latency-svc-tsprw
+Mar 20 08:57:12.698: INFO: Got endpoints: latency-svc-rd6ww [327.259732ms]
+Mar 20 08:57:12.714: INFO: Created: latency-svc-4rw8r
+Mar 20 08:57:12.748: INFO: Got endpoints: latency-svc-5vmk7 [371.599426ms]
+Mar 20 08:57:12.757: INFO: Created: latency-svc-224ll
+Mar 20 08:57:12.797: INFO: Got endpoints: latency-svc-nkpgg [408.883816ms]
+Mar 20 08:57:12.806: INFO: Created: latency-svc-2brz8
+Mar 20 08:57:12.847: INFO: Got endpoints: latency-svc-cmrxn [455.020972ms]
+Mar 20 08:57:12.857: INFO: Created: latency-svc-5hnnk
+Mar 20 08:57:12.897: INFO: Got endpoints: latency-svc-lnrw9 [492.940312ms]
+Mar 20 08:57:12.911: INFO: Created: latency-svc-lzczw
+Mar 20 08:57:12.947: INFO: Got endpoints: latency-svc-74hk8 [538.284707ms]
+Mar 20 08:57:12.956: INFO: Created: latency-svc-c7jtq
+Mar 20 08:57:12.998: INFO: Got endpoints: latency-svc-npxb7 [568.517211ms]
+Mar 20 08:57:13.009: INFO: Created: latency-svc-5wvrd
+Mar 20 08:57:13.048: INFO: Got endpoints: latency-svc-zddjr [614.217235ms]
+Mar 20 08:57:13.056: INFO: Created: latency-svc-cgwsw
+Mar 20 08:57:13.097: INFO: Got endpoints: latency-svc-fmxhj [652.149154ms]
+Mar 20 08:57:13.106: INFO: Created: latency-svc-dd2g7
+Mar 20 08:57:13.147: INFO: Got endpoints: latency-svc-5fjhf [697.647801ms]
+Mar 20 08:57:13.156: INFO: Created: latency-svc-d2vqw
+Mar 20 08:57:13.197: INFO: Got endpoints: latency-svc-9659m [736.16608ms]
+Mar 20 08:57:13.205: INFO: Created: latency-svc-xj6xv
+Mar 20 08:57:13.248: INFO: Got endpoints: latency-svc-7ktp4 [744.284456ms]
+Mar 20 08:57:13.256: INFO: Created: latency-svc-ht8kf
+Mar 20 08:57:13.298: INFO: Got endpoints: latency-svc-h4h7c [750.570767ms]
+Mar 20 08:57:13.308: INFO: Created: latency-svc-f2pdc
+Mar 20 08:57:13.348: INFO: Got endpoints: latency-svc-2j55q [743.363693ms]
+Mar 20 08:57:13.356: INFO: Created: latency-svc-hxqz8
+Mar 20 08:57:13.397: INFO: Got endpoints: latency-svc-tsprw [743.114387ms]
+Mar 20 08:57:13.406: INFO: Created: latency-svc-kqwrp
+Mar 20 08:57:13.448: INFO: Got endpoints: latency-svc-4rw8r [750.244577ms]
+Mar 20 08:57:13.457: INFO: Created: latency-svc-k794m
+Mar 20 08:57:13.498: INFO: Got endpoints: latency-svc-224ll [749.521054ms]
+Mar 20 08:57:13.506: INFO: Created: latency-svc-lk2ls
+Mar 20 08:57:13.548: INFO: Got endpoints: latency-svc-2brz8 [750.159644ms]
+Mar 20 08:57:13.556: INFO: Created: latency-svc-nlk2l
+Mar 20 08:57:13.598: INFO: Got endpoints: latency-svc-5hnnk [750.319741ms]
+Mar 20 08:57:13.607: INFO: Created: latency-svc-77qv4
+Mar 20 08:57:13.651: INFO: Got endpoints: latency-svc-lzczw [753.162813ms]
+Mar 20 08:57:13.662: INFO: Created: latency-svc-fcbsv
+Mar 20 08:57:13.698: INFO: Got endpoints: latency-svc-c7jtq [750.640493ms]
+Mar 20 08:57:13.707: INFO: Created: latency-svc-kcm8h
+Mar 20 08:57:13.748: INFO: Got endpoints: latency-svc-5wvrd [750.005013ms]
+Mar 20 08:57:13.756: INFO: Created: latency-svc-tzzbn
+Mar 20 08:57:13.798: INFO: Got endpoints: latency-svc-cgwsw [749.857343ms]
+Mar 20 08:57:13.806: INFO: Created: latency-svc-vrwbr
+Mar 20 08:57:13.848: INFO: Got endpoints: latency-svc-dd2g7 [751.052081ms]
+Mar 20 08:57:13.858: INFO: Created: latency-svc-z2s5r
+Mar 20 08:57:13.898: INFO: Got endpoints: latency-svc-d2vqw [750.439572ms]
+Mar 20 08:57:13.906: INFO: Created: latency-svc-vhxp4
+Mar 20 08:57:13.948: INFO: Got endpoints: latency-svc-xj6xv [750.241677ms]
+Mar 20 08:57:13.956: INFO: Created: latency-svc-fj9fh
+Mar 20 08:57:13.998: INFO: Got endpoints: latency-svc-ht8kf [750.031084ms]
+Mar 20 08:57:14.006: INFO: Created: latency-svc-l5pv2
+Mar 20 08:57:14.048: INFO: Got endpoints: latency-svc-f2pdc [750.022899ms]
+Mar 20 08:57:14.056: INFO: Created: latency-svc-g44sg
+Mar 20 08:57:14.099: INFO: Got endpoints: latency-svc-hxqz8 [751.072872ms]
+Mar 20 08:57:14.107: INFO: Created: latency-svc-r2fsz
+Mar 20 08:57:14.147: INFO: Got endpoints: latency-svc-kqwrp [749.87361ms]
+Mar 20 08:57:14.157: INFO: Created: latency-svc-xrhhx
+Mar 20 08:57:14.198: INFO: Got endpoints: latency-svc-k794m [749.107843ms]
+Mar 20 08:57:14.206: INFO: Created: latency-svc-69qgq
+Mar 20 08:57:14.248: INFO: Got endpoints: latency-svc-lk2ls [749.975272ms]
+Mar 20 08:57:14.256: INFO: Created: latency-svc-jdclj
+Mar 20 08:57:14.298: INFO: Got endpoints: latency-svc-nlk2l [750.192132ms]
+Mar 20 08:57:14.307: INFO: Created: latency-svc-2rp9m
+Mar 20 08:57:14.348: INFO: Got endpoints: latency-svc-77qv4 [749.935177ms]
+Mar 20 08:57:14.357: INFO: Created: latency-svc-552w7
+Mar 20 08:57:14.398: INFO: Got endpoints: latency-svc-fcbsv [744.972409ms]
+Mar 20 08:57:14.407: INFO: Created: latency-svc-46kgp
+Mar 20 08:57:14.448: INFO: Got endpoints: latency-svc-kcm8h [750.031607ms]
+Mar 20 08:57:14.457: INFO: Created: latency-svc-cf9b2
+Mar 20 08:57:14.498: INFO: Got endpoints: latency-svc-tzzbn [749.814615ms]
+Mar 20 08:57:14.506: INFO: Created: latency-svc-86kn8
+Mar 20 08:57:14.548: INFO: Got endpoints: latency-svc-vrwbr [749.669247ms]
+Mar 20 08:57:14.556: INFO: Created: latency-svc-q79kf
+Mar 20 08:57:14.597: INFO: Got endpoints: latency-svc-z2s5r [749.028226ms]
+Mar 20 08:57:14.608: INFO: Created: latency-svc-qmp97
+Mar 20 08:57:14.648: INFO: Got endpoints: latency-svc-vhxp4 [749.918767ms]
+Mar 20 08:57:14.658: INFO: Created: latency-svc-wpqvp
+Mar 20 08:57:14.698: INFO: Got endpoints: latency-svc-fj9fh [750.332055ms]
+Mar 20 08:57:14.707: INFO: Created: latency-svc-dcwdr
+Mar 20 08:57:14.748: INFO: Got endpoints: latency-svc-l5pv2 [749.915557ms]
+Mar 20 08:57:14.760: INFO: Created: latency-svc-7db4m
+Mar 20 08:57:14.798: INFO: Got endpoints: latency-svc-g44sg [749.817484ms]
+Mar 20 08:57:14.810: INFO: Created: latency-svc-nqcnq
+Mar 20 08:57:14.848: INFO: Got endpoints: latency-svc-r2fsz [748.687606ms]
+Mar 20 08:57:14.857: INFO: Created: latency-svc-vlc82
+Mar 20 08:57:14.898: INFO: Got endpoints: latency-svc-xrhhx [750.440129ms]
+Mar 20 08:57:14.908: INFO: Created: latency-svc-tzwrs
+Mar 20 08:57:14.948: INFO: Got endpoints: latency-svc-69qgq [750.454645ms]
+Mar 20 08:57:14.958: INFO: Created: latency-svc-wktl4
+Mar 20 08:57:14.998: INFO: Got endpoints: latency-svc-jdclj [750.312269ms]
+Mar 20 08:57:15.008: INFO: Created: latency-svc-nk82c
+Mar 20 08:57:15.048: INFO: Got endpoints: latency-svc-2rp9m [749.884165ms]
+Mar 20 08:57:15.057: INFO: Created: latency-svc-djhgb
+Mar 20 08:57:15.099: INFO: Got endpoints: latency-svc-552w7 [751.462852ms]
+Mar 20 08:57:15.109: INFO: Created: latency-svc-f4mv6
+Mar 20 08:57:15.148: INFO: Got endpoints: latency-svc-46kgp [749.737055ms]
+Mar 20 08:57:15.158: INFO: Created: latency-svc-v2vxv
+Mar 20 08:57:15.198: INFO: Got endpoints: latency-svc-cf9b2 [749.619584ms]
+Mar 20 08:57:15.209: INFO: Created: latency-svc-297k9
+Mar 20 08:57:15.248: INFO: Got endpoints: latency-svc-86kn8 [750.419015ms]
+Mar 20 08:57:15.258: INFO: Created: latency-svc-jrtjm
+Mar 20 08:57:15.298: INFO: Got endpoints: latency-svc-q79kf [750.060998ms]
+Mar 20 08:57:15.308: INFO: Created: latency-svc-h79rd
+Mar 20 08:57:15.348: INFO: Got endpoints: latency-svc-qmp97 [750.676302ms]
+Mar 20 08:57:15.357: INFO: Created: latency-svc-zgrg4
+Mar 20 08:57:15.398: INFO: Got endpoints: latency-svc-wpqvp [749.727649ms]
+Mar 20 08:57:15.407: INFO: Created: latency-svc-wt25f
+Mar 20 08:57:15.447: INFO: Got endpoints: latency-svc-dcwdr [749.126193ms]
+Mar 20 08:57:15.457: INFO: Created: latency-svc-c4pkd
+Mar 20 08:57:15.498: INFO: Got endpoints: latency-svc-7db4m [750.388201ms]
+Mar 20 08:57:15.507: INFO: Created: latency-svc-bzq89
+Mar 20 08:57:15.548: INFO: Got endpoints: latency-svc-nqcnq [749.916748ms]
+Mar 20 08:57:15.559: INFO: Created: latency-svc-lc7ld
+Mar 20 08:57:15.598: INFO: Got endpoints: latency-svc-vlc82 [750.162085ms]
+Mar 20 08:57:15.607: INFO: Created: latency-svc-97vzb
+Mar 20 08:57:15.648: INFO: Got endpoints: latency-svc-tzwrs [749.524759ms]
+Mar 20 08:57:15.657: INFO: Created: latency-svc-hfsrf
+Mar 20 08:57:15.699: INFO: Got endpoints: latency-svc-wktl4 [750.763043ms]
+Mar 20 08:57:15.709: INFO: Created: latency-svc-j8rcw
+Mar 20 08:57:15.748: INFO: Got endpoints: latency-svc-nk82c [749.480992ms]
+Mar 20 08:57:15.757: INFO: Created: latency-svc-8f5n5
+Mar 20 08:57:15.798: INFO: Got endpoints: latency-svc-djhgb [749.933816ms]
+Mar 20 08:57:15.809: INFO: Created: latency-svc-hgzgj
+Mar 20 08:57:15.848: INFO: Got endpoints: latency-svc-f4mv6 [748.52994ms]
+Mar 20 08:57:15.857: INFO: Created: latency-svc-2chbp
+Mar 20 08:57:15.897: INFO: Got endpoints: latency-svc-v2vxv [749.452896ms]
+Mar 20 08:57:15.906: INFO: Created: latency-svc-wzqnl
+Mar 20 08:57:15.948: INFO: Got endpoints: latency-svc-297k9 [749.709416ms]
+Mar 20 08:57:15.956: INFO: Created: latency-svc-tp94k
+Mar 20 08:57:15.998: INFO: Got endpoints: latency-svc-jrtjm [749.64556ms]
+Mar 20 08:57:16.008: INFO: Created: latency-svc-9hf7g
+Mar 20 08:57:16.047: INFO: Got endpoints: latency-svc-h79rd [749.633475ms]
+Mar 20 08:57:16.057: INFO: Created: latency-svc-979ww
+Mar 20 08:57:16.097: INFO: Got endpoints: latency-svc-zgrg4 [749.258961ms]
+Mar 20 08:57:16.107: INFO: Created: latency-svc-bgr8j
+Mar 20 08:57:16.148: INFO: Got endpoints: latency-svc-wt25f [749.939749ms]
+Mar 20 08:57:16.157: INFO: Created: latency-svc-9cswm
+Mar 20 08:57:16.198: INFO: Got endpoints: latency-svc-c4pkd [750.433028ms]
+Mar 20 08:57:16.207: INFO: Created: latency-svc-bl9n7
+Mar 20 08:57:16.248: INFO: Got endpoints: latency-svc-bzq89 [749.504071ms]
+Mar 20 08:57:16.257: INFO: Created: latency-svc-kbn92
+Mar 20 08:57:16.298: INFO: Got endpoints: latency-svc-lc7ld [748.384829ms]
+Mar 20 08:57:16.307: INFO: Created: latency-svc-5g6wc
+Mar 20 08:57:16.347: INFO: Got endpoints: latency-svc-97vzb [749.391161ms]
+Mar 20 08:57:16.358: INFO: Created: latency-svc-2ppqp
+Mar 20 08:57:16.397: INFO: Got endpoints: latency-svc-hfsrf [749.501427ms]
+Mar 20 08:57:16.411: INFO: Created: latency-svc-q9cfv
+Mar 20 08:57:16.447: INFO: Got endpoints: latency-svc-j8rcw [748.458729ms]
+Mar 20 08:57:16.457: INFO: Created: latency-svc-s2qp9
+Mar 20 08:57:16.497: INFO: Got endpoints: latency-svc-8f5n5 [749.50272ms]
+Mar 20 08:57:16.508: INFO: Created: latency-svc-j2wc9
+Mar 20 08:57:16.551: INFO: Got endpoints: latency-svc-hgzgj [753.523714ms]
+Mar 20 08:57:16.561: INFO: Created: latency-svc-6lsb5
+Mar 20 08:57:16.598: INFO: Got endpoints: latency-svc-2chbp [749.694411ms]
+Mar 20 08:57:16.607: INFO: Created: latency-svc-85gfn
+Mar 20 08:57:16.648: INFO: Got endpoints: latency-svc-wzqnl [749.965303ms]
+Mar 20 08:57:16.659: INFO: Created: latency-svc-mj8cw
+Mar 20 08:57:16.697: INFO: Got endpoints: latency-svc-tp94k [749.856744ms]
+Mar 20 08:57:16.706: INFO: Created: latency-svc-tp486
+Mar 20 08:57:16.748: INFO: Got endpoints: latency-svc-9hf7g [749.814911ms]
+Mar 20 08:57:16.759: INFO: Created: latency-svc-h8856
+Mar 20 08:57:16.798: INFO: Got endpoints: latency-svc-979ww [750.031649ms]
+Mar 20 08:57:16.807: INFO: Created: latency-svc-pclt7
+Mar 20 08:57:16.848: INFO: Got endpoints: latency-svc-bgr8j [750.675724ms]
+Mar 20 08:57:16.858: INFO: Created: latency-svc-2rfjm
+Mar 20 08:57:16.897: INFO: Got endpoints: latency-svc-9cswm [749.888802ms]
+Mar 20 08:57:16.907: INFO: Created: latency-svc-8rz9l
+Mar 20 08:57:16.948: INFO: Got endpoints: latency-svc-bl9n7 [750.081047ms]
+Mar 20 08:57:16.958: INFO: Created: latency-svc-dqcsb
+Mar 20 08:57:16.998: INFO: Got endpoints: latency-svc-kbn92 [750.080377ms]
+Mar 20 08:57:17.007: INFO: Created: latency-svc-r6xnz
+Mar 20 08:57:17.048: INFO: Got endpoints: latency-svc-5g6wc [749.935741ms]
+Mar 20 08:57:17.058: INFO: Created: latency-svc-c7trv
+Mar 20 08:57:17.098: INFO: Got endpoints: latency-svc-2ppqp [750.553884ms]
+Mar 20 08:57:17.108: INFO: Created: latency-svc-lvr9n
+Mar 20 08:57:17.147: INFO: Got endpoints: latency-svc-q9cfv [749.418769ms]
+Mar 20 08:57:17.155: INFO: Created: latency-svc-rjfhz
+Mar 20 08:57:17.198: INFO: Got endpoints: latency-svc-s2qp9 [750.189194ms]
+Mar 20 08:57:17.207: INFO: Created: latency-svc-gdgrh
+Mar 20 08:57:17.248: INFO: Got endpoints: latency-svc-j2wc9 [750.509509ms]
+Mar 20 08:57:17.258: INFO: Created: latency-svc-vdrj4
+Mar 20 08:57:17.298: INFO: Got endpoints: latency-svc-6lsb5 [746.478323ms]
+Mar 20 08:57:17.307: INFO: Created: latency-svc-4sjzm
+Mar 20 08:57:17.348: INFO: Got endpoints: latency-svc-85gfn [750.018567ms]
+Mar 20 08:57:17.358: INFO: Created: latency-svc-hbcwq
+Mar 20 08:57:17.398: INFO: Got endpoints: latency-svc-mj8cw [750.623164ms]
+Mar 20 08:57:17.413: INFO: Created: latency-svc-qsj8l
+Mar 20 08:57:17.447: INFO: Got endpoints: latency-svc-tp486 [749.812561ms]
+Mar 20 08:57:17.456: INFO: Created: latency-svc-nf4gh
+Mar 20 08:57:17.498: INFO: Got endpoints: latency-svc-h8856 [750.240733ms]
+Mar 20 08:57:17.507: INFO: Created: latency-svc-fsbrs
+Mar 20 08:57:17.548: INFO: Got endpoints: latency-svc-pclt7 [750.328085ms]
+Mar 20 08:57:17.556: INFO: Created: latency-svc-xczfw
+Mar 20 08:57:17.599: INFO: Got endpoints: latency-svc-2rfjm [750.515984ms]
+Mar 20 08:57:17.609: INFO: Created: latency-svc-cjplw
+Mar 20 08:57:17.648: INFO: Got endpoints: latency-svc-8rz9l [750.018018ms]
+Mar 20 08:57:17.657: INFO: Created: latency-svc-97r9r
+Mar 20 08:57:17.698: INFO: Got endpoints: latency-svc-dqcsb [749.410411ms]
+Mar 20 08:57:17.706: INFO: Created: latency-svc-4hn4m
+Mar 20 08:57:17.748: INFO: Got endpoints: latency-svc-r6xnz [749.75757ms]
+Mar 20 08:57:17.756: INFO: Created: latency-svc-ksqzf
+Mar 20 08:57:17.799: INFO: Got endpoints: latency-svc-c7trv [750.878063ms]
+Mar 20 08:57:17.808: INFO: Created: latency-svc-9dcgc
+Mar 20 08:57:17.847: INFO: Got endpoints: latency-svc-lvr9n [749.080798ms]
+Mar 20 08:57:17.857: INFO: Created: latency-svc-67pbn
+Mar 20 08:57:17.898: INFO: Got endpoints: latency-svc-rjfhz [750.793299ms]
+Mar 20 08:57:17.907: INFO: Created: latency-svc-txkkd
+Mar 20 08:57:17.948: INFO: Got endpoints: latency-svc-gdgrh [749.764275ms]
+Mar 20 08:57:17.956: INFO: Created: latency-svc-25lvj
+Mar 20 08:57:17.998: INFO: Got endpoints: latency-svc-vdrj4 [749.691139ms]
+Mar 20 08:57:18.006: INFO: Created: latency-svc-v98bl
+Mar 20 08:57:18.048: INFO: Got endpoints: latency-svc-4sjzm [749.786393ms]
+Mar 20 08:57:18.056: INFO: Created: latency-svc-8vwgw
+Mar 20 08:57:18.097: INFO: Got endpoints: latency-svc-hbcwq [749.38502ms]
+Mar 20 08:57:18.109: INFO: Created: latency-svc-2sdxq
+Mar 20 08:57:18.148: INFO: Got endpoints: latency-svc-qsj8l [749.232234ms]
+Mar 20 08:57:18.158: INFO: Created: latency-svc-8625c
+Mar 20 08:57:18.197: INFO: Got endpoints: latency-svc-nf4gh [749.508408ms]
+Mar 20 08:57:18.204: INFO: Created: latency-svc-ml4n4
+Mar 20 08:57:18.247: INFO: Got endpoints: latency-svc-fsbrs [749.048487ms]
+Mar 20 08:57:18.256: INFO: Created: latency-svc-rg2s5
+Mar 20 08:57:18.297: INFO: Got endpoints: latency-svc-xczfw [749.441521ms]
+Mar 20 08:57:18.305: INFO: Created: latency-svc-m89q4
+Mar 20 08:57:18.348: INFO: Got endpoints: latency-svc-cjplw [748.50814ms]
+Mar 20 08:57:18.359: INFO: Created: latency-svc-q6jgx
+Mar 20 08:57:18.397: INFO: Got endpoints: latency-svc-97r9r [749.664295ms]
+Mar 20 08:57:18.405: INFO: Created: latency-svc-hh9xs
+Mar 20 08:57:18.448: INFO: Got endpoints: latency-svc-4hn4m [749.883014ms]
+Mar 20 08:57:18.456: INFO: Created: latency-svc-n4vnn
+Mar 20 08:57:18.498: INFO: Got endpoints: latency-svc-ksqzf [750.237925ms]
+Mar 20 08:57:18.505: INFO: Created: latency-svc-mpl67
+Mar 20 08:57:18.548: INFO: Got endpoints: latency-svc-9dcgc [748.674719ms]
+Mar 20 08:57:18.555: INFO: Created: latency-svc-d2n44
+Mar 20 08:57:18.598: INFO: Got endpoints: latency-svc-67pbn [750.241554ms]
+Mar 20 08:57:18.606: INFO: Created: latency-svc-44tw4
+Mar 20 08:57:18.647: INFO: Got endpoints: latency-svc-txkkd [749.700815ms]
+Mar 20 08:57:18.656: INFO: Created: latency-svc-qtp8z
+Mar 20 08:57:18.698: INFO: Got endpoints: latency-svc-25lvj [749.943195ms]
+Mar 20 08:57:18.705: INFO: Created: latency-svc-bqmm4
+Mar 20 08:57:18.748: INFO: Got endpoints: latency-svc-v98bl [750.538579ms]
+Mar 20 08:57:18.757: INFO: Created: latency-svc-mrqpf
+Mar 20 08:57:18.797: INFO: Got endpoints: latency-svc-8vwgw [749.571811ms]
+Mar 20 08:57:18.810: INFO: Created: latency-svc-4bzlx
+Mar 20 08:57:18.847: INFO: Got endpoints: latency-svc-2sdxq [749.924969ms]
+Mar 20 08:57:18.856: INFO: Created: latency-svc-rvqg9
+Mar 20 08:57:18.897: INFO: Got endpoints: latency-svc-8625c [749.495413ms]
+Mar 20 08:57:18.905: INFO: Created: latency-svc-zpmr6
+Mar 20 08:57:18.948: INFO: Got endpoints: latency-svc-ml4n4 [750.663033ms]
+Mar 20 08:57:18.956: INFO: Created: latency-svc-8vdcv
+Mar 20 08:57:18.999: INFO: Got endpoints: latency-svc-rg2s5 [751.48503ms]
+Mar 20 08:57:19.006: INFO: Created: latency-svc-czsl2
+Mar 20 08:57:19.048: INFO: Got endpoints: latency-svc-m89q4 [749.909643ms]
+Mar 20 08:57:19.057: INFO: Created: latency-svc-gwjfg
+Mar 20 08:57:19.098: INFO: Got endpoints: latency-svc-q6jgx [750.00637ms]
+Mar 20 08:57:19.106: INFO: Created: latency-svc-g7rh6
+Mar 20 08:57:19.147: INFO: Got endpoints: latency-svc-hh9xs [749.960464ms]
+Mar 20 08:57:19.158: INFO: Created: latency-svc-ch6bv
+Mar 20 08:57:19.198: INFO: Got endpoints: latency-svc-n4vnn [749.816073ms]
+Mar 20 08:57:19.206: INFO: Created: latency-svc-tb82v
+Mar 20 08:57:19.248: INFO: Got endpoints: latency-svc-mpl67 [750.538101ms]
+Mar 20 08:57:19.257: INFO: Created: latency-svc-gkkfg
+Mar 20 08:57:19.298: INFO: Got endpoints: latency-svc-d2n44 [749.935532ms]
+Mar 20 08:57:19.306: INFO: Created: latency-svc-hkkgh
+Mar 20 08:57:19.348: INFO: Got endpoints: latency-svc-44tw4 [750.254317ms]
+Mar 20 08:57:19.355: INFO: Created: latency-svc-jnqvp
+Mar 20 08:57:19.398: INFO: Got endpoints: latency-svc-qtp8z [749.874983ms]
+Mar 20 08:57:19.405: INFO: Created: latency-svc-nbhq5
+Mar 20 08:57:19.447: INFO: Got endpoints: latency-svc-bqmm4 [749.598318ms]
+Mar 20 08:57:19.455: INFO: Created: latency-svc-dgbjd
+Mar 20 08:57:19.497: INFO: Got endpoints: latency-svc-mrqpf [748.861588ms]
+Mar 20 08:57:19.505: INFO: Created: latency-svc-rngbj
+Mar 20 08:57:19.548: INFO: Got endpoints: latency-svc-4bzlx [750.870962ms]
+Mar 20 08:57:19.559: INFO: Created: latency-svc-6kmpb
+Mar 20 08:57:19.598: INFO: Got endpoints: latency-svc-rvqg9 [750.611575ms]
+Mar 20 08:57:19.605: INFO: Created: latency-svc-2wpn9
+Mar 20 08:57:19.647: INFO: Got endpoints: latency-svc-zpmr6 [750.051281ms]
+Mar 20 08:57:19.655: INFO: Created: latency-svc-bc885
+Mar 20 08:57:19.698: INFO: Got endpoints: latency-svc-8vdcv [750.026149ms]
+Mar 20 08:57:19.707: INFO: Created: latency-svc-24gxp
+Mar 20 08:57:19.748: INFO: Got endpoints: latency-svc-czsl2 [749.248826ms]
+Mar 20 08:57:19.756: INFO: Created: latency-svc-x2qxb
+Mar 20 08:57:19.798: INFO: Got endpoints: latency-svc-gwjfg [749.827408ms]
+Mar 20 08:57:19.806: INFO: Created: latency-svc-z9w94
+Mar 20 08:57:19.849: INFO: Got endpoints: latency-svc-g7rh6 [751.419005ms]
+Mar 20 08:57:19.857: INFO: Created: latency-svc-r4w4p
+Mar 20 08:57:19.897: INFO: Got endpoints: latency-svc-ch6bv [749.531796ms]
+Mar 20 08:57:19.948: INFO: Got endpoints: latency-svc-tb82v [749.744567ms]
+Mar 20 08:57:19.998: INFO: Got endpoints: latency-svc-gkkfg [749.018092ms]
+Mar 20 08:57:20.047: INFO: Got endpoints: latency-svc-hkkgh [749.757232ms]
+Mar 20 08:57:20.097: INFO: Got endpoints: latency-svc-jnqvp [749.408058ms]
+Mar 20 08:57:20.148: INFO: Got endpoints: latency-svc-nbhq5 [749.761624ms]
+Mar 20 08:57:20.198: INFO: Got endpoints: latency-svc-dgbjd [750.099761ms]
+Mar 20 08:57:20.248: INFO: Got endpoints: latency-svc-rngbj [750.5458ms]
+Mar 20 08:57:20.298: INFO: Got endpoints: latency-svc-6kmpb [749.461508ms]
+Mar 20 08:57:20.348: INFO: Got endpoints: latency-svc-2wpn9 [749.56347ms]
+Mar 20 08:57:20.397: INFO: Got endpoints: latency-svc-bc885 [749.81467ms]
+Mar 20 08:57:20.448: INFO: Got endpoints: latency-svc-24gxp [749.908284ms]
+Mar 20 08:57:20.498: INFO: Got endpoints: latency-svc-x2qxb [749.693052ms]
+Mar 20 08:57:20.548: INFO: Got endpoints: latency-svc-z9w94 [749.741415ms]
+Mar 20 08:57:20.598: INFO: Got endpoints: latency-svc-r4w4p [748.697017ms]
+Mar 20 08:57:20.598: INFO: Latencies: [13.385595ms 17.670819ms 21.810176ms 26.160904ms 43.880625ms 47.434294ms 53.066219ms 63.596557ms 67.747757ms 79.194823ms 83.534898ms 104.825734ms 126.731395ms 129.137629ms 135.802804ms 138.237043ms 139.578257ms 143.626167ms 146.058592ms 147.322749ms 147.605302ms 149.799701ms 152.953644ms 155.149997ms 155.860581ms 156.142478ms 157.189011ms 157.827242ms 160.915353ms 162.049359ms 164.010495ms 164.80229ms 165.297266ms 166.567217ms 169.43788ms 172.194872ms 173.733661ms 185.303091ms 210.572731ms 263.18166ms 300.437129ms 327.259732ms 371.599426ms 408.883816ms 455.020972ms 492.940312ms 538.284707ms 568.517211ms 614.217235ms 652.149154ms 697.647801ms 736.16608ms 743.114387ms 743.363693ms 744.284456ms 744.972409ms 746.478323ms 748.384829ms 748.458729ms 748.50814ms 748.52994ms 748.674719ms 748.687606ms 748.697017ms 748.861588ms 749.018092ms 749.028226ms 749.048487ms 749.080798ms 749.107843ms 749.126193ms 749.232234ms 749.248826ms 749.258961ms 749.38502ms 749.391161ms 749.408058ms 749.410411ms 749.418769ms 749.441521ms 749.452896ms 749.461508ms 749.480992ms 749.495413ms 749.501427ms 749.50272ms 749.504071ms 749.508408ms 749.521054ms 749.524759ms 749.531796ms 749.56347ms 749.571811ms 749.598318ms 749.619584ms 749.633475ms 749.64556ms 749.664295ms 749.669247ms 749.691139ms 749.693052ms 749.694411ms 749.700815ms 749.709416ms 749.727649ms 749.737055ms 749.741415ms 749.744567ms 749.757232ms 749.75757ms 749.761624ms 749.764275ms 749.786393ms 749.812561ms 749.814615ms 749.81467ms 749.814911ms 749.816073ms 749.817484ms 749.827408ms 749.856744ms 749.857343ms 749.87361ms 749.874983ms 749.883014ms 749.884165ms 749.888802ms 749.908284ms 749.909643ms 749.915557ms 749.916748ms 749.918767ms 749.924969ms 749.933816ms 749.935177ms 749.935532ms 749.935741ms 749.939749ms 749.943195ms 749.960464ms 749.965303ms 749.975272ms 750.005013ms 750.00637ms 750.018018ms 750.018567ms 750.022899ms 750.026149ms 750.031084ms 750.031607ms 750.031649ms 750.051281ms 750.060998ms 750.080377ms 750.081047ms 750.099761ms 750.159644ms 750.162085ms 750.189194ms 750.192132ms 750.237925ms 750.240733ms 750.241554ms 750.241677ms 750.244577ms 750.254317ms 750.312269ms 750.319741ms 750.328085ms 750.332055ms 750.388201ms 750.419015ms 750.433028ms 750.439572ms 750.440129ms 750.454645ms 750.509509ms 750.515984ms 750.538101ms 750.538579ms 750.5458ms 750.553884ms 750.570767ms 750.611575ms 750.623164ms 750.640493ms 750.663033ms 750.675724ms 750.676302ms 750.763043ms 750.793299ms 750.870962ms 750.878063ms 751.052081ms 751.072872ms 751.419005ms 751.462852ms 751.48503ms 753.162813ms 753.523714ms]
+Mar 20 08:57:20.598: INFO: 50 %ile: 749.693052ms
+Mar 20 08:57:20.598: INFO: 90 %ile: 750.5458ms
+Mar 20 08:57:20.598: INFO: 99 %ile: 753.162813ms
+Mar 20 08:57:20.598: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:57:20.598: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-m5vsp" for this suite.
+Mar 20 08:57:34.608: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:57:34.653: INFO: namespace: e2e-tests-svc-latency-m5vsp, resource: bindings, ignored listing per whitelist
+Mar 20 08:57:34.706: INFO: namespace e2e-tests-svc-latency-m5vsp deletion completed in 14.104252169s
+
+• [SLOW TEST:24.762 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:57:34.706: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:37
+[It] should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test hostPath mode
+Mar 20 08:57:34.748: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-rhzr8" to be "success or failure"
+Mar 20 08:57:34.750: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 2.088116ms
+Mar 20 08:57:36.753: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005169953s
+STEP: Saw pod success
+Mar 20 08:57:36.753: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Mar 20 08:57:36.755: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Mar 20 08:57:36.770: INFO: Waiting for pod pod-host-path-test to disappear
+Mar 20 08:57:36.773: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:57:36.773: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-rhzr8" for this suite.
+Mar 20 08:57:42.784: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:57:42.813: INFO: namespace: e2e-tests-hostpath-rhzr8, resource: bindings, ignored listing per whitelist
+Mar 20 08:57:42.875: INFO: namespace e2e-tests-hostpath-rhzr8 deletion completed in 6.098505567s
+
+• [SLOW TEST:8.169 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:34
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:57:42.875: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-map-c0241227-2c1c-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 08:57:42.917: INFO: Waiting up to 5m0s for pod "pod-configmaps-c0249d75-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-configmap-rrmng" to be "success or failure"
+Mar 20 08:57:42.919: INFO: Pod "pod-configmaps-c0249d75-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.849513ms
+Mar 20 08:57:44.922: INFO: Pod "pod-configmaps-c0249d75-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005008772s
+STEP: Saw pod success
+Mar 20 08:57:44.922: INFO: Pod "pod-configmaps-c0249d75-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:57:44.924: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-configmaps-c0249d75-2c1c-11e8-bd77-b6fcf399588c container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 08:57:44.938: INFO: Waiting for pod pod-configmaps-c0249d75-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:57:44.940: INFO: Pod pod-configmaps-c0249d75-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:57:44.940: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-rrmng" for this suite.
+Mar 20 08:57:50.953: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:57:50.989: INFO: namespace: e2e-tests-configmap-rrmng, resource: bindings, ignored listing per whitelist
+Mar 20 08:57:51.046: INFO: namespace e2e-tests-configmap-rrmng deletion completed in 6.103842752s
+
+• [SLOW TEST:8.171 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:57:51.046: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:57:51.095: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c503f782-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-brkhv" to be "success or failure"
+Mar 20 08:57:51.097: INFO: Pod "downwardapi-volume-c503f782-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.762471ms
+Mar 20 08:57:53.100: INFO: Pod "downwardapi-volume-c503f782-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005319548s
+STEP: Saw pod success
+Mar 20 08:57:53.101: INFO: Pod "downwardapi-volume-c503f782-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:57:53.103: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod downwardapi-volume-c503f782-2c1c-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:57:53.117: INFO: Waiting for pod downwardapi-volume-c503f782-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:57:53.125: INFO: Pod downwardapi-volume-c503f782-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:57:53.125: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-brkhv" for this suite.
+Mar 20 08:57:59.137: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:57:59.192: INFO: namespace: e2e-tests-downward-api-brkhv, resource: bindings, ignored listing per whitelist
+Mar 20 08:57:59.233: INFO: namespace e2e-tests-downward-api-brkhv deletion completed in 6.103958182s
+
+• [SLOW TEST:8.186 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:57:59.233: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:57:59.274: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c9e47684-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-4g8j7" to be "success or failure"
+Mar 20 08:57:59.276: INFO: Pod "downwardapi-volume-c9e47684-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.132676ms
+Mar 20 08:58:01.280: INFO: Pod "downwardapi-volume-c9e47684-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.0059077s
+Mar 20 08:58:03.284: INFO: Pod "downwardapi-volume-c9e47684-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009712094s
+STEP: Saw pod success
+Mar 20 08:58:03.284: INFO: Pod "downwardapi-volume-c9e47684-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:58:03.287: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downwardapi-volume-c9e47684-2c1c-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:58:03.302: INFO: Waiting for pod downwardapi-volume-c9e47684-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:58:03.305: INFO: Pod downwardapi-volume-c9e47684-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:58:03.305: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-4g8j7" for this suite.
+Mar 20 08:58:09.316: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:58:09.392: INFO: namespace: e2e-tests-downward-api-4g8j7, resource: bindings, ignored listing per whitelist
+Mar 20 08:58:09.412: INFO: namespace e2e-tests-downward-api-4g8j7 deletion completed in 6.104386372s
+
+• [SLOW TEST:10.179 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:58:09.412: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Mar 20 08:58:09.961: INFO: Waiting up to 5m0s for pod "pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-5spmp" in namespace "e2e-tests-svcaccounts-lw44g" to be "success or failure"
+Mar 20 08:58:09.963: INFO: Pod "pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-5spmp": Phase="Pending", Reason="", readiness=false. Elapsed: 2.388783ms
+Mar 20 08:58:11.966: INFO: Pod "pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-5spmp": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005528217s
+STEP: Saw pod success
+Mar 20 08:58:11.966: INFO: Pod "pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-5spmp" satisfied condition "success or failure"
+Mar 20 08:58:11.969: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-5spmp container token-test: <nil>
+STEP: delete the pod
+Mar 20 08:58:11.982: INFO: Waiting for pod pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-5spmp to disappear
+Mar 20 08:58:11.984: INFO: Pod pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-5spmp no longer exists
+STEP: Creating a pod to test consume service account root CA
+Mar 20 08:58:11.986: INFO: Waiting up to 5m0s for pod "pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-tgzt4" in namespace "e2e-tests-svcaccounts-lw44g" to be "success or failure"
+Mar 20 08:58:11.988: INFO: Pod "pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-tgzt4": Phase="Pending", Reason="", readiness=false. Elapsed: 1.97271ms
+Mar 20 08:58:13.993: INFO: Pod "pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-tgzt4": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006463571s
+STEP: Saw pod success
+Mar 20 08:58:13.993: INFO: Pod "pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-tgzt4" satisfied condition "success or failure"
+Mar 20 08:58:13.995: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-tgzt4 container root-ca-test: <nil>
+STEP: delete the pod
+Mar 20 08:58:14.008: INFO: Waiting for pod pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-tgzt4 to disappear
+Mar 20 08:58:14.010: INFO: Pod pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-tgzt4 no longer exists
+STEP: Creating a pod to test consume service account namespace
+Mar 20 08:58:14.012: INFO: Waiting up to 5m0s for pod "pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-t89mc" in namespace "e2e-tests-svcaccounts-lw44g" to be "success or failure"
+Mar 20 08:58:14.014: INFO: Pod "pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-t89mc": Phase="Pending", Reason="", readiness=false. Elapsed: 1.991361ms
+Mar 20 08:58:16.017: INFO: Pod "pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-t89mc": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005229712s
+STEP: Saw pod success
+Mar 20 08:58:16.017: INFO: Pod "pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-t89mc" satisfied condition "success or failure"
+Mar 20 08:58:16.020: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-t89mc container namespace-test: <nil>
+STEP: delete the pod
+Mar 20 08:58:16.035: INFO: Waiting for pod pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-t89mc to disappear
+Mar 20 08:58:16.037: INFO: Pod pod-service-account-d04327fb-2c1c-11e8-bd77-b6fcf399588c-t89mc no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:58:16.037: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-lw44g" for this suite.
+Mar 20 08:58:22.047: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:58:22.121: INFO: namespace: e2e-tests-svcaccounts-lw44g, resource: bindings, ignored listing per whitelist
+Mar 20 08:58:22.145: INFO: namespace e2e-tests-svcaccounts-lw44g deletion completed in 6.105151509s
+
+• [SLOW TEST:12.733 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:58:22.145: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 20 08:58:22.190: INFO: (0) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.000622ms)
+Mar 20 08:58:22.196: INFO: (1) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.269319ms)
+Mar 20 08:58:22.199: INFO: (2) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.676163ms)
+Mar 20 08:58:22.203: INFO: (3) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.767881ms)
+Mar 20 08:58:22.207: INFO: (4) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.16209ms)
+Mar 20 08:58:22.211: INFO: (5) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.674103ms)
+Mar 20 08:58:22.215: INFO: (6) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.375373ms)
+Mar 20 08:58:22.218: INFO: (7) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.495667ms)
+Mar 20 08:58:22.222: INFO: (8) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.574924ms)
+Mar 20 08:58:22.226: INFO: (9) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.905266ms)
+Mar 20 08:58:22.229: INFO: (10) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.58151ms)
+Mar 20 08:58:22.233: INFO: (11) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.685571ms)
+Mar 20 08:58:22.237: INFO: (12) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.799056ms)
+Mar 20 08:58:22.240: INFO: (13) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.70881ms)
+Mar 20 08:58:22.244: INFO: (14) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.725518ms)
+Mar 20 08:58:22.248: INFO: (15) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.802476ms)
+Mar 20 08:58:22.252: INFO: (16) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.64663ms)
+Mar 20 08:58:22.255: INFO: (17) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.58449ms)
+Mar 20 08:58:22.259: INFO: (18) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.610443ms)
+Mar 20 08:58:22.263: INFO: (19) /api/v1/proxy/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.661688ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:58:22.263: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-dl5l4" for this suite.
+Mar 20 08:58:28.273: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:58:28.335: INFO: namespace: e2e-tests-proxy-dl5l4, resource: bindings, ignored listing per whitelist
+Mar 20 08:58:28.367: INFO: namespace e2e-tests-proxy-dl5l4 deletion completed in 6.101435897s
+
+• [SLOW TEST:6.222 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node with explicit kubelet port  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:58:28.367: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 20 08:58:30.930: INFO: Successfully updated pod "labelsupdatedb41fae6-2c1c-11e8-bd77-b6fcf399588c"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:58:34.956: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-fhvn2" for this suite.
+Mar 20 08:58:56.971: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:58:57.022: INFO: namespace: e2e-tests-downward-api-fhvn2, resource: bindings, ignored listing per whitelist
+Mar 20 08:58:57.066: INFO: namespace e2e-tests-downward-api-fhvn2 deletion completed in 22.107584024s
+
+• [SLOW TEST:28.699 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:58:57.066: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 08:58:57.118: INFO: Waiting up to 5m0s for pod "downwardapi-volume-ec5e5b7e-2c1c-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-pc64d" to be "success or failure"
+Mar 20 08:58:57.120: INFO: Pod "downwardapi-volume-ec5e5b7e-2c1c-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.55348ms
+Mar 20 08:58:59.124: INFO: Pod "downwardapi-volume-ec5e5b7e-2c1c-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006302202s
+STEP: Saw pod success
+Mar 20 08:58:59.124: INFO: Pod "downwardapi-volume-ec5e5b7e-2c1c-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 08:58:59.126: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downwardapi-volume-ec5e5b7e-2c1c-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 08:58:59.142: INFO: Waiting for pod downwardapi-volume-ec5e5b7e-2c1c-11e8-bd77-b6fcf399588c to disappear
+Mar 20 08:58:59.144: INFO: Pod downwardapi-volume-ec5e5b7e-2c1c-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 08:58:59.144: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-pc64d" for this suite.
+Mar 20 08:59:05.154: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 08:59:05.235: INFO: namespace: e2e-tests-downward-api-pc64d, resource: bindings, ignored listing per whitelist
+Mar 20 08:59:05.246: INFO: namespace e2e-tests-downward-api-pc64d deletion completed in 6.099596262s
+
+• [SLOW TEST:8.180 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 08:59:05.246: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-b9qjk
+Mar 20 08:59:07.291: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-b9qjk
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 20 08:59:07.293: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:01:07.499: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-b9qjk" for this suite.
+Mar 20 09:01:13.511: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:01:13.559: INFO: namespace: e2e-tests-container-probe-b9qjk, resource: bindings, ignored listing per whitelist
+Mar 20 09:01:13.603: INFO: namespace e2e-tests-container-probe-b9qjk deletion completed in 6.100467573s
+
+• [SLOW TEST:128.356 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:01:13.603: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-3dbf0ad2-2c1d-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 09:01:13.648: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-3dbf9819-2c1d-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-l4svf" to be "success or failure"
+Mar 20 09:01:13.650: INFO: Pod "pod-projected-configmaps-3dbf9819-2c1d-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.831143ms
+Mar 20 09:01:15.653: INFO: Pod "pod-projected-configmaps-3dbf9819-2c1d-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005424908s
+STEP: Saw pod success
+Mar 20 09:01:15.653: INFO: Pod "pod-projected-configmaps-3dbf9819-2c1d-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 09:01:15.656: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-projected-configmaps-3dbf9819-2c1d-11e8-bd77-b6fcf399588c container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 09:01:15.671: INFO: Waiting for pod pod-projected-configmaps-3dbf9819-2c1d-11e8-bd77-b6fcf399588c to disappear
+Mar 20 09:01:15.673: INFO: Pod pod-projected-configmaps-3dbf9819-2c1d-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:01:15.673: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-l4svf" for this suite.
+Mar 20 09:01:21.688: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:01:21.765: INFO: namespace: e2e-tests-projected-l4svf, resource: bindings, ignored listing per whitelist
+Mar 20 09:01:21.783: INFO: namespace e2e-tests-projected-l4svf deletion completed in 6.104027412s
+
+• [SLOW TEST:8.180 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] Pods 
+  should be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:01:21.783: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Mar 20 09:01:24.341: INFO: Successfully updated pod "pod-update-429f1f4d-2c1d-11e8-bd77-b6fcf399588c"
+STEP: verifying the updated pod is in kubernetes
+Mar 20 09:01:24.346: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:01:24.346: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-r7xjw" for this suite.
+Mar 20 09:01:46.357: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:01:46.432: INFO: namespace: e2e-tests-pods-r7xjw, resource: bindings, ignored listing per whitelist
+Mar 20 09:01:46.451: INFO: namespace e2e-tests-pods-r7xjw deletion completed in 22.102346862s
+
+• [SLOW TEST:24.668 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:01:46.451: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-4v4j9
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 20 09:01:46.490: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 20 09:02:08.534: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.4.56:8080/dial?request=hostName&protocol=udp&host=100.96.4.55&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-4v4j9 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 09:02:08.534: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 09:02:08.644: INFO: Waiting for endpoints: map[]
+Mar 20 09:02:08.647: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.4.56:8080/dial?request=hostName&protocol=udp&host=100.96.5.78&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-4v4j9 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 20 09:02:08.647: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+Mar 20 09:02:08.795: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:02:08.795: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-4v4j9" for this suite.
+Mar 20 09:02:30.807: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:02:30.859: INFO: namespace: e2e-tests-pod-network-test-4v4j9, resource: bindings, ignored listing per whitelist
+Mar 20 09:02:30.906: INFO: namespace e2e-tests-pod-network-test-4v4j9 deletion completed in 22.107003388s
+
+• [SLOW TEST:44.455 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:02:30.906: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:51
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-mbbb9
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-mbbb9 to expose endpoints map[]
+Mar 20 09:02:30.955: INFO: Get endpoints failed (2.139105ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Mar 20 09:02:31.958: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-mbbb9 exposes endpoints map[] (1.005694634s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-mbbb9
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-mbbb9 to expose endpoints map[pod1:[100]]
+Mar 20 09:02:33.981: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-mbbb9 exposes endpoints map[pod1:[100]] (2.017193042s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-mbbb9
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-mbbb9 to expose endpoints map[pod1:[100] pod2:[101]]
+Mar 20 09:02:36.006: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-mbbb9 exposes endpoints map[pod1:[100] pod2:[101]] (2.020449548s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-mbbb9
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-mbbb9 to expose endpoints map[pod2:[101]]
+Mar 20 09:02:37.019: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-mbbb9 exposes endpoints map[pod2:[101]] (1.009247635s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-mbbb9
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-mbbb9 to expose endpoints map[]
+Mar 20 09:02:38.029: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-mbbb9 exposes endpoints map[] (1.00665019s elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:02:38.039: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-mbbb9" for this suite.
+Mar 20 09:02:44.050: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:02:44.081: INFO: namespace: e2e-tests-services-mbbb9, resource: bindings, ignored listing per whitelist
+Mar 20 09:02:44.147: INFO: namespace e2e-tests-services-mbbb9 deletion completed in 6.105146892s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:56
+
+• [SLOW TEST:13.241 seconds]
+[sig-network] Services
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:02:44.147: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:03:44.191: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-mrtgd" for this suite.
+Mar 20 09:04:06.203: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:04:06.262: INFO: namespace: e2e-tests-container-probe-mrtgd, resource: bindings, ignored listing per whitelist
+Mar 20 09:04:06.301: INFO: namespace e2e-tests-container-probe-mrtgd deletion completed in 22.10650045s
+
+• [SLOW TEST:82.154 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:04:06.301: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 20 09:04:08.869: INFO: Successfully updated pod "annotationupdatea4aedc74-2c1d-11e8-bd77-b6fcf399588c"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:05:43.661: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-zrfvp" for this suite.
+Mar 20 09:06:05.673: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:06:05.719: INFO: namespace: e2e-tests-projected-zrfvp, resource: bindings, ignored listing per whitelist
+Mar 20 09:06:05.763: INFO: namespace e2e-tests-projected-zrfvp deletion completed in 22.098347252s
+
+• [SLOW TEST:119.461 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default commmand (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:06:05.763: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default commmand (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test override command
+Mar 20 09:06:05.803: INFO: Waiting up to 5m0s for pod "client-containers-ebe300a0-2c1d-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-containers-8tgb9" to be "success or failure"
+Mar 20 09:06:05.804: INFO: Pod "client-containers-ebe300a0-2c1d-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.796189ms
+Mar 20 09:06:07.808: INFO: Pod "client-containers-ebe300a0-2c1d-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004993333s
+STEP: Saw pod success
+Mar 20 09:06:07.808: INFO: Pod "client-containers-ebe300a0-2c1d-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 09:06:07.810: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod client-containers-ebe300a0-2c1d-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 09:06:07.825: INFO: Waiting for pod client-containers-ebe300a0-2c1d-11e8-bd77-b6fcf399588c to disappear
+Mar 20 09:06:07.828: INFO: Pod client-containers-ebe300a0-2c1d-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:06:07.829: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-8tgb9" for this suite.
+Mar 20 09:06:13.841: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:06:13.885: INFO: namespace: e2e-tests-containers-8tgb9, resource: bindings, ignored listing per whitelist
+Mar 20 09:06:13.938: INFO: namespace e2e-tests-containers-8tgb9 deletion completed in 6.106193192s
+
+• [SLOW TEST:8.176 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be able to override the image's default commmand (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:06:13.938: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-map-f0c24a5e-2c1d-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume configMaps
+Mar 20 09:06:13.980: INFO: Waiting up to 5m0s for pod "pod-configmaps-f0c2a937-2c1d-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-configmap-24br9" to be "success or failure"
+Mar 20 09:06:13.982: INFO: Pod "pod-configmaps-f0c2a937-2c1d-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.975016ms
+Mar 20 09:06:15.985: INFO: Pod "pod-configmaps-f0c2a937-2c1d-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005176333s
+STEP: Saw pod success
+Mar 20 09:06:15.985: INFO: Pod "pod-configmaps-f0c2a937-2c1d-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 09:06:15.987: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod pod-configmaps-f0c2a937-2c1d-11e8-bd77-b6fcf399588c container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 20 09:06:16.001: INFO: Waiting for pod pod-configmaps-f0c2a937-2c1d-11e8-bd77-b6fcf399588c to disappear
+Mar 20 09:06:16.003: INFO: Pod pod-configmaps-f0c2a937-2c1d-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:06:16.003: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-24br9" for this suite.
+Mar 20 09:06:22.014: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:06:22.121: INFO: namespace: e2e-tests-configmap-24br9, resource: bindings, ignored listing per whitelist
+Mar 20 09:06:22.123: INFO: namespace e2e-tests-configmap-24br9 deletion completed in 6.117143713s
+
+• [SLOW TEST:8.184 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:06:22.123: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 09:06:22.165: INFO: Waiting up to 5m0s for pod "downwardapi-volume-f5a39a07-2c1d-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-7hqf8" to be "success or failure"
+Mar 20 09:06:22.167: INFO: Pod "downwardapi-volume-f5a39a07-2c1d-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.048774ms
+Mar 20 09:06:24.170: INFO: Pod "downwardapi-volume-f5a39a07-2c1d-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005234405s
+Mar 20 09:06:26.174: INFO: Pod "downwardapi-volume-f5a39a07-2c1d-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009059516s
+STEP: Saw pod success
+Mar 20 09:06:26.174: INFO: Pod "downwardapi-volume-f5a39a07-2c1d-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 09:06:26.177: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod downwardapi-volume-f5a39a07-2c1d-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 09:06:26.194: INFO: Waiting for pod downwardapi-volume-f5a39a07-2c1d-11e8-bd77-b6fcf399588c to disappear
+Mar 20 09:06:26.196: INFO: Pod downwardapi-volume-f5a39a07-2c1d-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:06:26.197: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-7hqf8" for this suite.
+Mar 20 09:06:32.209: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:06:32.266: INFO: namespace: e2e-tests-projected-7hqf8, resource: bindings, ignored listing per whitelist
+Mar 20 09:06:32.306: INFO: namespace e2e-tests-projected-7hqf8 deletion completed in 6.10638172s
+
+• [SLOW TEST:10.183 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:06:32.306: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-upd-fbb5e5cf-2c1d-11e8-bd77-b6fcf399588c
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-fbb5e5cf-2c1d-11e8-bd77-b6fcf399588c
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:06:36.430: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-q4sjr" for this suite.
+Mar 20 09:06:58.442: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:06:58.481: INFO: namespace: e2e-tests-configmap-q4sjr, resource: bindings, ignored listing per whitelist
+Mar 20 09:06:58.550: INFO: namespace e2e-tests-configmap-q4sjr deletion completed in 22.116760971s
+
+• [SLOW TEST:26.244 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:06:58.551: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-0b5a2d6a-2c1e-11e8-bd77-b6fcf399588c
+STEP: Creating a pod to test consume secrets
+Mar 20 09:06:58.597: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-0b5a914b-2c1e-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-4xcdh" to be "success or failure"
+Mar 20 09:06:58.599: INFO: Pod "pod-projected-secrets-0b5a914b-2c1e-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.060466ms
+Mar 20 09:07:00.602: INFO: Pod "pod-projected-secrets-0b5a914b-2c1e-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005130604s
+STEP: Saw pod success
+Mar 20 09:07:00.602: INFO: Pod "pod-projected-secrets-0b5a914b-2c1e-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 09:07:00.604: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod pod-projected-secrets-0b5a914b-2c1e-11e8-bd77-b6fcf399588c container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 20 09:07:00.619: INFO: Waiting for pod pod-projected-secrets-0b5a914b-2c1e-11e8-bd77-b6fcf399588c to disappear
+Mar 20 09:07:00.622: INFO: Pod pod-projected-secrets-0b5a914b-2c1e-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:07:00.622: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4xcdh" for this suite.
+Mar 20 09:07:06.635: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:07:06.729: INFO: namespace: e2e-tests-projected-4xcdh, resource: bindings, ignored listing per whitelist
+Mar 20 09:07:06.739: INFO: namespace e2e-tests-projected-4xcdh deletion completed in 6.113643164s
+
+• [SLOW TEST:8.189 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:07:06.739: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-hhrb2
+Mar 20 09:07:10.786: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-hhrb2
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 20 09:07:10.788: INFO: Initial restart count of pod liveness-exec is 0
+Mar 20 09:08:02.882: INFO: Restart count of pod e2e-tests-container-probe-hhrb2/liveness-exec is now 1 (52.093811667s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:08:02.888: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-hhrb2" for this suite.
+Mar 20 09:08:08.899: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:08:08.992: INFO: namespace: e2e-tests-container-probe-hhrb2, resource: bindings, ignored listing per whitelist
+Mar 20 09:08:08.994: INFO: namespace e2e-tests-container-probe-hhrb2 deletion completed in 6.102330048s
+
+• [SLOW TEST:62.255 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:08:08.994: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 20 09:08:09.041: INFO: (0) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.903158ms)
+Mar 20 09:08:09.045: INFO: (1) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.604184ms)
+Mar 20 09:08:09.049: INFO: (2) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.916468ms)
+Mar 20 09:08:09.053: INFO: (3) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.922091ms)
+Mar 20 09:08:09.056: INFO: (4) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.844293ms)
+Mar 20 09:08:09.060: INFO: (5) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.635512ms)
+Mar 20 09:08:09.064: INFO: (6) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.003404ms)
+Mar 20 09:08:09.069: INFO: (7) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.061183ms)
+Mar 20 09:08:09.073: INFO: (8) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.318495ms)
+Mar 20 09:08:09.076: INFO: (9) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.756881ms)
+Mar 20 09:08:09.080: INFO: (10) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.492588ms)
+Mar 20 09:08:09.084: INFO: (11) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.623999ms)
+Mar 20 09:08:09.088: INFO: (12) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.106116ms)
+Mar 20 09:08:09.092: INFO: (13) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.482774ms)
+Mar 20 09:08:09.096: INFO: (14) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.756388ms)
+Mar 20 09:08:09.099: INFO: (15) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.306732ms)
+Mar 20 09:08:09.103: INFO: (16) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.623897ms)
+Mar 20 09:08:09.107: INFO: (17) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.453348ms)
+Mar 20 09:08:09.110: INFO: (18) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.126728ms)
+Mar 20 09:08:09.113: INFO: (19) /api/v1/nodes/shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.531418ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:08:09.113: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-spf6j" for this suite.
+Mar 20 09:08:15.125: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:08:15.178: INFO: namespace: e2e-tests-proxy-spf6j, resource: bindings, ignored listing per whitelist
+Mar 20 09:08:15.218: INFO: namespace e2e-tests-proxy-spf6j deletion completed in 6.100338038s
+
+• [SLOW TEST:6.224 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:08:15.218: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 09:08:15.259: INFO: Waiting up to 5m0s for pod "downwardapi-volume-390c44c8-2c1e-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-projected-r49b7" to be "success or failure"
+Mar 20 09:08:15.261: INFO: Pod "downwardapi-volume-390c44c8-2c1e-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.830704ms
+Mar 20 09:08:17.264: INFO: Pod "downwardapi-volume-390c44c8-2c1e-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005082074s
+Mar 20 09:08:19.268: INFO: Pod "downwardapi-volume-390c44c8-2c1e-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008963884s
+STEP: Saw pod success
+Mar 20 09:08:19.268: INFO: Pod "downwardapi-volume-390c44c8-2c1e-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 09:08:19.270: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downwardapi-volume-390c44c8-2c1e-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 09:08:19.285: INFO: Waiting for pod downwardapi-volume-390c44c8-2c1e-11e8-bd77-b6fcf399588c to disappear
+Mar 20 09:08:19.287: INFO: Pod downwardapi-volume-390c44c8-2c1e-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:08:19.287: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-r49b7" for this suite.
+Mar 20 09:08:25.299: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:08:25.364: INFO: namespace: e2e-tests-projected-r49b7, resource: bindings, ignored listing per whitelist
+Mar 20 09:08:25.395: INFO: namespace e2e-tests-projected-r49b7 deletion completed in 6.104739542s
+
+• [SLOW TEST:10.177 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:08:25.395: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 20 09:08:25.440: INFO: Waiting up to 5m0s for pod "downward-api-3f1dd68b-2c1e-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-hlpr2" to be "success or failure"
+Mar 20 09:08:25.442: INFO: Pod "downward-api-3f1dd68b-2c1e-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.086338ms
+Mar 20 09:08:27.446: INFO: Pod "downward-api-3f1dd68b-2c1e-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00554084s
+Mar 20 09:08:29.449: INFO: Pod "downward-api-3f1dd68b-2c1e-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009059465s
+STEP: Saw pod success
+Mar 20 09:08:29.449: INFO: Pod "downward-api-3f1dd68b-2c1e-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 09:08:29.452: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downward-api-3f1dd68b-2c1e-11e8-bd77-b6fcf399588c container dapi-container: <nil>
+STEP: delete the pod
+Mar 20 09:08:29.468: INFO: Waiting for pod downward-api-3f1dd68b-2c1e-11e8-bd77-b6fcf399588c to disappear
+Mar 20 09:08:29.470: INFO: Pod downward-api-3f1dd68b-2c1e-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:08:29.470: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-hlpr2" for this suite.
+Mar 20 09:08:35.481: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:08:35.522: INFO: namespace: e2e-tests-downward-api-hlpr2, resource: bindings, ignored listing per whitelist
+Mar 20 09:08:35.581: INFO: namespace e2e-tests-downward-api-hlpr2 deletion completed in 6.108315084s
+
+• [SLOW TEST:10.186 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:08:35.581: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-nnq47
+Mar 20 09:08:37.629: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-nnq47
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 20 09:08:37.631: INFO: Initial restart count of pod liveness-http is 0
+Mar 20 09:08:53.660: INFO: Restart count of pod e2e-tests-container-probe-nnq47/liveness-http is now 1 (16.029142236s elapsed)
+Mar 20 09:09:13.694: INFO: Restart count of pod e2e-tests-container-probe-nnq47/liveness-http is now 2 (36.063245789s elapsed)
+Mar 20 09:09:33.727: INFO: Restart count of pod e2e-tests-container-probe-nnq47/liveness-http is now 3 (56.096232877s elapsed)
+Mar 20 09:09:53.759: INFO: Restart count of pod e2e-tests-container-probe-nnq47/liveness-http is now 4 (1m16.127990667s elapsed)
+Mar 20 09:11:05.880: INFO: Restart count of pod e2e-tests-container-probe-nnq47/liveness-http is now 5 (2m28.249498162s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:11:05.890: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-nnq47" for this suite.
+Mar 20 09:11:11.904: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:11:11.968: INFO: namespace: e2e-tests-container-probe-nnq47, resource: bindings, ignored listing per whitelist
+Mar 20 09:11:11.997: INFO: namespace e2e-tests-container-probe-nnq47 deletion completed in 6.101040022s
+
+• [SLOW TEST:156.416 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:11:11.997: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 09:11:12.039: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a26ad589-2c1e-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-cd8vm" to be "success or failure"
+Mar 20 09:11:12.041: INFO: Pod "downwardapi-volume-a26ad589-2c1e-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.82752ms
+Mar 20 09:11:14.045: INFO: Pod "downwardapi-volume-a26ad589-2c1e-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005448164s
+STEP: Saw pod success
+Mar 20 09:11:14.045: INFO: Pod "downwardapi-volume-a26ad589-2c1e-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 09:11:14.047: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downwardapi-volume-a26ad589-2c1e-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 09:11:14.061: INFO: Waiting for pod downwardapi-volume-a26ad589-2c1e-11e8-bd77-b6fcf399588c to disappear
+Mar 20 09:11:14.063: INFO: Pod downwardapi-volume-a26ad589-2c1e-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:11:14.063: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-cd8vm" for this suite.
+Mar 20 09:11:20.074: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:11:20.138: INFO: namespace: e2e-tests-downward-api-cd8vm, resource: bindings, ignored listing per whitelist
+Mar 20 09:11:20.174: INFO: namespace e2e-tests-downward-api-cd8vm deletion completed in 6.108306239s
+
+• [SLOW TEST:8.177 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:11:20.174: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating replication controller my-hostname-basic-a74a2494-2c1e-11e8-bd77-b6fcf399588c
+Mar 20 09:11:20.218: INFO: Pod name my-hostname-basic-a74a2494-2c1e-11e8-bd77-b6fcf399588c: Found 0 pods out of 1
+Mar 20 09:11:25.222: INFO: Pod name my-hostname-basic-a74a2494-2c1e-11e8-bd77-b6fcf399588c: Found 1 pods out of 1
+Mar 20 09:11:25.222: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-a74a2494-2c1e-11e8-bd77-b6fcf399588c" are running
+Mar 20 09:11:25.225: INFO: Pod "my-hostname-basic-a74a2494-2c1e-11e8-bd77-b6fcf399588c-5l5f2" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-20 09:11:20 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-20 09:11:21 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-20 09:11:20 +0000 UTC Reason: Message:}])
+Mar 20 09:11:25.225: INFO: Trying to dial the pod
+Mar 20 09:11:30.278: INFO: Controller my-hostname-basic-a74a2494-2c1e-11e8-bd77-b6fcf399588c: Got expected result from replica 1 [my-hostname-basic-a74a2494-2c1e-11e8-bd77-b6fcf399588c-5l5f2]: "my-hostname-basic-a74a2494-2c1e-11e8-bd77-b6fcf399588c-5l5f2", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:11:30.278: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-fnqrt" for this suite.
+Mar 20 09:11:36.290: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:11:36.337: INFO: namespace: e2e-tests-replication-controller-fnqrt, resource: bindings, ignored listing per whitelist
+Mar 20 09:11:36.390: INFO: namespace e2e-tests-replication-controller-fnqrt deletion completed in 6.108403963s
+
+• [SLOW TEST:16.216 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:11:36.390: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 09:11:36.433: INFO: Waiting up to 5m0s for pod "downwardapi-volume-b0f4fa1e-2c1e-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-8bgtz" to be "success or failure"
+Mar 20 09:11:36.434: INFO: Pod "downwardapi-volume-b0f4fa1e-2c1e-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.825581ms
+Mar 20 09:11:38.438: INFO: Pod "downwardapi-volume-b0f4fa1e-2c1e-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005611s
+STEP: Saw pod success
+Mar 20 09:11:38.438: INFO: Pod "downwardapi-volume-b0f4fa1e-2c1e-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 09:11:38.441: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downwardapi-volume-b0f4fa1e-2c1e-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 09:11:38.454: INFO: Waiting for pod downwardapi-volume-b0f4fa1e-2c1e-11e8-bd77-b6fcf399588c to disappear
+Mar 20 09:11:38.456: INFO: Pod downwardapi-volume-b0f4fa1e-2c1e-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:11:38.457: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-8bgtz" for this suite.
+Mar 20 09:11:44.467: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:11:44.533: INFO: namespace: e2e-tests-downward-api-8bgtz, resource: bindings, ignored listing per whitelist
+Mar 20 09:11:44.565: INFO: namespace e2e-tests-downward-api-8bgtz deletion completed in 6.105974753s
+
+• [SLOW TEST:8.175 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:11:44.565: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test use defaults
+Mar 20 09:11:44.606: INFO: Waiting up to 5m0s for pod "client-containers-b5d415b6-2c1e-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-containers-6kwm8" to be "success or failure"
+Mar 20 09:11:44.611: INFO: Pod "client-containers-b5d415b6-2c1e-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 5.379432ms
+Mar 20 09:11:46.615: INFO: Pod "client-containers-b5d415b6-2c1e-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008885882s
+STEP: Saw pod success
+Mar 20 09:11:46.615: INFO: Pod "client-containers-b5d415b6-2c1e-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 09:11:46.617: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb pod client-containers-b5d415b6-2c1e-11e8-bd77-b6fcf399588c container test-container: <nil>
+STEP: delete the pod
+Mar 20 09:11:46.637: INFO: Waiting for pod client-containers-b5d415b6-2c1e-11e8-bd77-b6fcf399588c to disappear
+Mar 20 09:11:46.639: INFO: Pod client-containers-b5d415b6-2c1e-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:11:46.639: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-6kwm8" for this suite.
+Mar 20 09:11:52.653: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:11:52.744: INFO: namespace: e2e-tests-containers-6kwm8, resource: bindings, ignored listing per whitelist
+Mar 20 09:11:52.748: INFO: namespace e2e-tests-containers-6kwm8 deletion completed in 6.105137542s
+
+• [SLOW TEST:8.183 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:11:52.749: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 20 09:11:52.790: INFO: Waiting up to 5m0s for pod "downwardapi-volume-bab4e22a-2c1e-11e8-bd77-b6fcf399588c" in namespace "e2e-tests-downward-api-4xr4t" to be "success or failure"
+Mar 20 09:11:52.792: INFO: Pod "downwardapi-volume-bab4e22a-2c1e-11e8-bd77-b6fcf399588c": Phase="Pending", Reason="", readiness=false. Elapsed: 1.918625ms
+Mar 20 09:11:54.795: INFO: Pod "downwardapi-volume-bab4e22a-2c1e-11e8-bd77-b6fcf399588c": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005301483s
+STEP: Saw pod success
+Mar 20 09:11:54.795: INFO: Pod "downwardapi-volume-bab4e22a-2c1e-11e8-bd77-b6fcf399588c" satisfied condition "success or failure"
+Mar 20 09:11:54.797: INFO: Trying to get logs from node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 pod downwardapi-volume-bab4e22a-2c1e-11e8-bd77-b6fcf399588c container client-container: <nil>
+STEP: delete the pod
+Mar 20 09:11:54.813: INFO: Waiting for pod downwardapi-volume-bab4e22a-2c1e-11e8-bd77-b6fcf399588c to disappear
+Mar 20 09:11:54.815: INFO: Pod downwardapi-volume-bab4e22a-2c1e-11e8-bd77-b6fcf399588c no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:11:54.815: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-4xr4t" for this suite.
+Mar 20 09:12:00.826: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:12:00.918: INFO: namespace: e2e-tests-downward-api-4xr4t, resource: bindings, ignored listing per whitelist
+Mar 20 09:12:00.918: INFO: namespace e2e-tests-downward-api-4xr4t deletion completed in 6.099787202s
+
+• [SLOW TEST:8.169 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 20 09:12:00.918: INFO: >>> kubeConfig: /tmp/kubeconfig-163837168
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Mar 20 09:12:00.955: INFO: Waiting up to 1m0s for all nodes to be ready
+Mar 20 09:13:00.975: INFO: Waiting for terminating namespaces to be deleted...
+Mar 20 09:13:00.979: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 20 09:13:00.988: INFO: 20 / 20 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 20 09:13:00.988: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 20 09:13:00.992: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 20 09:13:00.992: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb before test
+Mar 20 09:13:01.000: INFO: kube-dns-858cbcf6ff-v9lzv from kube-system started at 2018-03-20 07:15:45 +0000 UTC (3 container statuses recorded)
+Mar 20 09:13:01.000: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 20 09:13:01.000: INFO: 	Container kubedns ready: true, restart count 0
+Mar 20 09:13:01.000: INFO: 	Container sidecar ready: true, restart count 0
+Mar 20 09:13:01.000: INFO: sonobuoy-e2e-job-f715eaa3bda849d5 from sonobuoy started at 2018-03-20 08:24:36 +0000 UTC (2 container statuses recorded)
+Mar 20 09:13:01.000: INFO: 	Container e2e ready: true, restart count 0
+Mar 20 09:13:01.000: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Mar 20 09:13:01.000: INFO: node-exporter-82hj9 from kube-system started at 2018-03-20 07:13:26 +0000 UTC (1 container statuses recorded)
+Mar 20 09:13:01.000: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 20 09:13:01.000: INFO: calico-node-j7bpr from kube-system started at 2018-03-20 07:13:26 +0000 UTC (2 container statuses recorded)
+Mar 20 09:13:01.000: INFO: 	Container calico-node ready: true, restart count 0
+Mar 20 09:13:01.000: INFO: 	Container install-cni ready: true, restart count 0
+Mar 20 09:13:01.000: INFO: addons-nginx-ingress-controller-cb447d457-6k6qt from kube-system started at 2018-03-20 07:13:51 +0000 UTC (1 container statuses recorded)
+Mar 20 09:13:01.000: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Mar 20 09:13:01.000: INFO: vpn-shoot-67c4cbdfdf-q9qpk from kube-system started at 2018-03-20 07:13:52 +0000 UTC (1 container statuses recorded)
+Mar 20 09:13:01.000: INFO: 	Container vpn-shoot ready: true, restart count 1
+Mar 20 09:13:01.000: INFO: kube-proxy-msxf5 from kube-system started at 2018-03-20 07:13:26 +0000 UTC (1 container statuses recorded)
+Mar 20 09:13:01.000: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 20 09:13:01.000: INFO: addons-heapster-e3b0c-b9ff79bbd-pq8mw from kube-system started at 2018-03-20 07:15:05 +0000 UTC (2 container statuses recorded)
+Mar 20 09:13:01.000: INFO: 	Container heapster ready: true, restart count 0
+Mar 20 09:13:01.000: INFO: 	Container heapster-nanny ready: true, restart count 0
+Mar 20 09:13:01.000: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-nztd2 before test
+Mar 20 09:13:01.009: INFO: node-exporter-vpz2p from kube-system started at 2018-03-20 07:13:26 +0000 UTC (1 container statuses recorded)
+Mar 20 09:13:01.009: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 20 09:13:01.009: INFO: kube-dns-autoscaler-6966fd6fb6-28zlr from kube-system started at 2018-03-20 07:13:52 +0000 UTC (1 container statuses recorded)
+Mar 20 09:13:01.009: INFO: 	Container autoscaler ready: true, restart count 0
+Mar 20 09:13:01.009: INFO: addons-kubernetes-dashboard-7fc5877997-j6s5j from kube-system started at 2018-03-20 07:15:45 +0000 UTC (1 container statuses recorded)
+Mar 20 09:13:01.009: INFO: 	Container main ready: true, restart count 0
+Mar 20 09:13:01.009: INFO: kube-proxy-xgwsm from kube-system started at 2018-03-20 07:13:26 +0000 UTC (1 container statuses recorded)
+Mar 20 09:13:01.009: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 20 09:13:01.009: INFO: calico-node-h25k8 from kube-system started at 2018-03-20 07:13:26 +0000 UTC (2 container statuses recorded)
+Mar 20 09:13:01.009: INFO: 	Container calico-node ready: true, restart count 0
+Mar 20 09:13:01.009: INFO: 	Container install-cni ready: true, restart count 0
+Mar 20 09:13:01.009: INFO: kube-dns-858cbcf6ff-5frzh from kube-system started at 2018-03-20 07:13:52 +0000 UTC (3 container statuses recorded)
+Mar 20 09:13:01.009: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 20 09:13:01.009: INFO: 	Container kubedns ready: true, restart count 0
+Mar 20 09:13:01.009: INFO: 	Container sidecar ready: true, restart count 0
+Mar 20 09:13:01.009: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-dccwt from kube-system started at 2018-03-20 07:15:05 +0000 UTC (1 container statuses recorded)
+Mar 20 09:13:01.009: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Mar 20 09:13:01.009: INFO: sonobuoy from sonobuoy started at 2018-03-20 08:24:21 +0000 UTC (1 container statuses recorded)
+Mar 20 09:13:01.009: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-e4932d19-2c1e-11e8-bd77-b6fcf399588c 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-e4932d19-2c1e-11e8-bd77-b6fcf399588c off the node shoot-core-conf-gcp-worker-z4nyy-z1-744866b564-27scb
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-e4932d19-2c1e-11e8-bd77-b6fcf399588c
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 20 09:13:05.061: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-zlpbx" for this suite.
+Mar 20 09:13:27.076: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 20 09:13:27.145: INFO: namespace: e2e-tests-sched-pred-zlpbx, resource: bindings, ignored listing per whitelist
+Mar 20 09:13:27.168: INFO: namespace e2e-tests-sched-pred-zlpbx deletion completed in 22.103409355s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:86.250 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSMar 20 09:13:27.168: INFO: Running AfterSuite actions on all node
+Mar 20 09:13:27.168: INFO: Running AfterSuite actions on node 1
+Mar 20 09:13:27.168: INFO: Skipping dumping logs from cluster
+
+Ran 125 of 782 Specs in 2916.198 seconds
+SUCCESS! -- 125 Passed | 0 Failed | 0 Pending | 657 Skipped PASS
+
+Ginkgo ran 1 suite in 48m36.575050359s
+Test Suite Passed

--- a/v1.9/sap-cp-gcp/junit_01.xml
+++ b/v1.9/sap-cp-gcp/junit_01.xml
@@ -1,0 +1,2099 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="125" failures="0" time="2916.198117639">
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when using local volume provisioner should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.189413152"></testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="134.369971226"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="90.652063343"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.231413328"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [Conformance]" classname="Kubernetes e2e suite" time="8.172797064"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.188917281"></testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var  [Conformance]" classname="Kubernetes e2e suite" time="12.181878959"></testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="30.16899385"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="6.678047966"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="8.167102351"></testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="6.681936145"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod&#39;s node is different from PV&#39;s NodeName should not be able to mount due to different NodeName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="13.236787424"></testcase>
+      <testcase name="[k8s.io] Pods should get a host IP  [Conformance]" classname="Kubernetes e2e suite" time="24.155294978"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod using local volume with non-existant path should not be able to mount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod using local volume with non-existant path should not be able to mount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [Conformance]" classname="Kubernetes e2e suite" time="8.191573751"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="27.461084001"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated  [Conformance]" classname="Kubernetes e2e suite" time="14.66635934"></testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd)  [Conformance]" classname="Kubernetes e2e suite" time="10.175992778"></testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable  [Conformance]" classname="Kubernetes e2e suite" time="10.183339445"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit  [Conformance]" classname="Kubernetes e2e suite" time="8.181884276"></testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.176451929"></testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout  [Conformance]" classname="Kubernetes e2e suite" time="6.145651323">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection] [Conformance]" classname="Kubernetes e2e suite" time="10.182727757"></testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="51.228856375"></testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.184889703"></testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set  [Conformance]" classname="Kubernetes e2e suite" time="8.184520924"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.184853646"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.196787816"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="12.183889105"></testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPU] run Nvidia GPU tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.179645594"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.181329195"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod  [Conformance]" classname="Kubernetes e2e suite" time="8.172114384"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.166492235"></testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.174233491"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="32.265602935"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should autoscale with Custom Metrics from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services  [Conformance]" classname="Kubernetes e2e suite" time="28.198712042"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod  [Conformance]" classname="Kubernetes e2e suite" time="8.17964614"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.184155728"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.183602311"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="85.30064725"></testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.176913196"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.168403461"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]" classname="Kubernetes e2e suite" time="8.185054363"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should schedule pods in the same zones as statically provisioned PVs [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.171184782"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]" classname="Kubernetes e2e suite" time="8.177528127"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.OrphanDependents is true" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.21893262"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.166955764"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should have a working scale subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable  [Conformance]" classname="Kubernetes e2e suite" time="10.173654755"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.22458749"></testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.167345799"></testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [DisabledForLargeClusters] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.164488867"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.184561596"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.202451143"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [Conformance]" classname="Kubernetes e2e suite" time="8.177188567"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="19.06237844"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args  [Conformance]" classname="Kubernetes e2e suite" time="10.1718971"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="204.147752627"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [Conformance]" classname="Kubernetes e2e suite" time="8.182361917"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="18.964390627"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="8.195762904"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="40.460430163"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.1491528540000004"></testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file  [Conformance]" classname="Kubernetes e2e suite" time="61.942164482"></testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when StatefulSet has pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.179950822"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only  [Conformance]" classname="Kubernetes e2e suite" time="8.172052349"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command  [Conformance]" classname="Kubernetes e2e suite" time="10.203609543"></testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.209566087"></testcase>
+      <testcase name="[k8s.io] Sysctls should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.223411773"></testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.442617358"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [Conformance]" classname="Kubernetes e2e suite" time="26.69526524"></testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart  [Conformance]" classname="Kubernetes e2e suite" time="40.153860795"></testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node  [Conformance]" classname="Kubernetes e2e suite" time="9.354975225"></testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [Conformance]" classname="Kubernetes e2e suite" time="8.173340552"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.17223975"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor using proxy subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="32.20297089"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.171702501"></testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should rollback without unnecessary restarts" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.422946528"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="45.37851177"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [Conformance]" classname="Kubernetes e2e suite" time="8.167600876"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification  [Conformance]" classname="Kubernetes e2e suite" time="110.84485564"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.174516129"></testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [Conformance]" classname="Kubernetes e2e suite" time="8.169306122"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="36.443523995"></testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="10.013096454"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.172166796"></testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.160028623"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that a pod with an invalid NodeAffinity is rejected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod using local volume with non-existant path should not be able to mount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should update pod when spec was updated and update strategy is RollingUpdate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.19683663"></testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Node Auto Repairs [Slow] [Disruptive] should repair node [Feature:NodeAutoRepairs]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate crd" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.208481018"></testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.181679926"></testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [Conformance]" classname="Kubernetes e2e suite" time="8.183739244"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.429444119"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod&#39;s node is different from PV&#39;s NodeName should not be able to mount due to different NodeName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.176696172"></testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.187857193"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.164901133"></testcase>
+      <testcase name="[k8s.io] LimitRange should create a LimitRange with default ephemeral storage and ensure pod has the default applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments  [Conformance]" classname="Kubernetes e2e suite" time="10.175044669"></testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation [Feature:MountPropagation] should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="24.762164005"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should adopt existing pods when creating a RollingUpdate DaemonSet regardless of templateGeneration" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.168840886"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.171338297"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file  [Conformance]" classname="Kubernetes e2e suite" time="8.186216779"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request  [Conformance]" classname="Kubernetes e2e suite" time="10.179440312"></testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="12.732897755"></testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port  [Conformance]" classname="Kubernetes e2e suite" time="6.221799438"></testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification  [Conformance]" classname="Kubernetes e2e suite" time="28.699074672"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request  [Conformance]" classname="Kubernetes e2e suite" time="8.18008825"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="128.356465035"></testcase>
+      <testcase name="[sig-storage] HostPath should support subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [Conformance]" classname="Kubernetes e2e suite" time="8.180319794"></testcase>
+      <testcase name="[k8s.io] Pods should be updated  [Conformance]" classname="Kubernetes e2e suite" time="24.667729987"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existent secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="44.454672007"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="13.241175615"></testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart  [Conformance]" classname="Kubernetes e2e suite" time="82.15391921"></testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [Conformance]" classname="Kubernetes e2e suite" time="119.46127089"></testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default commmand (docker entrypoint)  [Conformance]" classname="Kubernetes e2e suite" time="8.175580164"></testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.184292913"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="10.183370159"></testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.244162657"></testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.188554703"></testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="62.254570151"></testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.22396019"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [Conformance]" classname="Kubernetes e2e suite" time="10.176848203"></testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.186346068"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count  [Slow] [Conformance]" classname="Kubernetes e2e suite" time="156.41590516"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit  [Conformance]" classname="Kubernetes e2e suite" time="8.176787967"></testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [DisabledForLargeClusters] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.215720331"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha docker/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod&#39;s node is different from PV&#39;s NodeName should not be able to mount due to different NodeName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.174825236"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank  [Conformance]" classname="Kubernetes e2e suite" time="8.183210354"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files  [Conformance]" classname="Kubernetes e2e suite" time="8.169120565"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="86.249865671"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.9/sap-cp-gcp/version.txt
+++ b/v1.9/sap-cp-gcp/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.4", GitCommit:"bee2d1505c4fe820744d26d41ecd3fdd4a3d6546", GitTreeState:"clean", BuildDate:"2018-03-12T16:29:47Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.4", GitCommit:"bee2d1505c4fe820744d26d41ecd3fdd4a3d6546", GitTreeState:"clean", BuildDate:"2018-03-12T16:21:35Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}

--- a/v1.9/sap-cp-openstack/PRODUCT.yaml
+++ b/v1.9/sap-cp-openstack/PRODUCT.yaml
@@ -1,0 +1,6 @@
+vendor: SAP
+name: Cloud Platform - Gardener (https://github.com/gardener/gardener) shoot cluster deployed on Openstack
+version: 0.1.0 (changed with Open Source shipment)
+website_url: https://cloudplatform.sap.com/index.html
+documentation_url: https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/
+product_logo_url: https://www.sap.com/dam/application/shared/logos/sap-logo-svg.svg

--- a/v1.9/sap-cp-openstack/README.md
+++ b/v1.9/sap-cp-openstack/README.md
@@ -1,0 +1,43 @@
+# To reproduce:
+
+## Create Kubernetes Cluster
+
+Login to SAP Gardener Dashboard to create a Kubernetes Clusters on Amazon Web Services, Microsoft Azure, Google Cloud Platform, or OpenStack cloud provider.
+
+After the creation completed, copy the cluster's kubeconfig, which is provided by the Gardener Dashboard in the cluster's detail view, to ~/.kube/config and launch the Kubernetes E2E conformance tests.
+
+## Launch E2E Conformance Tests
+1. Launch e2e pod and sonobuoy master under namespace `sonobuoy`   
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+    ```
+
+2. Check logs of `sonobuoy` pod to see when test can be finished   
+Run
+
+    ```shell
+    kubectl logs -f -n sonobuoy sonobuoy
+    ```
+    and wait for line `no-exit was specified, sonobuoy is now blocking`.
+
+3. Use `kubectl cp` to copy the results to the client   
+Get the name of the <result archive> from the log output in step 2.
+
+    ```shell
+    kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy/<result archive> /home/result
+    ```
+
+4. Delete the conformance test resources
+
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl delete -f -
+    ```
+
+5. Untar the tarball
+
+    ```shell
+    cd /home/result
+    tar -xzf *_sonobuoy_*.tar.gz
+    ```
+
+    The result files `e2e.log` and `junit_01.xml` are located in the in the directory `plugins/e2e/results/`.

--- a/v1.9/sap-cp-openstack/e2e.log
+++ b/v1.9/sap-cp-openstack/e2e.log
@@ -1,0 +1,6323 @@
+Mar 19 16:08:00.218: INFO: Overriding default scale value of zero to 1
+Mar 19 16:08:00.218: INFO: Overriding default milliseconds value of zero to 5000
+I0319 16:08:00.337537      17 test_context.go:349] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-053991314
+I0319 16:08:00.337674      17 e2e.go:331] Starting e2e run "b1ff4fa8-2b8f-11e8-a904-72008c49cf21" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1521475680 - Will randomize all specs
+Will run 126 of 782 specs
+
+Mar 19 16:08:00.399: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:08:00.400: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
+Mar 19 16:08:00.414: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 19 16:08:00.486: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 19 16:08:00.486: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 19 16:08:00.490: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 19 16:08:00.491: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Mar 19 16:08:00.495: INFO: e2e test version: v1.9.4
+Mar 19 16:08:00.496: INFO: kube-apiserver version: v1.9.4
+[sig-storage] Downward API volume 
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:08:00.496: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+Mar 19 16:08:00.533: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:08:00.541: INFO: Waiting up to 5m0s for pod "downwardapi-volume-b23b7b61-2b8f-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-4xclz" to be "success or failure"
+Mar 19 16:08:00.543: INFO: Pod "downwardapi-volume-b23b7b61-2b8f-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.963413ms
+Mar 19 16:08:02.545: INFO: Pod "downwardapi-volume-b23b7b61-2b8f-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004468729s
+STEP: Saw pod success
+Mar 19 16:08:02.545: INFO: Pod "downwardapi-volume-b23b7b61-2b8f-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:08:02.548: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downwardapi-volume-b23b7b61-2b8f-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:08:02.644: INFO: Waiting for pod downwardapi-volume-b23b7b61-2b8f-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:08:02.646: INFO: Pod downwardapi-volume-b23b7b61-2b8f-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:08:02.647: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-4xclz" for this suite.
+Mar 19 16:08:08.658: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:08:08.737: INFO: namespace: e2e-tests-downward-api-4xclz, resource: bindings, ignored listing per whitelist
+Mar 19 16:08:08.769: INFO: namespace e2e-tests-downward-api-4xclz deletion completed in 6.118123027s
+
+• [SLOW TEST:8.272 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:08:08.769: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:08:08.814: INFO: Waiting up to 5m0s for pod "downwardapi-volume-b729ab8a-2b8f-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-xvxdh" to be "success or failure"
+Mar 19 16:08:08.816: INFO: Pod "downwardapi-volume-b729ab8a-2b8f-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.526171ms
+Mar 19 16:08:10.820: INFO: Pod "downwardapi-volume-b729ab8a-2b8f-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006458125s
+STEP: Saw pod success
+Mar 19 16:08:10.820: INFO: Pod "downwardapi-volume-b729ab8a-2b8f-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:08:10.822: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downwardapi-volume-b729ab8a-2b8f-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:08:10.835: INFO: Waiting for pod downwardapi-volume-b729ab8a-2b8f-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:08:10.837: INFO: Pod downwardapi-volume-b729ab8a-2b8f-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:08:10.837: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-xvxdh" for this suite.
+Mar 19 16:08:16.846: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:08:16.939: INFO: namespace: e2e-tests-downward-api-xvxdh, resource: bindings, ignored listing per whitelist
+Mar 19 16:08:16.950: INFO: namespace e2e-tests-downward-api-xvxdh deletion completed in 6.111158085s
+
+• [SLOW TEST:8.181 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:08:16.950: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:37
+[It] should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test hostPath mode
+Mar 19 16:08:16.987: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-tv5zz" to be "success or failure"
+Mar 19 16:08:16.989: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 1.918111ms
+Mar 19 16:08:18.992: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004747128s
+STEP: Saw pod success
+Mar 19 16:08:18.992: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Mar 19 16:08:18.994: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Mar 19 16:08:19.008: INFO: Waiting for pod pod-host-path-test to disappear
+Mar 19 16:08:19.015: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:08:19.015: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-tv5zz" for this suite.
+Mar 19 16:08:25.028: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:08:25.124: INFO: namespace: e2e-tests-hostpath-tv5zz, resource: bindings, ignored listing per whitelist
+Mar 19 16:08:25.132: INFO: namespace e2e-tests-hostpath-tv5zz deletion completed in 6.112477803s
+
+• [SLOW TEST:8.181 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:34
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:08:25.132: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:08:25.168: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c0e96c3e-2b8f-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-5gkdh" to be "success or failure"
+Mar 19 16:08:25.171: INFO: Pod "downwardapi-volume-c0e96c3e-2b8f-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.87892ms
+Mar 19 16:08:27.174: INFO: Pod "downwardapi-volume-c0e96c3e-2b8f-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006218849s
+STEP: Saw pod success
+Mar 19 16:08:27.174: INFO: Pod "downwardapi-volume-c0e96c3e-2b8f-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:08:27.176: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downwardapi-volume-c0e96c3e-2b8f-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:08:27.188: INFO: Waiting for pod downwardapi-volume-c0e96c3e-2b8f-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:08:27.190: INFO: Pod downwardapi-volume-c0e96c3e-2b8f-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:08:27.190: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-5gkdh" for this suite.
+Mar 19 16:08:33.199: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:08:33.256: INFO: namespace: e2e-tests-downward-api-5gkdh, resource: bindings, ignored listing per whitelist
+Mar 19 16:08:33.306: INFO: namespace e2e-tests-downward-api-5gkdh deletion completed in 6.113733029s
+
+• [SLOW TEST:8.174 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:08:33.307: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-vlnmf.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-vlnmf.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-vlnmf.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-vlnmf.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-vlnmf.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-vlnmf.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Mar 19 16:08:54.165: INFO: DNS probes using dns-test-c5c948bc-2b8f-11e8-a904-72008c49cf21 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:08:54.171: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-vlnmf" for this suite.
+Mar 19 16:09:00.198: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:09:00.277: INFO: namespace: e2e-tests-dns-vlnmf, resource: bindings, ignored listing per whitelist
+Mar 19 16:09:00.309: INFO: namespace e2e-tests-dns-vlnmf deletion completed in 6.126095067s
+
+• [SLOW TEST:27.002 seconds]
+[sig-network] DNS
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:09:00.309: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-map-d5e3a0ba-2b8f-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:09:00.364: INFO: Waiting up to 5m0s for pod "pod-configmaps-d5e3f3c1-2b8f-11e8-a904-72008c49cf21" in namespace "e2e-tests-configmap-998dr" to be "success or failure"
+Mar 19 16:09:00.366: INFO: Pod "pod-configmaps-d5e3f3c1-2b8f-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.994095ms
+Mar 19 16:09:02.368: INFO: Pod "pod-configmaps-d5e3f3c1-2b8f-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004565763s
+STEP: Saw pod success
+Mar 19 16:09:02.368: INFO: Pod "pod-configmaps-d5e3f3c1-2b8f-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:09:02.370: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-configmaps-d5e3f3c1-2b8f-11e8-a904-72008c49cf21 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:09:02.383: INFO: Waiting for pod pod-configmaps-d5e3f3c1-2b8f-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:09:02.385: INFO: Pod pod-configmaps-d5e3f3c1-2b8f-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:09:02.385: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-998dr" for this suite.
+Mar 19 16:09:08.395: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:09:08.493: INFO: namespace: e2e-tests-configmap-998dr, resource: bindings, ignored listing per whitelist
+Mar 19 16:09:08.497: INFO: namespace e2e-tests-configmap-998dr deletion completed in 6.108788683s
+
+• [SLOW TEST:8.188 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:09:08.497: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 19 16:09:11.063: INFO: Successfully updated pod "annotationupdatedac2bc50-2b8f-11e8-a904-72008c49cf21"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:10:19.211: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-7kwk9" for this suite.
+Mar 19 16:10:41.220: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:10:41.263: INFO: namespace: e2e-tests-downward-api-7kwk9, resource: bindings, ignored listing per whitelist
+Mar 19 16:10:41.331: INFO: namespace e2e-tests-downward-api-7kwk9 deletion completed in 22.117692321s
+
+• [SLOW TEST:92.834 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:10:41.331: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-1218796a-2b90-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:10:41.375: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-1218f3cb-2b90-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-4qxkz" to be "success or failure"
+Mar 19 16:10:41.380: INFO: Pod "pod-projected-configmaps-1218f3cb-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 4.362141ms
+Mar 19 16:10:43.382: INFO: Pod "pod-projected-configmaps-1218f3cb-2b90-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006962073s
+STEP: Saw pod success
+Mar 19 16:10:43.382: INFO: Pod "pod-projected-configmaps-1218f3cb-2b90-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:10:43.384: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-projected-configmaps-1218f3cb-2b90-11e8-a904-72008c49cf21 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:10:43.398: INFO: Waiting for pod pod-projected-configmaps-1218f3cb-2b90-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:10:43.399: INFO: Pod pod-projected-configmaps-1218f3cb-2b90-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:10:43.399: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4qxkz" for this suite.
+Mar 19 16:10:49.412: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:10:49.509: INFO: namespace: e2e-tests-projected-4qxkz, resource: bindings, ignored listing per whitelist
+Mar 19 16:10:49.521: INFO: namespace e2e-tests-projected-4qxkz deletion completed in 6.119476s
+
+• [SLOW TEST:8.190 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:10:49.521: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-map-16fb1885-2b90-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:10:49.570: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-16fb7804-2b90-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-xw26k" to be "success or failure"
+Mar 19 16:10:49.572: INFO: Pod "pod-projected-configmaps-16fb7804-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.343399ms
+Mar 19 16:10:51.575: INFO: Pod "pod-projected-configmaps-16fb7804-2b90-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005332408s
+STEP: Saw pod success
+Mar 19 16:10:51.575: INFO: Pod "pod-projected-configmaps-16fb7804-2b90-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:10:51.577: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-projected-configmaps-16fb7804-2b90-11e8-a904-72008c49cf21 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:10:51.591: INFO: Waiting for pod pod-projected-configmaps-16fb7804-2b90-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:10:51.593: INFO: Pod pod-projected-configmaps-16fb7804-2b90-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:10:51.593: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xw26k" for this suite.
+Mar 19 16:10:57.606: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:10:57.689: INFO: namespace: e2e-tests-projected-xw26k, resource: bindings, ignored listing per whitelist
+Mar 19 16:10:57.712: INFO: namespace e2e-tests-projected-xw26k deletion completed in 6.114812132s
+
+• [SLOW TEST:8.191 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default commmand (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:10:57.713: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default commmand (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test override command
+Mar 19 16:10:57.752: INFO: Waiting up to 5m0s for pod "client-containers-1bdc0481-2b90-11e8-a904-72008c49cf21" in namespace "e2e-tests-containers-qpxkg" to be "success or failure"
+Mar 19 16:10:57.754: INFO: Pod "client-containers-1bdc0481-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.736631ms
+Mar 19 16:10:59.757: INFO: Pod "client-containers-1bdc0481-2b90-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005390101s
+STEP: Saw pod success
+Mar 19 16:10:59.757: INFO: Pod "client-containers-1bdc0481-2b90-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:10:59.760: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod client-containers-1bdc0481-2b90-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:10:59.771: INFO: Waiting for pod client-containers-1bdc0481-2b90-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:10:59.773: INFO: Pod client-containers-1bdc0481-2b90-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:10:59.773: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-qpxkg" for this suite.
+Mar 19 16:11:05.789: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:11:05.865: INFO: namespace: e2e-tests-containers-qpxkg, resource: bindings, ignored listing per whitelist
+Mar 19 16:11:05.901: INFO: namespace e2e-tests-containers-qpxkg deletion completed in 6.125147484s
+
+• [SLOW TEST:8.188 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be able to override the image's default commmand (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:11:05.902: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:11:05.941: INFO: Waiting up to 5m0s for pod "downwardapi-volume-20bd6af9-2b90-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-965fw" to be "success or failure"
+Mar 19 16:11:05.946: INFO: Pod "downwardapi-volume-20bd6af9-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 5.09346ms
+Mar 19 16:11:07.950: INFO: Pod "downwardapi-volume-20bd6af9-2b90-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009161974s
+STEP: Saw pod success
+Mar 19 16:11:07.950: INFO: Pod "downwardapi-volume-20bd6af9-2b90-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:11:07.953: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downwardapi-volume-20bd6af9-2b90-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:11:07.967: INFO: Waiting for pod downwardapi-volume-20bd6af9-2b90-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:11:07.969: INFO: Pod downwardapi-volume-20bd6af9-2b90-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:11:07.969: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-965fw" for this suite.
+Mar 19 16:11:13.979: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:11:14.072: INFO: namespace: e2e-tests-projected-965fw, resource: bindings, ignored listing per whitelist
+Mar 19 16:11:14.084: INFO: namespace e2e-tests-projected-965fw deletion completed in 6.112836222s
+
+• [SLOW TEST:8.183 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:11:14.085: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-259ddaf0-2b90-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:11:14.124: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-259e3057-2b90-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-6wdpb" to be "success or failure"
+Mar 19 16:11:14.126: INFO: Pod "pod-projected-configmaps-259e3057-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.038803ms
+Mar 19 16:11:16.130: INFO: Pod "pod-projected-configmaps-259e3057-2b90-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005575201s
+STEP: Saw pod success
+Mar 19 16:11:16.130: INFO: Pod "pod-projected-configmaps-259e3057-2b90-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:11:16.132: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-projected-configmaps-259e3057-2b90-11e8-a904-72008c49cf21 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:11:16.144: INFO: Waiting for pod pod-projected-configmaps-259e3057-2b90-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:11:16.146: INFO: Pod pod-projected-configmaps-259e3057-2b90-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:11:16.146: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6wdpb" for this suite.
+Mar 19 16:11:22.155: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:11:22.242: INFO: namespace: e2e-tests-projected-6wdpb, resource: bindings, ignored listing per whitelist
+Mar 19 16:11:22.251: INFO: namespace e2e-tests-projected-6wdpb deletion completed in 6.102279788s
+
+• [SLOW TEST:8.166 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:11:22.252: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 16:11:22.293: INFO: (0) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.899572ms)
+Mar 19 16:11:22.297: INFO: (1) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.91932ms)
+Mar 19 16:11:22.301: INFO: (2) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.168959ms)
+Mar 19 16:11:22.305: INFO: (3) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.94825ms)
+Mar 19 16:11:22.310: INFO: (4) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.415616ms)
+Mar 19 16:11:22.314: INFO: (5) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.102358ms)
+Mar 19 16:11:22.319: INFO: (6) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.527002ms)
+Mar 19 16:11:22.323: INFO: (7) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.683241ms)
+Mar 19 16:11:22.327: INFO: (8) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.79039ms)
+Mar 19 16:11:22.331: INFO: (9) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.944235ms)
+Mar 19 16:11:22.335: INFO: (10) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.89817ms)
+Mar 19 16:11:22.339: INFO: (11) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.099283ms)
+Mar 19 16:11:22.344: INFO: (12) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.38624ms)
+Mar 19 16:11:22.349: INFO: (13) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.2584ms)
+Mar 19 16:11:22.353: INFO: (14) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.890592ms)
+Mar 19 16:11:22.357: INFO: (15) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.92456ms)
+Mar 19 16:11:22.361: INFO: (16) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.229906ms)
+Mar 19 16:11:22.366: INFO: (17) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.83633ms)
+Mar 19 16:11:22.370: INFO: (18) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.540979ms)
+Mar 19 16:11:22.374: INFO: (19) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.911536ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:11:22.374: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-ldmhd" for this suite.
+Mar 19 16:11:28.383: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:11:28.446: INFO: namespace: e2e-tests-proxy-ldmhd, resource: bindings, ignored listing per whitelist
+Mar 19 16:11:28.493: INFO: namespace e2e-tests-proxy-ldmhd deletion completed in 6.115912016s
+
+• [SLOW TEST:6.241 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node with explicit kubelet port  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:11:28.493: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating secret e2e-tests-secrets-rbbzj/secret-test-2e34af10-2b90-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:11:28.535: INFO: Waiting up to 5m0s for pod "pod-configmaps-2e350c7c-2b90-11e8-a904-72008c49cf21" in namespace "e2e-tests-secrets-rbbzj" to be "success or failure"
+Mar 19 16:11:28.537: INFO: Pod "pod-configmaps-2e350c7c-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.398317ms
+Mar 19 16:11:30.540: INFO: Pod "pod-configmaps-2e350c7c-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005629207s
+Mar 19 16:11:32.543: INFO: Pod "pod-configmaps-2e350c7c-2b90-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008579614s
+STEP: Saw pod success
+Mar 19 16:11:32.543: INFO: Pod "pod-configmaps-2e350c7c-2b90-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:11:32.545: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-configmaps-2e350c7c-2b90-11e8-a904-72008c49cf21 container env-test: <nil>
+STEP: delete the pod
+Mar 19 16:11:32.557: INFO: Waiting for pod pod-configmaps-2e350c7c-2b90-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:11:32.559: INFO: Pod pod-configmaps-2e350c7c-2b90-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:11:32.559: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-rbbzj" for this suite.
+Mar 19 16:11:38.575: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:11:38.613: INFO: namespace: e2e-tests-secrets-rbbzj, resource: bindings, ignored listing per whitelist
+Mar 19 16:11:38.674: INFO: namespace e2e-tests-secrets-rbbzj deletion completed in 6.112990879s
+
+• [SLOW TEST:10.181 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:11:38.675: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:11:38.720: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-rpjvq" for this suite.
+Mar 19 16:11:58.730: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:11:58.768: INFO: namespace: e2e-tests-pods-rpjvq, resource: bindings, ignored listing per whitelist
+Mar 19 16:11:58.836: INFO: namespace e2e-tests-pods-rpjvq deletion completed in 20.113148646s
+
+• [SLOW TEST:20.161 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:11:58.836: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 19 16:11:58.876: INFO: Waiting up to 5m0s for pod "downward-api-404aa2ea-2b90-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-qphl5" to be "success or failure"
+Mar 19 16:11:58.878: INFO: Pod "downward-api-404aa2ea-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.807668ms
+Mar 19 16:12:00.882: INFO: Pod "downward-api-404aa2ea-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006657663s
+Mar 19 16:12:02.886: INFO: Pod "downward-api-404aa2ea-2b90-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010447474s
+STEP: Saw pod success
+Mar 19 16:12:02.886: INFO: Pod "downward-api-404aa2ea-2b90-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:12:02.888: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downward-api-404aa2ea-2b90-11e8-a904-72008c49cf21 container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 16:12:02.904: INFO: Waiting for pod downward-api-404aa2ea-2b90-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:12:02.906: INFO: Pod downward-api-404aa2ea-2b90-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:12:02.906: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-qphl5" for this suite.
+Mar 19 16:12:08.916: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:12:08.961: INFO: namespace: e2e-tests-downward-api-qphl5, resource: bindings, ignored listing per whitelist
+Mar 19 16:12:09.026: INFO: namespace e2e-tests-downward-api-qphl5 deletion completed in 6.117762171s
+
+• [SLOW TEST:10.190 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:12:09.027: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-map-465dec6b-2b90-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:12:09.070: INFO: Waiting up to 5m0s for pod "pod-secrets-465e4c4e-2b90-11e8-a904-72008c49cf21" in namespace "e2e-tests-secrets-6tc8m" to be "success or failure"
+Mar 19 16:12:09.072: INFO: Pod "pod-secrets-465e4c4e-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.253001ms
+Mar 19 16:12:11.075: INFO: Pod "pod-secrets-465e4c4e-2b90-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005041151s
+STEP: Saw pod success
+Mar 19 16:12:11.075: INFO: Pod "pod-secrets-465e4c4e-2b90-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:12:11.081: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-secrets-465e4c4e-2b90-11e8-a904-72008c49cf21 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:12:11.092: INFO: Waiting for pod pod-secrets-465e4c4e-2b90-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:12:11.094: INFO: Pod pod-secrets-465e4c4e-2b90-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:12:11.094: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-6tc8m" for this suite.
+Mar 19 16:12:17.104: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:12:17.159: INFO: namespace: e2e-tests-secrets-6tc8m, resource: bindings, ignored listing per whitelist
+Mar 19 16:12:17.211: INFO: namespace e2e-tests-secrets-6tc8m deletion completed in 6.11463947s
+
+• [SLOW TEST:8.184 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:12:17.211: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 19 16:12:19.777: INFO: Successfully updated pod "labelsupdate4b3eebf0-2b90-11e8-a904-72008c49cf21"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:12:23.852: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-zqw54" for this suite.
+Mar 19 16:12:46.509: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:12:46.599: INFO: namespace: e2e-tests-projected-zqw54, resource: bindings, ignored listing per whitelist
+Mar 19 16:12:46.612: INFO: namespace e2e-tests-projected-zqw54 deletion completed in 22.757700611s
+
+• [SLOW TEST:29.401 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:12:46.613: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Mar 19 16:12:46.647: INFO: Waiting up to 1m0s for all nodes to be ready
+Mar 19 16:13:46.664: INFO: Waiting for terminating namespaces to be deleted...
+Mar 19 16:13:46.667: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 19 16:13:46.680: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 19 16:13:46.681: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 19 16:13:46.684: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 19 16:13:46.684: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 before test
+Mar 19 16:13:46.694: INFO: calico-node-2d2fj from kube-system started at 2018-03-15 15:26:47 +0000 UTC (2 container statuses recorded)
+Mar 19 16:13:46.694: INFO: 	Container calico-node ready: true, restart count 0
+Mar 19 16:13:46.694: INFO: 	Container install-cni ready: true, restart count 0
+Mar 19 16:13:46.694: INFO: kube-proxy-kkvkb from kube-system started at 2018-03-15 15:26:47 +0000 UTC (1 container statuses recorded)
+Mar 19 16:13:46.694: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 19 16:13:46.694: INFO: sonobuoy from sonobuoy started at 2018-03-19 16:07:57 +0000 UTC (1 container statuses recorded)
+Mar 19 16:13:46.694: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Mar 19 16:13:46.694: INFO: sonobuoy-e2e-job-a39407418b2d4b45 from sonobuoy started at 2018-03-19 16:07:58 +0000 UTC (2 container statuses recorded)
+Mar 19 16:13:46.694: INFO: 	Container e2e ready: true, restart count 0
+Mar 19 16:13:46.694: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Mar 19 16:13:46.694: INFO: addons-kubernetes-dashboard-7fc5877997-d8t2l from kube-system started at 2018-03-15 15:27:47 +0000 UTC (1 container statuses recorded)
+Mar 19 16:13:46.695: INFO: 	Container main ready: true, restart count 0
+Mar 19 16:13:46.695: INFO: kube-dns-858cbcf6ff-597hx from kube-system started at 2018-03-15 15:27:48 +0000 UTC (3 container statuses recorded)
+Mar 19 16:13:46.695: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 19 16:13:46.695: INFO: 	Container kubedns ready: true, restart count 0
+Mar 19 16:13:46.695: INFO: 	Container sidecar ready: true, restart count 0
+Mar 19 16:13:46.695: INFO: node-exporter-kljbt from kube-system started at 2018-03-15 15:26:47 +0000 UTC (1 container statuses recorded)
+Mar 19 16:13:46.695: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 19 16:13:46.695: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg before test
+Mar 19 16:13:46.706: INFO: vpn-shoot-74647f84fc-s48bf from kube-system started at 2018-03-19 10:55:32 +0000 UTC (1 container statuses recorded)
+Mar 19 16:13:46.706: INFO: 	Container vpn-shoot ready: true, restart count 0
+Mar 19 16:13:46.706: INFO: addons-heapster-e3b0c-b9ff79bbd-ch9vw from kube-system started at 2018-03-15 15:27:54 +0000 UTC (2 container statuses recorded)
+Mar 19 16:13:46.707: INFO: 	Container heapster ready: true, restart count 0
+Mar 19 16:13:46.707: INFO: 	Container heapster-nanny ready: true, restart count 0
+Mar 19 16:13:46.707: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-cwvlm from kube-system started at 2018-03-15 15:27:54 +0000 UTC (1 container statuses recorded)
+Mar 19 16:13:46.707: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Mar 19 16:13:46.707: INFO: kube-dns-autoscaler-6966fd6fb6-zqlsg from kube-system started at 2018-03-15 15:27:54 +0000 UTC (1 container statuses recorded)
+Mar 19 16:13:46.707: INFO: 	Container autoscaler ready: true, restart count 0
+Mar 19 16:13:46.707: INFO: node-exporter-q42qq from kube-system started at 2018-03-15 15:26:45 +0000 UTC (1 container statuses recorded)
+Mar 19 16:13:46.707: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 19 16:13:46.707: INFO: kube-proxy-jnck2 from kube-system started at 2018-03-15 15:26:45 +0000 UTC (1 container statuses recorded)
+Mar 19 16:13:46.707: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 19 16:13:46.707: INFO: calico-node-lr4fx from kube-system started at 2018-03-15 15:26:45 +0000 UTC (2 container statuses recorded)
+Mar 19 16:13:46.707: INFO: 	Container calico-node ready: true, restart count 0
+Mar 19 16:13:46.707: INFO: 	Container install-cni ready: true, restart count 0
+Mar 19 16:13:46.707: INFO: addons-nginx-ingress-controller-ddcb6d7fc-w2vjr from kube-system started at 2018-03-15 15:27:54 +0000 UTC (1 container statuses recorded)
+Mar 19 16:13:46.707: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Mar 19 16:13:46.707: INFO: kube-dns-858cbcf6ff-lfttj from kube-system started at 2018-03-15 15:27:54 +0000 UTC (3 container statuses recorded)
+Mar 19 16:13:46.707: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 19 16:13:46.707: INFO: 	Container kubedns ready: true, restart count 0
+Mar 19 16:13:46.707: INFO: 	Container sidecar ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-81c504bf-2b90-11e8-a904-72008c49cf21 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-81c504bf-2b90-11e8-a904-72008c49cf21 off the node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-81c504bf-2b90-11e8-a904-72008c49cf21
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:13:50.760: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-6lvd7" for this suite.
+Mar 19 16:14:12.769: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:14:12.852: INFO: namespace: e2e-tests-sched-pred-6lvd7, resource: bindings, ignored listing per whitelist
+Mar 19 16:14:12.872: INFO: namespace e2e-tests-sched-pred-6lvd7 deletion completed in 22.110103462s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:86.259 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:14:12.873: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 19 16:14:12.913: INFO: Waiting up to 5m0s for pod "downward-api-902f400e-2b90-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-pd4h7" to be "success or failure"
+Mar 19 16:14:12.915: INFO: Pod "downward-api-902f400e-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.886255ms
+Mar 19 16:14:14.919: INFO: Pod "downward-api-902f400e-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005765588s
+Mar 19 16:14:16.923: INFO: Pod "downward-api-902f400e-2b90-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009329988s
+STEP: Saw pod success
+Mar 19 16:14:16.923: INFO: Pod "downward-api-902f400e-2b90-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:14:16.925: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downward-api-902f400e-2b90-11e8-a904-72008c49cf21 container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 16:14:16.937: INFO: Waiting for pod downward-api-902f400e-2b90-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:14:16.939: INFO: Pod downward-api-902f400e-2b90-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:14:16.939: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-pd4h7" for this suite.
+Mar 19 16:14:22.949: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:14:23.037: INFO: namespace: e2e-tests-downward-api-pd4h7, resource: bindings, ignored listing per whitelist
+Mar 19 16:14:23.040: INFO: namespace e2e-tests-downward-api-pd4h7 deletion completed in 6.098619079s
+
+• [SLOW TEST:10.168 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:14:23.041: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-gsnww
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 19 16:14:23.076: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 19 16:14:43.115: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.2.179:8080/dial?request=hostName&protocol=udp&host=100.96.2.178&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-gsnww PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:14:43.115: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:14:43.253: INFO: Waiting for endpoints: map[]
+Mar 19 16:14:43.257: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.2.179:8080/dial?request=hostName&protocol=udp&host=100.96.3.145&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-gsnww PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:14:43.257: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:14:43.450: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:14:43.450: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-gsnww" for this suite.
+Mar 19 16:15:05.468: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:15:05.546: INFO: namespace: e2e-tests-pod-network-test-gsnww, resource: bindings, ignored listing per whitelist
+Mar 19 16:15:05.581: INFO: namespace e2e-tests-pod-network-test-gsnww deletion completed in 22.127995334s
+
+• [SLOW TEST:42.540 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:15:05.581: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-af998bd6-2b90-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:15:05.622: INFO: Waiting up to 5m0s for pod "pod-secrets-af99ed39-2b90-11e8-a904-72008c49cf21" in namespace "e2e-tests-secrets-bqbfs" to be "success or failure"
+Mar 19 16:15:05.624: INFO: Pod "pod-secrets-af99ed39-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.055663ms
+Mar 19 16:15:07.628: INFO: Pod "pod-secrets-af99ed39-2b90-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006066667s
+STEP: Saw pod success
+Mar 19 16:15:07.628: INFO: Pod "pod-secrets-af99ed39-2b90-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:15:07.630: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-secrets-af99ed39-2b90-11e8-a904-72008c49cf21 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:15:07.642: INFO: Waiting for pod pod-secrets-af99ed39-2b90-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:15:07.644: INFO: Pod pod-secrets-af99ed39-2b90-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:15:07.644: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-bqbfs" for this suite.
+Mar 19 16:15:13.654: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:15:13.718: INFO: namespace: e2e-tests-secrets-bqbfs, resource: bindings, ignored listing per whitelist
+Mar 19 16:15:13.759: INFO: namespace e2e-tests-secrets-bqbfs deletion completed in 6.11238331s
+
+• [SLOW TEST:8.178 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:15:13.759: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test substitution in container's args
+Mar 19 16:15:13.802: INFO: Waiting up to 5m0s for pod "var-expansion-b47a1857-2b90-11e8-a904-72008c49cf21" in namespace "e2e-tests-var-expansion-vv5ln" to be "success or failure"
+Mar 19 16:15:13.805: INFO: Pod "var-expansion-b47a1857-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.497817ms
+Mar 19 16:15:15.808: INFO: Pod "var-expansion-b47a1857-2b90-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006175925s
+Mar 19 16:15:17.812: INFO: Pod "var-expansion-b47a1857-2b90-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009508388s
+STEP: Saw pod success
+Mar 19 16:15:17.812: INFO: Pod "var-expansion-b47a1857-2b90-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:15:17.813: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod var-expansion-b47a1857-2b90-11e8-a904-72008c49cf21 container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 16:15:17.825: INFO: Waiting for pod var-expansion-b47a1857-2b90-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:15:17.827: INFO: Pod var-expansion-b47a1857-2b90-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:15:17.827: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-vv5ln" for this suite.
+Mar 19 16:15:23.843: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:15:23.945: INFO: namespace: e2e-tests-var-expansion-vv5ln, resource: bindings, ignored listing per whitelist
+Mar 19 16:15:23.950: INFO: namespace e2e-tests-var-expansion-vv5ln deletion completed in 6.11529681s
+
+• [SLOW TEST:10.190 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:15:23.950: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-ba8d7167-2b90-11e8-a904-72008c49cf21
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-ba8d7167-2b90-11e8-a904-72008c49cf21
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:15:28.066: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-tp9k5" for this suite.
+Mar 19 16:15:50.077: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:15:50.140: INFO: namespace: e2e-tests-projected-tp9k5, resource: bindings, ignored listing per whitelist
+Mar 19 16:15:50.184: INFO: namespace e2e-tests-projected-tp9k5 deletion completed in 22.115615057s
+
+• [SLOW TEST:26.234 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:15:50.185: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-56ntm
+Mar 19 16:15:54.231: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-56ntm
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 19 16:15:54.233: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:17:54.457: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-56ntm" for this suite.
+Mar 19 16:18:00.473: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:18:00.552: INFO: namespace: e2e-tests-container-probe-56ntm, resource: bindings, ignored listing per whitelist
+Mar 19 16:18:00.573: INFO: namespace e2e-tests-container-probe-56ntm deletion completed in 6.111957761s
+
+• [SLOW TEST:130.388 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:18:00.573: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap e2e-tests-configmap-c2tgx/configmap-test-17e7c995-2b91-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:18:00.618: INFO: Waiting up to 5m0s for pod "pod-configmaps-17e82587-2b91-11e8-a904-72008c49cf21" in namespace "e2e-tests-configmap-c2tgx" to be "success or failure"
+Mar 19 16:18:00.621: INFO: Pod "pod-configmaps-17e82587-2b91-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.535451ms
+Mar 19 16:18:02.624: INFO: Pod "pod-configmaps-17e82587-2b91-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005516238s
+Mar 19 16:18:04.627: INFO: Pod "pod-configmaps-17e82587-2b91-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008655969s
+STEP: Saw pod success
+Mar 19 16:18:04.627: INFO: Pod "pod-configmaps-17e82587-2b91-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:18:04.629: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-configmaps-17e82587-2b91-11e8-a904-72008c49cf21 container env-test: <nil>
+STEP: delete the pod
+Mar 19 16:18:04.642: INFO: Waiting for pod pod-configmaps-17e82587-2b91-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:18:04.644: INFO: Pod pod-configmaps-17e82587-2b91-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:18:04.644: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-c2tgx" for this suite.
+Mar 19 16:18:10.655: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:18:10.709: INFO: namespace: e2e-tests-configmap-c2tgx, resource: bindings, ignored listing per whitelist
+Mar 19 16:18:10.754: INFO: namespace e2e-tests-configmap-c2tgx deletion completed in 6.106899545s
+
+• [SLOW TEST:10.180 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:18:10.754: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:18:10.794: INFO: Waiting up to 5m0s for pod "downwardapi-volume-1df8e7ce-2b91-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-gprcn" to be "success or failure"
+Mar 19 16:18:10.799: INFO: Pod "downwardapi-volume-1df8e7ce-2b91-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 4.651002ms
+Mar 19 16:18:12.803: INFO: Pod "downwardapi-volume-1df8e7ce-2b91-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008594342s
+STEP: Saw pod success
+Mar 19 16:18:12.803: INFO: Pod "downwardapi-volume-1df8e7ce-2b91-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:18:12.805: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downwardapi-volume-1df8e7ce-2b91-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:18:12.818: INFO: Waiting for pod downwardapi-volume-1df8e7ce-2b91-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:18:12.820: INFO: Pod downwardapi-volume-1df8e7ce-2b91-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:18:12.820: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-gprcn" for this suite.
+Mar 19 16:18:18.830: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:18:18.865: INFO: namespace: e2e-tests-downward-api-gprcn, resource: bindings, ignored listing per whitelist
+Mar 19 16:18:18.929: INFO: namespace e2e-tests-downward-api-gprcn deletion completed in 6.106227337s
+
+• [SLOW TEST:8.175 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:18:18.930: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-tz88t
+Mar 19 16:18:20.979: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-tz88t
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 19 16:18:20.981: INFO: Initial restart count of pod liveness-http is 0
+Mar 19 16:18:41.016: INFO: Restart count of pod e2e-tests-container-probe-tz88t/liveness-http is now 1 (20.034832514s elapsed)
+Mar 19 16:19:01.053: INFO: Restart count of pod e2e-tests-container-probe-tz88t/liveness-http is now 2 (40.071793617s elapsed)
+Mar 19 16:19:19.085: INFO: Restart count of pod e2e-tests-container-probe-tz88t/liveness-http is now 3 (58.103939807s elapsed)
+Mar 19 16:19:39.119: INFO: Restart count of pod e2e-tests-container-probe-tz88t/liveness-http is now 4 (1m18.138045747s elapsed)
+Mar 19 16:20:45.230: INFO: Restart count of pod e2e-tests-container-probe-tz88t/liveness-http is now 5 (2m24.248927304s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:20:45.236: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-tz88t" for this suite.
+Mar 19 16:20:51.247: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:20:51.357: INFO: namespace: e2e-tests-container-probe-tz88t, resource: bindings, ignored listing per whitelist
+Mar 19 16:20:51.357: INFO: namespace e2e-tests-container-probe-tz88t deletion completed in 6.117813315s
+
+• [SLOW TEST:152.428 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:20:51.357: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name projected-secret-test-7db30797-2b91-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:20:51.399: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-7db356d6-2b91-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-wrq9b" to be "success or failure"
+Mar 19 16:20:51.401: INFO: Pod "pod-projected-secrets-7db356d6-2b91-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.807236ms
+Mar 19 16:20:53.404: INFO: Pod "pod-projected-secrets-7db356d6-2b91-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004984876s
+STEP: Saw pod success
+Mar 19 16:20:53.404: INFO: Pod "pod-projected-secrets-7db356d6-2b91-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:20:53.406: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-projected-secrets-7db356d6-2b91-11e8-a904-72008c49cf21 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:20:53.429: INFO: Waiting for pod pod-projected-secrets-7db356d6-2b91-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:20:53.431: INFO: Pod pod-projected-secrets-7db356d6-2b91-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:20:53.431: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wrq9b" for this suite.
+Mar 19 16:20:59.445: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:20:59.547: INFO: namespace: e2e-tests-projected-wrq9b, resource: bindings, ignored listing per whitelist
+Mar 19 16:20:59.551: INFO: namespace e2e-tests-projected-wrq9b deletion completed in 6.114807857s
+
+• [SLOW TEST:8.194 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:20:59.551: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test env composition
+Mar 19 16:20:59.589: INFO: Waiting up to 5m0s for pod "var-expansion-8294eb07-2b91-11e8-a904-72008c49cf21" in namespace "e2e-tests-var-expansion-kx8wt" to be "success or failure"
+Mar 19 16:20:59.591: INFO: Pod "var-expansion-8294eb07-2b91-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.347156ms
+Mar 19 16:21:01.595: INFO: Pod "var-expansion-8294eb07-2b91-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006147478s
+Mar 19 16:21:03.599: INFO: Pod "var-expansion-8294eb07-2b91-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010040682s
+STEP: Saw pod success
+Mar 19 16:21:03.599: INFO: Pod "var-expansion-8294eb07-2b91-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:21:03.601: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod var-expansion-8294eb07-2b91-11e8-a904-72008c49cf21 container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 16:21:03.616: INFO: Waiting for pod var-expansion-8294eb07-2b91-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:21:03.617: INFO: Pod var-expansion-8294eb07-2b91-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:21:03.618: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-kx8wt" for this suite.
+Mar 19 16:21:09.627: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:21:09.715: INFO: namespace: e2e-tests-var-expansion-kx8wt, resource: bindings, ignored listing per whitelist
+Mar 19 16:21:09.739: INFO: namespace e2e-tests-var-expansion-kx8wt deletion completed in 6.119148006s
+
+• [SLOW TEST:10.188 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:21:09.739: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:21:09.781: INFO: Waiting up to 5m0s for pod "downwardapi-volume-88a83196-2b91-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-wg5t7" to be "success or failure"
+Mar 19 16:21:09.783: INFO: Pod "downwardapi-volume-88a83196-2b91-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.796967ms
+Mar 19 16:21:11.787: INFO: Pod "downwardapi-volume-88a83196-2b91-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005361357s
+STEP: Saw pod success
+Mar 19 16:21:11.787: INFO: Pod "downwardapi-volume-88a83196-2b91-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:21:11.789: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod downwardapi-volume-88a83196-2b91-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:21:11.802: INFO: Waiting for pod downwardapi-volume-88a83196-2b91-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:21:11.806: INFO: Pod downwardapi-volume-88a83196-2b91-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:21:11.806: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-wg5t7" for this suite.
+Mar 19 16:21:17.825: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:21:17.914: INFO: namespace: e2e-tests-downward-api-wg5t7, resource: bindings, ignored listing per whitelist
+Mar 19 16:21:17.930: INFO: namespace e2e-tests-downward-api-wg5t7 deletion completed in 6.120861331s
+
+• [SLOW TEST:8.190 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:21:17.930: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name s-test-opt-del-8d89a81a-2b91-11e8-a904-72008c49cf21
+STEP: Creating secret with name s-test-opt-upd-8d89a850-2b91-11e8-a904-72008c49cf21
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-8d89a81a-2b91-11e8-a904-72008c49cf21
+STEP: Updating secret s-test-opt-upd-8d89a850-2b91-11e8-a904-72008c49cf21
+STEP: Creating secret with name s-test-opt-create-8d89a863-2b91-11e8-a904-72008c49cf21
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:22:45.263: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-kd95j" for this suite.
+Mar 19 16:23:07.273: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:23:07.334: INFO: namespace: e2e-tests-projected-kd95j, resource: bindings, ignored listing per whitelist
+Mar 19 16:23:07.373: INFO: namespace e2e-tests-projected-kd95j deletion completed in 22.10759364s
+
+• [SLOW TEST:109.444 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:23:07.373: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test substitution in container's command
+Mar 19 16:23:07.411: INFO: Waiting up to 5m0s for pod "var-expansion-cec52765-2b91-11e8-a904-72008c49cf21" in namespace "e2e-tests-var-expansion-hvwxw" to be "success or failure"
+Mar 19 16:23:07.413: INFO: Pod "var-expansion-cec52765-2b91-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.616308ms
+Mar 19 16:23:09.415: INFO: Pod "var-expansion-cec52765-2b91-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004469286s
+Mar 19 16:23:11.419: INFO: Pod "var-expansion-cec52765-2b91-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008021786s
+STEP: Saw pod success
+Mar 19 16:23:11.419: INFO: Pod "var-expansion-cec52765-2b91-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:23:11.421: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod var-expansion-cec52765-2b91-11e8-a904-72008c49cf21 container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 16:23:11.437: INFO: Waiting for pod var-expansion-cec52765-2b91-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:23:11.440: INFO: Pod var-expansion-cec52765-2b91-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:23:11.440: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-hvwxw" for this suite.
+Mar 19 16:23:17.470: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:23:17.524: INFO: namespace: e2e-tests-var-expansion-hvwxw, resource: bindings, ignored listing per whitelist
+Mar 19 16:23:17.578: INFO: namespace e2e-tests-var-expansion-hvwxw deletion completed in 6.128130111s
+
+• [SLOW TEST:10.205 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:23:17.578: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-upd-d4db2cf4-2b91-11e8-a904-72008c49cf21
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-d4db2cf4-2b91-11e8-a904-72008c49cf21
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:23:21.695: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-kmpq5" for this suite.
+Mar 19 16:23:43.706: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:23:43.788: INFO: namespace: e2e-tests-configmap-kmpq5, resource: bindings, ignored listing per whitelist
+Mar 19 16:23:43.816: INFO: namespace e2e-tests-configmap-kmpq5 deletion completed in 22.117396945s
+
+• [SLOW TEST:26.237 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:23:43.817: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 19 16:23:43.857: INFO: Waiting up to 5m0s for pod "downward-api-e47e45ef-2b91-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-wpgbm" to be "success or failure"
+Mar 19 16:23:43.859: INFO: Pod "downward-api-e47e45ef-2b91-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.798724ms
+Mar 19 16:23:45.862: INFO: Pod "downward-api-e47e45ef-2b91-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005199005s
+Mar 19 16:23:47.865: INFO: Pod "downward-api-e47e45ef-2b91-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008317284s
+STEP: Saw pod success
+Mar 19 16:23:47.865: INFO: Pod "downward-api-e47e45ef-2b91-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:23:47.867: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod downward-api-e47e45ef-2b91-11e8-a904-72008c49cf21 container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 16:23:47.882: INFO: Waiting for pod downward-api-e47e45ef-2b91-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:23:47.884: INFO: Pod downward-api-e47e45ef-2b91-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:23:47.884: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-wpgbm" for this suite.
+Mar 19 16:23:53.899: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:23:54.007: INFO: namespace: e2e-tests-downward-api-wpgbm, resource: bindings, ignored listing per whitelist
+Mar 19 16:23:54.009: INFO: namespace e2e-tests-downward-api-wpgbm deletion completed in 6.121709162s
+
+• [SLOW TEST:10.193 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:23:54.010: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:24:54.053: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-fwms9" for this suite.
+Mar 19 16:25:16.066: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:25:16.180: INFO: namespace: e2e-tests-container-probe-fwms9, resource: bindings, ignored listing per whitelist
+Mar 19 16:25:16.180: INFO: namespace e2e-tests-container-probe-fwms9 deletion completed in 22.124164598s
+
+• [SLOW TEST:82.170 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:25:16.180: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-1b8b70f1-2b92-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:25:16.221: INFO: Waiting up to 5m0s for pod "pod-secrets-1b8bccb5-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-secrets-rzqb8" to be "success or failure"
+Mar 19 16:25:16.223: INFO: Pod "pod-secrets-1b8bccb5-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.762119ms
+Mar 19 16:25:18.227: INFO: Pod "pod-secrets-1b8bccb5-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005404108s
+STEP: Saw pod success
+Mar 19 16:25:18.227: INFO: Pod "pod-secrets-1b8bccb5-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:25:18.229: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-secrets-1b8bccb5-2b92-11e8-a904-72008c49cf21 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:25:18.245: INFO: Waiting for pod pod-secrets-1b8bccb5-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:25:18.250: INFO: Pod pod-secrets-1b8bccb5-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:25:18.250: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-rzqb8" for this suite.
+Mar 19 16:25:24.267: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:25:24.374: INFO: namespace: e2e-tests-secrets-rzqb8, resource: bindings, ignored listing per whitelist
+Mar 19 16:25:24.378: INFO: namespace e2e-tests-secrets-rzqb8 deletion completed in 6.121255812s
+
+• [SLOW TEST:8.198 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:25:24.379: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-cwgp6
+Mar 19 16:25:26.422: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-cwgp6
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 19 16:25:26.424: INFO: Initial restart count of pod liveness-http is 0
+Mar 19 16:25:48.464: INFO: Restart count of pod e2e-tests-container-probe-cwgp6/liveness-http is now 1 (22.039802879s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:25:48.469: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-cwgp6" for this suite.
+Mar 19 16:25:54.479: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:25:54.518: INFO: namespace: e2e-tests-container-probe-cwgp6, resource: bindings, ignored listing per whitelist
+Mar 19 16:25:54.586: INFO: namespace e2e-tests-container-probe-cwgp6 deletion completed in 6.113542628s
+
+• [SLOW TEST:30.207 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:25:54.587: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating server pod server in namespace e2e-tests-prestop-dbq77
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-dbq77
+STEP: Deleting pre-stop pod
+Mar 19 16:26:05.690: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:26:05.694: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-dbq77" for this suite.
+Mar 19 16:26:43.709: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:26:43.805: INFO: namespace: e2e-tests-prestop-dbq77, resource: bindings, ignored listing per whitelist
+Mar 19 16:26:43.827: INFO: namespace e2e-tests-prestop-dbq77 deletion completed in 38.129299211s
+
+• [SLOW TEST:49.240 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:26:43.827: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap e2e-tests-configmap-lvlpx/configmap-test-4fc9530b-2b92-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:26:43.867: INFO: Waiting up to 5m0s for pod "pod-configmaps-4fc9b1b4-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-configmap-lvlpx" to be "success or failure"
+Mar 19 16:26:43.869: INFO: Pod "pod-configmaps-4fc9b1b4-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.644785ms
+Mar 19 16:26:45.872: INFO: Pod "pod-configmaps-4fc9b1b4-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004699758s
+Mar 19 16:26:47.875: INFO: Pod "pod-configmaps-4fc9b1b4-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.00783284s
+STEP: Saw pod success
+Mar 19 16:26:47.875: INFO: Pod "pod-configmaps-4fc9b1b4-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:26:47.877: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-configmaps-4fc9b1b4-2b92-11e8-a904-72008c49cf21 container env-test: <nil>
+STEP: delete the pod
+Mar 19 16:26:47.897: INFO: Waiting for pod pod-configmaps-4fc9b1b4-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:26:47.910: INFO: Pod pod-configmaps-4fc9b1b4-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:26:47.910: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-lvlpx" for this suite.
+Mar 19 16:26:53.928: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:26:53.988: INFO: namespace: e2e-tests-configmap-lvlpx, resource: bindings, ignored listing per whitelist
+Mar 19 16:26:54.038: INFO: namespace e2e-tests-configmap-lvlpx deletion completed in 6.12089146s
+
+• [SLOW TEST:10.211 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:26:54.038: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:51
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-m8wwh
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-m8wwh to expose endpoints map[]
+Mar 19 16:26:54.081: INFO: Get endpoints failed (1.814093ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Mar 19 16:26:55.084: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-m8wwh exposes endpoints map[] (1.004744577s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-m8wwh
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-m8wwh to expose endpoints map[pod1:[80]]
+Mar 19 16:26:57.105: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-m8wwh exposes endpoints map[pod1:[80]] (2.0148848s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-m8wwh
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-m8wwh to expose endpoints map[pod1:[80] pod2:[80]]
+Mar 19 16:26:59.136: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-m8wwh exposes endpoints map[pod2:[80] pod1:[80]] (2.026979403s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-m8wwh
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-m8wwh to expose endpoints map[pod2:[80]]
+Mar 19 16:27:00.152: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-m8wwh exposes endpoints map[pod2:[80]] (1.012432576s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-m8wwh
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-m8wwh to expose endpoints map[]
+Mar 19 16:27:00.165: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-m8wwh exposes endpoints map[] (6.582497ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:27:00.173: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-m8wwh" for this suite.
+Mar 19 16:27:22.193: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:27:22.268: INFO: namespace: e2e-tests-services-m8wwh, resource: bindings, ignored listing per whitelist
+Mar 19 16:27:22.295: INFO: namespace e2e-tests-services-m8wwh deletion completed in 22.116562655s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:56
+
+• [SLOW TEST:28.257 seconds]
+[sig-network] Services
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:27:22.295: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-66b75ee4-2b92-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:27:22.337: INFO: Waiting up to 5m0s for pod "pod-configmaps-66b7b709-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-configmap-vwz2t" to be "success or failure"
+Mar 19 16:27:22.340: INFO: Pod "pod-configmaps-66b7b709-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 3.04354ms
+Mar 19 16:27:24.344: INFO: Pod "pod-configmaps-66b7b709-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006477356s
+STEP: Saw pod success
+Mar 19 16:27:24.344: INFO: Pod "pod-configmaps-66b7b709-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:27:24.346: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-configmaps-66b7b709-2b92-11e8-a904-72008c49cf21 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:27:24.361: INFO: Waiting for pod pod-configmaps-66b7b709-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:27:24.363: INFO: Pod pod-configmaps-66b7b709-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:27:24.363: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-vwz2t" for this suite.
+Mar 19 16:27:30.372: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:27:30.420: INFO: namespace: e2e-tests-configmap-vwz2t, resource: bindings, ignored listing per whitelist
+Mar 19 16:27:30.486: INFO: namespace e2e-tests-configmap-vwz2t deletion completed in 6.120434758s
+
+• [SLOW TEST:8.191 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:27:30.486: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:27:30.526: INFO: Waiting up to 5m0s for pod "downwardapi-volume-6b99351c-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-t25s5" to be "success or failure"
+Mar 19 16:27:30.527: INFO: Pod "downwardapi-volume-6b99351c-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.642252ms
+Mar 19 16:27:32.531: INFO: Pod "downwardapi-volume-6b99351c-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00558512s
+STEP: Saw pod success
+Mar 19 16:27:32.531: INFO: Pod "downwardapi-volume-6b99351c-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:27:32.534: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downwardapi-volume-6b99351c-2b92-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:27:32.547: INFO: Waiting for pod downwardapi-volume-6b99351c-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:27:32.549: INFO: Pod downwardapi-volume-6b99351c-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:27:32.549: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-t25s5" for this suite.
+Mar 19 16:27:38.560: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:27:38.662: INFO: namespace: e2e-tests-projected-t25s5, resource: bindings, ignored listing per whitelist
+Mar 19 16:27:38.672: INFO: namespace e2e-tests-projected-t25s5 deletion completed in 6.120885109s
+
+• [SLOW TEST:8.186 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:27:38.673: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 16:27:38.709: INFO: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:27:38.710: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-z2qzn" for this suite.
+Mar 19 16:27:44.721: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:27:44.830: INFO: namespace: e2e-tests-container-probe-z2qzn, resource: bindings, ignored listing per whitelist
+Mar 19 16:27:44.834: INFO: namespace e2e-tests-container-probe-z2qzn deletion completed in 6.121102252s
+
+S [SKIPPING] [6.161 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be restarted with a docker exec liveness probe with timeout  [Conformance] [It]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+
+  Mar 19 16:27:38.709: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:289
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:27:44.835: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-74265cbb-2b92-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:27:44.875: INFO: Waiting up to 5m0s for pod "pod-configmaps-7426b2d2-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-configmap-ndz6l" to be "success or failure"
+Mar 19 16:27:44.877: INFO: Pod "pod-configmaps-7426b2d2-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.809251ms
+Mar 19 16:27:46.880: INFO: Pod "pod-configmaps-7426b2d2-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005659279s
+STEP: Saw pod success
+Mar 19 16:27:46.880: INFO: Pod "pod-configmaps-7426b2d2-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:27:46.882: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-configmaps-7426b2d2-2b92-11e8-a904-72008c49cf21 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:27:46.903: INFO: Waiting for pod pod-configmaps-7426b2d2-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:27:46.905: INFO: Pod pod-configmaps-7426b2d2-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:27:46.905: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-ndz6l" for this suite.
+Mar 19 16:27:52.915: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:27:53.003: INFO: namespace: e2e-tests-configmap-ndz6l, resource: bindings, ignored listing per whitelist
+Mar 19 16:27:53.023: INFO: namespace e2e-tests-configmap-ndz6l deletion completed in 6.115890125s
+
+• [SLOW TEST:8.189 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:27:53.023: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Mar 19 16:27:53.063: INFO: Waiting up to 5m0s for pod "pod-79080fe6-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-4xz77" to be "success or failure"
+Mar 19 16:27:53.069: INFO: Pod "pod-79080fe6-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 5.885091ms
+Mar 19 16:27:55.072: INFO: Pod "pod-79080fe6-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009427401s
+STEP: Saw pod success
+Mar 19 16:27:55.072: INFO: Pod "pod-79080fe6-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:27:55.074: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-79080fe6-2b92-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:27:55.088: INFO: Waiting for pod pod-79080fe6-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:27:55.090: INFO: Pod pod-79080fe6-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:27:55.091: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-4xz77" for this suite.
+Mar 19 16:28:01.110: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:28:01.194: INFO: namespace: e2e-tests-emptydir-4xz77, resource: bindings, ignored listing per whitelist
+Mar 19 16:28:01.217: INFO: namespace e2e-tests-emptydir-4xz77 deletion completed in 6.116482566s
+
+• [SLOW TEST:8.194 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:28:01.217: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:28:01.265: INFO: Waiting up to 5m0s for pod "downwardapi-volume-7deb9887-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-sgjg5" to be "success or failure"
+Mar 19 16:28:01.268: INFO: Pod "downwardapi-volume-7deb9887-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.631873ms
+Mar 19 16:28:03.271: INFO: Pod "downwardapi-volume-7deb9887-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005757363s
+STEP: Saw pod success
+Mar 19 16:28:03.271: INFO: Pod "downwardapi-volume-7deb9887-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:28:03.273: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downwardapi-volume-7deb9887-2b92-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:28:03.285: INFO: Waiting for pod downwardapi-volume-7deb9887-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:28:03.287: INFO: Pod downwardapi-volume-7deb9887-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:28:03.287: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-sgjg5" for this suite.
+Mar 19 16:28:09.297: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:28:09.378: INFO: namespace: e2e-tests-projected-sgjg5, resource: bindings, ignored listing per whitelist
+Mar 19 16:28:09.404: INFO: namespace e2e-tests-projected-sgjg5 deletion completed in 6.114003636s
+
+• [SLOW TEST:8.186 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:28:09.405: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 16:28:29.453: INFO: Container started at 2018-03-19 16:28:10 +0000 UTC, pod became ready at 2018-03-19 16:28:27 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:28:29.453: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-4fd65" for this suite.
+Mar 19 16:28:51.465: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:28:51.532: INFO: namespace: e2e-tests-container-probe-4fd65, resource: bindings, ignored listing per whitelist
+Mar 19 16:28:51.573: INFO: namespace e2e-tests-container-probe-4fd65 deletion completed in 22.117370083s
+
+• [SLOW TEST:42.169 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:28:51.574: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:51
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:28:51.612: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-mjzqb" for this suite.
+Mar 19 16:28:57.621: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:28:57.668: INFO: namespace: e2e-tests-services-mjzqb, resource: bindings, ignored listing per whitelist
+Mar 19 16:28:57.726: INFO: namespace e2e-tests-services-mjzqb deletion completed in 6.111859951s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:56
+
+• [SLOW TEST:6.153 seconds]
+[sig-network] Services
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:28:57.728: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Mar 19 16:28:57.765: INFO: Waiting up to 5m0s for pod "pod-9f98d66c-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-9hbwk" to be "success or failure"
+Mar 19 16:28:57.768: INFO: Pod "pod-9f98d66c-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.324634ms
+Mar 19 16:28:59.771: INFO: Pod "pod-9f98d66c-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005791189s
+STEP: Saw pod success
+Mar 19 16:28:59.771: INFO: Pod "pod-9f98d66c-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:28:59.773: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-9f98d66c-2b92-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:28:59.785: INFO: Waiting for pod pod-9f98d66c-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:28:59.792: INFO: Pod pod-9f98d66c-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:28:59.792: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-9hbwk" for this suite.
+Mar 19 16:29:05.802: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:29:05.840: INFO: namespace: e2e-tests-emptydir-9hbwk, resource: bindings, ignored listing per whitelist
+Mar 19 16:29:05.906: INFO: namespace e2e-tests-emptydir-9hbwk deletion completed in 6.110881467s
+
+• [SLOW TEST:8.178 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:29:05.906: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:29:05.948: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a47965db-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-b9b4g" to be "success or failure"
+Mar 19 16:29:05.951: INFO: Pod "downwardapi-volume-a47965db-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.895522ms
+Mar 19 16:29:07.954: INFO: Pod "downwardapi-volume-a47965db-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006336535s
+STEP: Saw pod success
+Mar 19 16:29:07.954: INFO: Pod "downwardapi-volume-a47965db-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:29:07.956: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod downwardapi-volume-a47965db-2b92-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:29:07.968: INFO: Waiting for pod downwardapi-volume-a47965db-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:29:07.970: INFO: Pod downwardapi-volume-a47965db-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:29:07.970: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-b9b4g" for this suite.
+Mar 19 16:29:13.988: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:29:14.077: INFO: namespace: e2e-tests-projected-b9b4g, resource: bindings, ignored listing per whitelist
+Mar 19 16:29:14.091: INFO: namespace e2e-tests-projected-b9b4g deletion completed in 6.116377636s
+
+• [SLOW TEST:8.185 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:29:14.092: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 16:29:14.125: INFO: Creating ReplicaSet my-hostname-basic-a959ce0a-2b92-11e8-a904-72008c49cf21
+Mar 19 16:29:14.130: INFO: Pod name my-hostname-basic-a959ce0a-2b92-11e8-a904-72008c49cf21: Found 0 pods out of 1
+Mar 19 16:29:19.133: INFO: Pod name my-hostname-basic-a959ce0a-2b92-11e8-a904-72008c49cf21: Found 1 pods out of 1
+Mar 19 16:29:19.133: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-a959ce0a-2b92-11e8-a904-72008c49cf21" is running
+Mar 19 16:29:19.135: INFO: Pod "my-hostname-basic-a959ce0a-2b92-11e8-a904-72008c49cf21-tr7ms" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-19 16:29:14 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-19 16:29:15 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-19 16:29:14 +0000 UTC Reason: Message:}])
+Mar 19 16:29:19.135: INFO: Trying to dial the pod
+Mar 19 16:29:24.186: INFO: Controller my-hostname-basic-a959ce0a-2b92-11e8-a904-72008c49cf21: Got expected result from replica 1 [my-hostname-basic-a959ce0a-2b92-11e8-a904-72008c49cf21-tr7ms]: "my-hostname-basic-a959ce0a-2b92-11e8-a904-72008c49cf21-tr7ms", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:29:24.186: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-l4qf7" for this suite.
+Mar 19 16:29:30.196: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:29:30.275: INFO: namespace: e2e-tests-replicaset-l4qf7, resource: bindings, ignored listing per whitelist
+Mar 19 16:29:30.311: INFO: namespace e2e-tests-replicaset-l4qf7 deletion completed in 6.122117829s
+
+• [SLOW TEST:16.219 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:29:30.312: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Mar 19 16:29:32.884: INFO: Successfully updated pod "pod-update-activedeadlineseconds-b306d183-2b92-11e8-a904-72008c49cf21"
+Mar 19 16:29:32.884: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-b306d183-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-pods-pcgxn" to be "terminated due to deadline exceeded"
+Mar 19 16:29:32.887: INFO: Pod "pod-update-activedeadlineseconds-b306d183-2b92-11e8-a904-72008c49cf21": Phase="Running", Reason="", readiness=true. Elapsed: 3.758337ms
+Mar 19 16:29:34.891: INFO: Pod "pod-update-activedeadlineseconds-b306d183-2b92-11e8-a904-72008c49cf21": Phase="Running", Reason="", readiness=true. Elapsed: 2.007236045s
+Mar 19 16:29:36.894: INFO: Pod "pod-update-activedeadlineseconds-b306d183-2b92-11e8-a904-72008c49cf21": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 4.010772056s
+Mar 19 16:29:36.894: INFO: Pod "pod-update-activedeadlineseconds-b306d183-2b92-11e8-a904-72008c49cf21" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:29:36.894: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-pcgxn" for this suite.
+Mar 19 16:29:42.908: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:29:42.983: INFO: namespace: e2e-tests-pods-pcgxn, resource: bindings, ignored listing per whitelist
+Mar 19 16:29:43.016: INFO: namespace e2e-tests-pods-pcgxn deletion completed in 6.118824425s
+
+• [SLOW TEST:12.704 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:29:43.016: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Mar 19 16:29:43.056: INFO: Waiting up to 5m0s for pod "pod-ba97a5e2-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-5r46q" to be "success or failure"
+Mar 19 16:29:43.057: INFO: Pod "pod-ba97a5e2-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.797157ms
+Mar 19 16:29:45.061: INFO: Pod "pod-ba97a5e2-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005541519s
+STEP: Saw pod success
+Mar 19 16:29:45.061: INFO: Pod "pod-ba97a5e2-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:29:45.063: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-ba97a5e2-2b92-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:29:45.078: INFO: Waiting for pod pod-ba97a5e2-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:29:45.080: INFO: Pod pod-ba97a5e2-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:29:45.080: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-5r46q" for this suite.
+Mar 19 16:29:51.091: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:29:51.169: INFO: namespace: e2e-tests-emptydir-5r46q, resource: bindings, ignored listing per whitelist
+Mar 19 16:29:51.204: INFO: namespace e2e-tests-emptydir-5r46q deletion completed in 6.120706658s
+
+• [SLOW TEST:8.188 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:29:51.204: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Mar 19 16:29:51.751: INFO: Waiting up to 5m0s for pod "pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-shbb2" in namespace "e2e-tests-svcaccounts-8stj6" to be "success or failure"
+Mar 19 16:29:51.755: INFO: Pod "pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-shbb2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.66543ms
+Mar 19 16:29:53.758: INFO: Pod "pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-shbb2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00698602s
+STEP: Saw pod success
+Mar 19 16:29:53.758: INFO: Pod "pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-shbb2" satisfied condition "success or failure"
+Mar 19 16:29:53.760: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-shbb2 container token-test: <nil>
+STEP: delete the pod
+Mar 19 16:29:53.774: INFO: Waiting for pod pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-shbb2 to disappear
+Mar 19 16:29:53.798: INFO: Pod pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-shbb2 no longer exists
+STEP: Creating a pod to test consume service account root CA
+Mar 19 16:29:53.802: INFO: Waiting up to 5m0s for pod "pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-g8n97" in namespace "e2e-tests-svcaccounts-8stj6" to be "success or failure"
+Mar 19 16:29:53.806: INFO: Pod "pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-g8n97": Phase="Pending", Reason="", readiness=false. Elapsed: 4.233994ms
+Mar 19 16:29:55.809: INFO: Pod "pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-g8n97": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007125807s
+STEP: Saw pod success
+Mar 19 16:29:55.809: INFO: Pod "pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-g8n97" satisfied condition "success or failure"
+Mar 19 16:29:55.811: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-g8n97 container root-ca-test: <nil>
+STEP: delete the pod
+Mar 19 16:29:55.824: INFO: Waiting for pod pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-g8n97 to disappear
+Mar 19 16:29:55.826: INFO: Pod pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-g8n97 no longer exists
+STEP: Creating a pod to test consume service account namespace
+Mar 19 16:29:55.829: INFO: Waiting up to 5m0s for pod "pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-7kshz" in namespace "e2e-tests-svcaccounts-8stj6" to be "success or failure"
+Mar 19 16:29:55.833: INFO: Pod "pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-7kshz": Phase="Pending", Reason="", readiness=false. Elapsed: 3.208196ms
+Mar 19 16:29:57.836: INFO: Pod "pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-7kshz": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007039577s
+STEP: Saw pod success
+Mar 19 16:29:57.836: INFO: Pod "pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-7kshz" satisfied condition "success or failure"
+Mar 19 16:29:57.838: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-7kshz container namespace-test: <nil>
+STEP: delete the pod
+Mar 19 16:29:57.851: INFO: Waiting for pod pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-7kshz to disappear
+Mar 19 16:29:57.860: INFO: Pod pod-service-account-bfc65e8f-2b92-11e8-a904-72008c49cf21-7kshz no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:29:57.865: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-8stj6" for this suite.
+Mar 19 16:30:03.880: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:30:03.938: INFO: namespace: e2e-tests-svcaccounts-8stj6, resource: bindings, ignored listing per whitelist
+Mar 19 16:30:03.978: INFO: namespace e2e-tests-svcaccounts-8stj6 deletion completed in 6.106161746s
+
+• [SLOW TEST:12.774 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:30:03.978: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name cm-test-opt-del-c7168273-2b92-11e8-a904-72008c49cf21
+STEP: Creating configMap with name cm-test-opt-upd-c71682ad-2b92-11e8-a904-72008c49cf21
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-c7168273-2b92-11e8-a904-72008c49cf21
+STEP: Updating configmap cm-test-opt-upd-c71682ad-2b92-11e8-a904-72008c49cf21
+STEP: Creating configMap with name cm-test-opt-create-c71682ca-2b92-11e8-a904-72008c49cf21
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:30:08.274: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hnjdx" for this suite.
+Mar 19 16:30:30.284: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:30:30.350: INFO: namespace: e2e-tests-projected-hnjdx, resource: bindings, ignored listing per whitelist
+Mar 19 16:30:30.388: INFO: namespace e2e-tests-projected-hnjdx deletion completed in 22.110555308s
+
+• [SLOW TEST:26.409 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:30:30.388: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 19 16:30:32.951: INFO: Successfully updated pod "labelsupdated6d3f818-2b92-11e8-a904-72008c49cf21"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:30:36.977: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-r2s7p" for this suite.
+Mar 19 16:30:58.988: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:30:59.029: INFO: namespace: e2e-tests-downward-api-r2s7p, resource: bindings, ignored listing per whitelist
+Mar 19 16:30:59.089: INFO: namespace e2e-tests-downward-api-r2s7p deletion completed in 22.109897318s
+
+• [SLOW TEST:28.702 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:30:59.090: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:30:59.126: INFO: Waiting up to 5m0s for pod "downwardapi-volume-e7ef2827-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-4tjmg" to be "success or failure"
+Mar 19 16:30:59.128: INFO: Pod "downwardapi-volume-e7ef2827-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.637037ms
+Mar 19 16:31:01.131: INFO: Pod "downwardapi-volume-e7ef2827-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005271722s
+STEP: Saw pod success
+Mar 19 16:31:01.132: INFO: Pod "downwardapi-volume-e7ef2827-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:31:01.134: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downwardapi-volume-e7ef2827-2b92-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:31:01.147: INFO: Waiting for pod downwardapi-volume-e7ef2827-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:31:01.149: INFO: Pod downwardapi-volume-e7ef2827-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:31:01.149: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-4tjmg" for this suite.
+Mar 19 16:31:07.159: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:31:07.229: INFO: namespace: e2e-tests-downward-api-4tjmg, resource: bindings, ignored listing per whitelist
+Mar 19 16:31:07.268: INFO: namespace e2e-tests-downward-api-4tjmg deletion completed in 6.11549039s
+
+• [SLOW TEST:8.178 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:31:07.268: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:31:07.306: INFO: Waiting up to 5m0s for pod "downwardapi-volume-eccf53a4-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-zdtpv" to be "success or failure"
+Mar 19 16:31:07.308: INFO: Pod "downwardapi-volume-eccf53a4-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.203509ms
+Mar 19 16:31:09.316: INFO: Pod "downwardapi-volume-eccf53a4-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010113308s
+STEP: Saw pod success
+Mar 19 16:31:09.317: INFO: Pod "downwardapi-volume-eccf53a4-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:31:09.319: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod downwardapi-volume-eccf53a4-2b92-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:31:09.337: INFO: Waiting for pod downwardapi-volume-eccf53a4-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:31:09.346: INFO: Pod downwardapi-volume-eccf53a4-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:31:09.346: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-zdtpv" for this suite.
+Mar 19 16:31:15.356: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:31:15.431: INFO: namespace: e2e-tests-projected-zdtpv, resource: bindings, ignored listing per whitelist
+Mar 19 16:31:15.459: INFO: namespace e2e-tests-projected-zdtpv deletion completed in 6.109626323s
+
+• [SLOW TEST:8.191 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:31:15.459: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-f1b13a5d-2b92-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:31:15.500: INFO: Waiting up to 5m0s for pod "pod-configmaps-f1b18c63-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-configmap-xxfwk" to be "success or failure"
+Mar 19 16:31:15.502: INFO: Pod "pod-configmaps-f1b18c63-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.911222ms
+Mar 19 16:31:17.505: INFO: Pod "pod-configmaps-f1b18c63-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004881885s
+STEP: Saw pod success
+Mar 19 16:31:17.505: INFO: Pod "pod-configmaps-f1b18c63-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:31:17.507: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-configmaps-f1b18c63-2b92-11e8-a904-72008c49cf21 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:31:21.884: INFO: Waiting for pod pod-configmaps-f1b18c63-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:31:21.886: INFO: Pod pod-configmaps-f1b18c63-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:31:21.886: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-xxfwk" for this suite.
+Mar 19 16:31:27.896: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:31:27.961: INFO: namespace: e2e-tests-configmap-xxfwk, resource: bindings, ignored listing per whitelist
+Mar 19 16:31:27.994: INFO: namespace e2e-tests-configmap-xxfwk deletion completed in 6.105074111s
+
+• [SLOW TEST:12.535 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:31:27.994: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-map-f92a238d-2b92-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:31:28.037: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-f92a8dd3-2b92-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-7vw5r" to be "success or failure"
+Mar 19 16:31:28.038: INFO: Pod "pod-projected-configmaps-f92a8dd3-2b92-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.709049ms
+Mar 19 16:31:30.042: INFO: Pod "pod-projected-configmaps-f92a8dd3-2b92-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005157107s
+STEP: Saw pod success
+Mar 19 16:31:30.042: INFO: Pod "pod-projected-configmaps-f92a8dd3-2b92-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:31:30.044: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-projected-configmaps-f92a8dd3-2b92-11e8-a904-72008c49cf21 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:31:30.062: INFO: Waiting for pod pod-projected-configmaps-f92a8dd3-2b92-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:31:30.072: INFO: Pod pod-projected-configmaps-f92a8dd3-2b92-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:31:30.072: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-7vw5r" for this suite.
+Mar 19 16:31:36.082: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:31:36.137: INFO: namespace: e2e-tests-projected-7vw5r, resource: bindings, ignored listing per whitelist
+Mar 19 16:31:36.186: INFO: namespace e2e-tests-projected-7vw5r deletion completed in 6.111579177s
+
+• [SLOW TEST:8.192 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:31:36.186: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name cm-test-opt-del-fe0c253f-2b92-11e8-a904-72008c49cf21
+STEP: Creating configMap with name cm-test-opt-upd-fe0c2595-2b92-11e8-a904-72008c49cf21
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-fe0c253f-2b92-11e8-a904-72008c49cf21
+STEP: Updating configmap cm-test-opt-upd-fe0c2595-2b92-11e8-a904-72008c49cf21
+STEP: Creating configMap with name cm-test-opt-create-fe0c25ab-2b92-11e8-a904-72008c49cf21
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:31:40.482: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-5dl5m" for this suite.
+Mar 19 16:31:58.492: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:31:58.538: INFO: namespace: e2e-tests-configmap-5dl5m, resource: bindings, ignored listing per whitelist
+Mar 19 16:31:58.599: INFO: namespace e2e-tests-configmap-5dl5m deletion completed in 18.114678496s
+
+• [SLOW TEST:22.413 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:31:58.600: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 16:31:58.644: INFO: (0) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.175902ms)
+Mar 19 16:31:58.648: INFO: (1) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.042807ms)
+Mar 19 16:31:58.652: INFO: (2) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.898971ms)
+Mar 19 16:31:58.655: INFO: (3) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.623738ms)
+Mar 19 16:31:58.659: INFO: (4) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.49838ms)
+Mar 19 16:31:58.662: INFO: (5) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.184338ms)
+Mar 19 16:31:58.665: INFO: (6) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.290047ms)
+Mar 19 16:31:58.669: INFO: (7) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.223438ms)
+Mar 19 16:31:58.672: INFO: (8) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.944905ms)
+Mar 19 16:31:58.675: INFO: (9) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.267885ms)
+Mar 19 16:31:58.678: INFO: (10) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.321352ms)
+Mar 19 16:31:58.682: INFO: (11) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.417139ms)
+Mar 19 16:31:58.685: INFO: (12) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.507006ms)
+Mar 19 16:31:58.688: INFO: (13) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.203465ms)
+Mar 19 16:31:58.692: INFO: (14) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.268188ms)
+Mar 19 16:31:58.696: INFO: (15) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.743805ms)
+Mar 19 16:31:58.699: INFO: (16) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.518811ms)
+Mar 19 16:31:58.703: INFO: (17) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.955954ms)
+Mar 19 16:31:58.707: INFO: (18) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.00698ms)
+Mar 19 16:31:58.711: INFO: (19) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.599461ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:31:58.711: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-2w84z" for this suite.
+Mar 19 16:32:04.721: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:32:04.809: INFO: namespace: e2e-tests-proxy-2w84z, resource: bindings, ignored listing per whitelist
+Mar 19 16:32:04.829: INFO: namespace e2e-tests-proxy-2w84z deletion completed in 6.114951948s
+
+• [SLOW TEST:6.228 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] Pods 
+  should be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:32:04.829: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Mar 19 16:32:07.382: INFO: Successfully updated pod "pod-update-0f1e47fd-2b93-11e8-a904-72008c49cf21"
+STEP: verifying the updated pod is in kubernetes
+Mar 19 16:32:07.386: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:32:07.386: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-vqzm9" for this suite.
+Mar 19 16:32:29.397: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:32:29.444: INFO: namespace: e2e-tests-pods-vqzm9, resource: bindings, ignored listing per whitelist
+Mar 19 16:32:29.502: INFO: namespace e2e-tests-pods-vqzm9 deletion completed in 22.113365001s
+
+• [SLOW TEST:24.674 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be updated  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:32:29.503: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:32:29.543: INFO: Waiting up to 5m0s for pod "downwardapi-volume-1dd3ae38-2b93-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-8mq4f" to be "success or failure"
+Mar 19 16:32:29.545: INFO: Pod "downwardapi-volume-1dd3ae38-2b93-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.645075ms
+Mar 19 16:32:31.548: INFO: Pod "downwardapi-volume-1dd3ae38-2b93-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005090014s
+STEP: Saw pod success
+Mar 19 16:32:31.548: INFO: Pod "downwardapi-volume-1dd3ae38-2b93-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:32:31.550: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downwardapi-volume-1dd3ae38-2b93-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:32:31.565: INFO: Waiting for pod downwardapi-volume-1dd3ae38-2b93-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:32:31.566: INFO: Pod downwardapi-volume-1dd3ae38-2b93-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:32:31.567: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8mq4f" for this suite.
+Mar 19 16:32:37.577: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:32:37.610: INFO: namespace: e2e-tests-projected-8mq4f, resource: bindings, ignored listing per whitelist
+Mar 19 16:32:37.673: INFO: namespace e2e-tests-projected-8mq4f deletion completed in 6.103808332s
+
+• [SLOW TEST:8.170 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:32:37.673: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-ns7c7
+Mar 19 16:32:39.716: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-ns7c7
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 19 16:32:39.718: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:34:39.914: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-ns7c7" for this suite.
+Mar 19 16:34:45.925: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:34:45.977: INFO: namespace: e2e-tests-container-probe-ns7c7, resource: bindings, ignored listing per whitelist
+Mar 19 16:34:46.021: INFO: namespace e2e-tests-container-probe-ns7c7 deletion completed in 6.104136131s
+
+• [SLOW TEST:128.348 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:34:46.021: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Mar 19 16:34:46.059: INFO: Waiting up to 5m0s for pod "pod-6f325f7f-2b93-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-7vg7m" to be "success or failure"
+Mar 19 16:34:46.061: INFO: Pod "pod-6f325f7f-2b93-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.731159ms
+Mar 19 16:34:48.064: INFO: Pod "pod-6f325f7f-2b93-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005411895s
+STEP: Saw pod success
+Mar 19 16:34:48.065: INFO: Pod "pod-6f325f7f-2b93-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:34:48.066: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-6f325f7f-2b93-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:34:48.081: INFO: Waiting for pod pod-6f325f7f-2b93-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:34:48.084: INFO: Pod pod-6f325f7f-2b93-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:34:48.084: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-7vg7m" for this suite.
+Mar 19 16:34:54.093: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:34:54.139: INFO: namespace: e2e-tests-emptydir-7vg7m, resource: bindings, ignored listing per whitelist
+Mar 19 16:34:54.194: INFO: namespace e2e-tests-emptydir-7vg7m deletion completed in 6.107456073s
+
+• [SLOW TEST:8.173 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:34:54.195: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-7411705f-2b93-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:34:54.235: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-7411ccf5-2b93-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-72xw6" to be "success or failure"
+Mar 19 16:34:54.236: INFO: Pod "pod-projected-secrets-7411ccf5-2b93-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.692107ms
+Mar 19 16:34:56.239: INFO: Pod "pod-projected-secrets-7411ccf5-2b93-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004675951s
+STEP: Saw pod success
+Mar 19 16:34:56.239: INFO: Pod "pod-projected-secrets-7411ccf5-2b93-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:34:56.242: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-projected-secrets-7411ccf5-2b93-11e8-a904-72008c49cf21 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:34:56.255: INFO: Waiting for pod pod-projected-secrets-7411ccf5-2b93-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:34:56.275: INFO: Pod pod-projected-secrets-7411ccf5-2b93-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:34:56.275: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-72xw6" for this suite.
+Mar 19 16:35:02.285: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:35:02.338: INFO: namespace: e2e-tests-projected-72xw6, resource: bindings, ignored listing per whitelist
+Mar 19 16:35:02.386: INFO: namespace e2e-tests-projected-72xw6 deletion completed in 6.108317559s
+
+• [SLOW TEST:8.192 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:35:02.387: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Mar 19 16:35:06.444: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-48d86 PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:35:06.444: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:35:06.665: INFO: Exec stderr: ""
+Mar 19 16:35:06.665: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-48d86 PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:35:06.665: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:35:06.861: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Mar 19 16:35:06.861: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-48d86 PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:35:06.861: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:35:12.374: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Mar 19 16:35:12.374: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-48d86 PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:35:12.374: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:35:12.469: INFO: Exec stderr: ""
+Mar 19 16:35:12.470: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-48d86 PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:35:12.470: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:35:12.556: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:35:12.556: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-48d86" for this suite.
+Mar 19 16:36:02.567: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:36:02.607: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-48d86, resource: bindings, ignored listing per whitelist
+Mar 19 16:36:02.669: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-48d86 deletion completed in 50.110423464s
+
+• [SLOW TEST:60.282 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:36:02.669: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 16:36:02.712: INFO: (0) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.463319ms)
+Mar 19 16:36:02.715: INFO: (1) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.142692ms)
+Mar 19 16:36:02.718: INFO: (2) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.217367ms)
+Mar 19 16:36:02.722: INFO: (3) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.147363ms)
+Mar 19 16:36:02.725: INFO: (4) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.324861ms)
+Mar 19 16:36:02.728: INFO: (5) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.201158ms)
+Mar 19 16:36:02.732: INFO: (6) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.311555ms)
+Mar 19 16:36:02.735: INFO: (7) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.035232ms)
+Mar 19 16:36:02.738: INFO: (8) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.34489ms)
+Mar 19 16:36:02.741: INFO: (9) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.499034ms)
+Mar 19 16:36:02.745: INFO: (10) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.533725ms)
+Mar 19 16:36:02.749: INFO: (11) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.572547ms)
+Mar 19 16:36:02.752: INFO: (12) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.508369ms)
+Mar 19 16:36:02.756: INFO: (13) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.562395ms)
+Mar 19 16:36:02.759: INFO: (14) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.539019ms)
+Mar 19 16:36:02.763: INFO: (15) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.445662ms)
+Mar 19 16:36:02.766: INFO: (16) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.459684ms)
+Mar 19 16:36:02.770: INFO: (17) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.554136ms)
+Mar 19 16:36:02.774: INFO: (18) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.623618ms)
+Mar 19 16:36:02.777: INFO: (19) /api/v1/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.779435ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:36:02.778: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-tlgm5" for this suite.
+Mar 19 16:36:08.787: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:36:08.873: INFO: namespace: e2e-tests-proxy-tlgm5, resource: bindings, ignored listing per whitelist
+Mar 19 16:36:08.890: INFO: namespace e2e-tests-proxy-tlgm5 deletion completed in 6.109909737s
+
+• [SLOW TEST:6.221 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:36:08.891: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test override all
+Mar 19 16:36:08.929: INFO: Waiting up to 5m0s for pod "client-containers-a097623f-2b93-11e8-a904-72008c49cf21" in namespace "e2e-tests-containers-kz8t4" to be "success or failure"
+Mar 19 16:36:08.931: INFO: Pod "client-containers-a097623f-2b93-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.793449ms
+Mar 19 16:36:10.935: INFO: Pod "client-containers-a097623f-2b93-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00516187s
+STEP: Saw pod success
+Mar 19 16:36:10.935: INFO: Pod "client-containers-a097623f-2b93-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:36:10.937: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod client-containers-a097623f-2b93-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:36:10.950: INFO: Waiting for pod client-containers-a097623f-2b93-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:36:10.952: INFO: Pod client-containers-a097623f-2b93-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:36:10.952: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-kz8t4" for this suite.
+Mar 19 16:36:16.963: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:36:17.042: INFO: namespace: e2e-tests-containers-kz8t4, resource: bindings, ignored listing per whitelist
+Mar 19 16:36:17.066: INFO: namespace e2e-tests-containers-kz8t4 deletion completed in 6.110501615s
+
+• [SLOW TEST:8.175 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:36:17.067: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 19 16:36:17.107: INFO: Waiting up to 5m0s for pod "downward-api-a5773022-2b93-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-xvfzx" to be "success or failure"
+Mar 19 16:36:17.108: INFO: Pod "downward-api-a5773022-2b93-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.625423ms
+Mar 19 16:36:19.112: INFO: Pod "downward-api-a5773022-2b93-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005438378s
+Mar 19 16:36:21.117: INFO: Pod "downward-api-a5773022-2b93-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010059678s
+STEP: Saw pod success
+Mar 19 16:36:21.117: INFO: Pod "downward-api-a5773022-2b93-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:36:21.120: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downward-api-a5773022-2b93-11e8-a904-72008c49cf21 container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 16:36:21.133: INFO: Waiting for pod downward-api-a5773022-2b93-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:36:21.135: INFO: Pod downward-api-a5773022-2b93-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:36:21.135: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-xvfzx" for this suite.
+Mar 19 16:36:27.146: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:36:27.222: INFO: namespace: e2e-tests-downward-api-xvfzx, resource: bindings, ignored listing per whitelist
+Mar 19 16:36:27.248: INFO: namespace e2e-tests-downward-api-xvfzx deletion completed in 6.109761188s
+
+• [SLOW TEST:10.181 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:36:27.248: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Mar 19 16:36:27.285: INFO: Waiting up to 5m0s for pod "pod-ab882772-2b93-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-7pgz8" to be "success or failure"
+Mar 19 16:36:27.286: INFO: Pod "pod-ab882772-2b93-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.577334ms
+Mar 19 16:36:29.289: INFO: Pod "pod-ab882772-2b93-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004500459s
+STEP: Saw pod success
+Mar 19 16:36:29.289: INFO: Pod "pod-ab882772-2b93-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:36:29.291: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-ab882772-2b93-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:36:29.304: INFO: Waiting for pod pod-ab882772-2b93-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:36:29.307: INFO: Pod pod-ab882772-2b93-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:36:29.308: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-7pgz8" for this suite.
+Mar 19 16:36:35.318: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:36:35.391: INFO: namespace: e2e-tests-emptydir-7pgz8, resource: bindings, ignored listing per whitelist
+Mar 19 16:36:35.418: INFO: namespace e2e-tests-emptydir-7pgz8 deletion completed in 6.107673182s
+
+• [SLOW TEST:8.171 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:36:35.418: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward api env vars
+Mar 19 16:36:35.458: INFO: Waiting up to 5m0s for pod "downward-api-b06711aa-2b93-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-n5896" to be "success or failure"
+Mar 19 16:36:35.460: INFO: Pod "downward-api-b06711aa-2b93-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.471819ms
+Mar 19 16:36:37.463: INFO: Pod "downward-api-b06711aa-2b93-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005349701s
+Mar 19 16:36:39.467: INFO: Pod "downward-api-b06711aa-2b93-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.0084371s
+STEP: Saw pod success
+Mar 19 16:36:39.467: INFO: Pod "downward-api-b06711aa-2b93-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:36:39.469: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downward-api-b06711aa-2b93-11e8-a904-72008c49cf21 container dapi-container: <nil>
+STEP: delete the pod
+Mar 19 16:36:39.489: INFO: Waiting for pod downward-api-b06711aa-2b93-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:36:39.491: INFO: Pod downward-api-b06711aa-2b93-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:36:39.491: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-n5896" for this suite.
+Mar 19 16:36:45.503: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:36:45.599: INFO: namespace: e2e-tests-downward-api-n5896, resource: bindings, ignored listing per whitelist
+Mar 19 16:36:45.603: INFO: namespace e2e-tests-downward-api-n5896 deletion completed in 6.109335317s
+
+• [SLOW TEST:10.184 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:36:45.603: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:36:45.644: INFO: Waiting up to 5m0s for pod "downwardapi-volume-b67987b7-2b93-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-plhdj" to be "success or failure"
+Mar 19 16:36:45.647: INFO: Pod "downwardapi-volume-b67987b7-2b93-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.426463ms
+Mar 19 16:36:47.650: INFO: Pod "downwardapi-volume-b67987b7-2b93-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005615945s
+STEP: Saw pod success
+Mar 19 16:36:47.650: INFO: Pod "downwardapi-volume-b67987b7-2b93-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:36:47.652: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downwardapi-volume-b67987b7-2b93-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:36:47.665: INFO: Waiting for pod downwardapi-volume-b67987b7-2b93-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:36:47.667: INFO: Pod downwardapi-volume-b67987b7-2b93-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:36:47.668: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-plhdj" for this suite.
+Mar 19 16:36:53.678: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:36:53.728: INFO: namespace: e2e-tests-projected-plhdj, resource: bindings, ignored listing per whitelist
+Mar 19 16:36:53.777: INFO: namespace e2e-tests-projected-plhdj deletion completed in 6.107161674s
+
+• [SLOW TEST:8.174 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:36:53.778: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-sxztc
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 19 16:36:53.810: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 19 16:37:15.855: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.3.168:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-sxztc PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:37:15.855: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:37:15.975: INFO: Found all expected endpoints: [netserver-0]
+Mar 19 16:37:15.978: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.2.212:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-sxztc PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:37:15.978: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:37:16.098: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:37:16.098: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-sxztc" for this suite.
+Mar 19 16:37:38.111: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:37:38.143: INFO: namespace: e2e-tests-pod-network-test-sxztc, resource: bindings, ignored listing per whitelist
+Mar 19 16:37:38.211: INFO: namespace e2e-tests-pod-network-test-sxztc deletion completed in 22.110291903s
+
+• [SLOW TEST:44.434 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:37:38.212: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-map-d5d4f831-2b93-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:37:38.255: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-d5d565d1-2b93-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-r4p9x" to be "success or failure"
+Mar 19 16:37:38.257: INFO: Pod "pod-projected-secrets-d5d565d1-2b93-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.465274ms
+Mar 19 16:37:40.260: INFO: Pod "pod-projected-secrets-d5d565d1-2b93-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004443612s
+STEP: Saw pod success
+Mar 19 16:37:40.260: INFO: Pod "pod-projected-secrets-d5d565d1-2b93-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:37:40.262: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-projected-secrets-d5d565d1-2b93-11e8-a904-72008c49cf21 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:37:40.284: INFO: Waiting for pod pod-projected-secrets-d5d565d1-2b93-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:37:40.287: INFO: Pod pod-projected-secrets-d5d565d1-2b93-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:37:40.287: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-r4p9x" for this suite.
+Mar 19 16:37:46.301: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:37:46.362: INFO: namespace: e2e-tests-projected-r4p9x, resource: bindings, ignored listing per whitelist
+Mar 19 16:37:46.406: INFO: namespace e2e-tests-projected-r4p9x deletion completed in 6.112344509s
+
+• [SLOW TEST:8.194 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:37:46.406: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating the pod
+Mar 19 16:37:48.970: INFO: Successfully updated pod "annotationupdatedab6b6c3-2b93-11e8-a904-72008c49cf21"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:37:50.988: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6f5nj" for this suite.
+Mar 19 16:38:12.999: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:38:13.102: INFO: namespace: e2e-tests-projected-6f5nj, resource: bindings, ignored listing per whitelist
+Mar 19 16:38:13.102: INFO: namespace e2e-tests-projected-6f5nj deletion completed in 22.111474384s
+
+• [SLOW TEST:26.697 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:38:13.102: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-sggkv in namespace e2e-tests-proxy-mqmsb
+I0319 16:38:13.145919      17 runners.go:178] Created replication controller with name: proxy-service-sggkv, namespace: e2e-tests-proxy-mqmsb, replica count: 1
+I0319 16:38:14.146199      17 runners.go:178] proxy-service-sggkv Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0319 16:38:15.146468      17 runners.go:178] proxy-service-sggkv Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0319 16:38:16.146754      17 runners.go:178] proxy-service-sggkv Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0319 16:38:17.147185      17 runners.go:178] proxy-service-sggkv Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0319 16:38:18.147502      17 runners.go:178] proxy-service-sggkv Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0319 16:38:19.147810      17 runners.go:178] proxy-service-sggkv Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0319 16:38:20.148094      17 runners.go:178] proxy-service-sggkv Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0319 16:38:21.148334      17 runners.go:178] proxy-service-sggkv Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0319 16:38:22.148578      17 runners.go:178] proxy-service-sggkv Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0319 16:38:23.148974      17 runners.go:178] proxy-service-sggkv Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0319 16:38:24.149155      17 runners.go:178] proxy-service-sggkv Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Mar 19 16:38:24.152: INFO: setup took 11.015665022s, starting test cases
+STEP: running 34 cases, 20 attempts per case, 680 total attempts
+Mar 19 16:38:24.160: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 7.87467ms)
+Mar 19 16:38:24.161: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 7.977554ms)
+Mar 19 16:38:24.161: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 8.27782ms)
+Mar 19 16:38:24.163: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 9.753156ms)
+Mar 19 16:38:24.163: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 9.653939ms)
+Mar 19 16:38:24.163: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 10.255606ms)
+Mar 19 16:38:24.163: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 10.122347ms)
+Mar 19 16:38:24.163: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 10.636315ms)
+Mar 19 16:38:24.163: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 10.121638ms)
+Mar 19 16:38:24.163: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 10.294655ms)
+Mar 19 16:38:24.163: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 10.581506ms)
+Mar 19 16:38:24.167: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 14.456563ms)
+Mar 19 16:38:24.171: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 18.206538ms)
+Mar 19 16:38:24.171: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 18.259614ms)
+Mar 19 16:38:24.172: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 18.506207ms)
+Mar 19 16:38:24.172: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 18.613374ms)
+Mar 19 16:38:24.172: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 18.736182ms)
+Mar 19 16:38:24.173: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 20.055546ms)
+Mar 19 16:38:24.173: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 20.358005ms)
+Mar 19 16:38:24.173: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 20.09969ms)
+Mar 19 16:38:24.175: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 22.922063ms)
+Mar 19 16:38:24.178: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 25.957147ms)
+Mar 19 16:38:24.179: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 25.47886ms)
+Mar 19 16:38:24.179: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 25.476212ms)
+Mar 19 16:38:24.179: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 25.641473ms)
+Mar 19 16:38:24.179: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 25.824213ms)
+Mar 19 16:38:24.179: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 27.116183ms)
+Mar 19 16:38:24.179: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 26.06973ms)
+Mar 19 16:38:24.179: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 26.191636ms)
+Mar 19 16:38:24.179: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 26.663059ms)
+Mar 19 16:38:24.179: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 26.414853ms)
+Mar 19 16:38:24.180: INFO: (0) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 27.078785ms)
+Mar 19 16:38:24.180: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 27.285983ms)
+Mar 19 16:38:24.184: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 30.867641ms)
+Mar 19 16:38:24.188: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 3.977028ms)
+Mar 19 16:38:24.188: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 4.430049ms)
+Mar 19 16:38:24.189: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 4.934115ms)
+Mar 19 16:38:24.189: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 5.205027ms)
+Mar 19 16:38:24.190: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 6.142339ms)
+Mar 19 16:38:24.191: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 6.728978ms)
+Mar 19 16:38:24.191: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 6.452084ms)
+Mar 19 16:38:24.191: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 6.387538ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 8.985594ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 9.162695ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 9.28526ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 9.994926ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 10.137411ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 8.907634ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 10.176938ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 9.820911ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 8.866411ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 10.067957ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 9.282861ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 9.304609ms)
+Mar 19 16:38:24.194: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 9.290717ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 9.821779ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 9.178546ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 9.324183ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 9.201562ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 9.713044ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 9.931514ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 9.259112ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 10.193997ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 10.501055ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 10.330057ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 10.397634ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 10.464781ms)
+Mar 19 16:38:24.195: INFO: (1) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 10.829146ms)
+Mar 19 16:38:24.215: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 19.720908ms)
+Mar 19 16:38:24.216: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 20.353414ms)
+Mar 19 16:38:24.217: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 21.351422ms)
+Mar 19 16:38:24.217: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 21.54767ms)
+Mar 19 16:38:24.217: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 21.790934ms)
+Mar 19 16:38:24.218: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 22.076045ms)
+Mar 19 16:38:24.218: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 22.253262ms)
+Mar 19 16:38:24.218: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 22.008554ms)
+Mar 19 16:38:24.218: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 21.994106ms)
+Mar 19 16:38:24.218: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 22.012549ms)
+Mar 19 16:38:24.219: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 23.771048ms)
+Mar 19 16:38:24.220: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 24.563239ms)
+Mar 19 16:38:24.220: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 24.738498ms)
+Mar 19 16:38:24.223: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 27.324354ms)
+Mar 19 16:38:24.223: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 27.667914ms)
+Mar 19 16:38:24.223: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 27.49247ms)
+Mar 19 16:38:24.225: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 28.888924ms)
+Mar 19 16:38:24.225: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 29.868925ms)
+Mar 19 16:38:24.225: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 29.956766ms)
+Mar 19 16:38:24.225: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 29.373765ms)
+Mar 19 16:38:24.225: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 29.602759ms)
+Mar 19 16:38:24.225: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 29.838792ms)
+Mar 19 16:38:24.225: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 29.675616ms)
+Mar 19 16:38:24.225: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 29.554705ms)
+Mar 19 16:38:24.225: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 29.657773ms)
+Mar 19 16:38:24.225: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 29.422835ms)
+Mar 19 16:38:24.225: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 29.449687ms)
+Mar 19 16:38:24.238: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 42.137451ms)
+Mar 19 16:38:24.238: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 42.689631ms)
+Mar 19 16:38:24.238: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 42.941528ms)
+Mar 19 16:38:24.239: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 43.549046ms)
+Mar 19 16:38:24.242: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 46.290355ms)
+Mar 19 16:38:24.242: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 47.036304ms)
+Mar 19 16:38:24.243: INFO: (2) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 46.76639ms)
+Mar 19 16:38:24.253: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 10.648004ms)
+Mar 19 16:38:24.254: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 10.649043ms)
+Mar 19 16:38:24.254: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 10.802486ms)
+Mar 19 16:38:24.254: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 11.070126ms)
+Mar 19 16:38:24.254: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 11.186284ms)
+Mar 19 16:38:24.254: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 10.736958ms)
+Mar 19 16:38:24.254: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 10.780788ms)
+Mar 19 16:38:24.255: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 11.414719ms)
+Mar 19 16:38:24.255: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 11.545631ms)
+Mar 19 16:38:24.255: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 11.908623ms)
+Mar 19 16:38:24.255: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 11.780804ms)
+Mar 19 16:38:24.255: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 11.566198ms)
+Mar 19 16:38:24.255: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 11.968339ms)
+Mar 19 16:38:24.256: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 13.167732ms)
+Mar 19 16:38:24.256: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 13.097306ms)
+Mar 19 16:38:24.257: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 13.984516ms)
+Mar 19 16:38:24.258: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 14.471178ms)
+Mar 19 16:38:24.258: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 14.219877ms)
+Mar 19 16:38:24.258: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 14.701451ms)
+Mar 19 16:38:24.258: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 8.886318ms)
+Mar 19 16:38:24.258: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 8.483976ms)
+Mar 19 16:38:24.258: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 14.6819ms)
+Mar 19 16:38:24.258: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 8.458533ms)
+Mar 19 16:38:24.259: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 9.354052ms)
+Mar 19 16:38:24.260: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 17.141182ms)
+Mar 19 16:38:24.261: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 17.714263ms)
+Mar 19 16:38:24.261: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 18.367854ms)
+Mar 19 16:38:24.262: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 5.9362ms)
+Mar 19 16:38:24.262: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 18.901766ms)
+Mar 19 16:38:24.262: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 6.409481ms)
+Mar 19 16:38:24.262: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 6.768751ms)
+Mar 19 16:38:24.262: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 18.786174ms)
+Mar 19 16:38:24.263: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 19.653819ms)
+Mar 19 16:38:24.263: INFO: (3) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 19.713485ms)
+Mar 19 16:38:24.270: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 7.339373ms)
+Mar 19 16:38:24.270: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 6.93095ms)
+Mar 19 16:38:24.270: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 6.221724ms)
+Mar 19 16:38:24.270: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 6.746097ms)
+Mar 19 16:38:24.270: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 6.351951ms)
+Mar 19 16:38:24.270: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 6.535322ms)
+Mar 19 16:38:24.270: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 6.775033ms)
+Mar 19 16:38:24.270: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 6.889881ms)
+Mar 19 16:38:24.270: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 6.956094ms)
+Mar 19 16:38:24.270: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 7.132375ms)
+Mar 19 16:38:24.270: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 7.213545ms)
+Mar 19 16:38:24.271: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 6.322126ms)
+Mar 19 16:38:24.272: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 8.029846ms)
+Mar 19 16:38:24.272: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 6.900679ms)
+Mar 19 16:38:24.272: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 8.125174ms)
+Mar 19 16:38:24.272: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 7.896008ms)
+Mar 19 16:38:24.273: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 8.757091ms)
+Mar 19 16:38:24.273: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 8.575181ms)
+Mar 19 16:38:24.273: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 8.940404ms)
+Mar 19 16:38:24.273: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 8.297421ms)
+Mar 19 16:38:24.273: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 9.577845ms)
+Mar 19 16:38:24.274: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 10.080807ms)
+Mar 19 16:38:24.274: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 9.353032ms)
+Mar 19 16:38:24.274: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 9.25119ms)
+Mar 19 16:38:24.274: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 9.347685ms)
+Mar 19 16:38:24.274: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 9.989793ms)
+Mar 19 16:38:24.274: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 10.125687ms)
+Mar 19 16:38:24.274: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 10.275712ms)
+Mar 19 16:38:24.274: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 10.384152ms)
+Mar 19 16:38:24.275: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 10.35082ms)
+Mar 19 16:38:24.275: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 10.50509ms)
+Mar 19 16:38:24.276: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 10.774019ms)
+Mar 19 16:38:24.276: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 11.365054ms)
+Mar 19 16:38:24.276: INFO: (4) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 12.005623ms)
+Mar 19 16:38:24.284: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 7.708633ms)
+Mar 19 16:38:24.285: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 8.721755ms)
+Mar 19 16:38:24.285: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 6.819055ms)
+Mar 19 16:38:24.286: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 9.104519ms)
+Mar 19 16:38:24.286: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 7.352032ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 9.832298ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 9.464439ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 9.596646ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 9.047289ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 9.187625ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 9.072537ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 8.56412ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 8.965869ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 9.225616ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 9.325231ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 9.582787ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 8.725557ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 9.753182ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 10.173949ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 10.271214ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 9.219704ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 8.092701ms)
+Mar 19 16:38:24.287: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 8.437272ms)
+Mar 19 16:38:24.288: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 8.769082ms)
+Mar 19 16:38:24.289: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 11.47369ms)
+Mar 19 16:38:24.289: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 9.287883ms)
+Mar 19 16:38:24.289: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 9.895391ms)
+Mar 19 16:38:24.289: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 9.391969ms)
+Mar 19 16:38:24.289: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 9.47894ms)
+Mar 19 16:38:24.289: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 11.680845ms)
+Mar 19 16:38:24.289: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 10.689739ms)
+Mar 19 16:38:24.289: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 9.746836ms)
+Mar 19 16:38:24.289: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 10.809945ms)
+Mar 19 16:38:24.289: INFO: (5) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 12.137285ms)
+Mar 19 16:38:24.295: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 5.872128ms)
+Mar 19 16:38:24.296: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 5.763134ms)
+Mar 19 16:38:24.298: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 7.766897ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 8.409728ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 8.442201ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 8.56764ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 8.821275ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 8.940315ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 8.864314ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 9.089901ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 8.944751ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 9.014423ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 9.441435ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 9.698169ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 9.232311ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 9.266442ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 9.315405ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 9.111826ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 8.896619ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 9.45991ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 9.492563ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 9.354796ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 9.337786ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 9.13379ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 9.610671ms)
+Mar 19 16:38:24.299: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 9.662343ms)
+Mar 19 16:38:24.300: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 10.108995ms)
+Mar 19 16:38:24.300: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 9.812935ms)
+Mar 19 16:38:24.300: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 9.404945ms)
+Mar 19 16:38:24.300: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 10.056796ms)
+Mar 19 16:38:24.300: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 10.269876ms)
+Mar 19 16:38:24.300: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 9.414547ms)
+Mar 19 16:38:24.300: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 10.216183ms)
+Mar 19 16:38:24.300: INFO: (6) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 10.372481ms)
+Mar 19 16:38:24.308: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 7.805385ms)
+Mar 19 16:38:24.308: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 7.868493ms)
+Mar 19 16:38:24.308: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 8.308826ms)
+Mar 19 16:38:24.309: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 9.17617ms)
+Mar 19 16:38:24.309: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 9.225434ms)
+Mar 19 16:38:24.309: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 9.045328ms)
+Mar 19 16:38:24.310: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 9.678175ms)
+Mar 19 16:38:24.310: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 9.373686ms)
+Mar 19 16:38:24.310: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 10.331427ms)
+Mar 19 16:38:24.310: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 9.867562ms)
+Mar 19 16:38:24.310: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 9.763499ms)
+Mar 19 16:38:24.310: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 9.979153ms)
+Mar 19 16:38:24.310: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 9.965873ms)
+Mar 19 16:38:24.311: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 10.059499ms)
+Mar 19 16:38:24.311: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 10.155792ms)
+Mar 19 16:38:24.311: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 10.751042ms)
+Mar 19 16:38:24.311: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 10.289796ms)
+Mar 19 16:38:24.311: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 10.214096ms)
+Mar 19 16:38:24.311: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 10.51635ms)
+Mar 19 16:38:24.311: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 10.785032ms)
+Mar 19 16:38:24.311: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 10.914765ms)
+Mar 19 16:38:24.311: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 10.759666ms)
+Mar 19 16:38:24.311: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 10.455751ms)
+Mar 19 16:38:24.311: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 10.947346ms)
+Mar 19 16:38:24.312: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 10.905548ms)
+Mar 19 16:38:24.312: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 11.005256ms)
+Mar 19 16:38:24.312: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 11.307464ms)
+Mar 19 16:38:24.312: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 11.42947ms)
+Mar 19 16:38:24.312: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 11.702158ms)
+Mar 19 16:38:24.312: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 11.520317ms)
+Mar 19 16:38:24.312: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 10.948121ms)
+Mar 19 16:38:24.312: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 10.979023ms)
+Mar 19 16:38:24.312: INFO: (7) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 12.027958ms)
+Mar 19 16:38:24.312: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 11.299256ms)
+Mar 19 16:38:24.318: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 5.257564ms)
+Mar 19 16:38:24.318: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 5.307741ms)
+Mar 19 16:38:24.321: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 8.463656ms)
+Mar 19 16:38:24.321: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 8.357513ms)
+Mar 19 16:38:24.321: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 8.128713ms)
+Mar 19 16:38:24.322: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 9.254778ms)
+Mar 19 16:38:24.322: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 9.209546ms)
+Mar 19 16:38:24.322: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 9.463251ms)
+Mar 19 16:38:24.322: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 8.743012ms)
+Mar 19 16:38:24.322: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 8.840904ms)
+Mar 19 16:38:24.322: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 8.519024ms)
+Mar 19 16:38:24.322: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 9.83188ms)
+Mar 19 16:38:24.322: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 8.830776ms)
+Mar 19 16:38:24.322: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 10.091849ms)
+Mar 19 16:38:27.657: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 3.343701026s)
+Mar 19 16:38:27.657: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 3.343322532s)
+Mar 19 16:38:27.657: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 3.343752019s)
+Mar 19 16:38:27.657: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 3.344234868s)
+Mar 19 16:38:27.658: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 3.344460805s)
+Mar 19 16:38:27.658: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 3.345159906s)
+Mar 19 16:38:27.658: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 3.344269546s)
+Mar 19 16:38:27.658: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 3.345156222s)
+Mar 19 16:38:27.658: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 3.345335502s)
+Mar 19 16:38:27.658: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 3.344817233s)
+Mar 19 16:38:27.658: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 3.344923217s)
+Mar 19 16:38:27.658: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 3.345448219s)
+Mar 19 16:38:27.659: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 3.345960126s)
+Mar 19 16:38:27.659: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 3.345131225s)
+Mar 19 16:38:27.659: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 3.345054538s)
+Mar 19 16:38:27.659: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 3.346017454s)
+Mar 19 16:38:27.659: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 3.346123317s)
+Mar 19 16:38:27.784: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 3.471634559s)
+Mar 19 16:38:30.794: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 6.48174776s)
+Mar 19 16:38:30.794: INFO: (8) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 6.480702772s)
+Mar 19 16:38:30.803: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 7.411988ms)
+Mar 19 16:38:30.803: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 8.068853ms)
+Mar 19 16:38:30.803: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 7.914817ms)
+Mar 19 16:38:30.803: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 8.149885ms)
+Mar 19 16:38:30.803: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 8.24354ms)
+Mar 19 16:38:30.803: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 8.340265ms)
+Mar 19 16:38:30.803: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 8.76553ms)
+Mar 19 16:38:30.803: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 8.97432ms)
+Mar 19 16:38:30.803: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 8.668546ms)
+Mar 19 16:38:30.804: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 8.91624ms)
+Mar 19 16:38:30.805: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 10.312834ms)
+Mar 19 16:38:30.806: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 10.354411ms)
+Mar 19 16:38:30.806: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 10.719243ms)
+Mar 19 16:38:30.806: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 11.299913ms)
+Mar 19 16:38:30.806: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 10.712147ms)
+Mar 19 16:38:30.806: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 11.105668ms)
+Mar 19 16:38:30.806: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 11.564028ms)
+Mar 19 16:38:30.806: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 10.86232ms)
+Mar 19 16:38:30.806: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 10.544999ms)
+Mar 19 16:38:30.806: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 11.309672ms)
+Mar 19 16:38:30.806: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 11.595454ms)
+Mar 19 16:38:30.806: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 11.838368ms)
+Mar 19 16:38:30.807: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 10.875713ms)
+Mar 19 16:38:30.807: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 11.480985ms)
+Mar 19 16:38:30.807: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 11.200311ms)
+Mar 19 16:38:30.807: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 11.487348ms)
+Mar 19 16:38:30.807: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 11.239567ms)
+Mar 19 16:38:30.807: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 11.204765ms)
+Mar 19 16:38:30.807: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 12.210063ms)
+Mar 19 16:38:30.807: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 11.210939ms)
+Mar 19 16:38:30.807: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 11.325875ms)
+Mar 19 16:38:30.807: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 12.166117ms)
+Mar 19 16:38:30.807: INFO: (9) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 11.224603ms)
+Mar 19 16:38:30.807: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 11.563305ms)
+Mar 19 16:38:30.820: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 11.808789ms)
+Mar 19 16:38:30.820: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 12.081305ms)
+Mar 19 16:38:30.820: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 12.577466ms)
+Mar 19 16:38:30.820: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 12.258309ms)
+Mar 19 16:38:30.823: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 16.11548ms)
+Mar 19 16:38:30.823: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 15.447038ms)
+Mar 19 16:38:30.824: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 15.601105ms)
+Mar 19 16:38:30.824: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 15.892753ms)
+Mar 19 16:38:30.824: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 16.046327ms)
+Mar 19 16:38:30.824: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 16.144045ms)
+Mar 19 16:38:30.825: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 17.518049ms)
+Mar 19 16:38:30.825: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 16.984285ms)
+Mar 19 16:38:30.825: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 17.425773ms)
+Mar 19 16:38:30.825: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 17.505506ms)
+Mar 19 16:38:30.825: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 18.298861ms)
+Mar 19 16:38:30.826: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 18.262068ms)
+Mar 19 16:38:30.826: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 18.071182ms)
+Mar 19 16:38:30.828: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 20.168631ms)
+Mar 19 16:38:30.828: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 20.664296ms)
+Mar 19 16:38:30.828: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 20.311602ms)
+Mar 19 16:38:30.828: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 20.559799ms)
+Mar 19 16:38:30.828: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 20.387135ms)
+Mar 19 16:38:30.829: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 20.267075ms)
+Mar 19 16:38:30.829: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 20.350257ms)
+Mar 19 16:38:30.829: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 20.546698ms)
+Mar 19 16:38:30.829: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 20.57171ms)
+Mar 19 16:38:30.829: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 20.334272ms)
+Mar 19 16:38:30.829: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 20.227803ms)
+Mar 19 16:38:30.829: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 20.685767ms)
+Mar 19 16:38:30.829: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 20.493446ms)
+Mar 19 16:38:30.829: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 20.749979ms)
+Mar 19 16:38:30.829: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 20.678155ms)
+Mar 19 16:38:30.829: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 20.552813ms)
+Mar 19 16:38:30.829: INFO: (10) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 20.578168ms)
+Mar 19 16:38:30.838: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 8.317031ms)
+Mar 19 16:38:30.838: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 8.263885ms)
+Mar 19 16:38:30.838: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 8.442572ms)
+Mar 19 16:38:30.838: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 8.683002ms)
+Mar 19 16:38:30.838: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 8.816588ms)
+Mar 19 16:38:30.838: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 9.490223ms)
+Mar 19 16:38:30.839: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 9.576124ms)
+Mar 19 16:38:30.839: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 9.844776ms)
+Mar 19 16:38:30.839: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 10.086308ms)
+Mar 19 16:38:30.839: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 10.271621ms)
+Mar 19 16:38:30.839: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 10.490119ms)
+Mar 19 16:38:30.839: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 10.715396ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 11.060331ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 10.8383ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 10.637784ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 10.079225ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 10.926734ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 10.91884ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 10.38985ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 10.302968ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 10.683957ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 11.191901ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 10.872237ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 10.694525ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 11.381072ms)
+Mar 19 16:38:30.840: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 11.001201ms)
+Mar 19 16:38:30.841: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 11.139038ms)
+Mar 19 16:38:30.841: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 11.369653ms)
+Mar 19 16:38:30.841: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 10.828324ms)
+Mar 19 16:38:30.841: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 10.787719ms)
+Mar 19 16:38:30.841: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 11.00682ms)
+Mar 19 16:38:30.841: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 11.229129ms)
+Mar 19 16:38:30.841: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 11.282393ms)
+Mar 19 16:38:30.841: INFO: (11) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 11.247693ms)
+Mar 19 16:38:30.849: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 8.186847ms)
+Mar 19 16:38:30.849: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 7.999194ms)
+Mar 19 16:38:30.850: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 8.879215ms)
+Mar 19 16:38:30.850: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 8.980054ms)
+Mar 19 16:38:30.850: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 9.001684ms)
+Mar 19 16:38:30.850: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 9.009557ms)
+Mar 19 16:38:30.850: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 9.532896ms)
+Mar 19 16:38:30.851: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 9.459545ms)
+Mar 19 16:38:30.851: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 10.182224ms)
+Mar 19 16:38:30.851: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 10.254899ms)
+Mar 19 16:38:30.851: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 9.751434ms)
+Mar 19 16:38:30.851: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 10.142537ms)
+Mar 19 16:38:30.851: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 10.410534ms)
+Mar 19 16:38:30.852: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 10.164389ms)
+Mar 19 16:38:30.852: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 10.07235ms)
+Mar 19 16:38:30.852: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 9.996825ms)
+Mar 19 16:38:30.852: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 10.947427ms)
+Mar 19 16:38:30.852: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 10.858797ms)
+Mar 19 16:38:30.852: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 10.704769ms)
+Mar 19 16:38:30.852: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 10.540689ms)
+Mar 19 16:38:30.852: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 10.701548ms)
+Mar 19 16:38:30.852: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 11.591113ms)
+Mar 19 16:38:30.852: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 10.961146ms)
+Mar 19 16:38:30.853: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 11.234436ms)
+Mar 19 16:38:30.853: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 10.809662ms)
+Mar 19 16:38:30.853: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 11.645878ms)
+Mar 19 16:38:30.853: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 12.042576ms)
+Mar 19 16:38:30.853: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 11.799201ms)
+Mar 19 16:38:30.853: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 12.243796ms)
+Mar 19 16:38:30.853: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 11.496835ms)
+Mar 19 16:38:30.853: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 11.671723ms)
+Mar 19 16:38:30.853: INFO: (12) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 11.726103ms)
+Mar 19 16:38:30.853: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 11.938299ms)
+Mar 19 16:38:30.853: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 11.640825ms)
+Mar 19 16:38:30.860: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 5.747861ms)
+Mar 19 16:38:30.860: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 6.22087ms)
+Mar 19 16:38:30.860: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 6.423024ms)
+Mar 19 16:38:30.860: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 6.424211ms)
+Mar 19 16:38:30.861: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 6.84349ms)
+Mar 19 16:38:30.861: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 7.392144ms)
+Mar 19 16:38:30.862: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 7.593219ms)
+Mar 19 16:38:30.862: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 8.21016ms)
+Mar 19 16:38:30.863: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 8.070959ms)
+Mar 19 16:38:30.863: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 8.240926ms)
+Mar 19 16:38:30.863: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 8.332669ms)
+Mar 19 16:38:30.863: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 8.364252ms)
+Mar 19 16:38:30.863: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 9.208946ms)
+Mar 19 16:38:30.864: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 9.202408ms)
+Mar 19 16:38:30.864: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 9.242302ms)
+Mar 19 16:38:30.864: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 9.599074ms)
+Mar 19 16:38:30.864: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 9.464883ms)
+Mar 19 16:38:30.864: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 9.663025ms)
+Mar 19 16:38:30.864: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 10.241745ms)
+Mar 19 16:38:30.864: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 10.543626ms)
+Mar 19 16:38:30.864: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 10.671138ms)
+Mar 19 16:38:30.865: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 10.039643ms)
+Mar 19 16:38:30.865: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 10.133912ms)
+Mar 19 16:38:30.865: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 10.825072ms)
+Mar 19 16:38:30.865: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 10.04223ms)
+Mar 19 16:38:30.865: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 10.354661ms)
+Mar 19 16:38:30.865: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 10.781645ms)
+Mar 19 16:38:30.865: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 10.431186ms)
+Mar 19 16:38:30.865: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 10.529896ms)
+Mar 19 16:38:30.865: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 10.846242ms)
+Mar 19 16:38:30.865: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 10.616486ms)
+Mar 19 16:38:30.865: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 10.417152ms)
+Mar 19 16:38:30.865: INFO: (13) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 11.185997ms)
+Mar 19 16:38:30.866: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 11.308546ms)
+Mar 19 16:38:30.875: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 8.877086ms)
+Mar 19 16:38:30.875: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 8.419009ms)
+Mar 19 16:38:30.875: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 9.118625ms)
+Mar 19 16:38:30.875: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 8.500207ms)
+Mar 19 16:38:30.875: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 9.294429ms)
+Mar 19 16:38:30.875: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 9.169066ms)
+Mar 19 16:38:30.875: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 8.950005ms)
+Mar 19 16:38:30.875: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 9.250793ms)
+Mar 19 16:38:30.875: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 9.40936ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 9.621122ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 9.840949ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 9.881357ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 10.550382ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 10.363186ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 10.106408ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 10.21658ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 10.552219ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 10.376116ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 10.498455ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 10.594495ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 10.32588ms)
+Mar 19 16:38:30.876: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 10.438237ms)
+Mar 19 16:38:30.877: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 11.110205ms)
+Mar 19 16:38:30.877: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 11.241481ms)
+Mar 19 16:38:30.877: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 11.42043ms)
+Mar 19 16:38:30.877: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 11.634945ms)
+Mar 19 16:38:30.877: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 11.128483ms)
+Mar 19 16:38:30.878: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 11.551194ms)
+Mar 19 16:38:30.878: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 11.312026ms)
+Mar 19 16:38:30.878: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 11.202803ms)
+Mar 19 16:38:30.878: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 11.797465ms)
+Mar 19 16:38:30.878: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 12.134323ms)
+Mar 19 16:38:30.878: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 12.460637ms)
+Mar 19 16:38:30.878: INFO: (14) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 12.580383ms)
+Mar 19 16:38:30.882: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 3.964846ms)
+Mar 19 16:38:30.883: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 4.181269ms)
+Mar 19 16:38:30.883: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 4.364493ms)
+Mar 19 16:38:30.887: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 7.976749ms)
+Mar 19 16:38:30.888: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 8.165354ms)
+Mar 19 16:38:30.889: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 10.276084ms)
+Mar 19 16:38:30.889: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 9.747042ms)
+Mar 19 16:38:30.889: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 9.950503ms)
+Mar 19 16:38:30.890: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 9.139082ms)
+Mar 19 16:38:30.890: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 9.48779ms)
+Mar 19 16:38:30.890: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 10.619731ms)
+Mar 19 16:38:30.890: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 10.160188ms)
+Mar 19 16:38:30.890: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 9.934044ms)
+Mar 19 16:38:30.890: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 10.5853ms)
+Mar 19 16:38:30.890: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 11.37047ms)
+Mar 19 16:38:30.890: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 10.44386ms)
+Mar 19 16:38:30.890: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 11.508329ms)
+Mar 19 16:38:30.891: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 11.676786ms)
+Mar 19 16:38:30.891: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 10.367637ms)
+Mar 19 16:38:30.891: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 12.022124ms)
+Mar 19 16:38:30.891: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 11.496826ms)
+Mar 19 16:38:30.892: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 12.578834ms)
+Mar 19 16:38:30.892: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 13.307162ms)
+Mar 19 16:38:30.892: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 12.424257ms)
+Mar 19 16:38:30.892: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 12.254242ms)
+Mar 19 16:38:30.892: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 12.156461ms)
+Mar 19 16:38:30.892: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 12.807399ms)
+Mar 19 16:38:30.892: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 13.096043ms)
+Mar 19 16:38:30.892: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 13.566384ms)
+Mar 19 16:38:30.892: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 13.737968ms)
+Mar 19 16:38:30.893: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 12.987196ms)
+Mar 19 16:38:30.893: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 12.258597ms)
+Mar 19 16:38:30.893: INFO: (15) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 13.723182ms)
+Mar 19 16:38:30.893: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 13.866522ms)
+Mar 19 16:38:30.900: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 6.755218ms)
+Mar 19 16:38:30.900: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 6.80883ms)
+Mar 19 16:38:30.900: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 7.339432ms)
+Mar 19 16:38:30.900: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 6.840847ms)
+Mar 19 16:38:30.901: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 6.866682ms)
+Mar 19 16:38:30.901: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 7.314495ms)
+Mar 19 16:38:30.901: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 6.761625ms)
+Mar 19 16:38:30.902: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 7.353529ms)
+Mar 19 16:38:30.902: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 7.636416ms)
+Mar 19 16:38:30.902: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 6.96411ms)
+Mar 19 16:38:30.902: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 7.821707ms)
+Mar 19 16:38:30.902: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 8.350779ms)
+Mar 19 16:38:30.902: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 7.438176ms)
+Mar 19 16:38:30.902: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 6.891456ms)
+Mar 19 16:38:30.903: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 8.809608ms)
+Mar 19 16:38:30.903: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 8.997935ms)
+Mar 19 16:38:30.904: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 8.57301ms)
+Mar 19 16:38:30.904: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 9.157121ms)
+Mar 19 16:38:30.904: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 9.389999ms)
+Mar 19 16:38:30.904: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 9.501515ms)
+Mar 19 16:38:30.904: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 9.830449ms)
+Mar 19 16:38:30.904: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 10.224074ms)
+Mar 19 16:38:30.904: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 10.403652ms)
+Mar 19 16:38:30.905: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 9.564753ms)
+Mar 19 16:38:30.905: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 9.468862ms)
+Mar 19 16:38:30.905: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 9.626947ms)
+Mar 19 16:38:30.905: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 9.374588ms)
+Mar 19 16:38:30.905: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 9.889214ms)
+Mar 19 16:38:30.905: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 10.246742ms)
+Mar 19 16:38:30.905: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 9.842224ms)
+Mar 19 16:38:30.905: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 10.428648ms)
+Mar 19 16:38:30.905: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 10.295907ms)
+Mar 19 16:38:30.905: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 10.640156ms)
+Mar 19 16:38:30.905: INFO: (16) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 11.158458ms)
+Mar 19 16:38:30.915: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 8.228965ms)
+Mar 19 16:38:30.915: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 8.765882ms)
+Mar 19 16:38:30.915: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 9.063052ms)
+Mar 19 16:38:30.915: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 9.129336ms)
+Mar 19 16:38:30.916: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 9.2945ms)
+Mar 19 16:38:30.916: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 9.060799ms)
+Mar 19 16:38:30.916: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 9.13732ms)
+Mar 19 16:38:30.916: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 9.989468ms)
+Mar 19 16:38:30.916: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 9.121368ms)
+Mar 19 16:38:30.916: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 9.652815ms)
+Mar 19 16:38:30.917: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 9.749334ms)
+Mar 19 16:38:30.917: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 10.072763ms)
+Mar 19 16:38:30.917: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 10.421197ms)
+Mar 19 16:38:30.917: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 9.765494ms)
+Mar 19 16:38:30.918: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 10.412802ms)
+Mar 19 16:38:30.918: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 10.426116ms)
+Mar 19 16:38:30.919: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 12.001324ms)
+Mar 19 16:38:30.919: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 11.822396ms)
+Mar 19 16:38:30.919: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 12.006816ms)
+Mar 19 16:38:30.919: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 12.717426ms)
+Mar 19 16:38:30.919: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 12.774992ms)
+Mar 19 16:38:30.919: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 12.50961ms)
+Mar 19 16:38:30.919: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 11.632813ms)
+Mar 19 16:38:30.919: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 13.68797ms)
+Mar 19 16:38:30.919: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 11.935964ms)
+Mar 19 16:38:30.920: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 12.320507ms)
+Mar 19 16:38:30.920: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 13.44421ms)
+Mar 19 16:38:30.920: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 12.054803ms)
+Mar 19 16:38:30.920: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 12.681831ms)
+Mar 19 16:38:30.920: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 12.433425ms)
+Mar 19 16:38:30.920: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 13.058305ms)
+Mar 19 16:38:30.920: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 12.978272ms)
+Mar 19 16:38:30.920: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 13.693414ms)
+Mar 19 16:38:30.921: INFO: (17) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 13.149753ms)
+Mar 19 16:38:30.929: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 7.901482ms)
+Mar 19 16:38:30.929: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 7.74943ms)
+Mar 19 16:38:30.929: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 7.89112ms)
+Mar 19 16:38:30.929: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 8.27419ms)
+Mar 19 16:38:30.929: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 5.818286ms)
+Mar 19 16:38:30.929: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 7.875215ms)
+Mar 19 16:38:30.929: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 6.870907ms)
+Mar 19 16:38:30.929: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 7.807092ms)
+Mar 19 16:38:30.929: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 8.02949ms)
+Mar 19 16:38:30.929: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 8.312783ms)
+Mar 19 16:38:30.931: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 9.175923ms)
+Mar 19 16:38:30.931: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 8.74647ms)
+Mar 19 16:38:30.931: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 8.088526ms)
+Mar 19 16:38:30.931: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 8.498396ms)
+Mar 19 16:38:30.931: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 8.939843ms)
+Mar 19 16:38:30.931: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 8.254167ms)
+Mar 19 16:38:30.932: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 8.554111ms)
+Mar 19 16:38:30.932: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 9.635384ms)
+Mar 19 16:38:30.932: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 9.439387ms)
+Mar 19 16:38:30.932: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 9.323424ms)
+Mar 19 16:38:30.932: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 10.224073ms)
+Mar 19 16:38:30.932: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 8.919492ms)
+Mar 19 16:38:30.932: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 9.669587ms)
+Mar 19 16:38:30.932: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 9.407316ms)
+Mar 19 16:38:30.932: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 9.336565ms)
+Mar 19 16:38:30.932: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 10.398864ms)
+Mar 19 16:38:30.932: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 10.683379ms)
+Mar 19 16:38:30.933: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 11.003123ms)
+Mar 19 16:38:30.933: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 10.575393ms)
+Mar 19 16:38:30.933: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 11.376455ms)
+Mar 19 16:38:30.933: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 10.482569ms)
+Mar 19 16:38:30.933: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 10.783628ms)
+Mar 19 16:38:30.933: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 10.341575ms)
+Mar 19 16:38:30.933: INFO: (18) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 11.148653ms)
+Mar 19 16:38:37.641: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/proxy/: bar (200; 6.707801342s)
+Mar 19 16:38:37.641: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/: foo (200; 6.707758705s)
+Mar 19 16:38:37.641: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/proxy/: foo (200; 6.707205198s)
+Mar 19 16:38:37.641: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/proxy/rewri... (200; 6.707080982s)
+Mar 19 16:38:37.642: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:1080/rewri... (200; 6.707996806s)
+Mar 19 16:38:37.642: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/: bar (200; 6.707955929s)
+Mar 19 16:38:37.642: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:460/proxy/: tls baz (200; 6.708272028s)
+Mar 19 16:38:37.642: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv/proxy/rewriteme"... (200; 6.708123101s)
+Mar 19 16:38:37.642: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/: tls baz (200; 6.708622011s)
+Mar 19 16:38:37.643: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname1/: foo (200; 6.709042181s)
+Mar 19 16:38:37.643: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/: <a href="/api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/... (200; 6.708910011s)
+Mar 19 16:38:37.643: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:1080/proxy/... (200; 6.709239698s)
+Mar 19 16:38:37.644: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/: bar (200; 6.709953471s)
+Mar 19 16:38:37.644: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 6.709812276s)
+Mar 19 16:38:37.645: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 6.711081784s)
+Mar 19 16:38:37.645: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:160/proxy/: foo (200; 6.711386056s)
+Mar 19 16:38:37.645: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname1/proxy/: tls baz (200; 6.711168338s)
+Mar 19 16:38:37.646: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:443/: tls baz (200; 6.711474468s)
+Mar 19 16:38:37.646: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/proxy/: bar (200; 6.71166711s)
+Mar 19 16:38:37.646: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/pods/proxy-service-sggkv-ndgfv:160/: foo (200; 6.711937065s)
+Mar 19 16:38:37.646: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/proxy/: foo (200; 6.712212066s)
+Mar 19 16:38:37.647: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/http:proxy-service-sggkv-ndgfv:162/proxy/: bar (200; 6.713226963s)
+Mar 19 16:38:37.647: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname2/: bar (200; 6.713417337s)
+Mar 19 16:38:37.648: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:80/: foo (200; 6.713658995s)
+Mar 19 16:38:37.648: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:portname1/: foo (200; 6.713702268s)
+Mar 19 16:38:37.648: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:81/: bar (200; 6.714212156s)
+Mar 19 16:38:37.648: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/proxy-service-sggkv:81/: bar (200; 6.714286167s)
+Mar 19 16:38:37.649: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:80/: foo (200; 6.715432545s)
+Mar 19 16:38:37.683: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/http:proxy-service-sggkv:portname2/: bar (200; 6.749193127s)
+Mar 19 16:38:38.815: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:462/proxy/: tls qux (200; 7.880437161s)
+Mar 19 16:38:38.815: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/proxy/: tls qux (200; 7.880234846s)
+Mar 19 16:38:38.815: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:444/: tls qux (200; 7.88122018s)
+Mar 19 16:38:38.815: INFO: (19) /api/v1/proxy/namespaces/e2e-tests-proxy-mqmsb/services/https:proxy-service-sggkv:tlsportname2/: tls qux (200; 7.881114895s)
+Mar 19 16:38:40.028: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-mqmsb/pods/https:proxy-service-sggkv-ndgfv:443/proxy/... (200; 9.093740057s)
+STEP: deleting { ReplicationController} proxy-service-sggkv in namespace e2e-tests-proxy-mqmsb
+Mar 19 16:38:40.161: INFO: Deleting { ReplicationController} proxy-service-sggkv took: 29.630018ms
+Mar 19 16:38:40.161: INFO: Terminating { ReplicationController} proxy-service-sggkv pods took: 25.998µs
+Mar 19 16:38:42.261: INFO: Garbage collecting { ReplicationController} proxy-service-sggkv pods took: 2.129781716s
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:38:42.262: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-mqmsb" for this suite.
+Mar 19 16:38:48.275: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:38:48.385: INFO: namespace: e2e-tests-proxy-mqmsb, resource: bindings, ignored listing per whitelist
+Mar 19 16:38:48.385: INFO: namespace e2e-tests-proxy-mqmsb deletion completed in 6.120853373s
+
+• [SLOW TEST:35.283 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:38:48.386: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-ffa8bf1e-2b93-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:38:48.429: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-ffa91ca3-2b93-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-4gqnt" to be "success or failure"
+Mar 19 16:38:48.431: INFO: Pod "pod-projected-secrets-ffa91ca3-2b93-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.83143ms
+Mar 19 16:38:50.435: INFO: Pod "pod-projected-secrets-ffa91ca3-2b93-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005603135s
+STEP: Saw pod success
+Mar 19 16:38:50.435: INFO: Pod "pod-projected-secrets-ffa91ca3-2b93-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:38:50.437: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-projected-secrets-ffa91ca3-2b93-11e8-a904-72008c49cf21 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:38:50.450: INFO: Waiting for pod pod-projected-secrets-ffa91ca3-2b93-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:38:50.452: INFO: Pod pod-projected-secrets-ffa91ca3-2b93-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:38:50.452: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4gqnt" for this suite.
+Mar 19 16:38:56.462: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:38:56.571: INFO: namespace: e2e-tests-projected-4gqnt, resource: bindings, ignored listing per whitelist
+Mar 19 16:38:56.571: INFO: namespace e2e-tests-projected-4gqnt deletion completed in 6.116363039s
+
+• [SLOW TEST:8.186 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:38:56.572: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:38:56.609: INFO: Waiting up to 5m0s for pod "downwardapi-volume-04894083-2b94-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-8rt6d" to be "success or failure"
+Mar 19 16:38:56.611: INFO: Pod "downwardapi-volume-04894083-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.862452ms
+Mar 19 16:38:58.614: INFO: Pod "downwardapi-volume-04894083-2b94-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004515749s
+STEP: Saw pod success
+Mar 19 16:38:58.614: INFO: Pod "downwardapi-volume-04894083-2b94-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:38:58.616: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod downwardapi-volume-04894083-2b94-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:38:58.628: INFO: Waiting for pod downwardapi-volume-04894083-2b94-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:38:58.639: INFO: Pod downwardapi-volume-04894083-2b94-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:38:58.646: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8rt6d" for this suite.
+Mar 19 16:39:04.655: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:39:04.689: INFO: namespace: e2e-tests-projected-8rt6d, resource: bindings, ignored listing per whitelist
+Mar 19 16:39:04.747: INFO: namespace e2e-tests-projected-8rt6d deletion completed in 6.097821973s
+
+• [SLOW TEST:8.175 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:39:04.747: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Mar 19 16:39:04.785: INFO: Waiting up to 5m0s for pod "pod-0968bfa8-2b94-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-s7nf6" to be "success or failure"
+Mar 19 16:39:04.787: INFO: Pod "pod-0968bfa8-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.934821ms
+Mar 19 16:39:06.790: INFO: Pod "pod-0968bfa8-2b94-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00502211s
+STEP: Saw pod success
+Mar 19 16:39:06.791: INFO: Pod "pod-0968bfa8-2b94-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:39:06.793: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-0968bfa8-2b94-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:39:06.805: INFO: Waiting for pod pod-0968bfa8-2b94-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:39:06.807: INFO: Pod pod-0968bfa8-2b94-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:39:06.807: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-s7nf6" for this suite.
+Mar 19 16:39:12.816: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:39:12.876: INFO: namespace: e2e-tests-emptydir-s7nf6, resource: bindings, ignored listing per whitelist
+Mar 19 16:39:12.919: INFO: namespace e2e-tests-emptydir-s7nf6 deletion completed in 6.109433164s
+
+• [SLOW TEST:8.172 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:39:12.919: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:39:12.965: INFO: Waiting up to 5m0s for pod "downwardapi-volume-0e48f193-2b94-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-52vkh" to be "success or failure"
+Mar 19 16:39:12.966: INFO: Pod "downwardapi-volume-0e48f193-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.79942ms
+Mar 19 16:39:14.970: INFO: Pod "downwardapi-volume-0e48f193-2b94-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005422239s
+STEP: Saw pod success
+Mar 19 16:39:14.970: INFO: Pod "downwardapi-volume-0e48f193-2b94-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:39:14.972: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod downwardapi-volume-0e48f193-2b94-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:39:14.995: INFO: Waiting for pod downwardapi-volume-0e48f193-2b94-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:39:15.001: INFO: Pod downwardapi-volume-0e48f193-2b94-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:39:15.002: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-52vkh" for this suite.
+Mar 19 16:39:21.013: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:39:21.060: INFO: namespace: e2e-tests-projected-52vkh, resource: bindings, ignored listing per whitelist
+Mar 19 16:39:21.115: INFO: namespace e2e-tests-projected-52vkh deletion completed in 6.11085168s
+
+• [SLOW TEST:8.197 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:39:21.116: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Mar 19 16:39:21.158: INFO: Waiting up to 5m0s for pod "pod-132a9152-2b94-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-p2prb" to be "success or failure"
+Mar 19 16:39:21.160: INFO: Pod "pod-132a9152-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.867505ms
+Mar 19 16:39:23.163: INFO: Pod "pod-132a9152-2b94-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004939478s
+STEP: Saw pod success
+Mar 19 16:39:23.163: INFO: Pod "pod-132a9152-2b94-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:39:23.166: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-132a9152-2b94-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:39:23.179: INFO: Waiting for pod pod-132a9152-2b94-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:39:23.181: INFO: Pod pod-132a9152-2b94-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:39:23.181: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-p2prb" for this suite.
+Mar 19 16:39:29.194: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:39:29.285: INFO: namespace: e2e-tests-emptydir-p2prb, resource: bindings, ignored listing per whitelist
+Mar 19 16:39:29.296: INFO: namespace e2e-tests-emptydir-p2prb deletion completed in 6.112646554s
+
+• [SLOW TEST:8.180 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:39:29.297: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Mar 19 16:39:29.337: INFO: Waiting up to 5m0s for pod "pod-180b292b-2b94-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-7dw28" to be "success or failure"
+Mar 19 16:39:29.339: INFO: Pod "pod-180b292b-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.976649ms
+Mar 19 16:39:31.343: INFO: Pod "pod-180b292b-2b94-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005370817s
+STEP: Saw pod success
+Mar 19 16:39:31.343: INFO: Pod "pod-180b292b-2b94-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:39:31.345: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-180b292b-2b94-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:39:31.366: INFO: Waiting for pod pod-180b292b-2b94-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:39:31.369: INFO: Pod pod-180b292b-2b94-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:39:31.370: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-7dw28" for this suite.
+Mar 19 16:39:37.380: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:39:37.437: INFO: namespace: e2e-tests-emptydir-7dw28, resource: bindings, ignored listing per whitelist
+Mar 19 16:39:37.494: INFO: namespace e2e-tests-emptydir-7dw28 deletion completed in 6.121088178s
+
+• [SLOW TEST:8.197 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:39:37.495: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Mar 19 16:39:37.542: INFO: Waiting up to 5m0s for pod "pod-1ceefb5a-2b94-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-2ff2q" to be "success or failure"
+Mar 19 16:39:37.544: INFO: Pod "pod-1ceefb5a-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.619751ms
+Mar 19 16:39:39.548: INFO: Pod "pod-1ceefb5a-2b94-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006368281s
+STEP: Saw pod success
+Mar 19 16:39:39.548: INFO: Pod "pod-1ceefb5a-2b94-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:39:39.550: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-1ceefb5a-2b94-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:39:39.563: INFO: Waiting for pod pod-1ceefb5a-2b94-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:39:39.565: INFO: Pod pod-1ceefb5a-2b94-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:39:39.565: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-2ff2q" for this suite.
+Mar 19 16:39:45.576: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:39:45.677: INFO: namespace: e2e-tests-emptydir-2ff2q, resource: bindings, ignored listing per whitelist
+Mar 19 16:39:45.679: INFO: namespace e2e-tests-emptydir-2ff2q deletion completed in 6.110965738s
+
+• [SLOW TEST:8.184 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:39:45.679: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test use defaults
+Mar 19 16:39:45.718: INFO: Waiting up to 5m0s for pod "client-containers-21ceaa54-2b94-11e8-a904-72008c49cf21" in namespace "e2e-tests-containers-dsvp6" to be "success or failure"
+Mar 19 16:39:45.720: INFO: Pod "client-containers-21ceaa54-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.747286ms
+Mar 19 16:39:47.723: INFO: Pod "client-containers-21ceaa54-2b94-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005403471s
+STEP: Saw pod success
+Mar 19 16:39:47.723: INFO: Pod "client-containers-21ceaa54-2b94-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:39:47.725: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod client-containers-21ceaa54-2b94-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:39:47.740: INFO: Waiting for pod client-containers-21ceaa54-2b94-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:39:47.743: INFO: Pod client-containers-21ceaa54-2b94-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:39:47.743: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-dsvp6" for this suite.
+Mar 19 16:39:53.755: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:39:53.820: INFO: namespace: e2e-tests-containers-dsvp6, resource: bindings, ignored listing per whitelist
+Mar 19 16:39:53.855: INFO: namespace e2e-tests-containers-dsvp6 deletion completed in 6.107265784s
+
+• [SLOW TEST:8.176 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:39:53.856: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-btp5v
+I0319 16:39:53.897297      17 runners.go:178] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-btp5v, replica count: 1
+I0319 16:39:54.897571      17 runners.go:178] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0319 16:39:55.897876      17 runners.go:178] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Mar 19 16:39:56.005: INFO: Created: latency-svc-99vnn
+Mar 19 16:39:56.009: INFO: Got endpoints: latency-svc-99vnn [11.168844ms]
+Mar 19 16:39:56.017: INFO: Created: latency-svc-j8h9c
+Mar 19 16:39:56.029: INFO: Got endpoints: latency-svc-j8h9c [18.060407ms]
+Mar 19 16:39:56.029: INFO: Created: latency-svc-tzvpb
+Mar 19 16:39:56.030: INFO: Got endpoints: latency-svc-tzvpb [18.498391ms]
+Mar 19 16:39:56.030: INFO: Created: latency-svc-g4sj5
+Mar 19 16:39:56.030: INFO: Got endpoints: latency-svc-g4sj5 [18.620251ms]
+Mar 19 16:39:56.030: INFO: Created: latency-svc-8dn5m
+Mar 19 16:39:56.032: INFO: Got endpoints: latency-svc-8dn5m [21.195197ms]
+Mar 19 16:39:56.032: INFO: Created: latency-svc-hwnh9
+Mar 19 16:39:56.033: INFO: Got endpoints: latency-svc-hwnh9 [21.946096ms]
+Mar 19 16:39:56.037: INFO: Created: latency-svc-44xm5
+Mar 19 16:39:56.040: INFO: Got endpoints: latency-svc-44xm5 [28.672225ms]
+Mar 19 16:39:56.040: INFO: Created: latency-svc-ffgzb
+Mar 19 16:39:56.045: INFO: Got endpoints: latency-svc-ffgzb [33.133398ms]
+Mar 19 16:39:56.049: INFO: Created: latency-svc-8dht8
+Mar 19 16:39:56.052: INFO: Created: latency-svc-kkcqg
+Mar 19 16:39:56.052: INFO: Got endpoints: latency-svc-8dht8 [40.574448ms]
+Mar 19 16:39:56.055: INFO: Created: latency-svc-g8jrh
+Mar 19 16:39:56.055: INFO: Got endpoints: latency-svc-kkcqg [43.189658ms]
+Mar 19 16:39:56.056: INFO: Got endpoints: latency-svc-g8jrh [44.306392ms]
+Mar 19 16:39:56.060: INFO: Created: latency-svc-7ld7v
+Mar 19 16:39:56.061: INFO: Got endpoints: latency-svc-7ld7v [48.669846ms]
+Mar 19 16:39:56.063: INFO: Created: latency-svc-dzx2f
+Mar 19 16:39:56.066: INFO: Created: latency-svc-dpxdd
+Mar 19 16:39:56.067: INFO: Got endpoints: latency-svc-dpxdd [54.804635ms]
+Mar 19 16:39:56.067: INFO: Got endpoints: latency-svc-dzx2f [55.309833ms]
+Mar 19 16:39:56.069: INFO: Created: latency-svc-rqqw5
+Mar 19 16:39:56.072: INFO: Got endpoints: latency-svc-rqqw5 [58.860902ms]
+Mar 19 16:39:56.074: INFO: Created: latency-svc-6l7m2
+Mar 19 16:39:56.077: INFO: Got endpoints: latency-svc-6l7m2 [64.533542ms]
+Mar 19 16:39:56.080: INFO: Created: latency-svc-njm4j
+Mar 19 16:39:56.081: INFO: Got endpoints: latency-svc-njm4j [52.543725ms]
+Mar 19 16:39:56.084: INFO: Created: latency-svc-4l2xk
+Mar 19 16:39:56.088: INFO: Created: latency-svc-zlnfj
+Mar 19 16:39:56.089: INFO: Got endpoints: latency-svc-4l2xk [58.992572ms]
+Mar 19 16:39:56.095: INFO: Got endpoints: latency-svc-zlnfj [64.995718ms]
+Mar 19 16:39:56.098: INFO: Created: latency-svc-65kz6
+Mar 19 16:39:56.099: INFO: Got endpoints: latency-svc-65kz6 [65.949077ms]
+Mar 19 16:39:56.098: INFO: Created: latency-svc-zkf5x
+Mar 19 16:39:56.099: INFO: Got endpoints: latency-svc-zkf5x [67.155948ms]
+Mar 19 16:39:56.104: INFO: Created: latency-svc-jm4xp
+Mar 19 16:39:56.105: INFO: Got endpoints: latency-svc-jm4xp [65.057782ms]
+Mar 19 16:39:56.110: INFO: Created: latency-svc-jzlqz
+Mar 19 16:39:56.113: INFO: Got endpoints: latency-svc-jzlqz [67.928873ms]
+Mar 19 16:39:56.113: INFO: Created: latency-svc-48jjj
+Mar 19 16:39:56.120: INFO: Created: latency-svc-rhlxk
+Mar 19 16:39:56.122: INFO: Got endpoints: latency-svc-48jjj [69.240513ms]
+Mar 19 16:39:56.126: INFO: Created: latency-svc-d5xxk
+Mar 19 16:39:56.128: INFO: Created: latency-svc-pfjjk
+Mar 19 16:39:56.128: INFO: Got endpoints: latency-svc-pfjjk [66.842154ms]
+Mar 19 16:39:56.128: INFO: Got endpoints: latency-svc-rhlxk [71.488143ms]
+Mar 19 16:39:56.129: INFO: Got endpoints: latency-svc-d5xxk [71.306241ms]
+Mar 19 16:39:56.129: INFO: Created: latency-svc-vw5gw
+Mar 19 16:39:56.132: INFO: Got endpoints: latency-svc-vw5gw [64.247539ms]
+Mar 19 16:39:56.133: INFO: Created: latency-svc-pzfs5
+Mar 19 16:39:56.137: INFO: Got endpoints: latency-svc-pzfs5 [69.171941ms]
+Mar 19 16:39:56.137: INFO: Created: latency-svc-djrjx
+Mar 19 16:39:56.141: INFO: Got endpoints: latency-svc-djrjx [69.01939ms]
+Mar 19 16:39:56.152: INFO: Created: latency-svc-w4wm2
+Mar 19 16:39:56.156: INFO: Got endpoints: latency-svc-w4wm2 [78.989725ms]
+Mar 19 16:39:56.160: INFO: Created: latency-svc-mb6ln
+Mar 19 16:39:56.162: INFO: Got endpoints: latency-svc-mb6ln [80.983133ms]
+Mar 19 16:39:56.171: INFO: Created: latency-svc-snll5
+Mar 19 16:39:56.175: INFO: Got endpoints: latency-svc-snll5 [86.42237ms]
+Mar 19 16:39:56.182: INFO: Created: latency-svc-8ccln
+Mar 19 16:39:56.184: INFO: Got endpoints: latency-svc-8ccln [89.575667ms]
+Mar 19 16:39:56.194: INFO: Created: latency-svc-l44qf
+Mar 19 16:39:56.195: INFO: Got endpoints: latency-svc-l44qf [95.31622ms]
+Mar 19 16:39:56.197: INFO: Created: latency-svc-lmfv7
+Mar 19 16:39:56.201: INFO: Created: latency-svc-qh4tt
+Mar 19 16:39:56.204: INFO: Created: latency-svc-8pl2x
+Mar 19 16:39:56.207: INFO: Created: latency-svc-snxh4
+Mar 19 16:39:56.211: INFO: Created: latency-svc-9zv29
+Mar 19 16:39:56.214: INFO: Created: latency-svc-57t6t
+Mar 19 16:39:56.219: INFO: Created: latency-svc-9ldrw
+Mar 19 16:39:56.221: INFO: Created: latency-svc-tg82w
+Mar 19 16:39:56.226: INFO: Created: latency-svc-cvclw
+Mar 19 16:39:56.229: INFO: Created: latency-svc-2txxs
+Mar 19 16:39:56.234: INFO: Created: latency-svc-kk9rz
+Mar 19 16:39:56.236: INFO: Created: latency-svc-pzczg
+Mar 19 16:39:56.241: INFO: Got endpoints: latency-svc-lmfv7 [141.35553ms]
+Mar 19 16:39:56.241: INFO: Created: latency-svc-khg9w
+Mar 19 16:39:56.243: INFO: Created: latency-svc-j25sc
+Mar 19 16:39:56.246: INFO: Created: latency-svc-bszsp
+Mar 19 16:39:56.249: INFO: Created: latency-svc-vk97h
+Mar 19 16:39:56.288: INFO: Got endpoints: latency-svc-qh4tt [182.269976ms]
+Mar 19 16:39:56.295: INFO: Created: latency-svc-qlhnw
+Mar 19 16:39:56.339: INFO: Got endpoints: latency-svc-8pl2x [225.96743ms]
+Mar 19 16:39:56.347: INFO: Created: latency-svc-ddc7q
+Mar 19 16:39:56.389: INFO: Got endpoints: latency-svc-snxh4 [267.26957ms]
+Mar 19 16:39:56.400: INFO: Created: latency-svc-zj59r
+Mar 19 16:39:56.439: INFO: Got endpoints: latency-svc-9zv29 [311.273967ms]
+Mar 19 16:39:56.446: INFO: Created: latency-svc-k7k8d
+Mar 19 16:39:56.489: INFO: Got endpoints: latency-svc-57t6t [360.268877ms]
+Mar 19 16:39:56.496: INFO: Created: latency-svc-cbmz4
+Mar 19 16:39:56.543: INFO: Got endpoints: latency-svc-9ldrw [415.277176ms]
+Mar 19 16:39:56.552: INFO: Created: latency-svc-h4q2x
+Mar 19 16:39:56.589: INFO: Got endpoints: latency-svc-tg82w [457.728802ms]
+Mar 19 16:39:56.608: INFO: Created: latency-svc-5fb5l
+Mar 19 16:39:56.639: INFO: Got endpoints: latency-svc-cvclw [502.769883ms]
+Mar 19 16:39:56.652: INFO: Created: latency-svc-wnbzq
+Mar 19 16:39:56.689: INFO: Got endpoints: latency-svc-2txxs [548.270036ms]
+Mar 19 16:39:56.696: INFO: Created: latency-svc-kbdtc
+Mar 19 16:39:56.739: INFO: Got endpoints: latency-svc-kk9rz [582.808263ms]
+Mar 19 16:39:56.746: INFO: Created: latency-svc-gl5dz
+Mar 19 16:39:56.789: INFO: Got endpoints: latency-svc-pzczg [627.007622ms]
+Mar 19 16:39:56.797: INFO: Created: latency-svc-f8xnk
+Mar 19 16:39:56.840: INFO: Got endpoints: latency-svc-khg9w [665.050864ms]
+Mar 19 16:39:56.854: INFO: Created: latency-svc-jxr48
+Mar 19 16:39:56.889: INFO: Got endpoints: latency-svc-j25sc [704.918467ms]
+Mar 19 16:39:56.896: INFO: Created: latency-svc-lldxt
+Mar 19 16:39:56.941: INFO: Got endpoints: latency-svc-bszsp [746.060861ms]
+Mar 19 16:39:56.948: INFO: Created: latency-svc-k64n6
+Mar 19 16:39:56.991: INFO: Got endpoints: latency-svc-vk97h [750.357562ms]
+Mar 19 16:39:57.000: INFO: Created: latency-svc-rmhkp
+Mar 19 16:39:57.040: INFO: Got endpoints: latency-svc-qlhnw [751.492275ms]
+Mar 19 16:39:57.046: INFO: Created: latency-svc-qswkf
+Mar 19 16:39:57.091: INFO: Got endpoints: latency-svc-ddc7q [751.709612ms]
+Mar 19 16:39:57.099: INFO: Created: latency-svc-xvmfj
+Mar 19 16:39:57.139: INFO: Got endpoints: latency-svc-zj59r [750.000104ms]
+Mar 19 16:39:57.146: INFO: Created: latency-svc-hr6g6
+Mar 19 16:39:57.189: INFO: Got endpoints: latency-svc-k7k8d [749.614622ms]
+Mar 19 16:39:57.196: INFO: Created: latency-svc-c7wg9
+Mar 19 16:39:57.239: INFO: Got endpoints: latency-svc-cbmz4 [749.875237ms]
+Mar 19 16:39:57.245: INFO: Created: latency-svc-228hg
+Mar 19 16:39:57.289: INFO: Got endpoints: latency-svc-h4q2x [745.859846ms]
+Mar 19 16:39:57.296: INFO: Created: latency-svc-49v44
+Mar 19 16:39:57.340: INFO: Got endpoints: latency-svc-5fb5l [750.542663ms]
+Mar 19 16:39:57.354: INFO: Created: latency-svc-9rfsp
+Mar 19 16:39:57.389: INFO: Got endpoints: latency-svc-wnbzq [747.498899ms]
+Mar 19 16:39:57.396: INFO: Created: latency-svc-jxmpg
+Mar 19 16:39:57.439: INFO: Got endpoints: latency-svc-kbdtc [750.150373ms]
+Mar 19 16:39:57.446: INFO: Created: latency-svc-vmc87
+Mar 19 16:39:57.489: INFO: Got endpoints: latency-svc-gl5dz [749.454279ms]
+Mar 19 16:39:57.498: INFO: Created: latency-svc-qxn9j
+Mar 19 16:39:57.539: INFO: Got endpoints: latency-svc-f8xnk [749.422479ms]
+Mar 19 16:39:57.547: INFO: Created: latency-svc-jnfx7
+Mar 19 16:39:57.589: INFO: Got endpoints: latency-svc-jxr48 [749.133423ms]
+Mar 19 16:39:57.596: INFO: Created: latency-svc-9qmd2
+Mar 19 16:39:57.639: INFO: Got endpoints: latency-svc-lldxt [749.850827ms]
+Mar 19 16:39:57.646: INFO: Created: latency-svc-72v9n
+Mar 19 16:39:57.689: INFO: Got endpoints: latency-svc-k64n6 [748.78625ms]
+Mar 19 16:39:57.697: INFO: Created: latency-svc-tctjq
+Mar 19 16:39:57.739: INFO: Got endpoints: latency-svc-rmhkp [747.545938ms]
+Mar 19 16:39:57.746: INFO: Created: latency-svc-s4nfk
+Mar 19 16:39:57.789: INFO: Got endpoints: latency-svc-qswkf [749.266692ms]
+Mar 19 16:39:57.804: INFO: Created: latency-svc-fw8p2
+Mar 19 16:39:57.839: INFO: Got endpoints: latency-svc-xvmfj [748.7541ms]
+Mar 19 16:39:57.849: INFO: Created: latency-svc-z6t7q
+Mar 19 16:39:57.894: INFO: Got endpoints: latency-svc-hr6g6 [754.857504ms]
+Mar 19 16:39:57.901: INFO: Created: latency-svc-p2j22
+Mar 19 16:39:57.939: INFO: Got endpoints: latency-svc-c7wg9 [750.478632ms]
+Mar 19 16:39:57.949: INFO: Created: latency-svc-gf8f9
+Mar 19 16:39:57.990: INFO: Got endpoints: latency-svc-228hg [751.404222ms]
+Mar 19 16:39:57.997: INFO: Created: latency-svc-t2k6q
+Mar 19 16:39:58.041: INFO: Got endpoints: latency-svc-49v44 [752.368316ms]
+Mar 19 16:39:58.049: INFO: Created: latency-svc-bhtmb
+Mar 19 16:39:58.090: INFO: Got endpoints: latency-svc-9rfsp [745.956543ms]
+Mar 19 16:39:58.097: INFO: Created: latency-svc-c6f7x
+Mar 19 16:39:58.139: INFO: Got endpoints: latency-svc-jxmpg [749.863248ms]
+Mar 19 16:39:58.146: INFO: Created: latency-svc-4sfqf
+Mar 19 16:39:58.189: INFO: Got endpoints: latency-svc-vmc87 [749.624913ms]
+Mar 19 16:39:58.202: INFO: Created: latency-svc-q8nxm
+Mar 19 16:39:58.240: INFO: Got endpoints: latency-svc-qxn9j [750.838676ms]
+Mar 19 16:39:58.251: INFO: Created: latency-svc-2gjk5
+Mar 19 16:39:58.289: INFO: Got endpoints: latency-svc-jnfx7 [750.263498ms]
+Mar 19 16:39:58.298: INFO: Created: latency-svc-jvjzz
+Mar 19 16:39:58.341: INFO: Got endpoints: latency-svc-9qmd2 [752.045249ms]
+Mar 19 16:39:58.352: INFO: Created: latency-svc-bg5cv
+Mar 19 16:39:58.390: INFO: Got endpoints: latency-svc-72v9n [750.207892ms]
+Mar 19 16:39:58.404: INFO: Created: latency-svc-bw6zl
+Mar 19 16:39:58.445: INFO: Got endpoints: latency-svc-tctjq [755.333009ms]
+Mar 19 16:39:58.457: INFO: Created: latency-svc-hzdml
+Mar 19 16:39:58.489: INFO: Got endpoints: latency-svc-s4nfk [750.283892ms]
+Mar 19 16:39:58.496: INFO: Created: latency-svc-gcqbf
+Mar 19 16:39:58.540: INFO: Got endpoints: latency-svc-fw8p2 [744.649012ms]
+Mar 19 16:39:58.551: INFO: Created: latency-svc-tjhqd
+Mar 19 16:39:58.589: INFO: Got endpoints: latency-svc-z6t7q [748.977032ms]
+Mar 19 16:39:58.596: INFO: Created: latency-svc-spztl
+Mar 19 16:39:58.640: INFO: Got endpoints: latency-svc-p2j22 [745.78729ms]
+Mar 19 16:39:58.648: INFO: Created: latency-svc-9l7f5
+Mar 19 16:39:58.690: INFO: Got endpoints: latency-svc-gf8f9 [750.532473ms]
+Mar 19 16:39:58.697: INFO: Created: latency-svc-xlx64
+Mar 19 16:39:58.739: INFO: Got endpoints: latency-svc-t2k6q [749.045277ms]
+Mar 19 16:39:58.759: INFO: Created: latency-svc-5msq9
+Mar 19 16:39:58.797: INFO: Got endpoints: latency-svc-bhtmb [755.979458ms]
+Mar 19 16:39:58.809: INFO: Created: latency-svc-t2c5z
+Mar 19 16:39:58.839: INFO: Got endpoints: latency-svc-c6f7x [749.053967ms]
+Mar 19 16:39:58.846: INFO: Created: latency-svc-prcrg
+Mar 19 16:39:58.889: INFO: Got endpoints: latency-svc-4sfqf [750.384495ms]
+Mar 19 16:39:58.896: INFO: Created: latency-svc-d7mbj
+Mar 19 16:39:58.940: INFO: Got endpoints: latency-svc-q8nxm [750.671741ms]
+Mar 19 16:39:58.947: INFO: Created: latency-svc-2bnhm
+Mar 19 16:39:58.993: INFO: Got endpoints: latency-svc-2gjk5 [750.506039ms]
+Mar 19 16:39:59.001: INFO: Created: latency-svc-58vnv
+Mar 19 16:39:59.040: INFO: Got endpoints: latency-svc-jvjzz [750.667772ms]
+Mar 19 16:39:59.049: INFO: Created: latency-svc-4jdnb
+Mar 19 16:39:59.090: INFO: Got endpoints: latency-svc-bg5cv [747.336783ms]
+Mar 19 16:39:59.097: INFO: Created: latency-svc-cx9xp
+Mar 19 16:39:59.143: INFO: Got endpoints: latency-svc-bw6zl [753.326985ms]
+Mar 19 16:39:59.150: INFO: Created: latency-svc-tdrlr
+Mar 19 16:39:59.189: INFO: Got endpoints: latency-svc-hzdml [739.10198ms]
+Mar 19 16:39:59.196: INFO: Created: latency-svc-nb7sq
+Mar 19 16:39:59.239: INFO: Got endpoints: latency-svc-gcqbf [749.572678ms]
+Mar 19 16:39:59.246: INFO: Created: latency-svc-5tmrx
+Mar 19 16:39:59.289: INFO: Got endpoints: latency-svc-tjhqd [748.170208ms]
+Mar 19 16:39:59.296: INFO: Created: latency-svc-bkln5
+Mar 19 16:39:59.339: INFO: Got endpoints: latency-svc-spztl [750.327335ms]
+Mar 19 16:39:59.347: INFO: Created: latency-svc-sr4s9
+Mar 19 16:39:59.389: INFO: Got endpoints: latency-svc-9l7f5 [749.059405ms]
+Mar 19 16:39:59.397: INFO: Created: latency-svc-22rsd
+Mar 19 16:39:59.440: INFO: Got endpoints: latency-svc-xlx64 [749.959131ms]
+Mar 19 16:39:59.455: INFO: Created: latency-svc-dczvm
+Mar 19 16:39:59.489: INFO: Got endpoints: latency-svc-5msq9 [749.573187ms]
+Mar 19 16:39:59.497: INFO: Created: latency-svc-vkpnc
+Mar 19 16:39:59.539: INFO: Got endpoints: latency-svc-t2c5z [740.534293ms]
+Mar 19 16:39:59.546: INFO: Created: latency-svc-qrdn7
+Mar 19 16:39:59.589: INFO: Got endpoints: latency-svc-prcrg [750.103587ms]
+Mar 19 16:39:59.596: INFO: Created: latency-svc-8std8
+Mar 19 16:39:59.640: INFO: Got endpoints: latency-svc-d7mbj [750.286173ms]
+Mar 19 16:39:59.647: INFO: Created: latency-svc-n8vgc
+Mar 19 16:39:59.690: INFO: Got endpoints: latency-svc-2bnhm [750.479428ms]
+Mar 19 16:39:59.699: INFO: Created: latency-svc-rhlz6
+Mar 19 16:39:59.761: INFO: Got endpoints: latency-svc-58vnv [767.819119ms]
+Mar 19 16:39:59.774: INFO: Created: latency-svc-8vq7d
+Mar 19 16:39:59.789: INFO: Got endpoints: latency-svc-4jdnb [748.75396ms]
+Mar 19 16:39:59.799: INFO: Created: latency-svc-zq47w
+Mar 19 16:39:59.840: INFO: Got endpoints: latency-svc-cx9xp [749.95626ms]
+Mar 19 16:39:59.849: INFO: Created: latency-svc-9pc6k
+Mar 19 16:39:59.889: INFO: Got endpoints: latency-svc-tdrlr [745.857222ms]
+Mar 19 16:39:59.895: INFO: Created: latency-svc-nstzn
+Mar 19 16:39:59.940: INFO: Got endpoints: latency-svc-nb7sq [750.564319ms]
+Mar 19 16:39:59.948: INFO: Created: latency-svc-ztft6
+Mar 19 16:39:59.989: INFO: Got endpoints: latency-svc-5tmrx [749.96046ms]
+Mar 19 16:40:00.002: INFO: Created: latency-svc-mzgx6
+Mar 19 16:40:00.039: INFO: Got endpoints: latency-svc-bkln5 [750.42411ms]
+Mar 19 16:40:00.046: INFO: Created: latency-svc-6xjmx
+Mar 19 16:40:00.089: INFO: Got endpoints: latency-svc-sr4s9 [749.042906ms]
+Mar 19 16:40:00.095: INFO: Created: latency-svc-xp7c6
+Mar 19 16:40:00.140: INFO: Got endpoints: latency-svc-22rsd [750.568762ms]
+Mar 19 16:40:00.149: INFO: Created: latency-svc-s6jns
+Mar 19 16:40:00.191: INFO: Got endpoints: latency-svc-dczvm [751.329783ms]
+Mar 19 16:40:00.200: INFO: Created: latency-svc-s56jn
+Mar 19 16:40:00.239: INFO: Got endpoints: latency-svc-vkpnc [750.199981ms]
+Mar 19 16:40:00.249: INFO: Created: latency-svc-p7lw4
+Mar 19 16:40:00.299: INFO: Got endpoints: latency-svc-qrdn7 [759.37655ms]
+Mar 19 16:40:00.314: INFO: Created: latency-svc-7wfrv
+Mar 19 16:40:00.340: INFO: Got endpoints: latency-svc-8std8 [750.452554ms]
+Mar 19 16:40:00.350: INFO: Created: latency-svc-mlmkr
+Mar 19 16:40:00.390: INFO: Got endpoints: latency-svc-n8vgc [750.354077ms]
+Mar 19 16:40:00.399: INFO: Created: latency-svc-bmrdh
+Mar 19 16:40:00.439: INFO: Got endpoints: latency-svc-rhlz6 [748.858403ms]
+Mar 19 16:40:00.458: INFO: Created: latency-svc-b87pw
+Mar 19 16:40:00.489: INFO: Got endpoints: latency-svc-8vq7d [727.528382ms]
+Mar 19 16:40:00.496: INFO: Created: latency-svc-tpjl9
+Mar 19 16:40:00.539: INFO: Got endpoints: latency-svc-zq47w [750.294791ms]
+Mar 19 16:40:00.547: INFO: Created: latency-svc-kqlvl
+Mar 19 16:40:00.589: INFO: Got endpoints: latency-svc-9pc6k [748.757946ms]
+Mar 19 16:40:00.598: INFO: Created: latency-svc-2rmt2
+Mar 19 16:40:00.639: INFO: Got endpoints: latency-svc-nstzn [749.961463ms]
+Mar 19 16:40:00.647: INFO: Created: latency-svc-9dhj2
+Mar 19 16:40:00.689: INFO: Got endpoints: latency-svc-ztft6 [749.267434ms]
+Mar 19 16:40:00.696: INFO: Created: latency-svc-6pft4
+Mar 19 16:40:00.739: INFO: Got endpoints: latency-svc-mzgx6 [750.041747ms]
+Mar 19 16:40:00.749: INFO: Created: latency-svc-x9kn6
+Mar 19 16:40:00.789: INFO: Got endpoints: latency-svc-6xjmx [749.792064ms]
+Mar 19 16:40:00.795: INFO: Created: latency-svc-bfrjq
+Mar 19 16:40:00.839: INFO: Got endpoints: latency-svc-xp7c6 [750.111508ms]
+Mar 19 16:40:00.845: INFO: Created: latency-svc-rl5r7
+Mar 19 16:40:00.890: INFO: Got endpoints: latency-svc-s6jns [750.069553ms]
+Mar 19 16:40:00.901: INFO: Created: latency-svc-5dhtb
+Mar 19 16:40:00.941: INFO: Got endpoints: latency-svc-s56jn [749.997402ms]
+Mar 19 16:40:00.959: INFO: Created: latency-svc-l8b6s
+Mar 19 16:40:00.990: INFO: Got endpoints: latency-svc-p7lw4 [748.57541ms]
+Mar 19 16:40:01.010: INFO: Created: latency-svc-jjkwf
+Mar 19 16:40:01.039: INFO: Got endpoints: latency-svc-7wfrv [740.582886ms]
+Mar 19 16:40:01.046: INFO: Created: latency-svc-wb8cg
+Mar 19 16:40:01.092: INFO: Got endpoints: latency-svc-mlmkr [749.541465ms]
+Mar 19 16:40:01.099: INFO: Created: latency-svc-s9x6c
+Mar 19 16:40:01.139: INFO: Got endpoints: latency-svc-bmrdh [748.618913ms]
+Mar 19 16:40:01.147: INFO: Created: latency-svc-m6k67
+Mar 19 16:40:01.189: INFO: Got endpoints: latency-svc-b87pw [749.406905ms]
+Mar 19 16:40:01.199: INFO: Created: latency-svc-lc8nm
+Mar 19 16:40:01.241: INFO: Got endpoints: latency-svc-tpjl9 [752.074641ms]
+Mar 19 16:40:01.263: INFO: Created: latency-svc-ksjh2
+Mar 19 16:40:01.290: INFO: Got endpoints: latency-svc-kqlvl [750.67441ms]
+Mar 19 16:40:01.300: INFO: Created: latency-svc-pp2hj
+Mar 19 16:40:01.358: INFO: Got endpoints: latency-svc-2rmt2 [769.174309ms]
+Mar 19 16:40:01.366: INFO: Created: latency-svc-wx4jq
+Mar 19 16:40:01.395: INFO: Got endpoints: latency-svc-9dhj2 [756.548292ms]
+Mar 19 16:40:01.404: INFO: Created: latency-svc-hmqdx
+Mar 19 16:40:01.439: INFO: Got endpoints: latency-svc-6pft4 [750.396387ms]
+Mar 19 16:40:01.447: INFO: Created: latency-svc-wv4d5
+Mar 19 16:40:01.489: INFO: Got endpoints: latency-svc-x9kn6 [750.419536ms]
+Mar 19 16:40:01.499: INFO: Created: latency-svc-tl5gj
+Mar 19 16:40:01.539: INFO: Got endpoints: latency-svc-bfrjq [750.045505ms]
+Mar 19 16:40:01.547: INFO: Created: latency-svc-s5fs8
+Mar 19 16:40:01.589: INFO: Got endpoints: latency-svc-rl5r7 [750.019353ms]
+Mar 19 16:40:01.598: INFO: Created: latency-svc-427xc
+Mar 19 16:40:01.640: INFO: Got endpoints: latency-svc-5dhtb [750.242271ms]
+Mar 19 16:40:01.651: INFO: Created: latency-svc-xmmkx
+Mar 19 16:40:01.689: INFO: Got endpoints: latency-svc-l8b6s [747.284749ms]
+Mar 19 16:40:01.698: INFO: Created: latency-svc-qrqwg
+Mar 19 16:40:01.740: INFO: Got endpoints: latency-svc-jjkwf [749.553978ms]
+Mar 19 16:40:01.748: INFO: Created: latency-svc-wmnsq
+Mar 19 16:40:01.790: INFO: Got endpoints: latency-svc-wb8cg [751.133776ms]
+Mar 19 16:40:01.799: INFO: Created: latency-svc-4nxmf
+Mar 19 16:40:01.844: INFO: Got endpoints: latency-svc-s9x6c [752.798014ms]
+Mar 19 16:40:01.859: INFO: Created: latency-svc-5b62x
+Mar 19 16:40:01.891: INFO: Got endpoints: latency-svc-m6k67 [752.609594ms]
+Mar 19 16:40:01.898: INFO: Created: latency-svc-r58hq
+Mar 19 16:40:01.939: INFO: Got endpoints: latency-svc-lc8nm [750.098447ms]
+Mar 19 16:40:01.946: INFO: Created: latency-svc-5bzvf
+Mar 19 16:40:01.990: INFO: Got endpoints: latency-svc-ksjh2 [748.429004ms]
+Mar 19 16:40:01.996: INFO: Created: latency-svc-hz8k9
+Mar 19 16:40:02.039: INFO: Got endpoints: latency-svc-pp2hj [748.952648ms]
+Mar 19 16:40:02.046: INFO: Created: latency-svc-xl86t
+Mar 19 16:40:02.090: INFO: Got endpoints: latency-svc-wx4jq [731.288735ms]
+Mar 19 16:40:02.097: INFO: Created: latency-svc-sqwm2
+Mar 19 16:40:02.140: INFO: Got endpoints: latency-svc-hmqdx [744.000842ms]
+Mar 19 16:40:02.147: INFO: Created: latency-svc-qcts7
+Mar 19 16:40:02.189: INFO: Got endpoints: latency-svc-wv4d5 [749.581965ms]
+Mar 19 16:40:02.198: INFO: Created: latency-svc-pvrgj
+Mar 19 16:40:02.239: INFO: Got endpoints: latency-svc-tl5gj [749.632674ms]
+Mar 19 16:40:02.249: INFO: Created: latency-svc-tv577
+Mar 19 16:40:02.289: INFO: Got endpoints: latency-svc-s5fs8 [749.747593ms]
+Mar 19 16:40:02.296: INFO: Created: latency-svc-7lkmr
+Mar 19 16:40:02.339: INFO: Got endpoints: latency-svc-427xc [750.239009ms]
+Mar 19 16:40:02.351: INFO: Created: latency-svc-tdsrq
+Mar 19 16:40:02.389: INFO: Got endpoints: latency-svc-xmmkx [746.970497ms]
+Mar 19 16:40:02.396: INFO: Created: latency-svc-8b6s2
+Mar 19 16:40:02.440: INFO: Got endpoints: latency-svc-qrqwg [751.286487ms]
+Mar 19 16:40:02.447: INFO: Created: latency-svc-mjfgj
+Mar 19 16:40:02.489: INFO: Got endpoints: latency-svc-wmnsq [749.260163ms]
+Mar 19 16:40:02.499: INFO: Created: latency-svc-jhq9j
+Mar 19 16:40:02.539: INFO: Got endpoints: latency-svc-4nxmf [748.523197ms]
+Mar 19 16:40:02.546: INFO: Created: latency-svc-vh8zq
+Mar 19 16:40:02.589: INFO: Got endpoints: latency-svc-5b62x [741.863342ms]
+Mar 19 16:40:02.607: INFO: Created: latency-svc-45lz5
+Mar 19 16:40:02.640: INFO: Got endpoints: latency-svc-r58hq [748.489208ms]
+Mar 19 16:40:02.655: INFO: Created: latency-svc-d67dk
+Mar 19 16:40:02.691: INFO: Got endpoints: latency-svc-5bzvf [751.660014ms]
+Mar 19 16:40:02.698: INFO: Created: latency-svc-xvdvc
+Mar 19 16:40:02.739: INFO: Got endpoints: latency-svc-hz8k9 [749.619904ms]
+Mar 19 16:40:02.749: INFO: Created: latency-svc-jm5x7
+Mar 19 16:40:02.789: INFO: Got endpoints: latency-svc-xl86t [750.243122ms]
+Mar 19 16:40:02.797: INFO: Created: latency-svc-j8b7r
+Mar 19 16:40:02.840: INFO: Got endpoints: latency-svc-sqwm2 [750.234448ms]
+Mar 19 16:40:02.847: INFO: Created: latency-svc-bb6gn
+Mar 19 16:40:02.889: INFO: Got endpoints: latency-svc-qcts7 [749.780194ms]
+Mar 19 16:40:02.900: INFO: Created: latency-svc-d6zjg
+Mar 19 16:40:02.941: INFO: Got endpoints: latency-svc-pvrgj [751.346005ms]
+Mar 19 16:40:02.947: INFO: Created: latency-svc-6gq88
+Mar 19 16:40:02.989: INFO: Got endpoints: latency-svc-tv577 [749.744941ms]
+Mar 19 16:40:02.998: INFO: Created: latency-svc-nh6vt
+Mar 19 16:40:03.040: INFO: Got endpoints: latency-svc-7lkmr [751.142741ms]
+Mar 19 16:40:03.055: INFO: Created: latency-svc-pz2p8
+Mar 19 16:40:03.090: INFO: Got endpoints: latency-svc-tdsrq [750.299163ms]
+Mar 19 16:40:03.098: INFO: Created: latency-svc-js8rf
+Mar 19 16:40:03.139: INFO: Got endpoints: latency-svc-8b6s2 [750.172089ms]
+Mar 19 16:40:03.146: INFO: Created: latency-svc-9qq6n
+Mar 19 16:40:03.193: INFO: Got endpoints: latency-svc-mjfgj [752.92736ms]
+Mar 19 16:40:03.201: INFO: Created: latency-svc-q8fc6
+Mar 19 16:40:03.240: INFO: Got endpoints: latency-svc-jhq9j [750.911519ms]
+Mar 19 16:40:03.247: INFO: Created: latency-svc-jh288
+Mar 19 16:40:03.289: INFO: Got endpoints: latency-svc-vh8zq [749.77688ms]
+Mar 19 16:40:03.296: INFO: Created: latency-svc-fqj8x
+Mar 19 16:40:03.340: INFO: Got endpoints: latency-svc-45lz5 [751.155839ms]
+Mar 19 16:40:03.347: INFO: Created: latency-svc-ngw4p
+Mar 19 16:40:03.390: INFO: Got endpoints: latency-svc-d67dk [750.129636ms]
+Mar 19 16:40:03.397: INFO: Created: latency-svc-xdnfz
+Mar 19 16:40:03.441: INFO: Got endpoints: latency-svc-xvdvc [749.723759ms]
+Mar 19 16:40:03.448: INFO: Created: latency-svc-s9qmg
+Mar 19 16:40:03.490: INFO: Got endpoints: latency-svc-jm5x7 [750.940383ms]
+Mar 19 16:40:03.507: INFO: Created: latency-svc-wtzf7
+Mar 19 16:40:03.540: INFO: Got endpoints: latency-svc-j8b7r [750.461424ms]
+Mar 19 16:40:03.548: INFO: Created: latency-svc-qw4hk
+Mar 19 16:40:03.590: INFO: Got endpoints: latency-svc-bb6gn [749.666842ms]
+Mar 19 16:40:03.597: INFO: Created: latency-svc-8pk44
+Mar 19 16:40:03.640: INFO: Got endpoints: latency-svc-d6zjg [750.050016ms]
+Mar 19 16:40:03.648: INFO: Created: latency-svc-wvzrk
+Mar 19 16:40:03.690: INFO: Got endpoints: latency-svc-6gq88 [749.829986ms]
+Mar 19 16:40:03.700: INFO: Created: latency-svc-shht6
+Mar 19 16:40:03.741: INFO: Got endpoints: latency-svc-nh6vt [751.591176ms]
+Mar 19 16:40:03.753: INFO: Created: latency-svc-whbbd
+Mar 19 16:40:03.791: INFO: Got endpoints: latency-svc-pz2p8 [751.05296ms]
+Mar 19 16:40:03.843: INFO: Got endpoints: latency-svc-js8rf [753.370216ms]
+Mar 19 16:40:03.890: INFO: Got endpoints: latency-svc-9qq6n [750.419913ms]
+Mar 19 16:40:03.941: INFO: Got endpoints: latency-svc-q8fc6 [747.658819ms]
+Mar 19 16:40:03.989: INFO: Got endpoints: latency-svc-jh288 [748.386378ms]
+Mar 19 16:40:04.039: INFO: Got endpoints: latency-svc-fqj8x [750.310554ms]
+Mar 19 16:40:04.089: INFO: Got endpoints: latency-svc-ngw4p [749.286533ms]
+Mar 19 16:40:04.140: INFO: Got endpoints: latency-svc-xdnfz [749.593948ms]
+Mar 19 16:40:04.189: INFO: Got endpoints: latency-svc-s9qmg [748.522692ms]
+Mar 19 16:40:04.239: INFO: Got endpoints: latency-svc-wtzf7 [744.66694ms]
+Mar 19 16:40:04.304: INFO: Got endpoints: latency-svc-qw4hk [764.511256ms]
+Mar 19 16:40:04.339: INFO: Got endpoints: latency-svc-8pk44 [749.265296ms]
+Mar 19 16:40:04.390: INFO: Got endpoints: latency-svc-wvzrk [749.911163ms]
+Mar 19 16:40:04.441: INFO: Got endpoints: latency-svc-shht6 [751.066346ms]
+Mar 19 16:40:04.489: INFO: Got endpoints: latency-svc-whbbd [745.321968ms]
+Mar 19 16:40:04.489: INFO: Latencies: [18.060407ms 18.498391ms 18.620251ms 21.195197ms 21.946096ms 28.672225ms 33.133398ms 40.574448ms 43.189658ms 44.306392ms 48.669846ms 52.543725ms 54.804635ms 55.309833ms 58.860902ms 58.992572ms 64.247539ms 64.533542ms 64.995718ms 65.057782ms 65.949077ms 66.842154ms 67.155948ms 67.928873ms 69.01939ms 69.171941ms 69.240513ms 71.306241ms 71.488143ms 78.989725ms 80.983133ms 86.42237ms 89.575667ms 95.31622ms 141.35553ms 182.269976ms 225.96743ms 267.26957ms 311.273967ms 360.268877ms 415.277176ms 457.728802ms 502.769883ms 548.270036ms 582.808263ms 627.007622ms 665.050864ms 704.918467ms 727.528382ms 731.288735ms 739.10198ms 740.534293ms 740.582886ms 741.863342ms 744.000842ms 744.649012ms 744.66694ms 745.321968ms 745.78729ms 745.857222ms 745.859846ms 745.956543ms 746.060861ms 746.970497ms 747.284749ms 747.336783ms 747.498899ms 747.545938ms 747.658819ms 748.170208ms 748.386378ms 748.429004ms 748.489208ms 748.522692ms 748.523197ms 748.57541ms 748.618913ms 748.75396ms 748.7541ms 748.757946ms 748.78625ms 748.858403ms 748.952648ms 748.977032ms 749.042906ms 749.045277ms 749.053967ms 749.059405ms 749.133423ms 749.260163ms 749.265296ms 749.266692ms 749.267434ms 749.286533ms 749.406905ms 749.422479ms 749.454279ms 749.541465ms 749.553978ms 749.572678ms 749.573187ms 749.581965ms 749.593948ms 749.614622ms 749.619904ms 749.624913ms 749.632674ms 749.666842ms 749.723759ms 749.744941ms 749.747593ms 749.77688ms 749.780194ms 749.792064ms 749.829986ms 749.850827ms 749.863248ms 749.875237ms 749.911163ms 749.95626ms 749.959131ms 749.96046ms 749.961463ms 749.997402ms 750.000104ms 750.019353ms 750.041747ms 750.045505ms 750.050016ms 750.069553ms 750.098447ms 750.103587ms 750.111508ms 750.129636ms 750.150373ms 750.172089ms 750.199981ms 750.207892ms 750.234448ms 750.239009ms 750.242271ms 750.243122ms 750.263498ms 750.283892ms 750.286173ms 750.294791ms 750.299163ms 750.310554ms 750.327335ms 750.354077ms 750.357562ms 750.384495ms 750.396387ms 750.419536ms 750.419913ms 750.42411ms 750.452554ms 750.461424ms 750.478632ms 750.479428ms 750.506039ms 750.532473ms 750.542663ms 750.564319ms 750.568762ms 750.667772ms 750.671741ms 750.67441ms 750.838676ms 750.911519ms 750.940383ms 751.05296ms 751.066346ms 751.133776ms 751.142741ms 751.155839ms 751.286487ms 751.329783ms 751.346005ms 751.404222ms 751.492275ms 751.591176ms 751.660014ms 751.709612ms 752.045249ms 752.074641ms 752.368316ms 752.609594ms 752.798014ms 752.92736ms 753.326985ms 753.370216ms 754.857504ms 755.333009ms 755.979458ms 756.548292ms 759.37655ms 764.511256ms 767.819119ms 769.174309ms]
+Mar 19 16:40:04.490: INFO: 50 %ile: 749.573187ms
+Mar 19 16:40:04.490: INFO: 90 %ile: 751.492275ms
+Mar 19 16:40:04.490: INFO: 99 %ile: 767.819119ms
+Mar 19 16:40:04.490: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:40:04.490: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-btp5v" for this suite.
+Mar 19 16:40:24.504: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:40:24.575: INFO: namespace: e2e-tests-svc-latency-btp5v, resource: bindings, ignored listing per whitelist
+Mar 19 16:40:24.606: INFO: namespace e2e-tests-svc-latency-btp5v deletion completed in 20.1124104s
+
+• [SLOW TEST:30.750 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:40:24.606: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-map-39028973-2b94-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:40:24.649: INFO: Waiting up to 5m0s for pod "pod-configmaps-39031229-2b94-11e8-a904-72008c49cf21" in namespace "e2e-tests-configmap-6kq4t" to be "success or failure"
+Mar 19 16:40:24.651: INFO: Pod "pod-configmaps-39031229-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.700446ms
+Mar 19 16:40:26.654: INFO: Pod "pod-configmaps-39031229-2b94-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004968447s
+STEP: Saw pod success
+Mar 19 16:40:26.654: INFO: Pod "pod-configmaps-39031229-2b94-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:40:26.656: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-configmaps-39031229-2b94-11e8-a904-72008c49cf21 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:40:26.668: INFO: Waiting for pod pod-configmaps-39031229-2b94-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:40:26.675: INFO: Pod pod-configmaps-39031229-2b94-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:40:26.675: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-6kq4t" for this suite.
+Mar 19 16:40:32.689: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:40:32.743: INFO: namespace: e2e-tests-configmap-6kq4t, resource: bindings, ignored listing per whitelist
+Mar 19 16:40:32.800: INFO: namespace e2e-tests-configmap-6kq4t deletion completed in 6.119151154s
+
+• [SLOW TEST:8.194 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:40:32.800: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Mar 19 16:40:32.833: INFO: Waiting up to 1m0s for all nodes to be ready
+Mar 19 16:41:32.851: INFO: Waiting for terminating namespaces to be deleted...
+Mar 19 16:41:32.855: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 19 16:41:32.864: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 19 16:41:32.864: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 19 16:41:32.866: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 19 16:41:32.866: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 before test
+Mar 19 16:41:32.873: INFO: kube-proxy-kkvkb from kube-system started at 2018-03-15 15:26:47 +0000 UTC (1 container statuses recorded)
+Mar 19 16:41:32.874: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 19 16:41:32.874: INFO: sonobuoy from sonobuoy started at 2018-03-19 16:07:57 +0000 UTC (1 container statuses recorded)
+Mar 19 16:41:32.874: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Mar 19 16:41:32.874: INFO: sonobuoy-e2e-job-a39407418b2d4b45 from sonobuoy started at 2018-03-19 16:07:58 +0000 UTC (2 container statuses recorded)
+Mar 19 16:41:32.874: INFO: 	Container e2e ready: true, restart count 0
+Mar 19 16:41:32.874: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Mar 19 16:41:32.874: INFO: addons-kubernetes-dashboard-7fc5877997-d8t2l from kube-system started at 2018-03-15 15:27:47 +0000 UTC (1 container statuses recorded)
+Mar 19 16:41:32.874: INFO: 	Container main ready: true, restart count 0
+Mar 19 16:41:32.874: INFO: kube-dns-858cbcf6ff-597hx from kube-system started at 2018-03-15 15:27:48 +0000 UTC (3 container statuses recorded)
+Mar 19 16:41:32.874: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 19 16:41:32.874: INFO: 	Container kubedns ready: true, restart count 0
+Mar 19 16:41:32.874: INFO: 	Container sidecar ready: true, restart count 0
+Mar 19 16:41:32.874: INFO: node-exporter-kljbt from kube-system started at 2018-03-15 15:26:47 +0000 UTC (1 container statuses recorded)
+Mar 19 16:41:32.874: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 19 16:41:32.874: INFO: calico-node-2d2fj from kube-system started at 2018-03-15 15:26:47 +0000 UTC (2 container statuses recorded)
+Mar 19 16:41:32.874: INFO: 	Container calico-node ready: true, restart count 0
+Mar 19 16:41:32.874: INFO: 	Container install-cni ready: true, restart count 0
+Mar 19 16:41:32.874: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg before test
+Mar 19 16:41:32.880: INFO: addons-heapster-e3b0c-b9ff79bbd-ch9vw from kube-system started at 2018-03-15 15:27:54 +0000 UTC (2 container statuses recorded)
+Mar 19 16:41:32.880: INFO: 	Container heapster ready: true, restart count 0
+Mar 19 16:41:32.880: INFO: 	Container heapster-nanny ready: true, restart count 0
+Mar 19 16:41:32.880: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-cwvlm from kube-system started at 2018-03-15 15:27:54 +0000 UTC (1 container statuses recorded)
+Mar 19 16:41:32.880: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Mar 19 16:41:32.880: INFO: kube-dns-autoscaler-6966fd6fb6-zqlsg from kube-system started at 2018-03-15 15:27:54 +0000 UTC (1 container statuses recorded)
+Mar 19 16:41:32.880: INFO: 	Container autoscaler ready: true, restart count 0
+Mar 19 16:41:32.880: INFO: vpn-shoot-74647f84fc-s48bf from kube-system started at 2018-03-19 10:55:32 +0000 UTC (1 container statuses recorded)
+Mar 19 16:41:32.880: INFO: 	Container vpn-shoot ready: true, restart count 0
+Mar 19 16:41:32.880: INFO: addons-nginx-ingress-controller-ddcb6d7fc-w2vjr from kube-system started at 2018-03-15 15:27:54 +0000 UTC (1 container statuses recorded)
+Mar 19 16:41:32.880: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Mar 19 16:41:32.880: INFO: kube-dns-858cbcf6ff-lfttj from kube-system started at 2018-03-15 15:27:54 +0000 UTC (3 container statuses recorded)
+Mar 19 16:41:32.880: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 19 16:41:32.880: INFO: 	Container kubedns ready: true, restart count 0
+Mar 19 16:41:32.880: INFO: 	Container sidecar ready: true, restart count 0
+Mar 19 16:41:32.880: INFO: node-exporter-q42qq from kube-system started at 2018-03-15 15:26:45 +0000 UTC (1 container statuses recorded)
+Mar 19 16:41:32.880: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 19 16:41:32.880: INFO: kube-proxy-jnck2 from kube-system started at 2018-03-15 15:26:45 +0000 UTC (1 container statuses recorded)
+Mar 19 16:41:32.880: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 19 16:41:32.880: INFO: calico-node-lr4fx from kube-system started at 2018-03-15 15:26:45 +0000 UTC (2 container statuses recorded)
+Mar 19 16:41:32.880: INFO: 	Container calico-node ready: true, restart count 0
+Mar 19 16:41:32.880: INFO: 	Container install-cni ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: verifying the node has the label node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2
+STEP: verifying the node has the label node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg
+Mar 19 16:41:32.905: INFO: Pod addons-heapster-e3b0c-b9ff79bbd-ch9vw requesting resource cpu=50m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg
+Mar 19 16:41:32.905: INFO: Pod addons-kubernetes-dashboard-7fc5877997-d8t2l requesting resource cpu=100m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2
+Mar 19 16:41:32.905: INFO: Pod addons-nginx-ingress-controller-ddcb6d7fc-w2vjr requesting resource cpu=0m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg
+Mar 19 16:41:32.905: INFO: Pod addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-cwvlm requesting resource cpu=0m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg
+Mar 19 16:41:32.905: INFO: Pod calico-node-2d2fj requesting resource cpu=250m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2
+Mar 19 16:41:32.905: INFO: Pod calico-node-lr4fx requesting resource cpu=250m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg
+Mar 19 16:41:32.905: INFO: Pod kube-dns-858cbcf6ff-597hx requesting resource cpu=260m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2
+Mar 19 16:41:32.905: INFO: Pod kube-dns-858cbcf6ff-lfttj requesting resource cpu=260m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg
+Mar 19 16:41:32.905: INFO: Pod kube-dns-autoscaler-6966fd6fb6-zqlsg requesting resource cpu=20m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg
+Mar 19 16:41:32.905: INFO: Pod kube-proxy-jnck2 requesting resource cpu=100m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg
+Mar 19 16:41:32.905: INFO: Pod kube-proxy-kkvkb requesting resource cpu=100m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2
+Mar 19 16:41:32.905: INFO: Pod node-exporter-kljbt requesting resource cpu=100m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2
+Mar 19 16:41:32.905: INFO: Pod node-exporter-q42qq requesting resource cpu=100m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg
+Mar 19 16:41:32.905: INFO: Pod vpn-shoot-74647f84fc-s48bf requesting resource cpu=100m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg
+Mar 19 16:41:32.905: INFO: Pod sonobuoy requesting resource cpu=0m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2
+Mar 19 16:41:32.905: INFO: Pod sonobuoy-e2e-job-a39407418b2d4b45 requesting resource cpu=0m on Node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-61b2c63d-2b94-11e8-a904-72008c49cf21.151d5fe68bdcb67e], Reason = [Scheduled], Message = [Successfully assigned filler-pod-61b2c63d-2b94-11e8-a904-72008c49cf21 to shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-61b2c63d-2b94-11e8-a904-72008c49cf21.151d5fe69c5e37b0], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-7679w" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-61b2c63d-2b94-11e8-a904-72008c49cf21.151d5fe6bba2ff1a], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-61b2c63d-2b94-11e8-a904-72008c49cf21.151d5fe6bd6cc3db], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-61b2c63d-2b94-11e8-a904-72008c49cf21.151d5fe6c5fdfba2], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-61b3b9ea-2b94-11e8-a904-72008c49cf21.151d5fe68c0f6aff], Reason = [Scheduled], Message = [Successfully assigned filler-pod-61b3b9ea-2b94-11e8-a904-72008c49cf21 to shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-61b3b9ea-2b94-11e8-a904-72008c49cf21.151d5fe69c9065b0], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-7679w" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-61b3b9ea-2b94-11e8-a904-72008c49cf21.151d5fe6baacb65f], Reason = [Pulled], Message = [Container image "gcr.io/google_containers/pause-amd64:3.0" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-61b3b9ea-2b94-11e8-a904-72008c49cf21.151d5fe6bda62afb], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-61b3b9ea-2b94-11e8-a904-72008c49cf21.151d5fe6c5fabbc7], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.151d5fe704aea8ee], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 Insufficient cpu.]
+STEP: removing the label node off the node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:41:35.968: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-twtfh" for this suite.
+Mar 19 16:41:57.980: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:41:58.056: INFO: namespace: e2e-tests-sched-pred-twtfh, resource: bindings, ignored listing per whitelist
+Mar 19 16:41:58.084: INFO: namespace e2e-tests-sched-pred-twtfh deletion completed in 22.113539229s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:85.284 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:41:58.084: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-rqqjq
+Mar 19 16:42:02.132: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-rqqjq
+STEP: checking the pod's current state and verifying that restartCount is present
+Mar 19 16:42:02.134: INFO: Initial restart count of pod liveness-exec is 0
+Mar 19 16:42:54.223: INFO: Restart count of pod e2e-tests-container-probe-rqqjq/liveness-exec is now 1 (52.088647382s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:42:54.228: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-rqqjq" for this suite.
+Mar 19 16:43:00.238: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:43:00.326: INFO: namespace: e2e-tests-container-probe-rqqjq, resource: bindings, ignored listing per whitelist
+Mar 19 16:43:00.353: INFO: namespace e2e-tests-container-probe-rqqjq deletion completed in 6.121960481s
+
+• [SLOW TEST:62.269 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:43:00.354: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-map-95d7afc6-2b94-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:43:00.395: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-95d8016e-2b94-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-hx2wp" to be "success or failure"
+Mar 19 16:43:00.399: INFO: Pod "pod-projected-secrets-95d8016e-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 3.440751ms
+Mar 19 16:43:02.401: INFO: Pod "pod-projected-secrets-95d8016e-2b94-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006023254s
+STEP: Saw pod success
+Mar 19 16:43:02.401: INFO: Pod "pod-projected-secrets-95d8016e-2b94-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:43:02.403: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-projected-secrets-95d8016e-2b94-11e8-a904-72008c49cf21 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:43:02.415: INFO: Waiting for pod pod-projected-secrets-95d8016e-2b94-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:43:02.420: INFO: Pod pod-projected-secrets-95d8016e-2b94-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:43:02.420: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hx2wp" for this suite.
+Mar 19 16:43:08.440: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:43:08.528: INFO: namespace: e2e-tests-projected-hx2wp, resource: bindings, ignored listing per whitelist
+Mar 19 16:43:08.545: INFO: namespace e2e-tests-projected-hx2wp deletion completed in 6.122038721s
+
+• [SLOW TEST:8.191 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:43:08.545: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Mar 19 16:43:10.594: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-9ab93181-2b94-11e8-a904-72008c49cf21", GenerateName:"", Namespace:"e2e-tests-pods-ckdl7", SelfLink:"/api/v1/namespaces/e2e-tests-pods-ckdl7/pods/pod-submit-remove-9ab93181-2b94-11e8-a904-72008c49cf21", UID:"9aba44a4-2b94-11e8-b227-2a1779109a2a", ResourceVersion:"491035", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63657074588, loc:(*time.Location)(0x619f460)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"578244141"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"100.96.2.221/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-kxtns", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc420df3440), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"gcr.io/google-containers/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-kxtns", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc420d518e8), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg", HostNetwork:false, HostPID:false, HostIPC:false, SecurityContext:(*v1.PodSecurityContext)(0xc420df34c0), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc420d51920)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc420d51940)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63657074588, loc:(*time.Location)(0x619f460)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63657074590, loc:(*time.Location)(0x619f460)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63657074588, loc:(*time.Location)(0x619f460)}}, Reason:"", Message:""}}, Message:"", Reason:"", HostIP:"10.250.0.15", PodIP:"100.96.2.221", StartTime:(*v1.Time)(0xc421636c40), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc421636c60), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"gcr.io/google-containers/nginx-slim-amd64:0.20", ImageID:"docker-pullable://gcr.io/google-containers/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://d4268bb2473fce12c6f799347b9e112422c6ebc223a28c6c2ed32cb340fa753d"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+Mar 19 16:43:15.609: INFO: no pod exists with the name we were looking for, assuming the termination request was observed and completed
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:43:15.612: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-ckdl7" for this suite.
+Mar 19 16:43:21.622: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:43:21.700: INFO: namespace: e2e-tests-pods-ckdl7, resource: bindings, ignored listing per whitelist
+Mar 19 16:43:21.732: INFO: namespace e2e-tests-pods-ckdl7 deletion completed in 6.118047568s
+
+• [SLOW TEST:13.188 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:43:21.733: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir volume type on node default medium
+Mar 19 16:43:21.774: INFO: Waiting up to 5m0s for pod "pod-a29625a2-2b94-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-rqqzr" to be "success or failure"
+Mar 19 16:43:21.785: INFO: Pod "pod-a29625a2-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 10.588407ms
+Mar 19 16:43:23.792: INFO: Pod "pod-a29625a2-2b94-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.017084146s
+STEP: Saw pod success
+Mar 19 16:43:23.792: INFO: Pod "pod-a29625a2-2b94-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:43:23.794: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-a29625a2-2b94-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:43:23.809: INFO: Waiting for pod pod-a29625a2-2b94-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:43:23.813: INFO: Pod pod-a29625a2-2b94-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:43:23.813: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-rqqzr" for this suite.
+Mar 19 16:43:29.825: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:43:29.866: INFO: namespace: e2e-tests-emptydir-rqqzr, resource: bindings, ignored listing per whitelist
+Mar 19 16:43:29.930: INFO: namespace e2e-tests-emptydir-rqqzr deletion completed in 6.111893885s
+
+• [SLOW TEST:8.197 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:43:29.931: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 16:43:31.988: INFO: Waiting up to 5m0s for pod "client-envvars-a8acb8f0-2b94-11e8-a904-72008c49cf21" in namespace "e2e-tests-pods-4cwvb" to be "success or failure"
+Mar 19 16:43:31.998: INFO: Pod "client-envvars-a8acb8f0-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 8.639795ms
+Mar 19 16:43:34.001: INFO: Pod "client-envvars-a8acb8f0-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011472628s
+Mar 19 16:43:36.004: INFO: Pod "client-envvars-a8acb8f0-2b94-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014884268s
+STEP: Saw pod success
+Mar 19 16:43:36.004: INFO: Pod "client-envvars-a8acb8f0-2b94-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:43:36.006: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod client-envvars-a8acb8f0-2b94-11e8-a904-72008c49cf21 container env3cont: <nil>
+STEP: delete the pod
+Mar 19 16:43:36.019: INFO: Waiting for pod client-envvars-a8acb8f0-2b94-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:43:36.021: INFO: Pod client-envvars-a8acb8f0-2b94-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:43:36.021: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-4cwvb" for this suite.
+Mar 19 16:43:58.043: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:43:58.095: INFO: namespace: e2e-tests-pods-4cwvb, resource: bindings, ignored listing per whitelist
+Mar 19 16:43:58.149: INFO: namespace e2e-tests-pods-4cwvb deletion completed in 22.119970932s
+
+• [SLOW TEST:28.218 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:43:58.150: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating projection with secret that has name projected-secret-test-b84ab224-2b94-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:43:58.192: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-b84b10af-2b94-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-6vkx9" to be "success or failure"
+Mar 19 16:43:58.194: INFO: Pod "pod-projected-secrets-b84b10af-2b94-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.901352ms
+Mar 19 16:44:00.197: INFO: Pod "pod-projected-secrets-b84b10af-2b94-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005277507s
+STEP: Saw pod success
+Mar 19 16:44:00.197: INFO: Pod "pod-projected-secrets-b84b10af-2b94-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:44:00.199: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-projected-secrets-b84b10af-2b94-11e8-a904-72008c49cf21 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:44:00.211: INFO: Waiting for pod pod-projected-secrets-b84b10af-2b94-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:44:00.214: INFO: Pod pod-projected-secrets-b84b10af-2b94-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:44:00.214: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6vkx9" for this suite.
+Mar 19 16:44:06.225: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:44:06.293: INFO: namespace: e2e-tests-projected-6vkx9, resource: bindings, ignored listing per whitelist
+Mar 19 16:44:06.330: INFO: namespace e2e-tests-projected-6vkx9 deletion completed in 6.112289431s
+
+• [SLOW TEST:8.180 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:44:06.330: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: getting the auto-created API token
+Mar 19 16:44:06.878: INFO: created pod pod-service-account-defaultsa
+Mar 19 16:44:06.878: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Mar 19 16:44:06.887: INFO: created pod pod-service-account-mountsa
+Mar 19 16:44:06.887: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Mar 19 16:44:06.889: INFO: created pod pod-service-account-nomountsa
+Mar 19 16:44:06.890: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Mar 19 16:44:06.893: INFO: created pod pod-service-account-defaultsa-mountspec
+Mar 19 16:44:06.893: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Mar 19 16:44:06.895: INFO: created pod pod-service-account-mountsa-mountspec
+Mar 19 16:44:06.895: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Mar 19 16:44:06.899: INFO: created pod pod-service-account-nomountsa-mountspec
+Mar 19 16:44:06.899: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Mar 19 16:44:06.907: INFO: created pod pod-service-account-defaultsa-nomountspec
+Mar 19 16:44:06.907: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Mar 19 16:44:06.910: INFO: created pod pod-service-account-mountsa-nomountspec
+Mar 19 16:44:06.910: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Mar 19 16:44:06.913: INFO: created pod pod-service-account-nomountsa-nomountspec
+Mar 19 16:44:06.913: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:44:06.913: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-7qgq9" for this suite.
+Mar 19 16:44:12.926: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:44:12.993: INFO: namespace: e2e-tests-svcaccounts-7qgq9, resource: bindings, ignored listing per whitelist
+Mar 19 16:44:13.050: INFO: namespace e2e-tests-svcaccounts-7qgq9 deletion completed in 6.133850788s
+
+• [SLOW TEST:6.720 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:44:13.050: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 16:44:13.084: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:44:13.620: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-nwzgg" for this suite.
+Mar 19 16:44:19.632: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:44:19.730: INFO: namespace: e2e-tests-custom-resource-definition-nwzgg, resource: bindings, ignored listing per whitelist
+Mar 19 16:44:19.744: INFO: namespace e2e-tests-custom-resource-definition-nwzgg deletion completed in 6.120776475s
+
+• [SLOW TEST:6.695 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:44:19.744: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Mar 19 16:44:19.786: INFO: Waiting up to 1m0s for all nodes to be ready
+Mar 19 16:45:19.804: INFO: Waiting for terminating namespaces to be deleted...
+Mar 19 16:45:19.808: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Mar 19 16:45:19.817: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Mar 19 16:45:19.817: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Mar 19 16:45:19.820: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Mar 19 16:45:19.820: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 before test
+Mar 19 16:45:19.826: INFO: calico-node-2d2fj from kube-system started at 2018-03-15 15:26:47 +0000 UTC (2 container statuses recorded)
+Mar 19 16:45:19.826: INFO: 	Container calico-node ready: true, restart count 0
+Mar 19 16:45:19.826: INFO: 	Container install-cni ready: true, restart count 0
+Mar 19 16:45:19.826: INFO: kube-proxy-kkvkb from kube-system started at 2018-03-15 15:26:47 +0000 UTC (1 container statuses recorded)
+Mar 19 16:45:19.826: INFO: 	Container kube-proxy ready: true, restart count 0
+Mar 19 16:45:19.826: INFO: sonobuoy from sonobuoy started at 2018-03-19 16:07:57 +0000 UTC (1 container statuses recorded)
+Mar 19 16:45:19.826: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Mar 19 16:45:19.826: INFO: sonobuoy-e2e-job-a39407418b2d4b45 from sonobuoy started at 2018-03-19 16:07:58 +0000 UTC (2 container statuses recorded)
+Mar 19 16:45:19.826: INFO: 	Container e2e ready: true, restart count 0
+Mar 19 16:45:19.826: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Mar 19 16:45:19.826: INFO: addons-kubernetes-dashboard-7fc5877997-d8t2l from kube-system started at 2018-03-15 15:27:47 +0000 UTC (1 container statuses recorded)
+Mar 19 16:45:19.826: INFO: 	Container main ready: true, restart count 0
+Mar 19 16:45:19.826: INFO: kube-dns-858cbcf6ff-597hx from kube-system started at 2018-03-15 15:27:48 +0000 UTC (3 container statuses recorded)
+Mar 19 16:45:19.826: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 19 16:45:19.826: INFO: 	Container kubedns ready: true, restart count 0
+Mar 19 16:45:19.826: INFO: 	Container sidecar ready: true, restart count 0
+Mar 19 16:45:19.826: INFO: node-exporter-kljbt from kube-system started at 2018-03-15 15:26:47 +0000 UTC (1 container statuses recorded)
+Mar 19 16:45:19.826: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 19 16:45:19.826: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg before test
+Mar 19 16:45:19.832: INFO: addons-heapster-e3b0c-b9ff79bbd-ch9vw from kube-system started at 2018-03-15 15:27:54 +0000 UTC (2 container statuses recorded)
+Mar 19 16:45:19.832: INFO: 	Container heapster ready: true, restart count 0
+Mar 19 16:45:19.832: INFO: 	Container heapster-nanny ready: true, restart count 0
+Mar 19 16:45:19.832: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-8546cb6999-cwvlm from kube-system started at 2018-03-15 15:27:54 +0000 UTC (1 container statuses recorded)
+Mar 19 16:45:19.832: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Mar 19 16:45:19.832: INFO: kube-dns-autoscaler-6966fd6fb6-zqlsg from kube-system started at 2018-03-15 15:27:54 +0000 UTC (1 container statuses recorded)
+Mar 19 16:45:19.832: INFO: 	Container autoscaler ready: true, restart count 0
+Mar 19 16:45:19.832: INFO: vpn-shoot-74647f84fc-s48bf from kube-system started at 2018-03-19 10:55:32 +0000 UTC (1 container statuses recorded)
+Mar 19 16:45:19.832: INFO: 	Container vpn-shoot ready: true, restart count 0
+Mar 19 16:45:19.832: INFO: calico-node-lr4fx from kube-system started at 2018-03-15 15:26:45 +0000 UTC (2 container statuses recorded)
+Mar 19 16:45:19.832: INFO: 	Container calico-node ready: true, restart count 0
+Mar 19 16:45:19.832: INFO: 	Container install-cni ready: true, restart count 0
+Mar 19 16:45:19.832: INFO: addons-nginx-ingress-controller-ddcb6d7fc-w2vjr from kube-system started at 2018-03-15 15:27:54 +0000 UTC (1 container statuses recorded)
+Mar 19 16:45:19.832: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Mar 19 16:45:19.832: INFO: kube-dns-858cbcf6ff-lfttj from kube-system started at 2018-03-15 15:27:54 +0000 UTC (3 container statuses recorded)
+Mar 19 16:45:19.832: INFO: 	Container dnsmasq ready: true, restart count 0
+Mar 19 16:45:19.832: INFO: 	Container kubedns ready: true, restart count 0
+Mar 19 16:45:19.833: INFO: 	Container sidecar ready: true, restart count 0
+Mar 19 16:45:19.833: INFO: node-exporter-q42qq from kube-system started at 2018-03-15 15:26:45 +0000 UTC (1 container statuses recorded)
+Mar 19 16:45:19.833: INFO: 	Container node-exporter ready: true, restart count 0
+Mar 19 16:45:19.833: INFO: kube-proxy-jnck2 from kube-system started at 2018-03-15 15:26:45 +0000 UTC (1 container statuses recorded)
+Mar 19 16:45:19.833: INFO: 	Container kube-proxy ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.151d601b62164693], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 MatchNodeSelector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:45:20.850: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-4x5xw" for this suite.
+Mar 19 16:45:42.860: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:45:42.907: INFO: namespace: e2e-tests-sched-pred-4x5xw, resource: bindings, ignored listing per whitelist
+Mar 19 16:45:42.970: INFO: namespace e2e-tests-sched-pred-4x5xw deletion completed in 22.117671889s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.226 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:45:42.970: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-v26fr A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-v26fr;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-v26fr A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-v26fr;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-v26fr.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-v26fr.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-v26fr.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-v26fr.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-v26fr.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-v26fr.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-v26fr.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-v26fr.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-v26fr.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-v26fr.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-v26fr.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-v26fr.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-v26fr.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 192.167.70.100.in-addr.arpa. PTR)" && echo OK > /results/100.70.167.192_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 192.167.70.100.in-addr.arpa. PTR)" && echo OK > /results/100.70.167.192_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-v26fr A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-v26fr;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-v26fr A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-v26fr;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-v26fr.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-v26fr.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-v26fr.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-v26fr.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-v26fr.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-v26fr.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-v26fr.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-v26fr.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-v26fr.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-v26fr.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-v26fr.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-v26fr.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-v26fr.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 192.167.70.100.in-addr.arpa. PTR)" && echo OK > /results/100.70.167.192_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 192.167.70.100.in-addr.arpa. PTR)" && echo OK > /results/100.70.167.192_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Mar 19 16:45:56.218: INFO: DNS probes using dns-test-f6c6a1f5-2b94-11e8-a904-72008c49cf21 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:45:56.243: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-v26fr" for this suite.
+Mar 19 16:46:02.254: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:46:02.347: INFO: namespace: e2e-tests-dns-v26fr, resource: bindings, ignored listing per whitelist
+Mar 19 16:46:02.369: INFO: namespace e2e-tests-dns-v26fr deletion completed in 6.123602699s
+
+• [SLOW TEST:19.399 seconds]
+[sig-network] DNS
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:46:02.369: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:46:02.408: INFO: Waiting up to 5m0s for pod "downwardapi-volume-0254f6dc-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-zfnlf" to be "success or failure"
+Mar 19 16:46:02.414: INFO: Pod "downwardapi-volume-0254f6dc-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 6.553305ms
+Mar 19 16:46:04.418: INFO: Pod "downwardapi-volume-0254f6dc-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010296377s
+STEP: Saw pod success
+Mar 19 16:46:04.418: INFO: Pod "downwardapi-volume-0254f6dc-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:46:04.420: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod downwardapi-volume-0254f6dc-2b95-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:46:04.434: INFO: Waiting for pod downwardapi-volume-0254f6dc-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:46:04.436: INFO: Pod downwardapi-volume-0254f6dc-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:46:04.436: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-zfnlf" for this suite.
+Mar 19 16:46:10.458: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:46:10.551: INFO: namespace: e2e-tests-downward-api-zfnlf, resource: bindings, ignored listing per whitelist
+Mar 19 16:46:10.563: INFO: namespace e2e-tests-downward-api-zfnlf deletion completed in 6.112178872s
+
+• [SLOW TEST:8.194 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:46:10.563: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Mar 19 16:46:10.600: INFO: Waiting up to 5m0s for pod "pod-07370798-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-vh4v7" to be "success or failure"
+Mar 19 16:46:10.602: INFO: Pod "pod-07370798-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.986852ms
+Mar 19 16:46:12.606: INFO: Pod "pod-07370798-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005697282s
+STEP: Saw pod success
+Mar 19 16:46:12.606: INFO: Pod "pod-07370798-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:46:12.609: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-07370798-2b95-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:46:12.621: INFO: Waiting for pod pod-07370798-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:46:12.622: INFO: Pod pod-07370798-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:46:12.622: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-vh4v7" for this suite.
+Mar 19 16:46:18.633: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:46:18.682: INFO: namespace: e2e-tests-emptydir-vh4v7, resource: bindings, ignored listing per whitelist
+Mar 19 16:46:18.733: INFO: namespace e2e-tests-emptydir-vh4v7 deletion completed in 6.108072585s
+
+• [SLOW TEST:8.170 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:46:18.733: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Mar 19 16:46:18.771: INFO: Waiting up to 5m0s for pod "pod-0c15d5d2-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-cgzlk" to be "success or failure"
+Mar 19 16:46:18.773: INFO: Pod "pod-0c15d5d2-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.953988ms
+Mar 19 16:46:20.776: INFO: Pod "pod-0c15d5d2-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005332157s
+STEP: Saw pod success
+Mar 19 16:46:20.776: INFO: Pod "pod-0c15d5d2-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:46:20.778: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-0c15d5d2-2b95-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:46:20.791: INFO: Waiting for pod pod-0c15d5d2-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:46:20.795: INFO: Pod pod-0c15d5d2-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:46:20.795: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-cgzlk" for this suite.
+Mar 19 16:46:26.809: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:46:26.853: INFO: namespace: e2e-tests-emptydir-cgzlk, resource: bindings, ignored listing per whitelist
+Mar 19 16:46:26.914: INFO: namespace e2e-tests-emptydir-cgzlk deletion completed in 6.115728943s
+
+• [SLOW TEST:8.181 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:46:26.914: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+Mar 19 16:46:26.974: INFO: (0) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.176923ms)
+Mar 19 16:46:26.978: INFO: (1) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.82359ms)
+Mar 19 16:46:26.982: INFO: (2) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.937647ms)
+Mar 19 16:46:26.985: INFO: (3) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.653773ms)
+Mar 19 16:46:26.989: INFO: (4) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.721614ms)
+Mar 19 16:46:26.992: INFO: (5) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.329348ms)
+Mar 19 16:46:26.996: INFO: (6) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.746544ms)
+Mar 19 16:46:27.000: INFO: (7) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.292733ms)
+Mar 19 16:46:27.003: INFO: (8) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.207432ms)
+Mar 19 16:46:27.006: INFO: (9) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.48618ms)
+Mar 19 16:46:27.010: INFO: (10) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.293535ms)
+Mar 19 16:46:27.013: INFO: (11) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.442562ms)
+Mar 19 16:46:27.017: INFO: (12) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.487518ms)
+Mar 19 16:46:27.020: INFO: (13) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.510487ms)
+Mar 19 16:46:27.023: INFO: (14) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.293111ms)
+Mar 19 16:46:27.027: INFO: (15) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.43358ms)
+Mar 19 16:46:27.030: INFO: (16) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.229277ms)
+Mar 19 16:46:27.034: INFO: (17) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.530098ms)
+Mar 19 16:46:27.037: INFO: (18) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.450364ms)
+Mar 19 16:46:27.041: INFO: (19) /api/v1/proxy/nodes/shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.512843ms)
+[AfterEach] version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:46:27.041: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-5jk89" for this suite.
+Mar 19 16:46:33.051: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:46:33.137: INFO: namespace: e2e-tests-proxy-5jk89, resource: bindings, ignored listing per whitelist
+Mar 19 16:46:33.150: INFO: namespace e2e-tests-proxy-5jk89 deletion completed in 6.10706228s
+
+• [SLOW TEST:6.237 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:46:33.151: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-map-14adcdf9-2b95-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:46:33.192: INFO: Waiting up to 5m0s for pod "pod-configmaps-14ae2ed5-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-configmap-gxshl" to be "success or failure"
+Mar 19 16:46:33.194: INFO: Pod "pod-configmaps-14ae2ed5-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.894132ms
+Mar 19 16:46:35.197: INFO: Pod "pod-configmaps-14ae2ed5-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004881503s
+STEP: Saw pod success
+Mar 19 16:46:35.197: INFO: Pod "pod-configmaps-14ae2ed5-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:46:35.199: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-configmaps-14ae2ed5-2b95-11e8-a904-72008c49cf21 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:46:35.211: INFO: Waiting for pod pod-configmaps-14ae2ed5-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:46:35.213: INFO: Pod pod-configmaps-14ae2ed5-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:46:35.213: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-gxshl" for this suite.
+Mar 19 16:46:41.225: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:46:41.302: INFO: namespace: e2e-tests-configmap-gxshl, resource: bindings, ignored listing per whitelist
+Mar 19 16:46:41.334: INFO: namespace e2e-tests-configmap-gxshl deletion completed in 6.117177223s
+
+• [SLOW TEST:8.183 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:46:41.334: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-map-198e99db-2b95-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:46:41.376: INFO: Waiting up to 5m0s for pod "pod-secrets-198eebe0-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-secrets-kxhl8" to be "success or failure"
+Mar 19 16:46:41.378: INFO: Pod "pod-secrets-198eebe0-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.026781ms
+Mar 19 16:46:43.382: INFO: Pod "pod-secrets-198eebe0-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00551719s
+STEP: Saw pod success
+Mar 19 16:46:43.382: INFO: Pod "pod-secrets-198eebe0-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:46:43.384: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-secrets-198eebe0-2b95-11e8-a904-72008c49cf21 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:46:43.397: INFO: Waiting for pod pod-secrets-198eebe0-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:46:43.398: INFO: Pod pod-secrets-198eebe0-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:46:43.398: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-kxhl8" for this suite.
+Mar 19 16:46:49.419: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:46:49.519: INFO: namespace: e2e-tests-secrets-kxhl8, resource: bindings, ignored listing per whitelist
+Mar 19 16:46:49.536: INFO: namespace e2e-tests-secrets-kxhl8 deletion completed in 6.126734652s
+
+• [SLOW TEST:8.201 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:46:49.536: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-1e74325c-2b95-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:46:49.591: INFO: Waiting up to 5m0s for pod "pod-secrets-1e748e0d-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-secrets-2lcbh" to be "success or failure"
+Mar 19 16:46:49.593: INFO: Pod "pod-secrets-1e748e0d-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.523324ms
+Mar 19 16:46:51.597: INFO: Pod "pod-secrets-1e748e0d-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005838719s
+STEP: Saw pod success
+Mar 19 16:46:51.597: INFO: Pod "pod-secrets-1e748e0d-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:46:51.599: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-secrets-1e748e0d-2b95-11e8-a904-72008c49cf21 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:46:51.611: INFO: Waiting for pod pod-secrets-1e748e0d-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:46:51.614: INFO: Pod pod-secrets-1e748e0d-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:46:51.614: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-2lcbh" for this suite.
+Mar 19 16:46:57.623: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:46:57.697: INFO: namespace: e2e-tests-secrets-2lcbh, resource: bindings, ignored listing per whitelist
+Mar 19 16:46:57.725: INFO: namespace e2e-tests-secrets-2lcbh deletion completed in 6.109284735s
+
+• [SLOW TEST:8.190 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:46:57.726: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating replication controller my-hostname-basic-2354d742-2b95-11e8-a904-72008c49cf21
+Mar 19 16:46:57.773: INFO: Pod name my-hostname-basic-2354d742-2b95-11e8-a904-72008c49cf21: Found 0 pods out of 1
+Mar 19 16:47:02.777: INFO: Pod name my-hostname-basic-2354d742-2b95-11e8-a904-72008c49cf21: Found 1 pods out of 1
+Mar 19 16:47:02.777: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-2354d742-2b95-11e8-a904-72008c49cf21" are running
+Mar 19 16:47:02.779: INFO: Pod "my-hostname-basic-2354d742-2b95-11e8-a904-72008c49cf21-q8c96" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-19 16:46:57 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-19 16:46:58 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-03-19 16:46:57 +0000 UTC Reason: Message:}])
+Mar 19 16:47:02.779: INFO: Trying to dial the pod
+Mar 19 16:47:07.830: INFO: Controller my-hostname-basic-2354d742-2b95-11e8-a904-72008c49cf21: Got expected result from replica 1 [my-hostname-basic-2354d742-2b95-11e8-a904-72008c49cf21-q8c96]: "my-hostname-basic-2354d742-2b95-11e8-a904-72008c49cf21-q8c96", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:47:07.830: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-m57rx" for this suite.
+Mar 19 16:47:13.841: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:47:13.946: INFO: namespace: e2e-tests-replication-controller-m57rx, resource: bindings, ignored listing per whitelist
+Mar 19 16:47:13.951: INFO: namespace e2e-tests-replication-controller-m57rx deletion completed in 6.11793074s
+
+• [SLOW TEST:16.225 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+[k8s.io] Pods 
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:47:13.951: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating pod
+Mar 19 16:47:16.004: INFO: Pod pod-hostip-2d000a04-2b95-11e8-a904-72008c49cf21 has hostIP: 10.250.0.15
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:47:16.004: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-mdr4c" for this suite.
+Mar 19 16:47:38.014: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:47:38.103: INFO: namespace: e2e-tests-pods-mdr4c, resource: bindings, ignored listing per whitelist
+Mar 19 16:47:38.113: INFO: namespace e2e-tests-pods-mdr4c deletion completed in 22.106481109s
+
+• [SLOW TEST:24.162 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:47:38.114: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-f8l4g
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 19 16:47:38.148: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 19 16:48:00.194: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.3.190 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-f8l4g PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:48:00.194: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:48:01.371: INFO: Found all expected endpoints: [netserver-0]
+Mar 19 16:48:01.373: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.2.233 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-f8l4g PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:48:01.373: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:48:11.182: INFO: Failed to execute "echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.2.233 8081 | grep -v '^\\s*$'": Internal error occurred: error executing command in container: container not running (e8fbf15403134cd3adf5c46b5bb007ef9b5681c133f96d0c9cd9a9a96f0c6cf6), stdout: "", stderr: ""
+Mar 19 16:48:11.182: INFO: Waiting for [netserver-1] endpoints (expected=[netserver-1], actual=[])
+Mar 19 16:48:13.186: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.2.233 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-f8l4g PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:48:13.186: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:48:14.285: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:48:14.285: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-f8l4g" for this suite.
+Mar 19 16:48:36.298: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:48:36.377: INFO: namespace: e2e-tests-pod-network-test-f8l4g, resource: bindings, ignored listing per whitelist
+Mar 19 16:48:36.398: INFO: namespace e2e-tests-pod-network-test-f8l4g deletion completed in 22.109876617s
+
+• [SLOW TEST:58.284 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:48:36.399: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:48:36.439: INFO: Waiting up to 5m0s for pod "downwardapi-volume-5e241d0e-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-8rr5s" to be "success or failure"
+Mar 19 16:48:36.441: INFO: Pod "downwardapi-volume-5e241d0e-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.968392ms
+Mar 19 16:48:38.446: INFO: Pod "downwardapi-volume-5e241d0e-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007732856s
+STEP: Saw pod success
+Mar 19 16:48:38.448: INFO: Pod "downwardapi-volume-5e241d0e-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:48:38.451: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod downwardapi-volume-5e241d0e-2b95-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:48:38.469: INFO: Waiting for pod downwardapi-volume-5e241d0e-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:48:38.471: INFO: Pod downwardapi-volume-5e241d0e-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:48:38.471: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-8rr5s" for this suite.
+Mar 19 16:48:44.491: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:48:44.551: INFO: namespace: e2e-tests-downward-api-8rr5s, resource: bindings, ignored listing per whitelist
+Mar 19 16:48:44.605: INFO: namespace e2e-tests-downward-api-8rr5s deletion completed in 6.124493061s
+
+• [SLOW TEST:8.207 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:48:44.605: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-6308281c-2b95-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:48:44.645: INFO: Waiting up to 5m0s for pod "pod-secrets-63087ce3-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-secrets-6mjgp" to be "success or failure"
+Mar 19 16:48:44.647: INFO: Pod "pod-secrets-63087ce3-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.626447ms
+Mar 19 16:48:46.650: INFO: Pod "pod-secrets-63087ce3-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00458923s
+STEP: Saw pod success
+Mar 19 16:48:46.650: INFO: Pod "pod-secrets-63087ce3-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:48:46.652: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-secrets-63087ce3-2b95-11e8-a904-72008c49cf21 container secret-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:48:46.678: INFO: Waiting for pod pod-secrets-63087ce3-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:48:46.680: INFO: Pod pod-secrets-63087ce3-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:48:46.680: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-6mjgp" for this suite.
+Mar 19 16:48:52.693: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:48:52.753: INFO: namespace: e2e-tests-secrets-6mjgp, resource: bindings, ignored listing per whitelist
+Mar 19 16:48:52.796: INFO: namespace e2e-tests-secrets-6mjgp deletion completed in 6.11370136s
+
+• [SLOW TEST:8.190 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:48:52.797: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test downward API volume plugin
+Mar 19 16:48:52.836: INFO: Waiting up to 5m0s for pod "downwardapi-volume-67ea32fe-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-downward-api-hb6jd" to be "success or failure"
+Mar 19 16:48:52.839: INFO: Pod "downwardapi-volume-67ea32fe-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 3.068599ms
+Mar 19 16:48:54.842: INFO: Pod "downwardapi-volume-67ea32fe-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005786321s
+STEP: Saw pod success
+Mar 19 16:48:54.842: INFO: Pod "downwardapi-volume-67ea32fe-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:48:54.844: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod downwardapi-volume-67ea32fe-2b95-11e8-a904-72008c49cf21 container client-container: <nil>
+STEP: delete the pod
+Mar 19 16:48:54.857: INFO: Waiting for pod downwardapi-volume-67ea32fe-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:48:54.859: INFO: Pod downwardapi-volume-67ea32fe-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:48:54.859: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-hb6jd" for this suite.
+Mar 19 16:49:00.870: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:49:00.933: INFO: namespace: e2e-tests-downward-api-hb6jd, resource: bindings, ignored listing per whitelist
+Mar 19 16:49:00.974: INFO: namespace e2e-tests-downward-api-hb6jd deletion completed in 6.112096057s
+
+• [SLOW TEST:8.177 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:49:00.974: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-44hss
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Mar 19 16:49:01.009: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Mar 19 16:49:19.069: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.2.237:8080/dial?request=hostName&protocol=http&host=100.96.2.236&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-44hss PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:49:19.069: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:49:19.215: INFO: Waiting for endpoints: map[]
+Mar 19 16:49:19.218: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.2.237:8080/dial?request=hostName&protocol=http&host=100.96.3.193&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-44hss PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Mar 19 16:49:19.218: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+Mar 19 16:49:19.432: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:49:19.433: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-44hss" for this suite.
+Mar 19 16:49:41.442: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:49:41.527: INFO: namespace: e2e-tests-pod-network-test-44hss, resource: bindings, ignored listing per whitelist
+Mar 19 16:49:41.551: INFO: namespace e2e-tests-pod-network-test-44hss deletion completed in 22.115635851s
+
+• [SLOW TEST:40.577 seconds]
+[sig-network] Networking
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http  [Conformance]
+    /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:49:41.552: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-84f9e887-2b95-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:49:41.595: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-84fa4bc5-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-4xhrr" to be "success or failure"
+Mar 19 16:49:41.598: INFO: Pod "pod-projected-configmaps-84fa4bc5-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.531486ms
+Mar 19 16:49:43.601: INFO: Pod "pod-projected-configmaps-84fa4bc5-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006121267s
+STEP: Saw pod success
+Mar 19 16:49:43.601: INFO: Pod "pod-projected-configmaps-84fa4bc5-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:49:43.604: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-projected-configmaps-84fa4bc5-2b95-11e8-a904-72008c49cf21 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:49:43.617: INFO: Waiting for pod pod-projected-configmaps-84fa4bc5-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:49:43.619: INFO: Pod pod-projected-configmaps-84fa4bc5-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:49:43.619: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4xhrr" for this suite.
+Mar 19 16:49:49.628: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:49:49.671: INFO: namespace: e2e-tests-projected-4xhrr, resource: bindings, ignored listing per whitelist
+Mar 19 16:49:49.729: INFO: namespace e2e-tests-projected-4xhrr deletion completed in 6.10740671s
+
+• [SLOW TEST:8.177 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:49:49.729: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-89d978ad-2b95-11e8-a904-72008c49cf21,GenerateName:,Namespace:e2e-tests-events-4hstr,SelfLink:/api/v1/namespaces/e2e-tests-events-4hstr/pods/send-events-89d978ad-2b95-11e8-a904-72008c49cf21,UID:89d9fa32-2b95-11e8-b227-2a1779109a2a,ResourceVersion:492108,Generation:0,CreationTimestamp:2018-03-19 16:49:49 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 765243105,},Annotations:map[string]string{cni.projectcalico.org/podIP: 100.96.3.194/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-ml9x7 {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-ml9x7,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-ml9x7 true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc42103f500} {node.kubernetes.io/unreachable Exists  NoExecute 0xc42103f520}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-03-19 16:49:49 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-03-19 16:49:51 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-03-19 16:49:49 +0000 UTC  }],Message:,Reason:,HostIP:10.250.0.10,PodIP:100.96.3.194,StartTime:2018-03-19 16:49:49 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-03-19 16:49:50 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://ba016e1ad5b4f280c54837f11b1b7eda37be98587196b130d46c81f6c44b9b3c}],QOSClass:BestEffort,InitContainerStatuses:[],},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:49:55.788: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-4hstr" for this suite.
+Mar 19 16:50:01.808: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:50:01.908: INFO: namespace: e2e-tests-events-4hstr, resource: bindings, ignored listing per whitelist
+Mar 19 16:50:01.912: INFO: namespace e2e-tests-events-4hstr deletion completed in 6.121191093s
+
+• [SLOW TEST:12.183 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:50:01.912: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-map-911c8945-2b95-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:50:01.955: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-911cf916-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-v9rj9" to be "success or failure"
+Mar 19 16:50:01.958: INFO: Pod "pod-projected-configmaps-911cf916-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 3.307534ms
+Mar 19 16:50:03.961: INFO: Pod "pod-projected-configmaps-911cf916-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006283403s
+STEP: Saw pod success
+Mar 19 16:50:03.961: INFO: Pod "pod-projected-configmaps-911cf916-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:50:03.963: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-projected-configmaps-911cf916-2b95-11e8-a904-72008c49cf21 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:50:03.976: INFO: Waiting for pod pod-projected-configmaps-911cf916-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:50:03.978: INFO: Pod pod-projected-configmaps-911cf916-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:50:03.978: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-v9rj9" for this suite.
+Mar 19 16:50:09.988: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:50:10.027: INFO: namespace: e2e-tests-projected-v9rj9, resource: bindings, ignored listing per whitelist
+Mar 19 16:50:10.088: INFO: namespace e2e-tests-projected-v9rj9 deletion completed in 6.10766691s
+
+• [SLOW TEST:8.176 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:50:10.089: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name projected-configmap-test-volume-95fc321d-2b95-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:50:10.131: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-95fc88d7-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-xwjsm" to be "success or failure"
+Mar 19 16:50:10.133: INFO: Pod "pod-projected-configmaps-95fc88d7-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.983658ms
+Mar 19 16:50:12.137: INFO: Pod "pod-projected-configmaps-95fc88d7-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005650336s
+STEP: Saw pod success
+Mar 19 16:50:12.137: INFO: Pod "pod-projected-configmaps-95fc88d7-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:50:12.139: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-projected-configmaps-95fc88d7-2b95-11e8-a904-72008c49cf21 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:50:12.152: INFO: Waiting for pod pod-projected-configmaps-95fc88d7-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:50:12.168: INFO: Pod pod-projected-configmaps-95fc88d7-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:50:12.168: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xwjsm" for this suite.
+Mar 19 16:50:18.180: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:50:18.231: INFO: namespace: e2e-tests-projected-xwjsm, resource: bindings, ignored listing per whitelist
+Mar 19 16:50:18.286: INFO: namespace e2e-tests-projected-xwjsm deletion completed in 6.115016316s
+
+• [SLOW TEST:8.198 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:50:18.287: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name s-test-opt-del-9adff90d-2b95-11e8-a904-72008c49cf21
+STEP: Creating secret with name s-test-opt-upd-9adff956-2b95-11e8-a904-72008c49cf21
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-9adff90d-2b95-11e8-a904-72008c49cf21
+STEP: Updating secret s-test-opt-upd-9adff956-2b95-11e8-a904-72008c49cf21
+STEP: Creating secret with name s-test-opt-create-9adff96c-2b95-11e8-a904-72008c49cf21
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:50:22.594: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-htjhc" for this suite.
+Mar 19 16:50:44.606: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:50:44.645: INFO: namespace: e2e-tests-secrets-htjhc, resource: bindings, ignored listing per whitelist
+Mar 19 16:50:44.702: INFO: namespace e2e-tests-secrets-htjhc deletion completed in 22.104615743s
+
+• [SLOW TEST:26.415 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:50:44.703: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test override arguments
+Mar 19 16:50:44.749: INFO: Waiting up to 5m0s for pod "client-containers-aa9ee121-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-containers-77bqz" to be "success or failure"
+Mar 19 16:50:44.751: INFO: Pod "client-containers-aa9ee121-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.922115ms
+Mar 19 16:50:46.754: INFO: Pod "client-containers-aa9ee121-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005412644s
+STEP: Saw pod success
+Mar 19 16:50:46.755: INFO: Pod "client-containers-aa9ee121-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:50:46.756: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod client-containers-aa9ee121-2b95-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:50:46.769: INFO: Waiting for pod client-containers-aa9ee121-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:50:46.782: INFO: Pod client-containers-aa9ee121-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:50:46.782: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-77bqz" for this suite.
+Mar 19 16:50:52.794: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:50:52.892: INFO: namespace: e2e-tests-containers-77bqz, resource: bindings, ignored listing per whitelist
+Mar 19 16:50:52.894: INFO: namespace e2e-tests-containers-77bqz deletion completed in 6.107406824s
+
+• [SLOW TEST:8.191 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:643
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:50:52.894: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-test-volume-af7f9e85-2b95-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume configMaps
+Mar 19 16:50:52.935: INFO: Waiting up to 5m0s for pod "pod-configmaps-af7ff5d9-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-configmap-dsdmx" to be "success or failure"
+Mar 19 16:50:52.938: INFO: Pod "pod-configmaps-af7ff5d9-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.643218ms
+Mar 19 16:50:54.942: INFO: Pod "pod-configmaps-af7ff5d9-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006457685s
+STEP: Saw pod success
+Mar 19 16:50:54.942: INFO: Pod "pod-configmaps-af7ff5d9-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:50:54.944: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-configmaps-af7ff5d9-2b95-11e8-a904-72008c49cf21 container configmap-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:50:54.956: INFO: Waiting for pod pod-configmaps-af7ff5d9-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:50:54.958: INFO: Pod pod-configmaps-af7ff5d9-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:50:54.959: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-dsdmx" for this suite.
+Mar 19 16:51:00.968: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:51:01.001: INFO: namespace: e2e-tests-configmap-dsdmx, resource: bindings, ignored listing per whitelist
+Mar 19 16:51:01.065: INFO: namespace e2e-tests-configmap-dsdmx deletion completed in 6.104000739s
+
+• [SLOW TEST:8.171 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:51:01.066: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Mar 19 16:51:01.119: INFO: Waiting up to 5m0s for pod "pod-b4609715-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-5rpjw" to be "success or failure"
+Mar 19 16:51:01.122: INFO: Pod "pod-b4609715-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 3.465658ms
+Mar 19 16:51:03.126: INFO: Pod "pod-b4609715-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007628508s
+STEP: Saw pod success
+Mar 19 16:51:03.126: INFO: Pod "pod-b4609715-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:51:03.129: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-b4609715-2b95-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:51:03.142: INFO: Waiting for pod pod-b4609715-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:51:03.144: INFO: Pod pod-b4609715-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:51:03.144: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-5rpjw" for this suite.
+Mar 19 16:51:09.161: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:51:09.206: INFO: namespace: e2e-tests-emptydir-5rpjw, resource: bindings, ignored listing per whitelist
+Mar 19 16:51:09.256: INFO: namespace e2e-tests-emptydir-5rpjw deletion completed in 6.104554956s
+
+• [SLOW TEST:8.190 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:51:09.256: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating secret with name secret-test-b9400698-2b95-11e8-a904-72008c49cf21
+STEP: Creating a pod to test consume secrets
+Mar 19 16:51:09.296: INFO: Waiting up to 5m0s for pod "pod-secrets-b9406e4b-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-secrets-dmvb4" to be "success or failure"
+Mar 19 16:51:09.298: INFO: Pod "pod-secrets-b9406e4b-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 1.861085ms
+Mar 19 16:51:11.302: INFO: Pod "pod-secrets-b9406e4b-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005375694s
+Mar 19 16:51:13.305: INFO: Pod "pod-secrets-b9406e4b-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009152319s
+STEP: Saw pod success
+Mar 19 16:51:13.305: INFO: Pod "pod-secrets-b9406e4b-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:51:13.307: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod pod-secrets-b9406e4b-2b95-11e8-a904-72008c49cf21 container secret-env-test: <nil>
+STEP: delete the pod
+Mar 19 16:51:13.320: INFO: Waiting for pod pod-secrets-b9406e4b-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:51:13.322: INFO: Pod pod-secrets-b9406e4b-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:51:13.322: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-dmvb4" for this suite.
+Mar 19 16:51:19.333: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:51:19.378: INFO: namespace: e2e-tests-secrets-dmvb4, resource: bindings, ignored listing per whitelist
+Mar 19 16:51:19.444: INFO: namespace e2e-tests-secrets-dmvb4 deletion completed in 6.1198947s
+
+• [SLOW TEST:10.188 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:51:19.445: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:51
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-979l8
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-979l8 to expose endpoints map[]
+Mar 19 16:51:19.488: INFO: Get endpoints failed (2.109796ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Mar 19 16:51:20.491: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-979l8 exposes endpoints map[] (1.005457135s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-979l8
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-979l8 to expose endpoints map[pod1:[100]]
+Mar 19 16:51:22.511: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-979l8 exposes endpoints map[pod1:[100]] (2.014325827s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-979l8
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-979l8 to expose endpoints map[pod2:[101] pod1:[100]]
+Mar 19 16:51:24.534: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-979l8 exposes endpoints map[pod1:[100] pod2:[101]] (2.018592757s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-979l8
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-979l8 to expose endpoints map[pod2:[101]]
+Mar 19 16:51:24.547: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-979l8 exposes endpoints map[pod2:[101]] (6.49576ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-979l8
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-979l8 to expose endpoints map[]
+Mar 19 16:51:24.557: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-979l8 exposes endpoints map[] (3.202522ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:51:24.566: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-979l8" for this suite.
+Mar 19 16:51:46.580: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:51:46.630: INFO: namespace: e2e-tests-services-979l8, resource: bindings, ignored listing per whitelist
+Mar 19 16:51:46.687: INFO: namespace e2e-tests-services-979l8 deletion completed in 22.114636474s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:56
+
+• [SLOW TEST:27.242 seconds]
+[sig-network] Services
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:51:46.688: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Mar 19 16:51:46.729: INFO: Waiting up to 5m0s for pod "pod-cf8ffe07-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-emptydir-7f78x" to be "success or failure"
+Mar 19 16:51:46.731: INFO: Pod "pod-cf8ffe07-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.08956ms
+Mar 19 16:51:48.734: INFO: Pod "pod-cf8ffe07-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005636206s
+STEP: Saw pod success
+Mar 19 16:51:48.734: INFO: Pod "pod-cf8ffe07-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:51:48.736: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-nqdp2 pod pod-cf8ffe07-2b95-11e8-a904-72008c49cf21 container test-container: <nil>
+STEP: delete the pod
+Mar 19 16:51:48.751: INFO: Waiting for pod pod-cf8ffe07-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:51:48.754: INFO: Pod pod-cf8ffe07-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:51:48.754: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-7f78x" for this suite.
+Mar 19 16:51:54.765: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:51:54.818: INFO: namespace: e2e-tests-emptydir-7f78x, resource: bindings, ignored listing per whitelist
+Mar 19 16:51:54.881: INFO: namespace e2e-tests-emptydir-7f78x deletion completed in 6.124606956s
+
+• [SLOW TEST:8.194 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
+STEP: Creating a kubernetes client
+Mar 19 16:51:54.882: INFO: >>> kubeConfig: /tmp/kubeconfig-053991314
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+STEP: Creating configMap with name configmap-projected-all-test-volume-d471fa2d-2b95-11e8-a904-72008c49cf21
+STEP: Creating secret with name secret-projected-all-test-volume-d471fa18-2b95-11e8-a904-72008c49cf21
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Mar 19 16:51:54.925: INFO: Waiting up to 5m0s for pod "projected-volume-d471f9f3-2b95-11e8-a904-72008c49cf21" in namespace "e2e-tests-projected-tm9wk" to be "success or failure"
+Mar 19 16:51:54.929: INFO: Pod "projected-volume-d471f9f3-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 4.091736ms
+Mar 19 16:51:56.932: INFO: Pod "projected-volume-d471f9f3-2b95-11e8-a904-72008c49cf21": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007677079s
+Mar 19 16:51:58.936: INFO: Pod "projected-volume-d471f9f3-2b95-11e8-a904-72008c49cf21": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01141596s
+STEP: Saw pod success
+Mar 19 16:51:58.936: INFO: Pod "projected-volume-d471f9f3-2b95-11e8-a904-72008c49cf21" satisfied condition "success or failure"
+Mar 19 16:51:58.939: INFO: Trying to get logs from node shoot-core-conf-os-worker-rsa36-z1-7676f7f85-r6zkg pod projected-volume-d471f9f3-2b95-11e8-a904-72008c49cf21 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Mar 19 16:51:58.953: INFO: Waiting for pod projected-volume-d471f9f3-2b95-11e8-a904-72008c49cf21 to disappear
+Mar 19 16:51:58.955: INFO: Pod projected-volume-d471f9f3-2b95-11e8-a904-72008c49cf21 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:135
+Mar 19 16:51:58.955: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-tm9wk" for this suite.
+Mar 19 16:52:04.966: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Mar 19 16:52:05.013: INFO: namespace: e2e-tests-projected-tm9wk, resource: bindings, ignored listing per whitelist
+Mar 19 16:52:05.076: INFO: namespace e2e-tests-projected-tm9wk deletion completed in 6.117656603s
+
+• [SLOW TEST:10.195 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.9.4-beta.0.53+bee2d1505c4fe8/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:648
+------------------------------
+SSMar 19 16:52:05.076: INFO: Running AfterSuite actions on all node
+Mar 19 16:52:05.076: INFO: Running AfterSuite actions on node 1
+Mar 19 16:52:05.076: INFO: Skipping dumping logs from cluster
+
+Ran 125 of 782 Specs in 2644.678 seconds
+SUCCESS! -- 125 Passed | 0 Failed | 0 Pending | 657 Skipped PASS
+
+Ginkgo ran 1 suite in 44m5.075112074s
+Test Suite Passed

--- a/v1.9/sap-cp-openstack/junit_01.xml
+++ b/v1.9/sap-cp-openstack/junit_01.xml
@@ -1,0 +1,2099 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="125" failures="0" time="2644.677644198">
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit  [Conformance]" classname="Kubernetes e2e suite" time="8.27238998"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod&#39;s node is different from PV&#39;s NodeName should not be able to mount due to different NodeName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] LimitRange should create a LimitRange with default ephemeral storage and ensure pod has the default applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.181094507"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod&#39;s node is different from PV&#39;s NodeName should not be able to mount due to different NodeName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.181386729"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request  [Conformance]" classname="Kubernetes e2e suite" time="8.174204935"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="27.001928439"></testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [DisabledForLargeClusters] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.188051657"></testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification  [Conformance]" classname="Kubernetes e2e suite" time="92.833849105"></testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when using local volume provisioner should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [Conformance]" classname="Kubernetes e2e suite" time="8.190104944"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.190854336"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default commmand (docker entrypoint)  [Conformance]" classname="Kubernetes e2e suite" time="8.188234512"></testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [Conformance]" classname="Kubernetes e2e suite" time="8.182517495"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.165936195"></testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port  [Conformance]" classname="Kubernetes e2e suite" time="6.241128551"></testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.180968194"></testcase>
+      <testcase name="[sig-storage] HostPath should support subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="20.161061401"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when two pods mount a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.190395109"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set  [Conformance]" classname="Kubernetes e2e suite" time="8.184059513"></testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [Conformance]" classname="Kubernetes e2e suite" time="29.400611676"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="86.259288198"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.167667081"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="42.539650336"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.177972282"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args  [Conformance]" classname="Kubernetes e2e suite" time="10.190410283"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.234375757"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should autoscale with Custom Metrics from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="130.388342833"></testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable  [Conformance]" classname="Kubernetes e2e suite" time="10.180456295"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request  [Conformance]" classname="Kubernetes e2e suite" time="8.174826381"></testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count  [Slow] [Conformance]" classname="Kubernetes e2e suite" time="152.42757633"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [Conformance]" classname="Kubernetes e2e suite" time="8.194180444"></testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.187525103"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should update pod when spec was updated and update strategy is RollingUpdate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files  [Conformance]" classname="Kubernetes e2e suite" time="8.190315198"></testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="109.443674793"></testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command  [Conformance]" classname="Kubernetes e2e suite" time="10.204631034"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPU] run Nvidia GPU tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod using local volume with non-existant path should not be able to mount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.237389229"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable  [Conformance]" classname="Kubernetes e2e suite" time="10.192737088"></testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart  [Conformance]" classname="Kubernetes e2e suite" time="82.170062298"></testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.19779819"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="30.206650542"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="49.240289132"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.210925052"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="28.256510382"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod  [Conformance]" classname="Kubernetes e2e suite" time="8.19074876"></testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [Conformance]" classname="Kubernetes e2e suite" time="8.186357217"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout  [Conformance]" classname="Kubernetes e2e suite" time="6.161319753">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.188655153"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.193978572"></testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.186412602"></testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart  [Conformance]" classname="Kubernetes e2e suite" time="42.168713173"></testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.153313792"></testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="8.178361047"></testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [Conformance]" classname="Kubernetes e2e suite" time="8.185197065"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.218931358"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated  [Conformance]" classname="Kubernetes e2e suite" time="12.70409371"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.187730584"></testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="12.774202215"></testcase>
+      <testcase name="[k8s.io] Sysctls should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.409214572"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification  [Conformance]" classname="Kubernetes e2e suite" time="28.701525692"></testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-multicluster] Multi-AZ Clusters should schedule pods in the same zones as statically provisioned PVs [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file  [Conformance]" classname="Kubernetes e2e suite" time="8.177772894"></testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [Conformance]" classname="Kubernetes e2e suite" time="8.190978979"></testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="12.534683085"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.192297739"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="22.413130363"></testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.2284667240000005"></testcase>
+      <testcase name="[k8s.io] Pods should be updated  [Conformance]" classname="Kubernetes e2e suite" time="24.673747203"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [Conformance]" classname="Kubernetes e2e suite" time="8.170103807"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="128.347772299"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.172776096"></testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.191621811"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file  [Conformance]" classname="Kubernetes e2e suite" time="60.282315457"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.22058463"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments  [Conformance]" classname="Kubernetes e2e suite" time="8.17501909"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.180609427"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.17058375"></testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var  [Conformance]" classname="Kubernetes e2e suite" time="10.184367636"></testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [Conformance]" classname="Kubernetes e2e suite" time="8.174481926"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="44.433856159"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate crd" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod using local volume with non-existant path should not be able to mount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Node Auto Repairs [Slow] [Disruptive] should repair node [Feature:NodeAutoRepairs]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.193657814"></testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [Conformance]" classname="Kubernetes e2e suite" time="26.696503688"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="35.283165315"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.185662449"></testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.175215606"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor using proxy subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.17159592"></testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [Conformance]" classname="Kubernetes e2e suite" time="8.196768155000001"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="8.179747569"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.197228565"></testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should adopt existing pods when creating a RollingUpdate DaemonSet regardless of templateGeneration" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.184119551"></testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank  [Conformance]" classname="Kubernetes e2e suite" time="8.175866343"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="30.749901993"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.193926571"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="85.283925145"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="62.268744217"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that a pod with an invalid NodeAffinity is rejected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [Conformance]" classname="Kubernetes e2e suite" time="8.191087201"></testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="13.187584365"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.197076137"></testcase>
+      <testcase name="[k8s.io] Sysctls should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services  [Conformance]" classname="Kubernetes e2e suite" time="28.218298085"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]" classname="Kubernetes e2e suite" time="8.180203365"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="6.719746199"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="6.694709671"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.225884797"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="19.398760685"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should rollback without unnecessary restarts" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when two pods mount a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.193726279"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.169637192"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.180559737"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] Should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node  [Conformance]" classname="Kubernetes e2e suite" time="6.236729051"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [DisabledForLargeClusters] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] [Feature:FlexVolume] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.182790138"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.201496434"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod  [Conformance]" classname="Kubernetes e2e suite" time="8.189736206"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.225291099"></testcase>
+      <testcase name="[k8s.io] Pods should get a host IP  [Conformance]" classname="Kubernetes e2e suite" time="24.162414774"></testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="58.284331666"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha docker/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existent secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.OrphanDependents is true" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only  [Conformance]" classname="Kubernetes e2e suite" time="8.206572431"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]" classname="Kubernetes e2e suite" time="8.190380277"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit  [Conformance]" classname="Kubernetes e2e suite" time="8.177478493"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="40.577196606"></testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.177121543"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [Feature:FSGroup] nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: dir] when pod&#39;s node is different from PV&#39;s NodeName should not be able to mount due to different NodeName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="12.182788336"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.175747121"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.197626938"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: tmpfs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.415414282"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd)  [Conformance]" classname="Kubernetes e2e suite" time="8.190722831"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when StatefulSet has pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.170983744"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.190119108"></testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.188116574"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod using local volume with non-existant path should not be able to mount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] [Volume type: gce-localssd-scsi-fs] when pod&#39;s node is different from PV&#39;s NodeAffinity should not be able to mount due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="27.242490342"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.193766782"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial] when one pod requests one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should have a working scale subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation [Feature:MountPropagation] should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePD] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection] [Conformance]" classname="Kubernetes e2e suite" time="10.194578642"></testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.9/sap-cp-openstack/version.txt
+++ b/v1.9/sap-cp-openstack/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.4", GitCommit:"bee2d1505c4fe820744d26d41ecd3fdd4a3d6546", GitTreeState:"clean", BuildDate:"2018-03-12T16:29:47Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.4", GitCommit:"bee2d1505c4fe820744d26d41ecd3fdd4a3d6546", GitTreeState:"clean", BuildDate:"2018-03-12T16:21:35Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}


### PR DESCRIPTION
SAP conformance results for kubernetes clusters deployed using Gardener 0.1.0.
Since Gardener was published as open source in the meanwhile the
version number was reset to 0.1.0.

Gardener is used internally at SAP but is not yet released as part of a product.

v1.9/sap-cp-aws       : cluster deployed on Amazon Web Services
v1.9/sap-cp-azure     : cluster deployed on Microsoft Azure
v1.9/sap-cp-gcp       : cluster deployed on Google Cloud Platform
v1.9/sap-cp-openstack : cluster deployed on OpenStack