### PR TITLE
Conformance test results for v1.10/sap-cp-*

### DIFF
--- a/v1.10/sap-cp-aws/PRODUCT.yaml
+++ b/v1.10/sap-cp-aws/PRODUCT.yaml
@@ -1,0 +1,6 @@
+vendor: SAP
+name: Cloud Platform - Gardener (https://github.com/gardener/gardener) shoot cluster deployed on Amazon Web Services
+version: 0.4.0
+website_url: https://cloudplatform.sap.com/index.html
+documentation_url: https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/
+product_logo_url: https://www.sap.com/dam/application/shared/logos/sap-logo-svg.svg

--- a/v1.10/sap-cp-aws/README.md
+++ b/v1.10/sap-cp-aws/README.md
@@ -1,0 +1,43 @@
+# To reproduce:
+
+## Create Kubernetes Cluster
+
+Login to SAP Gardener Dashboard to create a Kubernetes Clusters on Amazon Web Services, Microsoft Azure, Google Cloud Platform, or OpenStack cloud provider.
+
+After the creation completed, copy the cluster's kubeconfig, which is provided by the Gardener Dashboard in the cluster's detail view, to ~/.kube/config and launch the Kubernetes E2E conformance tests.
+
+## Launch E2E Conformance Tests
+1. Launch e2e pod and sonobuoy master under namespace `sonobuoy`   
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+    ```
+
+2. Check logs of `sonobuoy` pod to see when test can be finished   
+Run
+
+    ```shell
+    kubectl logs -f -n sonobuoy sonobuoy
+    ```
+    and wait for line `no-exit was specified, sonobuoy is now blocking`.
+
+3. Use `kubectl cp` to copy the results to the client   
+Get the name of the <result archive> from the log output in step 2.
+
+    ```shell
+    kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy/<result archive> /home/result
+    ```
+
+4. Delete the conformance test resources
+
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl delete -f -
+    ```
+
+5. Untar the tarball
+
+    ```shell
+    cd /home/result
+    tar -xzf *_sonobuoy_*.tar.gz
+    ```
+
+    The result files `e2e.log` and `junit_01.xml` are located in the in the directory `plugins/e2e/results/`.

--- a/v1.10/sap-cp-aws/e2e.log
+++ b/v1.10/sap-cp-aws/e2e.log
@@ -1,0 +1,6977 @@
+Apr 27 14:03:39.452: INFO: Overriding default scale value of zero to 1
+Apr 27 14:03:39.452: INFO: Overriding default milliseconds value of zero to 5000
+I0427 14:03:39.614322      13 test_context.go:358] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-892884186
+I0427 14:03:39.614482      13 e2e.go:333] Starting e2e run "c923cade-4a23-11e8-a1f3-0206690d449d" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1524837819 - Will randomize all specs
+Will run 141 of 836 specs
+
+Apr 27 14:03:39.693: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:03:39.695: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
+Apr 27 14:03:39.726: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 27 14:03:39.797: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 27 14:03:39.797: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 27 14:03:39.801: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 27 14:03:39.801: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Apr 27 14:03:39.805: INFO: e2e test version: v1.10.0
+Apr 27 14:03:39.806: INFO: kube-apiserver version: v1.10.1
+S
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:03:39.806: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+Apr 27 14:03:39.937: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:03:39.951: INFO: Waiting up to 5m0s for pod "downward-api-c97b0690-4a23-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-kbxs4" to be "success or failure"
+Apr 27 14:03:39.953: INFO: Pod "downward-api-c97b0690-4a23-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.488855ms
+Apr 27 14:03:41.958: INFO: Pod "downward-api-c97b0690-4a23-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006725659s
+Apr 27 14:03:43.962: INFO: Pod "downward-api-c97b0690-4a23-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.0110305s
+STEP: Saw pod success
+Apr 27 14:03:43.962: INFO: Pod "downward-api-c97b0690-4a23-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:03:43.965: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downward-api-c97b0690-4a23-11e8-a1f3-0206690d449d container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:03:44.003: INFO: Waiting for pod downward-api-c97b0690-4a23-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:03:44.008: INFO: Pod downward-api-c97b0690-4a23-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:03:44.008: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-kbxs4" for this suite.
+Apr 27 14:03:50.025: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:03:50.114: INFO: namespace: e2e-tests-downward-api-kbxs4, resource: bindings, ignored listing per whitelist
+Apr 27 14:03:50.154: INFO: namespace e2e-tests-downward-api-kbxs4 deletion completed in 6.141562161s
+
+• [SLOW TEST:10.347 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:03:50.154: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-cf9f081e-4a23-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:03:50.250: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-cf9f8c02-4a23-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-cxvzc" to be "success or failure"
+Apr 27 14:03:50.254: INFO: Pod "pod-projected-secrets-cf9f8c02-4a23-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.70423ms
+Apr 27 14:03:52.257: INFO: Pod "pod-projected-secrets-cf9f8c02-4a23-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006703329s
+Apr 27 14:03:54.263: INFO: Pod "pod-projected-secrets-cf9f8c02-4a23-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012613234s
+STEP: Saw pod success
+Apr 27 14:03:54.263: INFO: Pod "pod-projected-secrets-cf9f8c02-4a23-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:03:54.267: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-secrets-cf9f8c02-4a23-11e8-a1f3-0206690d449d container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:03:54.288: INFO: Waiting for pod pod-projected-secrets-cf9f8c02-4a23-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:03:54.293: INFO: Pod pod-projected-secrets-cf9f8c02-4a23-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:03:54.293: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-cxvzc" for this suite.
+Apr 27 14:04:00.306: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:04:00.412: INFO: namespace: e2e-tests-projected-cxvzc, resource: bindings, ignored listing per whitelist
+Apr 27 14:04:00.441: INFO: namespace e2e-tests-projected-cxvzc deletion completed in 6.145062266s
+
+• [SLOW TEST:10.287 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:04:00.441: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Apr 27 14:04:06.563: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-d5c2b51e-4a23-11e8-a1f3-0206690d449d", GenerateName:"", Namespace:"e2e-tests-pods-gjmsc", SelfLink:"/api/v1/namespaces/e2e-tests-pods-gjmsc/pods/pod-submit-remove-d5c2b51e-4a23-11e8-a1f3-0206690d449d", UID:"d5c4ae34-4a23-11e8-aa31-6e07c8c44ecd", ResourceVersion:"1866", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63660434640, loc:(*time.Location)(0x65972e0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"time":"541834938", "name":"foo"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"100.96.1.9/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-724m7", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc4213e0b40), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"k8s.gcr.io/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-724m7", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc420e5c088), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"ip-10-250-14-38.eu-west-1.compute.internal", HostNetwork:false, HostPID:false, HostIPC:false, ShareProcessNamespace:(*bool)(nil), SecurityContext:(*v1.PodSecurityContext)(0xc4213e0bc0), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc420e5c0c0)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc420e5c0e0)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63660434640, loc:(*time.Location)(0x65972e0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63660434646, loc:(*time.Location)(0x65972e0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63660434640, loc:(*time.Location)(0x65972e0)}}, Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"10.250.14.38", PodIP:"100.96.1.9", StartTime:(*v1.Time)(0xc421532720), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc421532740), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"k8s.gcr.io/nginx-slim-amd64:0.20", ImageID:"docker-pullable://k8s.gcr.io/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://5cea7e3886ddabf52c5c912b42941ca4997d2dff5e0464d8a65d74a6d84add93"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:04:16.235: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-gjmsc" for this suite.
+Apr 27 14:04:22.248: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:04:22.371: INFO: namespace: e2e-tests-pods-gjmsc, resource: bindings, ignored listing per whitelist
+Apr 27 14:04:22.378: INFO: namespace e2e-tests-pods-gjmsc deletion completed in 6.139875428s
+
+• [SLOW TEST:21.937 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:04:22.378: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-e2d46a6f-4a23-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:04:22.483: INFO: Waiting up to 5m0s for pod "pod-configmaps-e2d4fd2d-4a23-11e8-a1f3-0206690d449d" in namespace "e2e-tests-configmap-jzqg9" to be "success or failure"
+Apr 27 14:04:22.489: INFO: Pod "pod-configmaps-e2d4fd2d-4a23-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 6.5016ms
+Apr 27 14:04:24.493: INFO: Pod "pod-configmaps-e2d4fd2d-4a23-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009763748s
+STEP: Saw pod success
+Apr 27 14:04:24.493: INFO: Pod "pod-configmaps-e2d4fd2d-4a23-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:04:24.495: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-configmaps-e2d4fd2d-4a23-11e8-a1f3-0206690d449d container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:04:24.516: INFO: Waiting for pod pod-configmaps-e2d4fd2d-4a23-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:04:24.519: INFO: Pod pod-configmaps-e2d4fd2d-4a23-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:04:24.519: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-jzqg9" for this suite.
+Apr 27 14:04:30.531: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:04:30.621: INFO: namespace: e2e-tests-configmap-jzqg9, resource: bindings, ignored listing per whitelist
+Apr 27 14:04:30.678: INFO: namespace e2e-tests-configmap-jzqg9 deletion completed in 6.155772295s
+
+• [SLOW TEST:8.300 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:04:30.678: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:04:30.771: INFO: Waiting up to 5m0s for pod "downwardapi-volume-e7c68f92-4a23-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-7p846" to be "success or failure"
+Apr 27 14:04:30.773: INFO: Pod "downwardapi-volume-e7c68f92-4a23-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.499701ms
+Apr 27 14:04:32.779: INFO: Pod "downwardapi-volume-e7c68f92-4a23-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.0079447s
+Apr 27 14:04:34.782: INFO: Pod "downwardapi-volume-e7c68f92-4a23-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011117148s
+STEP: Saw pod success
+Apr 27 14:04:34.782: INFO: Pod "downwardapi-volume-e7c68f92-4a23-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:04:34.785: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-e7c68f92-4a23-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:04:34.802: INFO: Waiting for pod downwardapi-volume-e7c68f92-4a23-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:04:34.805: INFO: Pod downwardapi-volume-e7c68f92-4a23-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:04:34.805: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-7p846" for this suite.
+Apr 27 14:04:40.818: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:04:40.911: INFO: namespace: e2e-tests-downward-api-7p846, resource: bindings, ignored listing per whitelist
+Apr 27 14:04:40.941: INFO: namespace e2e-tests-downward-api-7p846 deletion completed in 6.1332363s
+
+• [SLOW TEST:10.263 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:04:40.942: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Apr 27 14:04:41.033: INFO: Waiting up to 5m0s for pod "pod-ede4705e-4a23-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-9q6qb" to be "success or failure"
+Apr 27 14:04:41.036: INFO: Pod "pod-ede4705e-4a23-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.284156ms
+Apr 27 14:04:43.040: INFO: Pod "pod-ede4705e-4a23-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007736726s
+STEP: Saw pod success
+Apr 27 14:04:43.041: INFO: Pod "pod-ede4705e-4a23-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:04:43.045: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-ede4705e-4a23-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:04:43.098: INFO: Waiting for pod pod-ede4705e-4a23-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:04:43.101: INFO: Pod pod-ede4705e-4a23-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:04:43.101: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-9q6qb" for this suite.
+Apr 27 14:04:49.113: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:04:49.169: INFO: namespace: e2e-tests-emptydir-9q6qb, resource: bindings, ignored listing per whitelist
+Apr 27 14:04:49.237: INFO: namespace e2e-tests-emptydir-9q6qb deletion completed in 6.132207245s
+
+• [SLOW TEST:8.295 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:04:49.237: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Apr 27 14:04:49.334: INFO: Waiting up to 5m0s for pod "pod-f2d7124e-4a23-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-w7n76" to be "success or failure"
+Apr 27 14:04:49.338: INFO: Pod "pod-f2d7124e-4a23-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.754359ms
+Apr 27 14:04:51.341: INFO: Pod "pod-f2d7124e-4a23-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00684473s
+STEP: Saw pod success
+Apr 27 14:04:51.341: INFO: Pod "pod-f2d7124e-4a23-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:04:51.344: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-f2d7124e-4a23-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:04:51.373: INFO: Waiting for pod pod-f2d7124e-4a23-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:04:51.375: INFO: Pod pod-f2d7124e-4a23-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:04:51.375: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-w7n76" for this suite.
+Apr 27 14:04:57.389: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:04:57.489: INFO: namespace: e2e-tests-emptydir-w7n76, resource: bindings, ignored listing per whitelist
+Apr 27 14:04:57.531: INFO: namespace e2e-tests-emptydir-w7n76 deletion completed in 6.153190479s
+
+• [SLOW TEST:8.294 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:04:57.532: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Apr 27 14:04:57.635: INFO: Waiting up to 5m0s for pod "pod-f7c9744b-4a23-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-hnzsf" to be "success or failure"
+Apr 27 14:04:57.639: INFO: Pod "pod-f7c9744b-4a23-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.181759ms
+Apr 27 14:04:59.642: INFO: Pod "pod-f7c9744b-4a23-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007012933s
+STEP: Saw pod success
+Apr 27 14:04:59.642: INFO: Pod "pod-f7c9744b-4a23-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:04:59.645: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-f7c9744b-4a23-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:04:59.659: INFO: Waiting for pod pod-f7c9744b-4a23-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:04:59.662: INFO: Pod pod-f7c9744b-4a23-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:04:59.662: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-hnzsf" for this suite.
+Apr 27 14:05:05.673: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:05:05.812: INFO: namespace: e2e-tests-emptydir-hnzsf, resource: bindings, ignored listing per whitelist
+Apr 27 14:05:05.841: INFO: namespace e2e-tests-emptydir-hnzsf deletion completed in 6.176532007s
+
+• [SLOW TEST:8.309 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:05:05.841: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for all rs to be garbage collected
+STEP: expected 0 rs, got 1 rs
+STEP: expected 0 Pods, got 2 Pods
+STEP: Gathering metrics
+W0427 14:05:06.993996      13 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:05:06.994: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:05:06.994: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-kvv5v" for this suite.
+Apr 27 14:05:13.006: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:05:13.131: INFO: namespace: e2e-tests-gc-kvv5v, resource: bindings, ignored listing per whitelist
+Apr 27 14:05:13.139: INFO: namespace e2e-tests-gc-kvv5v deletion completed in 6.142259594s
+
+• [SLOW TEST:7.298 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:05:13.139: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Apr 27 14:05:13.226: INFO: Waiting up to 1m0s for all nodes to be ready
+Apr 27 14:06:13.254: INFO: Waiting for terminating namespaces to be deleted...
+Apr 27 14:06:13.259: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 27 14:06:13.270: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 27 14:06:13.270: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 27 14:06:13.273: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 27 14:06:13.273: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-12-147.eu-west-1.compute.internal before test
+Apr 27 14:06:13.301: INFO: calico-node-6q8fw from kube-system started at 2018-04-27 13:49:28 +0000 UTC (2 container statuses recorded)
+Apr 27 14:06:13.301: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: kube-dns-67b49bdfd8-lbm4c from kube-system started at 2018-04-27 13:51:05 +0000 UTC (3 container statuses recorded)
+Apr 27 14:06:13.301: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: kube-proxy-cz98z from kube-system started at 2018-04-27 13:49:28 +0000 UTC (1 container statuses recorded)
+Apr 27 14:06:13.301: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-bfjjd from kube-system started at 2018-04-27 13:50:35 +0000 UTC (1 container statuses recorded)
+Apr 27 14:06:13.301: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: addons-heapster-e3b0c-5c98c994fc-qvtf9 from kube-system started at 2018-04-27 13:50:36 +0000 UTC (2 container statuses recorded)
+Apr 27 14:06:13.301: INFO: 	Container heapster ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: 	Container heapster-nanny ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: addons-kubernetes-dashboard-8478f49fbf-f642m from kube-system started at 2018-04-27 13:50:37 +0000 UTC (1 container statuses recorded)
+Apr 27 14:06:13.301: INFO: 	Container main ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: sonobuoy-e2e-job-2ded2f49b96d41b5 from sonobuoy started at 2018-04-27 14:03:23 +0000 UTC (2 container statuses recorded)
+Apr 27 14:06:13.301: INFO: 	Container e2e ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: node-exporter-pnnmw from kube-system started at 2018-04-27 13:49:28 +0000 UTC (1 container statuses recorded)
+Apr 27 14:06:13.301: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:06:13.301: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-14-38.eu-west-1.compute.internal before test
+Apr 27 14:06:13.310: INFO: calico-node-qmckv from kube-system started at 2018-04-27 13:49:29 +0000 UTC (2 container statuses recorded)
+Apr 27 14:06:13.310: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:06:13.310: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:06:13.310: INFO: kube-proxy-pnptq from kube-system started at 2018-04-27 13:49:29 +0000 UTC (1 container statuses recorded)
+Apr 27 14:06:13.310: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:06:13.310: INFO: vpn-shoot-8c58cd4d6-xjrwf from kube-system started at 2018-04-27 13:50:35 +0000 UTC (1 container statuses recorded)
+Apr 27 14:06:13.310: INFO: 	Container vpn-shoot ready: true, restart count 1
+Apr 27 14:06:13.310: INFO: addons-nginx-ingress-controller-858f4fc5d7-x27vt from kube-system started at 2018-04-27 13:50:36 +0000 UTC (1 container statuses recorded)
+Apr 27 14:06:13.310: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Apr 27 14:06:13.310: INFO: kube-dns-autoscaler-699b4b55c4-sxgbp from kube-system started at 2018-04-27 13:50:37 +0000 UTC (1 container statuses recorded)
+Apr 27 14:06:13.310: INFO: 	Container autoscaler ready: true, restart count 0
+Apr 27 14:06:13.310: INFO: kube-dns-67b49bdfd8-hm6sf from kube-system started at 2018-04-27 13:50:38 +0000 UTC (3 container statuses recorded)
+Apr 27 14:06:13.310: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:06:13.310: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:06:13.310: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:06:13.310: INFO: node-exporter-2gxj5 from kube-system started at 2018-04-27 13:49:29 +0000 UTC (1 container statuses recorded)
+Apr 27 14:06:13.310: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:06:13.311: INFO: sonobuoy from sonobuoy started at 2018-04-27 14:03:03 +0000 UTC (1 container statuses recorded)
+Apr 27 14:06:13.311: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: verifying the node has the label node ip-10-250-12-147.eu-west-1.compute.internal
+STEP: verifying the node has the label node ip-10-250-14-38.eu-west-1.compute.internal
+Apr 27 14:06:13.350: INFO: Pod addons-heapster-e3b0c-5c98c994fc-qvtf9 requesting resource cpu=50m on Node ip-10-250-12-147.eu-west-1.compute.internal
+Apr 27 14:06:13.350: INFO: Pod addons-kubernetes-dashboard-8478f49fbf-f642m requesting resource cpu=100m on Node ip-10-250-12-147.eu-west-1.compute.internal
+Apr 27 14:06:13.350: INFO: Pod addons-nginx-ingress-controller-858f4fc5d7-x27vt requesting resource cpu=0m on Node ip-10-250-14-38.eu-west-1.compute.internal
+Apr 27 14:06:13.350: INFO: Pod addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-bfjjd requesting resource cpu=0m on Node ip-10-250-12-147.eu-west-1.compute.internal
+Apr 27 14:06:13.350: INFO: Pod calico-node-6q8fw requesting resource cpu=250m on Node ip-10-250-12-147.eu-west-1.compute.internal
+Apr 27 14:06:13.350: INFO: Pod calico-node-qmckv requesting resource cpu=250m on Node ip-10-250-14-38.eu-west-1.compute.internal
+Apr 27 14:06:13.350: INFO: Pod kube-dns-67b49bdfd8-hm6sf requesting resource cpu=260m on Node ip-10-250-14-38.eu-west-1.compute.internal
+Apr 27 14:06:13.351: INFO: Pod kube-dns-67b49bdfd8-lbm4c requesting resource cpu=260m on Node ip-10-250-12-147.eu-west-1.compute.internal
+Apr 27 14:06:13.351: INFO: Pod kube-dns-autoscaler-699b4b55c4-sxgbp requesting resource cpu=20m on Node ip-10-250-14-38.eu-west-1.compute.internal
+Apr 27 14:06:13.351: INFO: Pod kube-proxy-cz98z requesting resource cpu=100m on Node ip-10-250-12-147.eu-west-1.compute.internal
+Apr 27 14:06:13.351: INFO: Pod kube-proxy-pnptq requesting resource cpu=100m on Node ip-10-250-14-38.eu-west-1.compute.internal
+Apr 27 14:06:13.351: INFO: Pod node-exporter-2gxj5 requesting resource cpu=100m on Node ip-10-250-14-38.eu-west-1.compute.internal
+Apr 27 14:06:13.351: INFO: Pod node-exporter-pnnmw requesting resource cpu=100m on Node ip-10-250-12-147.eu-west-1.compute.internal
+Apr 27 14:06:13.351: INFO: Pod vpn-shoot-8c58cd4d6-xjrwf requesting resource cpu=100m on Node ip-10-250-14-38.eu-west-1.compute.internal
+Apr 27 14:06:13.351: INFO: Pod sonobuoy requesting resource cpu=0m on Node ip-10-250-14-38.eu-west-1.compute.internal
+Apr 27 14:06:13.351: INFO: Pod sonobuoy-e2e-job-2ded2f49b96d41b5 requesting resource cpu=0m on Node ip-10-250-12-147.eu-west-1.compute.internal
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-24ebde73-4a24-11e8-a1f3-0206690d449d.1529500eced7e9c2], Reason = [Scheduled], Message = [Successfully assigned filler-pod-24ebde73-4a24-11e8-a1f3-0206690d449d to ip-10-250-12-147.eu-west-1.compute.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-24ebde73-4a24-11e8-a1f3-0206690d449d.1529500edb8c52a8], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-fdbf5" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-24ebde73-4a24-11e8-a1f3-0206690d449d.1529500efa584d4e], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause-amd64:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-24ebde73-4a24-11e8-a1f3-0206690d449d.1529500efc34ef2b], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-24ebde73-4a24-11e8-a1f3-0206690d449d.1529500f086f1e5f], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-24edd9b6-4a24-11e8-a1f3-0206690d449d.1529500ecf1baa00], Reason = [Scheduled], Message = [Successfully assigned filler-pod-24edd9b6-4a24-11e8-a1f3-0206690d449d to ip-10-250-14-38.eu-west-1.compute.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-24edd9b6-4a24-11e8-a1f3-0206690d449d.1529500ed8651d53], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-fdbf5" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-24edd9b6-4a24-11e8-a1f3-0206690d449d.1529500efd05ef25], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause-amd64:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-24edd9b6-4a24-11e8-a1f3-0206690d449d.1529500f0027f8c5], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-24edd9b6-4a24-11e8-a1f3-0206690d449d.1529500f09a56bca], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.1529500f47f297aa], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 Insufficient cpu.]
+STEP: removing the label node off the node ip-10-250-12-147.eu-west-1.compute.internal
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node ip-10-250-14-38.eu-west-1.compute.internal
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:06:16.434: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-cm59q" for this suite.
+Apr 27 14:06:38.446: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:06:38.498: INFO: namespace: e2e-tests-sched-pred-cm59q, resource: bindings, ignored listing per whitelist
+Apr 27 14:06:38.580: INFO: namespace e2e-tests-sched-pred-cm59q deletion completed in 22.142273617s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:85.441 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:06:38.581: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-340460ba-4a24-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:06:38.691: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-3404eaf3-4a24-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-jrwgq" to be "success or failure"
+Apr 27 14:06:38.693: INFO: Pod "pod-projected-configmaps-3404eaf3-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.663743ms
+Apr 27 14:06:40.697: INFO: Pod "pod-projected-configmaps-3404eaf3-4a24-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005850526s
+STEP: Saw pod success
+Apr 27 14:06:40.697: INFO: Pod "pod-projected-configmaps-3404eaf3-4a24-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:06:40.699: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-configmaps-3404eaf3-4a24-11e8-a1f3-0206690d449d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:06:40.715: INFO: Waiting for pod pod-projected-configmaps-3404eaf3-4a24-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:06:40.718: INFO: Pod pod-projected-configmaps-3404eaf3-4a24-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:06:40.718: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jrwgq" for this suite.
+Apr 27 14:06:46.732: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:06:46.839: INFO: namespace: e2e-tests-projected-jrwgq, resource: bindings, ignored listing per whitelist
+Apr 27 14:06:46.855: INFO: namespace e2e-tests-projected-jrwgq deletion completed in 6.132680583s
+
+• [SLOW TEST:8.274 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:06:46.855: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-zpm9j
+Apr 27 14:06:50.948: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-zpm9j
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:06:50.951: INFO: Initial restart count of pod liveness-exec is 0
+Apr 27 14:07:43.032: INFO: Restart count of pod e2e-tests-container-probe-zpm9j/liveness-exec is now 1 (52.081381145s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:07:43.040: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-zpm9j" for this suite.
+Apr 27 14:07:49.060: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:07:49.135: INFO: namespace: e2e-tests-container-probe-zpm9j, resource: bindings, ignored listing per whitelist
+Apr 27 14:07:49.204: INFO: namespace e2e-tests-container-probe-zpm9j deletion completed in 6.16157938s
+
+• [SLOW TEST:62.350 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:07:49.205: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-5e1de67e-4a24-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:07:49.321: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-5e1e83b0-4a24-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-4bg9r" to be "success or failure"
+Apr 27 14:07:49.325: INFO: Pod "pod-projected-configmaps-5e1e83b0-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.27759ms
+Apr 27 14:07:51.328: INFO: Pod "pod-projected-configmaps-5e1e83b0-4a24-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007129166s
+STEP: Saw pod success
+Apr 27 14:07:51.328: INFO: Pod "pod-projected-configmaps-5e1e83b0-4a24-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:07:51.330: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-configmaps-5e1e83b0-4a24-11e8-a1f3-0206690d449d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:07:51.346: INFO: Waiting for pod pod-projected-configmaps-5e1e83b0-4a24-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:07:51.350: INFO: Pod pod-projected-configmaps-5e1e83b0-4a24-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:07:51.350: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4bg9r" for this suite.
+Apr 27 14:07:57.366: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:07:57.437: INFO: namespace: e2e-tests-projected-4bg9r, resource: bindings, ignored listing per whitelist
+Apr 27 14:07:57.494: INFO: namespace e2e-tests-projected-4bg9r deletion completed in 6.137750602s
+
+• [SLOW TEST:8.289 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:07:57.494: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-630bff87-4a24-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:07:57.589: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-630c9d2c-4a24-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-llvbc" to be "success or failure"
+Apr 27 14:07:57.592: INFO: Pod "pod-projected-configmaps-630c9d2c-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.341686ms
+Apr 27 14:07:59.594: INFO: Pod "pod-projected-configmaps-630c9d2c-4a24-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005243426s
+STEP: Saw pod success
+Apr 27 14:07:59.595: INFO: Pod "pod-projected-configmaps-630c9d2c-4a24-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:07:59.597: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-configmaps-630c9d2c-4a24-11e8-a1f3-0206690d449d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:07:59.612: INFO: Waiting for pod pod-projected-configmaps-630c9d2c-4a24-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:07:59.616: INFO: Pod pod-projected-configmaps-630c9d2c-4a24-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:07:59.616: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-llvbc" for this suite.
+Apr 27 14:08:05.628: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:08:05.763: INFO: namespace: e2e-tests-projected-llvbc, resource: bindings, ignored listing per whitelist
+Apr 27 14:08:05.795: INFO: namespace e2e-tests-projected-llvbc deletion completed in 6.175330197s
+
+• [SLOW TEST:8.301 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:08:05.795: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:08:05.941: INFO: Waiting up to 5m0s for pod "downwardapi-volume-6806b05b-4a24-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-2b5ft" to be "success or failure"
+Apr 27 14:08:05.945: INFO: Pod "downwardapi-volume-6806b05b-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.57165ms
+Apr 27 14:08:07.949: INFO: Pod "downwardapi-volume-6806b05b-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007862707s
+Apr 27 14:08:09.952: INFO: Pod "downwardapi-volume-6806b05b-4a24-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011210459s
+STEP: Saw pod success
+Apr 27 14:08:09.952: INFO: Pod "downwardapi-volume-6806b05b-4a24-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:08:09.955: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-6806b05b-4a24-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:08:09.970: INFO: Waiting for pod downwardapi-volume-6806b05b-4a24-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:08:09.973: INFO: Pod downwardapi-volume-6806b05b-4a24-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:08:09.973: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2b5ft" for this suite.
+Apr 27 14:08:15.984: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:08:16.102: INFO: namespace: e2e-tests-projected-2b5ft, resource: bindings, ignored listing per whitelist
+Apr 27 14:08:16.115: INFO: namespace e2e-tests-projected-2b5ft deletion completed in 6.1393947s
+
+• [SLOW TEST:10.320 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:08:16.116: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Apr 27 14:08:16.221: INFO: Waiting up to 5m0s for pod "pod-6e277f38-4a24-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-mwwgh" to be "success or failure"
+Apr 27 14:08:16.223: INFO: Pod "pod-6e277f38-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.384999ms
+Apr 27 14:08:18.226: INFO: Pod "pod-6e277f38-4a24-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005220369s
+STEP: Saw pod success
+Apr 27 14:08:18.226: INFO: Pod "pod-6e277f38-4a24-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:08:18.228: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-6e277f38-4a24-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:08:18.268: INFO: Waiting for pod pod-6e277f38-4a24-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:08:18.270: INFO: Pod pod-6e277f38-4a24-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:08:18.271: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-mwwgh" for this suite.
+Apr 27 14:08:24.283: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:08:24.358: INFO: namespace: e2e-tests-emptydir-mwwgh, resource: bindings, ignored listing per whitelist
+Apr 27 14:08:24.418: INFO: namespace e2e-tests-emptydir-mwwgh deletion completed in 6.144068922s
+
+• [SLOW TEST:8.302 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:08:24.418: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Apr 27 14:08:24.511: INFO: Waiting up to 5m0s for pod "pod-73186734-4a24-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-p9whz" to be "success or failure"
+Apr 27 14:08:24.514: INFO: Pod "pod-73186734-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.185946ms
+Apr 27 14:08:26.517: INFO: Pod "pod-73186734-4a24-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006414562s
+STEP: Saw pod success
+Apr 27 14:08:26.517: INFO: Pod "pod-73186734-4a24-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:08:26.520: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-73186734-4a24-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:08:26.536: INFO: Waiting for pod pod-73186734-4a24-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:08:26.539: INFO: Pod pod-73186734-4a24-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:08:26.539: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-p9whz" for this suite.
+Apr 27 14:08:32.552: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:08:32.602: INFO: namespace: e2e-tests-emptydir-p9whz, resource: bindings, ignored listing per whitelist
+Apr 27 14:08:32.677: INFO: namespace e2e-tests-emptydir-p9whz deletion completed in 6.134330577s
+
+• [SLOW TEST:8.259 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:08:32.677: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-78092002-4a24-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:08:32.803: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-780997fa-4a24-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-8qp9j" to be "success or failure"
+Apr 27 14:08:32.806: INFO: Pod "pod-projected-secrets-780997fa-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.102697ms
+Apr 27 14:08:34.809: INFO: Pod "pod-projected-secrets-780997fa-4a24-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00595085s
+STEP: Saw pod success
+Apr 27 14:08:34.809: INFO: Pod "pod-projected-secrets-780997fa-4a24-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:08:34.811: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-secrets-780997fa-4a24-11e8-a1f3-0206690d449d container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:08:34.824: INFO: Waiting for pod pod-projected-secrets-780997fa-4a24-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:08:34.827: INFO: Pod pod-projected-secrets-780997fa-4a24-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:08:34.827: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8qp9j" for this suite.
+Apr 27 14:08:40.840: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:08:40.914: INFO: namespace: e2e-tests-projected-8qp9j, resource: bindings, ignored listing per whitelist
+Apr 27 14:08:40.975: INFO: namespace e2e-tests-projected-8qp9j deletion completed in 6.145660805s
+
+• [SLOW TEST:8.298 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:08:40.975: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name s-test-opt-del-7cf7ed2f-4a24-11e8-a1f3-0206690d449d
+STEP: Creating secret with name s-test-opt-upd-7cf7ed8c-4a24-11e8-a1f3-0206690d449d
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-7cf7ed2f-4a24-11e8-a1f3-0206690d449d
+STEP: Updating secret s-test-opt-upd-7cf7ed8c-4a24-11e8-a1f3-0206690d449d
+STEP: Creating secret with name s-test-opt-create-7cf7edb1-4a24-11e8-a1f3-0206690d449d
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:08:45.343: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-ttrj7" for this suite.
+Apr 27 14:09:07.354: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:09:07.412: INFO: namespace: e2e-tests-secrets-ttrj7, resource: bindings, ignored listing per whitelist
+Apr 27 14:09:07.505: INFO: namespace e2e-tests-secrets-ttrj7 deletion completed in 22.159628051s
+
+• [SLOW TEST:26.530 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:09:07.506: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-8cc800df-4a24-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:09:07.607: INFO: Waiting up to 5m0s for pod "pod-configmaps-8cc87f12-4a24-11e8-a1f3-0206690d449d" in namespace "e2e-tests-configmap-sdzk4" to be "success or failure"
+Apr 27 14:09:07.611: INFO: Pod "pod-configmaps-8cc87f12-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.0772ms
+Apr 27 14:09:09.614: INFO: Pod "pod-configmaps-8cc87f12-4a24-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006098014s
+STEP: Saw pod success
+Apr 27 14:09:09.614: INFO: Pod "pod-configmaps-8cc87f12-4a24-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:09:09.617: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-configmaps-8cc87f12-4a24-11e8-a1f3-0206690d449d container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:09:09.635: INFO: Waiting for pod pod-configmaps-8cc87f12-4a24-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:09:09.642: INFO: Pod pod-configmaps-8cc87f12-4a24-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:09:09.642: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-sdzk4" for this suite.
+Apr 27 14:09:15.654: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:09:15.785: INFO: namespace: e2e-tests-configmap-sdzk4, resource: bindings, ignored listing per whitelist
+Apr 27 14:09:15.816: INFO: namespace e2e-tests-configmap-sdzk4 deletion completed in 6.17161866s
+
+• [SLOW TEST:8.311 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:09:15.817: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0427 14:09:21.933594      13 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:09:21.933: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:09:21.933: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-bvqdz" for this suite.
+Apr 27 14:09:27.945: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:09:28.082: INFO: namespace: e2e-tests-gc-bvqdz, resource: bindings, ignored listing per whitelist
+Apr 27 14:09:28.089: INFO: namespace e2e-tests-gc-bvqdz deletion completed in 6.153199553s
+
+• [SLOW TEST:12.273 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:09:28.089: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-990beaf5-4a24-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:09:28.189: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-990d0b09-4a24-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-c7dds" to be "success or failure"
+Apr 27 14:09:28.192: INFO: Pod "pod-projected-secrets-990d0b09-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.450434ms
+Apr 27 14:09:30.195: INFO: Pod "pod-projected-secrets-990d0b09-4a24-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005392226s
+STEP: Saw pod success
+Apr 27 14:09:30.195: INFO: Pod "pod-projected-secrets-990d0b09-4a24-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:09:30.197: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-secrets-990d0b09-4a24-11e8-a1f3-0206690d449d container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:09:30.249: INFO: Waiting for pod pod-projected-secrets-990d0b09-4a24-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:09:30.252: INFO: Pod pod-projected-secrets-990d0b09-4a24-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:09:30.252: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-c7dds" for this suite.
+Apr 27 14:09:36.267: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:09:36.322: INFO: namespace: e2e-tests-projected-c7dds, resource: bindings, ignored listing per whitelist
+Apr 27 14:09:36.415: INFO: namespace e2e-tests-projected-c7dds deletion completed in 6.160068111s
+
+• [SLOW TEST:8.325 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:09:36.415: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-9e01ff35-4a24-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:09:36.509: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-9e0285c1-4a24-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-5kjpt" to be "success or failure"
+Apr 27 14:09:36.513: INFO: Pod "pod-projected-configmaps-9e0285c1-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.840412ms
+Apr 27 14:09:38.527: INFO: Pod "pod-projected-configmaps-9e0285c1-4a24-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.01759038s
+STEP: Saw pod success
+Apr 27 14:09:38.527: INFO: Pod "pod-projected-configmaps-9e0285c1-4a24-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:09:38.532: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-configmaps-9e0285c1-4a24-11e8-a1f3-0206690d449d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:09:38.563: INFO: Waiting for pod pod-projected-configmaps-9e0285c1-4a24-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:09:38.567: INFO: Pod pod-projected-configmaps-9e0285c1-4a24-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:09:38.567: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5kjpt" for this suite.
+Apr 27 14:09:44.582: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:09:44.676: INFO: namespace: e2e-tests-projected-5kjpt, resource: bindings, ignored listing per whitelist
+Apr 27 14:09:44.705: INFO: namespace e2e-tests-projected-5kjpt deletion completed in 6.133721496s
+
+• [SLOW TEST:8.290 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:09:44.706: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Apr 27 14:09:44.792: INFO: Waiting up to 1m0s for all nodes to be ready
+Apr 27 14:10:44.814: INFO: Waiting for terminating namespaces to be deleted...
+Apr 27 14:10:44.819: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 27 14:10:44.829: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 27 14:10:44.830: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 27 14:10:44.833: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 27 14:10:44.833: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-12-147.eu-west-1.compute.internal before test
+Apr 27 14:10:44.843: INFO: kube-proxy-cz98z from kube-system started at 2018-04-27 13:49:28 +0000 UTC (1 container statuses recorded)
+Apr 27 14:10:44.843: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: calico-node-6q8fw from kube-system started at 2018-04-27 13:49:28 +0000 UTC (2 container statuses recorded)
+Apr 27 14:10:44.843: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: kube-dns-67b49bdfd8-lbm4c from kube-system started at 2018-04-27 13:51:05 +0000 UTC (3 container statuses recorded)
+Apr 27 14:10:44.843: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: addons-kubernetes-dashboard-8478f49fbf-f642m from kube-system started at 2018-04-27 13:50:37 +0000 UTC (1 container statuses recorded)
+Apr 27 14:10:44.843: INFO: 	Container main ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: sonobuoy-e2e-job-2ded2f49b96d41b5 from sonobuoy started at 2018-04-27 14:03:23 +0000 UTC (2 container statuses recorded)
+Apr 27 14:10:44.843: INFO: 	Container e2e ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: node-exporter-pnnmw from kube-system started at 2018-04-27 13:49:28 +0000 UTC (1 container statuses recorded)
+Apr 27 14:10:44.843: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-bfjjd from kube-system started at 2018-04-27 13:50:35 +0000 UTC (1 container statuses recorded)
+Apr 27 14:10:44.843: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: addons-heapster-e3b0c-5c98c994fc-qvtf9 from kube-system started at 2018-04-27 13:50:36 +0000 UTC (2 container statuses recorded)
+Apr 27 14:10:44.843: INFO: 	Container heapster ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: 	Container heapster-nanny ready: true, restart count 0
+Apr 27 14:10:44.843: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-14-38.eu-west-1.compute.internal before test
+Apr 27 14:10:44.852: INFO: kube-proxy-pnptq from kube-system started at 2018-04-27 13:49:29 +0000 UTC (1 container statuses recorded)
+Apr 27 14:10:44.852: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:10:44.852: INFO: vpn-shoot-8c58cd4d6-xjrwf from kube-system started at 2018-04-27 13:50:35 +0000 UTC (1 container statuses recorded)
+Apr 27 14:10:44.852: INFO: 	Container vpn-shoot ready: true, restart count 1
+Apr 27 14:10:44.852: INFO: addons-nginx-ingress-controller-858f4fc5d7-x27vt from kube-system started at 2018-04-27 13:50:36 +0000 UTC (1 container statuses recorded)
+Apr 27 14:10:44.852: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Apr 27 14:10:44.852: INFO: kube-dns-autoscaler-699b4b55c4-sxgbp from kube-system started at 2018-04-27 13:50:37 +0000 UTC (1 container statuses recorded)
+Apr 27 14:10:44.852: INFO: 	Container autoscaler ready: true, restart count 0
+Apr 27 14:10:44.852: INFO: kube-dns-67b49bdfd8-hm6sf from kube-system started at 2018-04-27 13:50:38 +0000 UTC (3 container statuses recorded)
+Apr 27 14:10:44.852: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:10:44.852: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:10:44.852: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:10:44.852: INFO: sonobuoy from sonobuoy started at 2018-04-27 14:03:03 +0000 UTC (1 container statuses recorded)
+Apr 27 14:10:44.852: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Apr 27 14:10:44.852: INFO: node-exporter-2gxj5 from kube-system started at 2018-04-27 13:49:29 +0000 UTC (1 container statuses recorded)
+Apr 27 14:10:44.852: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:10:44.853: INFO: calico-node-qmckv from kube-system started at 2018-04-27 13:49:29 +0000 UTC (2 container statuses recorded)
+Apr 27 14:10:44.853: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:10:44.853: INFO: 	Container install-cni ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-c7f430b6-4a24-11e8-a1f3-0206690d449d 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-c7f430b6-4a24-11e8-a1f3-0206690d449d off the node ip-10-250-14-38.eu-west-1.compute.internal
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-c7f430b6-4a24-11e8-a1f3-0206690d449d
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:10:48.969: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-5kmcg" for this suite.
+Apr 27 14:11:11.001: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:11:11.137: INFO: namespace: e2e-tests-sched-pred-5kmcg, resource: bindings, ignored listing per whitelist
+Apr 27 14:11:11.165: INFO: namespace e2e-tests-sched-pred-5kmcg deletion completed in 22.185228788s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:86.459 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:11:11.165: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc1
+STEP: create the rc2
+STEP: set half of pods created by rc simpletest-rc-to-be-deleted to have rc simpletest-rc-to-stay as owner as well
+STEP: delete the rc simpletest-rc-to-be-deleted
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0427 14:11:21.313922      13 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:11:21.313: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:11:21.314: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-vmbj8" for this suite.
+Apr 27 14:11:27.326: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:11:27.411: INFO: namespace: e2e-tests-gc-vmbj8, resource: bindings, ignored listing per whitelist
+Apr 27 14:11:27.462: INFO: namespace e2e-tests-gc-vmbj8 deletion completed in 6.146157807s
+
+• [SLOW TEST:16.297 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:11:27.463: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for 2 Minute to see if the garbage collector mistakenly deletes the rs
+STEP: expected 0 Deploymentss, got 1 Deployments
+STEP: Gathering metrics
+W0427 14:11:33.132965      13 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:11:33.133: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:11:33.133: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-vrc52" for this suite.
+Apr 27 14:11:39.144: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:11:39.205: INFO: namespace: e2e-tests-gc-vrc52, resource: bindings, ignored listing per whitelist
+Apr 27 14:11:39.266: INFO: namespace e2e-tests-gc-vrc52 deletion completed in 6.130065347s
+
+• [SLOW TEST:11.803 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:11:39.266: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 27 14:11:41.886: INFO: Successfully updated pod "annotationupdatee73b6453-4a24-11e8-a1f3-0206690d449d"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:11:45.918: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8s87p" for this suite.
+Apr 27 14:12:07.930: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:12:08.034: INFO: namespace: e2e-tests-projected-8s87p, resource: bindings, ignored listing per whitelist
+Apr 27 14:12:08.056: INFO: namespace e2e-tests-projected-8s87p deletion completed in 22.134060757s
+
+• [SLOW TEST:28.790 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:12:08.062: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-f866016c-4a24-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:12:08.159: INFO: Waiting up to 5m0s for pod "pod-configmaps-f8667e20-4a24-11e8-a1f3-0206690d449d" in namespace "e2e-tests-configmap-ndxq5" to be "success or failure"
+Apr 27 14:12:08.163: INFO: Pod "pod-configmaps-f8667e20-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.686881ms
+Apr 27 14:12:10.166: INFO: Pod "pod-configmaps-f8667e20-4a24-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007574438s
+STEP: Saw pod success
+Apr 27 14:12:10.166: INFO: Pod "pod-configmaps-f8667e20-4a24-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:12:10.169: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-configmaps-f8667e20-4a24-11e8-a1f3-0206690d449d container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:12:10.184: INFO: Waiting for pod pod-configmaps-f8667e20-4a24-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:12:10.186: INFO: Pod pod-configmaps-f8667e20-4a24-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:12:10.186: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-ndxq5" for this suite.
+Apr 27 14:12:16.199: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:12:16.308: INFO: namespace: e2e-tests-configmap-ndxq5, resource: bindings, ignored listing per whitelist
+Apr 27 14:12:16.327: INFO: namespace e2e-tests-configmap-ndxq5 deletion completed in 6.137806188s
+
+• [SLOW TEST:8.269 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:12:16.327: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:12:16.433: INFO: Waiting up to 5m0s for pod "downwardapi-volume-fd54c0b0-4a24-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-jww29" to be "success or failure"
+Apr 27 14:12:16.437: INFO: Pod "downwardapi-volume-fd54c0b0-4a24-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.856896ms
+Apr 27 14:12:18.440: INFO: Pod "downwardapi-volume-fd54c0b0-4a24-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007260216s
+STEP: Saw pod success
+Apr 27 14:12:18.440: INFO: Pod "downwardapi-volume-fd54c0b0-4a24-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:12:18.443: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-fd54c0b0-4a24-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:12:18.458: INFO: Waiting for pod downwardapi-volume-fd54c0b0-4a24-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:12:18.461: INFO: Pod downwardapi-volume-fd54c0b0-4a24-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:12:18.461: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-jww29" for this suite.
+Apr 27 14:12:24.474: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:12:24.573: INFO: namespace: e2e-tests-downward-api-jww29, resource: bindings, ignored listing per whitelist
+Apr 27 14:12:24.602: INFO: namespace e2e-tests-downward-api-jww29 deletion completed in 6.138121145s
+
+• [SLOW TEST:8.275 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:12:24.603: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-02430cc6-4a25-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:12:24.719: INFO: Waiting up to 5m0s for pod "pod-configmaps-024411b3-4a25-11e8-a1f3-0206690d449d" in namespace "e2e-tests-configmap-2m4hw" to be "success or failure"
+Apr 27 14:12:24.722: INFO: Pod "pod-configmaps-024411b3-4a25-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.632103ms
+Apr 27 14:12:26.726: INFO: Pod "pod-configmaps-024411b3-4a25-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006762008s
+STEP: Saw pod success
+Apr 27 14:12:26.726: INFO: Pod "pod-configmaps-024411b3-4a25-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:12:26.728: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-configmaps-024411b3-4a25-11e8-a1f3-0206690d449d container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:12:26.748: INFO: Waiting for pod pod-configmaps-024411b3-4a25-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:12:26.750: INFO: Pod pod-configmaps-024411b3-4a25-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:12:26.751: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-2m4hw" for this suite.
+Apr 27 14:12:32.762: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:12:32.831: INFO: namespace: e2e-tests-configmap-2m4hw, resource: bindings, ignored listing per whitelist
+Apr 27 14:12:32.888: INFO: namespace e2e-tests-configmap-2m4hw deletion completed in 6.13435091s
+
+• [SLOW TEST:8.285 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:12:32.888: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:12:32.991: INFO: Waiting up to 5m0s for pod "downwardapi-volume-07332de9-4a25-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-8lp96" to be "success or failure"
+Apr 27 14:12:32.997: INFO: Pod "downwardapi-volume-07332de9-4a25-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 6.502216ms
+Apr 27 14:12:35.001: INFO: Pod "downwardapi-volume-07332de9-4a25-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010060793s
+STEP: Saw pod success
+Apr 27 14:12:35.001: INFO: Pod "downwardapi-volume-07332de9-4a25-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:12:35.003: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-07332de9-4a25-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:12:35.026: INFO: Waiting for pod downwardapi-volume-07332de9-4a25-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:12:35.029: INFO: Pod downwardapi-volume-07332de9-4a25-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:12:35.029: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8lp96" for this suite.
+Apr 27 14:12:41.040: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:12:41.109: INFO: namespace: e2e-tests-projected-8lp96, resource: bindings, ignored listing per whitelist
+Apr 27 14:12:41.171: INFO: namespace e2e-tests-projected-8lp96 deletion completed in 6.139510473s
+
+• [SLOW TEST:8.283 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[k8s.io] Pods 
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:12:41.171: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating pod
+Apr 27 14:12:43.276: INFO: Pod pod-hostip-0c21d335-4a25-11e8-a1f3-0206690d449d has hostIP: 10.250.14.38
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:12:43.276: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-h9s7r" for this suite.
+Apr 27 14:13:05.289: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:13:05.340: INFO: namespace: e2e-tests-pods-h9s7r, resource: bindings, ignored listing per whitelist
+Apr 27 14:13:05.436: INFO: namespace e2e-tests-pods-h9s7r deletion completed in 22.156645863s
+
+• [SLOW TEST:24.265 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:13:05.436: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-s2ff9
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 27 14:13:05.546: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 27 14:13:23.610: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.1.49 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-s2ff9 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:13:23.610: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:13:24.792: INFO: Found all expected endpoints: [netserver-0]
+Apr 27 14:13:24.795: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.0.17 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-s2ff9 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:13:24.795: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:13:25.957: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:13:25.957: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-s2ff9" for this suite.
+Apr 27 14:13:47.974: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:13:48.037: INFO: namespace: e2e-tests-pod-network-test-s2ff9, resource: bindings, ignored listing per whitelist
+Apr 27 14:13:48.156: INFO: namespace e2e-tests-pod-network-test-s2ff9 deletion completed in 22.196065637s
+
+• [SLOW TEST:42.720 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:13:48.157: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-upd-34121205-4a25-11e8-a1f3-0206690d449d
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-34121205-4a25-11e8-a1f3-0206690d449d
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:13:55.286: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-cg27v" for this suite.
+Apr 27 14:14:17.297: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:14:17.357: INFO: namespace: e2e-tests-configmap-cg27v, resource: bindings, ignored listing per whitelist
+Apr 27 14:14:17.426: INFO: namespace e2e-tests-configmap-cg27v deletion completed in 22.137186896s
+
+• [SLOW TEST:29.269 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:14:17.426: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-4586589e-4a25-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:14:17.556: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-4586d675-4a25-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-47r64" to be "success or failure"
+Apr 27 14:14:17.559: INFO: Pod "pod-projected-configmaps-4586d675-4a25-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.678262ms
+Apr 27 14:14:19.566: INFO: Pod "pod-projected-configmaps-4586d675-4a25-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009797541s
+STEP: Saw pod success
+Apr 27 14:14:19.566: INFO: Pod "pod-projected-configmaps-4586d675-4a25-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:14:19.572: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-configmaps-4586d675-4a25-11e8-a1f3-0206690d449d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:14:19.597: INFO: Waiting for pod pod-projected-configmaps-4586d675-4a25-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:14:19.605: INFO: Pod pod-projected-configmaps-4586d675-4a25-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:14:19.605: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-47r64" for this suite.
+Apr 27 14:14:25.633: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:14:25.693: INFO: namespace: e2e-tests-projected-47r64, resource: bindings, ignored listing per whitelist
+Apr 27 14:14:25.791: INFO: namespace e2e-tests-projected-47r64 deletion completed in 6.177033205s
+
+• [SLOW TEST:8.364 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:14:25.791: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-xshbs
+Apr 27 14:14:29.902: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-xshbs
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:14:29.905: INFO: Initial restart count of pod liveness-http is 0
+Apr 27 14:14:49.948: INFO: Restart count of pod e2e-tests-container-probe-xshbs/liveness-http is now 1 (20.043403089s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:14:49.958: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-xshbs" for this suite.
+Apr 27 14:14:55.978: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:14:56.100: INFO: namespace: e2e-tests-container-probe-xshbs, resource: bindings, ignored listing per whitelist
+Apr 27 14:14:56.112: INFO: namespace e2e-tests-container-probe-xshbs deletion completed in 6.149741382s
+
+• [SLOW TEST:30.321 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:14:56.112: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-5c8fbb6f-4a25-11e8-a1f3-0206690d449d,GenerateName:,Namespace:e2e-tests-events-ff2kx,SelfLink:/api/v1/namespaces/e2e-tests-events-ff2kx/pods/send-events-5c8fbb6f-4a25-11e8-a1f3-0206690d449d,UID:5c910a17-4a25-11e8-aa31-6e07c8c44ecd,ResourceVersion:3595,Generation:0,CreationTimestamp:2018-04-27 14:14:56 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 196907704,},Annotations:map[string]string{cni.projectcalico.org/podIP: 100.96.1.54/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-4mjx7 {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-4mjx7,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-4mjx7 true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:ip-10-250-14-38.eu-west-1.compute.internal,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc4217dd260} {node.kubernetes.io/unreachable Exists  NoExecute 0xc4217dd280}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:14:56 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:14:58 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:14:56 +0000 UTC  }],Message:,Reason:,HostIP:10.250.14.38,PodIP:100.96.1.54,StartTime:2018-04-27 14:14:56 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-04-27 14:14:58 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://2ee1efc65ed3108a597d52351dde80848e2e9ab543ddb36db46aa6fd26f025bf}],QOSClass:BestEffort,InitContainerStatuses:[],NominatedNodeName:,},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:15:04.233: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-ff2kx" for this suite.
+Apr 27 14:15:26.249: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:15:26.345: INFO: namespace: e2e-tests-events-ff2kx, resource: bindings, ignored listing per whitelist
+Apr 27 14:15:26.382: INFO: namespace e2e-tests-events-ff2kx deletion completed in 22.146371617s
+
+• [SLOW TEST:30.270 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:15:26.383: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-6e9b588d-4a25-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:15:26.480: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-6e9bcef1-4a25-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-82974" to be "success or failure"
+Apr 27 14:15:26.482: INFO: Pod "pod-projected-configmaps-6e9bcef1-4a25-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.069528ms
+Apr 27 14:15:28.485: INFO: Pod "pod-projected-configmaps-6e9bcef1-4a25-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004961104s
+STEP: Saw pod success
+Apr 27 14:15:28.485: INFO: Pod "pod-projected-configmaps-6e9bcef1-4a25-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:15:28.487: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-configmaps-6e9bcef1-4a25-11e8-a1f3-0206690d449d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:15:28.501: INFO: Waiting for pod pod-projected-configmaps-6e9bcef1-4a25-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:15:28.504: INFO: Pod pod-projected-configmaps-6e9bcef1-4a25-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:15:28.504: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-82974" for this suite.
+Apr 27 14:15:34.515: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:15:34.616: INFO: namespace: e2e-tests-projected-82974, resource: bindings, ignored listing per whitelist
+Apr 27 14:15:34.638: INFO: namespace e2e-tests-projected-82974 deletion completed in 6.130542568s
+
+• [SLOW TEST:8.255 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:15:34.638: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:15:34.746: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-47q7j" for this suite.
+Apr 27 14:15:56.758: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:15:56.837: INFO: namespace: e2e-tests-pods-47q7j, resource: bindings, ignored listing per whitelist
+Apr 27 14:15:56.883: INFO: namespace e2e-tests-pods-47q7j deletion completed in 22.133881199s
+
+• [SLOW TEST:22.245 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:15:56.884: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:15:56.976: INFO: Waiting up to 5m0s for pod "downwardapi-volume-80c8f9f6-4a25-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-xflrw" to be "success or failure"
+Apr 27 14:15:56.979: INFO: Pod "downwardapi-volume-80c8f9f6-4a25-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.280188ms
+Apr 27 14:15:58.982: INFO: Pod "downwardapi-volume-80c8f9f6-4a25-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006591607s
+STEP: Saw pod success
+Apr 27 14:15:58.982: INFO: Pod "downwardapi-volume-80c8f9f6-4a25-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:15:58.985: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-80c8f9f6-4a25-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:15:59.000: INFO: Waiting for pod downwardapi-volume-80c8f9f6-4a25-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:15:59.003: INFO: Pod downwardapi-volume-80c8f9f6-4a25-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:15:59.003: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-xflrw" for this suite.
+Apr 27 14:16:05.017: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:16:05.096: INFO: namespace: e2e-tests-downward-api-xflrw, resource: bindings, ignored listing per whitelist
+Apr 27 14:16:05.188: INFO: namespace e2e-tests-downward-api-xflrw deletion completed in 6.181193646s
+
+• [SLOW TEST:8.304 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:16:05.188: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:16:05.297: INFO: Waiting up to 5m0s for pod "downwardapi-volume-85beb20b-4a25-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-2pt6k" to be "success or failure"
+Apr 27 14:16:05.302: INFO: Pod "downwardapi-volume-85beb20b-4a25-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.293396ms
+Apr 27 14:16:07.305: INFO: Pod "downwardapi-volume-85beb20b-4a25-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007660455s
+STEP: Saw pod success
+Apr 27 14:16:07.305: INFO: Pod "downwardapi-volume-85beb20b-4a25-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:16:07.308: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-85beb20b-4a25-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:16:07.327: INFO: Waiting for pod downwardapi-volume-85beb20b-4a25-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:16:07.332: INFO: Pod downwardapi-volume-85beb20b-4a25-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:16:07.332: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2pt6k" for this suite.
+Apr 27 14:16:13.345: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:16:13.426: INFO: namespace: e2e-tests-projected-2pt6k, resource: bindings, ignored listing per whitelist
+Apr 27 14:16:13.481: INFO: namespace e2e-tests-projected-2pt6k deletion completed in 6.146266702s
+
+• [SLOW TEST:8.293 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:16:13.481: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 27 14:16:16.121: INFO: Successfully updated pod "annotationupdate8ab02d48-4a25-11e8-a1f3-0206690d449d"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:16:18.151: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-4q25k" for this suite.
+Apr 27 14:16:40.167: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:16:40.222: INFO: namespace: e2e-tests-downward-api-4q25k, resource: bindings, ignored listing per whitelist
+Apr 27 14:16:40.293: INFO: namespace e2e-tests-downward-api-4q25k deletion completed in 22.137565461s
+
+• [SLOW TEST:26.812 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:16:40.293: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-f2bgn in namespace e2e-tests-proxy-26mxn
+I0427 14:16:40.400369      13 runners.go:175] Created replication controller with name: proxy-service-f2bgn, namespace: e2e-tests-proxy-26mxn, replica count: 1
+I0427 14:16:41.400751      13 runners.go:175] proxy-service-f2bgn Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0427 14:16:42.400968      13 runners.go:175] proxy-service-f2bgn Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0427 14:16:43.401267      13 runners.go:175] proxy-service-f2bgn Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:16:44.401498      13 runners.go:175] proxy-service-f2bgn Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:16:45.401753      13 runners.go:175] proxy-service-f2bgn Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:16:46.402052      13 runners.go:175] proxy-service-f2bgn Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:16:47.402350      13 runners.go:175] proxy-service-f2bgn Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:16:48.402746      13 runners.go:175] proxy-service-f2bgn Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:16:49.402990      13 runners.go:175] proxy-service-f2bgn Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:16:50.403256      13 runners.go:175] proxy-service-f2bgn Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:16:51.403488      13 runners.go:175] proxy-service-f2bgn Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Apr 27 14:16:51.406: INFO: setup took 11.019401517s, starting test cases
+STEP: running 16 cases, 20 attempts per case, 320 total attempts
+Apr 27 14:16:51.424: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 17.935467ms)
+Apr 27 14:16:51.426: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 19.523709ms)
+Apr 27 14:16:51.431: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 24.703669ms)
+Apr 27 14:16:51.431: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 24.940559ms)
+Apr 27 14:16:51.432: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 25.01756ms)
+Apr 27 14:16:51.437: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 29.757445ms)
+Apr 27 14:16:51.437: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 29.595357ms)
+Apr 27 14:16:51.440: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 32.973071ms)
+Apr 27 14:16:51.440: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 32.691837ms)
+Apr 27 14:16:51.440: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 33.029314ms)
+Apr 27 14:16:51.440: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 33.260055ms)
+Apr 27 14:16:51.444: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 37.534566ms)
+Apr 27 14:16:51.449: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 42.188538ms)
+Apr 27 14:16:51.449: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 42.171028ms)
+Apr 27 14:16:51.451: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 44.304842ms)
+Apr 27 14:16:51.455: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 47.936873ms)
+Apr 27 14:16:51.462: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 7.112871ms)
+Apr 27 14:16:51.464: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 9.039678ms)
+Apr 27 14:16:51.464: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 8.857662ms)
+Apr 27 14:16:51.465: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 8.989916ms)
+Apr 27 14:16:51.465: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 9.963375ms)
+Apr 27 14:16:51.465: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 10.17688ms)
+Apr 27 14:16:51.466: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 10.263411ms)
+Apr 27 14:16:51.466: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 10.165237ms)
+Apr 27 14:16:51.466: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 11.205925ms)
+Apr 27 14:16:51.466: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 10.617497ms)
+Apr 27 14:16:51.466: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 10.77276ms)
+Apr 27 14:16:51.466: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 10.508301ms)
+Apr 27 14:16:51.467: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 12.044688ms)
+Apr 27 14:16:51.469: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 12.871311ms)
+Apr 27 14:16:51.471: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 15.092172ms)
+Apr 27 14:16:51.471: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 15.477117ms)
+Apr 27 14:16:51.479: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 8.343758ms)
+Apr 27 14:16:51.479: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 8.514118ms)
+Apr 27 14:16:51.480: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 9.66389ms)
+Apr 27 14:16:51.481: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 9.706995ms)
+Apr 27 14:16:51.481: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 9.678153ms)
+Apr 27 14:16:51.481: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 9.949918ms)
+Apr 27 14:16:51.481: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 9.868752ms)
+Apr 27 14:16:51.487: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 15.963937ms)
+Apr 27 14:16:51.487: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 16.392582ms)
+Apr 27 14:16:51.488: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 16.054886ms)
+Apr 27 14:16:51.488: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 16.333949ms)
+Apr 27 14:16:51.488: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 16.30296ms)
+Apr 27 14:16:51.488: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 17.175794ms)
+Apr 27 14:16:51.489: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 18.712146ms)
+Apr 27 14:16:51.490: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 18.135843ms)
+Apr 27 14:16:51.490: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 18.720451ms)
+Apr 27 14:16:51.504: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 14.01128ms)
+Apr 27 14:16:51.507: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 17.47387ms)
+Apr 27 14:16:51.508: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 17.541011ms)
+Apr 27 14:16:51.509: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 17.69158ms)
+Apr 27 14:16:51.509: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 18.240911ms)
+Apr 27 14:16:51.509: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 18.835047ms)
+Apr 27 14:16:51.509: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 18.984761ms)
+Apr 27 14:16:51.511: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 19.820523ms)
+Apr 27 14:16:51.511: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 20.384966ms)
+Apr 27 14:16:51.511: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 20.987555ms)
+Apr 27 14:16:51.511: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 19.983243ms)
+Apr 27 14:16:51.511: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 20.789354ms)
+Apr 27 14:16:51.549: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 58.287384ms)
+Apr 27 14:16:51.549: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 59.083716ms)
+Apr 27 14:16:51.549: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 59.150577ms)
+Apr 27 14:16:51.550: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 58.760946ms)
+Apr 27 14:16:51.557: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 6.772514ms)
+Apr 27 14:16:51.558: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 7.87087ms)
+Apr 27 14:16:51.558: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 8.26286ms)
+Apr 27 14:16:51.558: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 7.883365ms)
+Apr 27 14:16:51.559: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 8.608346ms)
+Apr 27 14:16:51.559: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 9.089682ms)
+Apr 27 14:16:51.560: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 9.691367ms)
+Apr 27 14:16:51.560: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 9.857774ms)
+Apr 27 14:16:51.561: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 10.211332ms)
+Apr 27 14:16:51.566: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 16.133346ms)
+Apr 27 14:16:51.566: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 15.543604ms)
+Apr 27 14:16:51.567: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 16.475036ms)
+Apr 27 14:16:51.567: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 16.460673ms)
+Apr 27 14:16:51.568: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 16.651192ms)
+Apr 27 14:16:51.568: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 16.901973ms)
+Apr 27 14:16:51.568: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 17.360346ms)
+Apr 27 14:16:51.578: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 9.090461ms)
+Apr 27 14:16:51.578: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 9.972198ms)
+Apr 27 14:16:51.578: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 9.960335ms)
+Apr 27 14:16:51.578: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 9.612347ms)
+Apr 27 14:16:51.578: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 9.748775ms)
+Apr 27 14:16:51.578: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 10.014813ms)
+Apr 27 14:16:51.579: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 10.526783ms)
+Apr 27 14:16:51.579: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 9.798772ms)
+Apr 27 14:16:51.579: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 10.378753ms)
+Apr 27 14:16:51.579: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 10.429497ms)
+Apr 27 14:16:51.580: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 10.146463ms)
+Apr 27 14:16:51.580: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 10.421607ms)
+Apr 27 14:16:51.580: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 11.611987ms)
+Apr 27 14:16:51.580: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 11.059394ms)
+Apr 27 14:16:51.580: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 11.484074ms)
+Apr 27 14:16:51.581: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 11.394348ms)
+Apr 27 14:16:51.590: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 8.829753ms)
+Apr 27 14:16:51.591: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 10.3144ms)
+Apr 27 14:16:51.591: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 10.006577ms)
+Apr 27 14:16:51.592: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 10.691971ms)
+Apr 27 14:16:51.592: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 10.704986ms)
+Apr 27 14:16:51.592: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 10.765363ms)
+Apr 27 14:16:51.594: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 11.61866ms)
+Apr 27 14:16:51.594: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 12.088068ms)
+Apr 27 14:16:51.594: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 13.024323ms)
+Apr 27 14:16:51.594: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 12.917561ms)
+Apr 27 14:16:51.594: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 13.067697ms)
+Apr 27 14:16:51.594: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 12.701721ms)
+Apr 27 14:16:51.594: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 13.104176ms)
+Apr 27 14:16:51.594: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 12.58397ms)
+Apr 27 14:16:51.595: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 13.721124ms)
+Apr 27 14:16:51.595: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 13.63405ms)
+Apr 27 14:16:51.603: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 7.817155ms)
+Apr 27 14:16:51.603: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 8.112221ms)
+Apr 27 14:16:51.604: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 8.733638ms)
+Apr 27 14:16:51.604: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 8.43524ms)
+Apr 27 14:16:51.606: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 9.672916ms)
+Apr 27 14:16:51.606: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 8.442444ms)
+Apr 27 14:16:51.606: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 9.083499ms)
+Apr 27 14:16:51.606: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 9.865906ms)
+Apr 27 14:16:51.606: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 10.083517ms)
+Apr 27 14:16:51.606: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 10.372663ms)
+Apr 27 14:16:51.606: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 10.570459ms)
+Apr 27 14:16:51.606: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 10.800427ms)
+Apr 27 14:16:51.607: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 10.997815ms)
+Apr 27 14:16:51.607: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 11.304155ms)
+Apr 27 14:16:51.607: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 11.660203ms)
+Apr 27 14:16:51.607: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 12.020099ms)
+Apr 27 14:16:51.614: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 6.538273ms)
+Apr 27 14:16:51.615: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 7.177221ms)
+Apr 27 14:16:51.615: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 7.519686ms)
+Apr 27 14:16:51.615: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 7.252571ms)
+Apr 27 14:16:51.616: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 7.387622ms)
+Apr 27 14:16:51.616: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 7.175699ms)
+Apr 27 14:16:51.616: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 7.5079ms)
+Apr 27 14:16:51.616: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 7.970887ms)
+Apr 27 14:16:51.616: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 7.670998ms)
+Apr 27 14:16:51.616: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 8.534179ms)
+Apr 27 14:16:51.618: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 9.360158ms)
+Apr 27 14:16:51.618: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 9.096586ms)
+Apr 27 14:16:51.618: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 9.894642ms)
+Apr 27 14:16:51.618: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 9.638098ms)
+Apr 27 14:16:51.618: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 11.007385ms)
+Apr 27 14:16:51.619: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 10.820529ms)
+Apr 27 14:16:51.627: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 7.585651ms)
+Apr 27 14:16:51.627: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 7.24713ms)
+Apr 27 14:16:51.627: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 7.413941ms)
+Apr 27 14:16:51.627: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 7.403351ms)
+Apr 27 14:16:51.627: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 7.84458ms)
+Apr 27 14:16:51.627: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 8.567464ms)
+Apr 27 14:16:51.627: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 7.886684ms)
+Apr 27 14:16:51.628: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 8.705553ms)
+Apr 27 14:16:51.628: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 8.480039ms)
+Apr 27 14:16:51.628: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 8.154362ms)
+Apr 27 14:16:51.628: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 9.293139ms)
+Apr 27 14:16:51.628: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 9.284539ms)
+Apr 27 14:16:51.629: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 9.894522ms)
+Apr 27 14:16:51.629: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 9.129517ms)
+Apr 27 14:16:51.629: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 10.239161ms)
+Apr 27 14:16:51.629: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 9.610631ms)
+Apr 27 14:16:51.638: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 8.446664ms)
+Apr 27 14:16:51.638: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 7.869891ms)
+Apr 27 14:16:51.638: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 8.581272ms)
+Apr 27 14:16:51.639: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 8.640355ms)
+Apr 27 14:16:51.639: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 9.049452ms)
+Apr 27 14:16:51.639: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 10.453895ms)
+Apr 27 14:16:51.640: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 10.482274ms)
+Apr 27 14:16:51.640: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 10.836232ms)
+Apr 27 14:16:51.640: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 10.68639ms)
+Apr 27 14:16:51.640: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 10.862425ms)
+Apr 27 14:16:51.640: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 10.28334ms)
+Apr 27 14:16:51.641: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 10.579256ms)
+Apr 27 14:16:51.641: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 11.250175ms)
+Apr 27 14:16:51.641: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 11.796285ms)
+Apr 27 14:16:51.641: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 11.354657ms)
+Apr 27 14:16:51.642: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 12.697808ms)
+Apr 27 14:16:51.651: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 7.710943ms)
+Apr 27 14:16:51.651: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 7.88052ms)
+Apr 27 14:16:51.651: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 8.761212ms)
+Apr 27 14:16:51.651: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 8.739753ms)
+Apr 27 14:16:51.652: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 8.670576ms)
+Apr 27 14:16:51.652: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 8.423705ms)
+Apr 27 14:16:51.652: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 8.905888ms)
+Apr 27 14:16:51.652: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 9.887412ms)
+Apr 27 14:16:51.654: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 10.701693ms)
+Apr 27 14:16:51.654: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 10.787391ms)
+Apr 27 14:16:51.655: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 10.908051ms)
+Apr 27 14:16:51.655: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 12.20852ms)
+Apr 27 14:16:51.655: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 11.574425ms)
+Apr 27 14:16:51.656: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 12.81707ms)
+Apr 27 14:16:51.657: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 14.30999ms)
+Apr 27 14:16:51.657: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 14.398647ms)
+Apr 27 14:16:51.666: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 8.991894ms)
+Apr 27 14:16:51.667: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 9.291083ms)
+Apr 27 14:16:51.667: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 9.225013ms)
+Apr 27 14:16:51.668: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 10.560899ms)
+Apr 27 14:16:51.668: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 10.485514ms)
+Apr 27 14:16:51.668: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 10.358182ms)
+Apr 27 14:16:51.669: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 10.562017ms)
+Apr 27 14:16:51.669: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 11.095485ms)
+Apr 27 14:16:51.669: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 11.34496ms)
+Apr 27 14:16:51.669: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 11.608345ms)
+Apr 27 14:16:51.670: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 11.852439ms)
+Apr 27 14:16:51.670: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 11.759079ms)
+Apr 27 14:16:51.670: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 12.233588ms)
+Apr 27 14:16:51.670: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 12.308816ms)
+Apr 27 14:16:51.670: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 12.43602ms)
+Apr 27 14:16:51.671: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 12.779952ms)
+Apr 27 14:16:51.681: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 9.621763ms)
+Apr 27 14:16:51.681: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 8.634783ms)
+Apr 27 14:16:51.683: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 11.010597ms)
+Apr 27 14:16:51.683: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 10.607054ms)
+Apr 27 14:16:51.683: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 10.707916ms)
+Apr 27 14:16:51.683: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 11.704786ms)
+Apr 27 14:16:51.683: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 12.109061ms)
+Apr 27 14:16:51.684: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 12.129625ms)
+Apr 27 14:16:51.684: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 12.172094ms)
+Apr 27 14:16:51.684: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 12.684027ms)
+Apr 27 14:16:51.685: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 13.348191ms)
+Apr 27 14:16:51.685: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 13.174784ms)
+Apr 27 14:16:51.685: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 13.736849ms)
+Apr 27 14:16:51.685: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 13.714682ms)
+Apr 27 14:16:51.685: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 13.727102ms)
+Apr 27 14:16:51.685: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 13.538076ms)
+Apr 27 14:16:51.694: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 8.06919ms)
+Apr 27 14:16:51.696: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 9.843204ms)
+Apr 27 14:16:51.696: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 9.959906ms)
+Apr 27 14:16:51.697: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 11.440003ms)
+Apr 27 14:16:51.698: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 12.262966ms)
+Apr 27 14:16:51.698: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 12.754979ms)
+Apr 27 14:16:51.699: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 12.410552ms)
+Apr 27 14:16:51.699: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 12.670302ms)
+Apr 27 14:16:51.699: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 13.029162ms)
+Apr 27 14:16:51.699: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 13.623416ms)
+Apr 27 14:16:51.699: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 13.630314ms)
+Apr 27 14:16:51.700: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 13.975882ms)
+Apr 27 14:16:51.700: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 14.052814ms)
+Apr 27 14:16:51.700: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 13.887722ms)
+Apr 27 14:16:51.700: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 14.634017ms)
+Apr 27 14:16:51.700: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 14.272144ms)
+Apr 27 14:16:51.707: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 6.058433ms)
+Apr 27 14:16:51.709: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 8.584744ms)
+Apr 27 14:16:51.710: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 8.865531ms)
+Apr 27 14:16:51.710: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 8.909276ms)
+Apr 27 14:16:51.710: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 9.639663ms)
+Apr 27 14:16:51.711: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 8.967077ms)
+Apr 27 14:16:51.713: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 11.405769ms)
+Apr 27 14:16:51.713: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 11.633008ms)
+Apr 27 14:16:51.713: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 12.365011ms)
+Apr 27 14:16:51.713: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 12.456952ms)
+Apr 27 14:16:51.713: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 12.068838ms)
+Apr 27 14:16:51.713: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 12.020543ms)
+Apr 27 14:16:51.715: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 13.848838ms)
+Apr 27 14:16:51.716: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 14.544029ms)
+Apr 27 14:16:51.716: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 14.615193ms)
+Apr 27 14:16:51.716: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 15.33974ms)
+Apr 27 14:16:51.723: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 6.889184ms)
+Apr 27 14:16:51.724: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 7.861667ms)
+Apr 27 14:16:51.725: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 8.163148ms)
+Apr 27 14:16:51.725: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 8.548592ms)
+Apr 27 14:16:51.725: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 8.539392ms)
+Apr 27 14:16:51.725: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 8.610339ms)
+Apr 27 14:16:51.725: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 8.369308ms)
+Apr 27 14:16:51.725: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 9.045999ms)
+Apr 27 14:16:51.726: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 9.436538ms)
+Apr 27 14:16:51.726: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 8.973924ms)
+Apr 27 14:16:51.726: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 9.41622ms)
+Apr 27 14:16:51.727: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 11.080216ms)
+Apr 27 14:16:51.727: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 10.160037ms)
+Apr 27 14:16:51.727: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 10.444699ms)
+Apr 27 14:16:51.727: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 10.639471ms)
+Apr 27 14:16:51.727: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 10.831538ms)
+Apr 27 14:16:51.735: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 7.45237ms)
+Apr 27 14:16:51.735: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 7.854864ms)
+Apr 27 14:16:51.736: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 7.317028ms)
+Apr 27 14:16:51.736: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 7.583675ms)
+Apr 27 14:16:51.737: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 8.522303ms)
+Apr 27 14:16:51.737: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 8.244389ms)
+Apr 27 14:16:51.739: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 10.154098ms)
+Apr 27 14:16:51.739: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 10.732005ms)
+Apr 27 14:16:51.739: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 10.675483ms)
+Apr 27 14:16:51.739: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 11.604109ms)
+Apr 27 14:16:51.739: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 10.6906ms)
+Apr 27 14:16:51.739: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 11.643409ms)
+Apr 27 14:16:51.740: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 11.134643ms)
+Apr 27 14:16:51.740: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 11.345622ms)
+Apr 27 14:16:51.740: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 11.756781ms)
+Apr 27 14:16:51.740: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 11.56181ms)
+Apr 27 14:16:51.746: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 6.26564ms)
+Apr 27 14:16:51.747: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 7.039479ms)
+Apr 27 14:16:51.747: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 7.337261ms)
+Apr 27 14:16:51.748: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 7.386413ms)
+Apr 27 14:16:51.749: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 8.554302ms)
+Apr 27 14:16:51.750: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 9.973934ms)
+Apr 27 14:16:51.751: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 10.637989ms)
+Apr 27 14:16:51.751: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 10.556282ms)
+Apr 27 14:16:51.751: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 10.617176ms)
+Apr 27 14:16:51.751: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 11.366312ms)
+Apr 27 14:16:51.752: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 11.168151ms)
+Apr 27 14:16:51.752: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 11.827204ms)
+Apr 27 14:16:51.754: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 13.032912ms)
+Apr 27 14:16:51.756: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 15.047133ms)
+Apr 27 14:16:51.756: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 15.261513ms)
+Apr 27 14:16:51.756: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 15.670708ms)
+Apr 27 14:16:51.763: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk/proxy/rewriteme"... (200; 6.087825ms)
+Apr 27 14:16:51.765: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:460/proxy/: tls baz (200; 8.235905ms)
+Apr 27 14:16:51.767: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:462/proxy/: tls qux (200; 10.846349ms)
+Apr 27 14:16:51.767: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname2/proxy/: tls qux (200; 11.155218ms)
+Apr 27 14:16:51.767: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/https:proxy-service-f2bgn-4gbwk:443/proxy/... (200; 10.681217ms)
+Apr 27 14:16:51.767: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 10.986938ms)
+Apr 27 14:16:51.768: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/https:proxy-service-f2bgn:tlsportname1/proxy/: tls baz (200; 11.017196ms)
+Apr 27 14:16:51.768: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 11.713978ms)
+Apr 27 14:16:51.769: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:1080/proxy/... (200; 11.775809ms)
+Apr 27 14:16:51.769: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:1080/proxy/rewri... (200; 12.224442ms)
+Apr 27 14:16:51.769: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname1/proxy/: foo (200; 12.323227ms)
+Apr 27 14:16:51.769: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname1/proxy/: foo (200; 12.42352ms)
+Apr 27 14:16:51.769: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/proxy-service-f2bgn:portname2/proxy/: bar (200; 11.618032ms)
+Apr 27 14:16:51.769: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/proxy-service-f2bgn-4gbwk:162/proxy/: bar (200; 12.79066ms)
+Apr 27 14:16:51.770: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/services/http:proxy-service-f2bgn:portname2/proxy/: bar (200; 13.441707ms)
+Apr 27 14:16:51.770: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-26mxn/pods/http:proxy-service-f2bgn-4gbwk:160/proxy/: foo (200; 13.191977ms)
+STEP: deleting { ReplicationController} proxy-service-f2bgn in namespace e2e-tests-proxy-26mxn
+Apr 27 14:16:52.898: INFO: Deleting { ReplicationController} proxy-service-f2bgn took: 1.024949342s
+Apr 27 14:16:52.898: INFO: Terminating { ReplicationController} proxy-service-f2bgn pods took: 33.754µs
+Apr 27 14:16:56.298: INFO: Garbage collecting { ReplicationController} proxy-service-f2bgn pods took: 4.425155407s
+[AfterEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:16:56.298: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-26mxn" for this suite.
+Apr 27 14:17:02.311: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:17:02.412: INFO: namespace: e2e-tests-proxy-26mxn, resource: bindings, ignored listing per whitelist
+Apr 27 14:17:02.435: INFO: namespace e2e-tests-proxy-26mxn deletion completed in 6.131803443s
+
+• [SLOW TEST:22.142 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:17:02.435: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Apr 27 14:17:02.601: INFO: Number of nodes with available pods: 0
+Apr 27 14:17:02.601: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:03.608: INFO: Number of nodes with available pods: 0
+Apr 27 14:17:03.608: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:04.610: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:04.610: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:05.608: INFO: Number of nodes with available pods: 2
+Apr 27 14:17:05.608: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Stop a daemon pod, check that the daemon pod is revived.
+Apr 27 14:17:05.627: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:05.627: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:06.636: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:06.636: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:07.634: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:07.634: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:08.634: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:08.634: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:09.636: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:09.636: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:10.634: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:10.634: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:11.634: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:11.634: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:12.634: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:12.634: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:13.634: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:13.634: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:14.634: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:14.634: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:15.634: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:15.634: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:16.637: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:16.637: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:17.634: INFO: Number of nodes with available pods: 1
+Apr 27 14:17:17.634: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:17:18.634: INFO: Number of nodes with available pods: 2
+Apr 27 14:17:18.634: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 27 14:17:26.654: INFO: Number of nodes with available pods: 0
+Apr 27 14:17:26.654: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 27 14:17:26.658: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-scb8v/daemonsets","resourceVersion":"3968"},"items":null}
+
+Apr 27 14:17:26.665: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-scb8v/pods","resourceVersion":"3969"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:17:26.678: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-scb8v" for this suite.
+Apr 27 14:17:32.691: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:17:32.750: INFO: namespace: e2e-tests-daemonsets-scb8v, resource: bindings, ignored listing per whitelist
+Apr 27 14:17:32.830: INFO: namespace e2e-tests-daemonsets-scb8v deletion completed in 6.148823325s
+
+• [SLOW TEST:30.395 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:17:32.830: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating secret e2e-tests-secrets-sr79d/secret-test-b9fe0222-4a25-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:17:32.955: INFO: Waiting up to 5m0s for pod "pod-configmaps-b9fe824f-4a25-11e8-a1f3-0206690d449d" in namespace "e2e-tests-secrets-sr79d" to be "success or failure"
+Apr 27 14:17:32.957: INFO: Pod "pod-configmaps-b9fe824f-4a25-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.335905ms
+Apr 27 14:17:34.960: INFO: Pod "pod-configmaps-b9fe824f-4a25-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005356042s
+Apr 27 14:17:36.964: INFO: Pod "pod-configmaps-b9fe824f-4a25-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008399298s
+STEP: Saw pod success
+Apr 27 14:17:36.964: INFO: Pod "pod-configmaps-b9fe824f-4a25-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:17:36.966: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-configmaps-b9fe824f-4a25-11e8-a1f3-0206690d449d container env-test: <nil>
+STEP: delete the pod
+Apr 27 14:17:36.990: INFO: Waiting for pod pod-configmaps-b9fe824f-4a25-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:17:36.994: INFO: Pod pod-configmaps-b9fe824f-4a25-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:17:36.994: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-sr79d" for this suite.
+Apr 27 14:17:43.009: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:17:43.112: INFO: namespace: e2e-tests-secrets-sr79d, resource: bindings, ignored listing per whitelist
+Apr 27 14:17:43.140: INFO: namespace e2e-tests-secrets-sr79d deletion completed in 6.141793607s
+
+• [SLOW TEST:10.310 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:17:43.140: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:17:43.229: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c01e0a69-4a25-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-8kzfm" to be "success or failure"
+Apr 27 14:17:43.231: INFO: Pod "downwardapi-volume-c01e0a69-4a25-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.629169ms
+Apr 27 14:17:45.234: INFO: Pod "downwardapi-volume-c01e0a69-4a25-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005507898s
+STEP: Saw pod success
+Apr 27 14:17:45.234: INFO: Pod "downwardapi-volume-c01e0a69-4a25-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:17:45.237: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-c01e0a69-4a25-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:17:45.264: INFO: Waiting for pod downwardapi-volume-c01e0a69-4a25-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:17:45.267: INFO: Pod downwardapi-volume-c01e0a69-4a25-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:17:45.267: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8kzfm" for this suite.
+Apr 27 14:17:51.278: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:17:51.325: INFO: namespace: e2e-tests-projected-8kzfm, resource: bindings, ignored listing per whitelist
+Apr 27 14:17:51.408: INFO: namespace e2e-tests-projected-8kzfm deletion completed in 6.138551977s
+
+• [SLOW TEST:8.268 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:17:51.408: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-px8k4
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 27 14:17:51.501: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 27 14:18:05.589: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.66:8080/dial?request=hostName&protocol=http&host=100.96.0.19&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-px8k4 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:18:05.589: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:18:05.749: INFO: Waiting for endpoints: map[]
+Apr 27 14:18:05.752: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.66:8080/dial?request=hostName&protocol=http&host=100.96.1.65&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-px8k4 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:18:05.752: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:18:05.913: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:18:05.913: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-px8k4" for this suite.
+Apr 27 14:18:27.927: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:18:28.028: INFO: namespace: e2e-tests-pod-network-test-px8k4, resource: bindings, ignored listing per whitelist
+Apr 27 14:18:28.044: INFO: namespace e2e-tests-pod-network-test-px8k4 deletion completed in 22.12652442s
+
+• [SLOW TEST:36.636 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:18:28.044: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating server pod server in namespace e2e-tests-prestop-mkcsh
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-mkcsh
+STEP: Deleting pre-stop pod
+Apr 27 14:18:41.229: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:18:41.233: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-mkcsh" for this suite.
+Apr 27 14:19:19.247: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:19:19.293: INFO: namespace: e2e-tests-prestop-mkcsh, resource: bindings, ignored listing per whitelist
+Apr 27 14:19:19.366: INFO: namespace e2e-tests-prestop-mkcsh deletion completed in 38.128355236s
+
+• [SLOW TEST:51.322 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:19:19.366: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:19:19.471: INFO: Waiting up to 5m0s for pod "downwardapi-volume-f97b7f48-4a25-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-8h5dl" to be "success or failure"
+Apr 27 14:19:19.475: INFO: Pod "downwardapi-volume-f97b7f48-4a25-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.964252ms
+Apr 27 14:19:21.479: INFO: Pod "downwardapi-volume-f97b7f48-4a25-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008135965s
+STEP: Saw pod success
+Apr 27 14:19:21.479: INFO: Pod "downwardapi-volume-f97b7f48-4a25-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:19:21.482: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-f97b7f48-4a25-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:19:21.514: INFO: Waiting for pod downwardapi-volume-f97b7f48-4a25-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:19:21.517: INFO: Pod downwardapi-volume-f97b7f48-4a25-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:19:21.517: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-8h5dl" for this suite.
+Apr 27 14:19:27.531: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:19:27.652: INFO: namespace: e2e-tests-downward-api-8h5dl, resource: bindings, ignored listing per whitelist
+Apr 27 14:19:27.670: INFO: namespace e2e-tests-downward-api-8h5dl deletion completed in 6.148550643s
+
+• [SLOW TEST:8.303 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:19:27.670: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-hv6h6
+Apr 27 14:19:31.785: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-hv6h6
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:19:31.788: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:21:32.001: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-hv6h6" for this suite.
+Apr 27 14:21:38.017: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:21:38.103: INFO: namespace: e2e-tests-container-probe-hv6h6, resource: bindings, ignored listing per whitelist
+Apr 27 14:21:38.143: INFO: namespace e2e-tests-container-probe-hv6h6 deletion completed in 6.137923007s
+
+• [SLOW TEST:130.474 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:21:38.144: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-map-4c31c41e-4a26-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:21:38.242: INFO: Waiting up to 5m0s for pod "pod-secrets-4c3248a5-4a26-11e8-a1f3-0206690d449d" in namespace "e2e-tests-secrets-f7dbr" to be "success or failure"
+Apr 27 14:21:38.244: INFO: Pod "pod-secrets-4c3248a5-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.352396ms
+Apr 27 14:21:40.247: INFO: Pod "pod-secrets-4c3248a5-4a26-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005309217s
+STEP: Saw pod success
+Apr 27 14:21:40.247: INFO: Pod "pod-secrets-4c3248a5-4a26-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:21:40.250: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-secrets-4c3248a5-4a26-11e8-a1f3-0206690d449d container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:21:40.275: INFO: Waiting for pod pod-secrets-4c3248a5-4a26-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:21:40.277: INFO: Pod pod-secrets-4c3248a5-4a26-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:21:40.277: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-f7dbr" for this suite.
+Apr 27 14:21:46.290: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:21:46.422: INFO: namespace: e2e-tests-secrets-f7dbr, resource: bindings, ignored listing per whitelist
+Apr 27 14:21:46.438: INFO: namespace e2e-tests-secrets-f7dbr deletion completed in 6.157353024s
+
+• [SLOW TEST:8.294 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:21:46.438: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-5123837b-4a26-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:21:46.537: INFO: Waiting up to 5m0s for pod "pod-secrets-51240000-4a26-11e8-a1f3-0206690d449d" in namespace "e2e-tests-secrets-qrgjg" to be "success or failure"
+Apr 27 14:21:46.540: INFO: Pod "pod-secrets-51240000-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.42733ms
+Apr 27 14:21:48.543: INFO: Pod "pod-secrets-51240000-4a26-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005211575s
+STEP: Saw pod success
+Apr 27 14:21:48.543: INFO: Pod "pod-secrets-51240000-4a26-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:21:48.546: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-secrets-51240000-4a26-11e8-a1f3-0206690d449d container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:21:48.563: INFO: Waiting for pod pod-secrets-51240000-4a26-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:21:48.565: INFO: Pod pod-secrets-51240000-4a26-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:21:48.565: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-qrgjg" for this suite.
+Apr 27 14:21:54.576: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:21:54.681: INFO: namespace: e2e-tests-secrets-qrgjg, resource: bindings, ignored listing per whitelist
+Apr 27 14:21:54.697: INFO: namespace e2e-tests-secrets-qrgjg deletion completed in 6.128581861s
+
+• [SLOW TEST:8.259 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:21:54.697: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:21:54.786: INFO: Waiting up to 5m0s for pod "downward-api-560ec25b-4a26-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-rfrkb" to be "success or failure"
+Apr 27 14:21:54.789: INFO: Pod "downward-api-560ec25b-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.816857ms
+Apr 27 14:21:56.793: INFO: Pod "downward-api-560ec25b-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006083043s
+Apr 27 14:21:58.796: INFO: Pod "downward-api-560ec25b-4a26-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009219695s
+STEP: Saw pod success
+Apr 27 14:21:58.796: INFO: Pod "downward-api-560ec25b-4a26-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:21:58.798: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downward-api-560ec25b-4a26-11e8-a1f3-0206690d449d container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:21:58.816: INFO: Waiting for pod downward-api-560ec25b-4a26-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:21:58.818: INFO: Pod downward-api-560ec25b-4a26-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:21:58.818: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-rfrkb" for this suite.
+Apr 27 14:22:04.832: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:22:04.891: INFO: namespace: e2e-tests-downward-api-rfrkb, resource: bindings, ignored listing per whitelist
+Apr 27 14:22:04.986: INFO: namespace e2e-tests-downward-api-rfrkb deletion completed in 6.164225277s
+
+• [SLOW TEST:10.289 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:22:04.986: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:22:05.104: INFO: Creating simple daemon set daemon-set
+STEP: Check that daemon pods launch on every node of the cluster.
+Apr 27 14:22:05.127: INFO: Number of nodes with available pods: 0
+Apr 27 14:22:05.127: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:22:06.139: INFO: Number of nodes with available pods: 1
+Apr 27 14:22:06.139: INFO: Node ip-10-250-14-38.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:22:07.134: INFO: Number of nodes with available pods: 2
+Apr 27 14:22:07.134: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Update daemon pods image.
+STEP: Check that daemon pods images are updated.
+Apr 27 14:22:07.156: INFO: Wrong image for pod: daemon-set-8t2p7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:07.156: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:08.165: INFO: Wrong image for pod: daemon-set-8t2p7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:08.165: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:09.165: INFO: Wrong image for pod: daemon-set-8t2p7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:09.165: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:10.165: INFO: Wrong image for pod: daemon-set-8t2p7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:10.165: INFO: Pod daemon-set-8t2p7 is not available
+Apr 27 14:22:10.165: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:11.166: INFO: Pod daemon-set-bnwj7 is not available
+Apr 27 14:22:11.167: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:12.165: INFO: Pod daemon-set-bnwj7 is not available
+Apr 27 14:22:12.165: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:13.165: INFO: Pod daemon-set-bnwj7 is not available
+Apr 27 14:22:13.165: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:14.167: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:15.164: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:16.164: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:16.164: INFO: Pod daemon-set-jtr9f is not available
+Apr 27 14:22:17.165: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:17.165: INFO: Pod daemon-set-jtr9f is not available
+Apr 27 14:22:18.165: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:18.165: INFO: Pod daemon-set-jtr9f is not available
+Apr 27 14:22:19.164: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:19.164: INFO: Pod daemon-set-jtr9f is not available
+Apr 27 14:22:20.164: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:20.164: INFO: Pod daemon-set-jtr9f is not available
+Apr 27 14:22:21.164: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:21.165: INFO: Pod daemon-set-jtr9f is not available
+Apr 27 14:22:22.166: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:22.166: INFO: Pod daemon-set-jtr9f is not available
+Apr 27 14:22:23.165: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:23.165: INFO: Pod daemon-set-jtr9f is not available
+Apr 27 14:22:24.164: INFO: Wrong image for pod: daemon-set-jtr9f. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:22:24.164: INFO: Pod daemon-set-jtr9f is not available
+Apr 27 14:22:25.166: INFO: Pod daemon-set-m2t94 is not available
+STEP: Check that daemon pods are still running on every node of the cluster.
+Apr 27 14:22:25.176: INFO: Number of nodes with available pods: 1
+Apr 27 14:22:25.176: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:22:26.184: INFO: Number of nodes with available pods: 1
+Apr 27 14:22:26.184: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:22:27.183: INFO: Number of nodes with available pods: 1
+Apr 27 14:22:27.183: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:22:28.196: INFO: Number of nodes with available pods: 2
+Apr 27 14:22:28.196: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 27 14:22:37.225: INFO: Number of nodes with available pods: 0
+Apr 27 14:22:37.225: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 27 14:22:37.228: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-cn8mx/daemonsets","resourceVersion":"4634"},"items":null}
+
+Apr 27 14:22:37.231: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-cn8mx/pods","resourceVersion":"4634"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:37.239: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-cn8mx" for this suite.
+Apr 27 14:22:43.251: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:22:43.304: INFO: namespace: e2e-tests-daemonsets-cn8mx, resource: bindings, ignored listing per whitelist
+Apr 27 14:22:43.377: INFO: namespace e2e-tests-daemonsets-cn8mx deletion completed in 6.134961205s
+
+• [SLOW TEST:38.391 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:22:43.377: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 27 14:22:46.009: INFO: Successfully updated pod "labelsupdate7312ebbc-4a26-11e8-a1f3-0206690d449d"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:48.029: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-s8mx2" for this suite.
+Apr 27 14:23:10.042: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:23:10.114: INFO: namespace: e2e-tests-downward-api-s8mx2, resource: bindings, ignored listing per whitelist
+Apr 27 14:23:10.166: INFO: namespace e2e-tests-downward-api-s8mx2 deletion completed in 22.133434637s
+
+• [SLOW TEST:26.789 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:23:10.166: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override all
+Apr 27 14:23:10.461: INFO: Waiting up to 5m0s for pod "client-containers-83297ffc-4a26-11e8-a1f3-0206690d449d" in namespace "e2e-tests-containers-qgmrv" to be "success or failure"
+Apr 27 14:23:10.465: INFO: Pod "client-containers-83297ffc-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.036374ms
+Apr 27 14:23:12.470: INFO: Pod "client-containers-83297ffc-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009226531s
+Apr 27 14:23:14.473: INFO: Pod "client-containers-83297ffc-4a26-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012323794s
+STEP: Saw pod success
+Apr 27 14:23:14.473: INFO: Pod "client-containers-83297ffc-4a26-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:23:14.475: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod client-containers-83297ffc-4a26-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:23:14.495: INFO: Waiting for pod client-containers-83297ffc-4a26-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:23:14.498: INFO: Pod client-containers-83297ffc-4a26-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:23:14.498: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-qgmrv" for this suite.
+Apr 27 14:23:20.510: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:23:20.573: INFO: namespace: e2e-tests-containers-qgmrv, resource: bindings, ignored listing per whitelist
+Apr 27 14:23:20.627: INFO: namespace e2e-tests-containers-qgmrv deletion completed in 6.125711381s
+
+• [SLOW TEST:10.461 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:23:20.627: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Apr 27 14:23:20.721: INFO: Waiting up to 5m0s for pod "pod-89473b46-4a26-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-mc75m" to be "success or failure"
+Apr 27 14:23:20.723: INFO: Pod "pod-89473b46-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.170267ms
+Apr 27 14:23:22.727: INFO: Pod "pod-89473b46-4a26-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005580199s
+STEP: Saw pod success
+Apr 27 14:23:22.727: INFO: Pod "pod-89473b46-4a26-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:23:22.729: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-89473b46-4a26-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:23:22.747: INFO: Waiting for pod pod-89473b46-4a26-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:23:22.749: INFO: Pod pod-89473b46-4a26-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:23:22.749: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-mc75m" for this suite.
+Apr 27 14:23:28.766: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:23:28.808: INFO: namespace: e2e-tests-emptydir-mc75m, resource: bindings, ignored listing per whitelist
+Apr 27 14:23:28.883: INFO: namespace e2e-tests-emptydir-mc75m deletion completed in 6.129880816s
+
+• [SLOW TEST:8.256 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:23:28.884: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-qvnt6 A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-qvnt6;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-qvnt6 A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-qvnt6;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-qvnt6.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-qvnt6.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-qvnt6.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-qvnt6.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-qvnt6.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-qvnt6.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-qvnt6.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-qvnt6.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-qvnt6.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-qvnt6.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-qvnt6.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-qvnt6.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-qvnt6.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 223.188.70.100.in-addr.arpa. PTR)" && echo OK > /results/100.70.188.223_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 223.188.70.100.in-addr.arpa. PTR)" && echo OK > /results/100.70.188.223_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-qvnt6 A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-qvnt6;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-qvnt6 A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-qvnt6;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-qvnt6.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-qvnt6.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-qvnt6.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-qvnt6.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-qvnt6.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-qvnt6.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-qvnt6.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-qvnt6.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-qvnt6.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-qvnt6.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-qvnt6.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-qvnt6.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-qvnt6.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 223.188.70.100.in-addr.arpa. PTR)" && echo OK > /results/100.70.188.223_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 223.188.70.100.in-addr.arpa. PTR)" && echo OK > /results/100.70.188.223_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Apr 27 14:23:52.240: INFO: DNS probes using dns-test-8e34a4e1-4a26-11e8-a1f3-0206690d449d succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:23:52.291: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-qvnt6" for this suite.
+Apr 27 14:23:58.306: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:23:58.421: INFO: namespace: e2e-tests-dns-qvnt6, resource: bindings, ignored listing per whitelist
+Apr 27 14:23:58.428: INFO: namespace e2e-tests-dns-qvnt6 deletion completed in 6.13337584s
+
+• [SLOW TEST:29.545 seconds]
+[sig-network] DNS
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:23:58.428: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:23:58.528: INFO: Waiting up to 5m0s for pod "downwardapi-volume-9fd03cf0-4a26-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-52rqb" to be "success or failure"
+Apr 27 14:23:58.532: INFO: Pod "downwardapi-volume-9fd03cf0-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.137746ms
+Apr 27 14:24:00.535: INFO: Pod "downwardapi-volume-9fd03cf0-4a26-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006078807s
+STEP: Saw pod success
+Apr 27 14:24:00.535: INFO: Pod "downwardapi-volume-9fd03cf0-4a26-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:24:00.537: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-9fd03cf0-4a26-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:24:00.566: INFO: Waiting for pod downwardapi-volume-9fd03cf0-4a26-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:24:00.570: INFO: Pod downwardapi-volume-9fd03cf0-4a26-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:24:00.570: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-52rqb" for this suite.
+Apr 27 14:24:06.582: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:24:06.651: INFO: namespace: e2e-tests-projected-52rqb, resource: bindings, ignored listing per whitelist
+Apr 27 14:24:06.706: INFO: namespace e2e-tests-projected-52rqb deletion completed in 6.133160211s
+
+• [SLOW TEST:8.278 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:24:06.706: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:24:06.814: INFO: pod1.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod3", UID:"a4c0abe9-4a26-11e8-aa31-6e07c8c44ecd", Controller:(*bool)(0xc4210d1b26), BlockOwnerDeletion:(*bool)(0xc4210d1b27)}}
+Apr 27 14:24:06.819: INFO: pod2.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod1", UID:"a4bf4a50-4a26-11e8-aa31-6e07c8c44ecd", Controller:(*bool)(0xc421b2ee76), BlockOwnerDeletion:(*bool)(0xc421b2ee77)}}
+Apr 27 14:24:06.826: INFO: pod3.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod2", UID:"a4bfd327-4a26-11e8-aa31-6e07c8c44ecd", Controller:(*bool)(0xc4210d1ce6), BlockOwnerDeletion:(*bool)(0xc4210d1ce7)}}
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:24:11.833: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-klgpt" for this suite.
+Apr 27 14:24:17.845: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:24:17.921: INFO: namespace: e2e-tests-gc-klgpt, resource: bindings, ignored listing per whitelist
+Apr 27 14:24:17.970: INFO: namespace e2e-tests-gc-klgpt deletion completed in 6.133923845s
+
+• [SLOW TEST:11.264 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:24:17.971: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:24:18.086: INFO: (0) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.859531ms)
+Apr 27 14:24:18.090: INFO: (1) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.44788ms)
+Apr 27 14:24:18.095: INFO: (2) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.414914ms)
+Apr 27 14:24:18.099: INFO: (3) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.231913ms)
+Apr 27 14:24:18.103: INFO: (4) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.32522ms)
+Apr 27 14:24:18.109: INFO: (5) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.626489ms)
+Apr 27 14:24:18.114: INFO: (6) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.544435ms)
+Apr 27 14:24:18.118: INFO: (7) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.832063ms)
+Apr 27 14:24:18.123: INFO: (8) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.171147ms)
+Apr 27 14:24:18.128: INFO: (9) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.832867ms)
+Apr 27 14:24:18.132: INFO: (10) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.008543ms)
+Apr 27 14:24:18.136: INFO: (11) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.644548ms)
+Apr 27 14:24:18.147: INFO: (12) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 10.323906ms)
+Apr 27 14:24:18.156: INFO: (13) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 9.24672ms)
+Apr 27 14:24:18.160: INFO: (14) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.561491ms)
+Apr 27 14:24:18.165: INFO: (15) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.291186ms)
+Apr 27 14:24:18.170: INFO: (16) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.087218ms)
+Apr 27 14:24:18.174: INFO: (17) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.532385ms)
+Apr 27 14:24:18.179: INFO: (18) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.498835ms)
+Apr 27 14:24:18.183: INFO: (19) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.826059ms)
+[AfterEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:24:18.183: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-gknd2" for this suite.
+Apr 27 14:24:24.195: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:24:24.304: INFO: namespace: e2e-tests-proxy-gknd2, resource: bindings, ignored listing per whitelist
+Apr 27 14:24:24.324: INFO: namespace e2e-tests-proxy-gknd2 deletion completed in 6.138163892s
+
+• [SLOW TEST:6.353 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:24:24.325: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:24:24.442: INFO: Waiting up to 5m0s for pod "downward-api-af4123f4-4a26-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-h9ckn" to be "success or failure"
+Apr 27 14:24:24.445: INFO: Pod "downward-api-af4123f4-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.579069ms
+Apr 27 14:24:26.448: INFO: Pod "downward-api-af4123f4-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005671823s
+Apr 27 14:24:28.451: INFO: Pod "downward-api-af4123f4-4a26-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008734039s
+STEP: Saw pod success
+Apr 27 14:24:28.451: INFO: Pod "downward-api-af4123f4-4a26-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:24:28.454: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downward-api-af4123f4-4a26-11e8-a1f3-0206690d449d container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:24:28.475: INFO: Waiting for pod downward-api-af4123f4-4a26-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:24:28.477: INFO: Pod downward-api-af4123f4-4a26-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:24:28.477: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-h9ckn" for this suite.
+Apr 27 14:24:34.492: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:24:34.625: INFO: namespace: e2e-tests-downward-api-h9ckn, resource: bindings, ignored listing per whitelist
+Apr 27 14:24:34.625: INFO: namespace e2e-tests-downward-api-h9ckn deletion completed in 6.145091184s
+
+• [SLOW TEST:10.301 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:24:34.626: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Apr 27 14:24:34.723: INFO: Waiting up to 5m0s for pod "pod-b5630ba9-4a26-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-hhnsp" to be "success or failure"
+Apr 27 14:24:34.728: INFO: Pod "pod-b5630ba9-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 5.084191ms
+Apr 27 14:24:36.732: INFO: Pod "pod-b5630ba9-4a26-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009034612s
+STEP: Saw pod success
+Apr 27 14:24:36.732: INFO: Pod "pod-b5630ba9-4a26-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:24:36.734: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-b5630ba9-4a26-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:24:36.754: INFO: Waiting for pod pod-b5630ba9-4a26-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:24:36.757: INFO: Pod pod-b5630ba9-4a26-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:24:36.757: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-hhnsp" for this suite.
+Apr 27 14:24:42.769: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:24:42.889: INFO: namespace: e2e-tests-emptydir-hhnsp, resource: bindings, ignored listing per whitelist
+Apr 27 14:24:42.892: INFO: namespace e2e-tests-emptydir-hhnsp deletion completed in 6.131404592s
+
+• [SLOW TEST:8.266 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:24:42.892: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:24:42.977: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:24:52.045: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-nnk97" for this suite.
+Apr 27 14:24:58.057: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:24:58.165: INFO: namespace: e2e-tests-custom-resource-definition-nnk97, resource: bindings, ignored listing per whitelist
+Apr 27 14:24:58.178: INFO: namespace e2e-tests-custom-resource-definition-nnk97 deletion completed in 6.128948471s
+
+• [SLOW TEST:15.286 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:24:58.178: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name s-test-opt-del-c3777cca-4a26-11e8-a1f3-0206690d449d
+STEP: Creating secret with name s-test-opt-upd-c3777d12-4a26-11e8-a1f3-0206690d449d
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-c3777cca-4a26-11e8-a1f3-0206690d449d
+STEP: Updating secret s-test-opt-upd-c3777d12-4a26-11e8-a1f3-0206690d449d
+STEP: Creating secret with name s-test-opt-create-c3777d31-4a26-11e8-a1f3-0206690d449d
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:25:02.637: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-pmwqk" for this suite.
+Apr 27 14:25:24.650: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:25:24.706: INFO: namespace: e2e-tests-projected-pmwqk, resource: bindings, ignored listing per whitelist
+Apr 27 14:25:24.768: INFO: namespace e2e-tests-projected-pmwqk deletion completed in 22.12684487s
+
+• [SLOW TEST:26.590 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:25:24.768: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:25:24.865: INFO: Requires at least 2 nodes (not -1)
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+Apr 27 14:25:24.871: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-wgxm7/daemonsets","resourceVersion":"5090"},"items":null}
+
+Apr 27 14:25:24.874: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-wgxm7/pods","resourceVersion":"5090"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:25:24.881: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-wgxm7" for this suite.
+Apr 27 14:25:30.894: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:25:31.004: INFO: namespace: e2e-tests-daemonsets-wgxm7, resource: bindings, ignored listing per whitelist
+Apr 27 14:25:31.011: INFO: namespace e2e-tests-daemonsets-wgxm7 deletion completed in 6.125594094s
+
+S [SKIPPING] [6.243 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should rollback without unnecessary restarts [Conformance] [It]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+
+  Apr 27 14:25:24.865: Requires at least 2 nodes (not -1)
+
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:296
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:25:31.012: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-d6fdf0ad-4a26-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:25:31.106: INFO: Waiting up to 5m0s for pod "pod-secrets-d6fe6695-4a26-11e8-a1f3-0206690d449d" in namespace "e2e-tests-secrets-9vmvs" to be "success or failure"
+Apr 27 14:25:31.108: INFO: Pod "pod-secrets-d6fe6695-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.207659ms
+Apr 27 14:25:33.111: INFO: Pod "pod-secrets-d6fe6695-4a26-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00530416s
+STEP: Saw pod success
+Apr 27 14:25:33.111: INFO: Pod "pod-secrets-d6fe6695-4a26-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:25:33.113: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-secrets-d6fe6695-4a26-11e8-a1f3-0206690d449d container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:25:33.129: INFO: Waiting for pod pod-secrets-d6fe6695-4a26-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:25:33.135: INFO: Pod pod-secrets-d6fe6695-4a26-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:25:33.135: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-9vmvs" for this suite.
+Apr 27 14:25:39.147: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:25:39.247: INFO: namespace: e2e-tests-secrets-9vmvs, resource: bindings, ignored listing per whitelist
+Apr 27 14:25:39.280: INFO: namespace e2e-tests-secrets-9vmvs deletion completed in 6.141347859s
+
+• [SLOW TEST:8.268 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:25:39.280: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Apr 27 14:25:39.371: INFO: Waiting up to 5m0s for pod "pod-dbeb9055-4a26-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-tvz2r" to be "success or failure"
+Apr 27 14:25:39.373: INFO: Pod "pod-dbeb9055-4a26-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.167989ms
+Apr 27 14:25:41.378: INFO: Pod "pod-dbeb9055-4a26-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006281497s
+STEP: Saw pod success
+Apr 27 14:25:41.378: INFO: Pod "pod-dbeb9055-4a26-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:25:41.381: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-dbeb9055-4a26-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:25:41.397: INFO: Waiting for pod pod-dbeb9055-4a26-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:25:41.400: INFO: Pod pod-dbeb9055-4a26-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:25:41.401: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-tvz2r" for this suite.
+Apr 27 14:25:47.413: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:25:47.537: INFO: namespace: e2e-tests-emptydir-tvz2r, resource: bindings, ignored listing per whitelist
+Apr 27 14:25:47.564: INFO: namespace e2e-tests-emptydir-tvz2r deletion completed in 6.160650452s
+
+• [SLOW TEST:8.285 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:25:47.565: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-8vz45
+[It] Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-8vz45
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-8vz45
+Apr 27 14:25:47.707: INFO: Found 0 stateful pods, waiting for 1
+Apr 27 14:25:57.712: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will not halt with unhealthy stateful pod
+Apr 27 14:25:57.715: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-8vz45 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:26:06.580: INFO: stderr: ""
+Apr 27 14:26:06.580: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:26:06.584: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Apr 27 14:26:16.588: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:26:16.588: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:26:16.599: INFO: POD   NODE                                        PHASE    GRACE  CONDITIONS
+Apr 27 14:26:16.599: INFO: ss-0  ip-10-250-14-38.eu-west-1.compute.internal  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:06 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  }]
+Apr 27 14:26:16.599: INFO: 
+Apr 27 14:26:16.599: INFO: StatefulSet ss has not reached scale 3, at 1
+Apr 27 14:26:17.603: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.996880156s
+Apr 27 14:26:18.607: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.992983549s
+Apr 27 14:26:19.610: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.989545636s
+Apr 27 14:26:20.614: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.98575597s
+Apr 27 14:26:21.617: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.982330568s
+Apr 27 14:26:22.622: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.978460143s
+Apr 27 14:26:23.625: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.974290879s
+Apr 27 14:26:24.629: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.970694215s
+Apr 27 14:26:25.633: INFO: Verifying statefulset ss doesn't scale past 3 for another 966.746493ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-8vz45
+Apr 27 14:26:26.637: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-8vz45 ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:26:26.886: INFO: stderr: ""
+Apr 27 14:26:26.886: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:26:26.886: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-8vz45 ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:26:27.163: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Apr 27 14:26:27.163: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: 
+Apr 27 14:26:27.163: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-8vz45 ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:26:27.472: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Apr 27 14:26:27.472: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Apr 27 14:26:27.476: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=false
+Apr 27 14:26:37.480: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:26:37.480: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:26:37.480: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Scale down will not halt with unhealthy stateful pod
+Apr 27 14:26:37.489: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-8vz45 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:26:37.782: INFO: stderr: ""
+Apr 27 14:26:37.782: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:26:37.782: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-8vz45 ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:26:38.058: INFO: stderr: ""
+Apr 27 14:26:38.058: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:26:38.058: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-8vz45 ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:26:38.352: INFO: stderr: ""
+Apr 27 14:26:38.352: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:26:38.352: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:26:38.355: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 2
+Apr 27 14:26:48.362: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:26:48.362: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:26:48.362: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:26:48.370: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Apr 27 14:26:48.370: INFO: ss-0  ip-10-250-14-38.eu-west-1.compute.internal   Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  }]
+Apr 27 14:26:48.370: INFO: ss-1  ip-10-250-12-147.eu-west-1.compute.internal  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:48.370: INFO: ss-2  ip-10-250-14-38.eu-west-1.compute.internal   Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:39 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:48.370: INFO: 
+Apr 27 14:26:48.370: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 27 14:26:49.374: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Apr 27 14:26:49.374: INFO: ss-0  ip-10-250-14-38.eu-west-1.compute.internal   Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  }]
+Apr 27 14:26:49.374: INFO: ss-1  ip-10-250-12-147.eu-west-1.compute.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:49.374: INFO: ss-2  ip-10-250-14-38.eu-west-1.compute.internal   Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:39 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:49.374: INFO: 
+Apr 27 14:26:49.374: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 27 14:26:50.378: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Apr 27 14:26:50.378: INFO: ss-0  ip-10-250-14-38.eu-west-1.compute.internal   Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  }]
+Apr 27 14:26:50.378: INFO: ss-1  ip-10-250-12-147.eu-west-1.compute.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:50.378: INFO: ss-2  ip-10-250-14-38.eu-west-1.compute.internal   Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:39 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:50.378: INFO: 
+Apr 27 14:26:50.378: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 27 14:26:51.382: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Apr 27 14:26:51.383: INFO: ss-0  ip-10-250-14-38.eu-west-1.compute.internal   Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  }]
+Apr 27 14:26:51.383: INFO: ss-1  ip-10-250-12-147.eu-west-1.compute.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:51.383: INFO: ss-2  ip-10-250-14-38.eu-west-1.compute.internal   Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:39 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:51.383: INFO: 
+Apr 27 14:26:51.383: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 27 14:26:52.386: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Apr 27 14:26:52.386: INFO: ss-0  ip-10-250-14-38.eu-west-1.compute.internal   Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  }]
+Apr 27 14:26:52.386: INFO: ss-1  ip-10-250-12-147.eu-west-1.compute.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:52.386: INFO: ss-2  ip-10-250-14-38.eu-west-1.compute.internal   Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:39 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:52.386: INFO: 
+Apr 27 14:26:52.386: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 27 14:26:53.390: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Apr 27 14:26:53.390: INFO: ss-0  ip-10-250-14-38.eu-west-1.compute.internal   Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  }]
+Apr 27 14:26:53.390: INFO: ss-1  ip-10-250-12-147.eu-west-1.compute.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:53.390: INFO: ss-2  ip-10-250-14-38.eu-west-1.compute.internal   Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:39 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:53.390: INFO: 
+Apr 27 14:26:53.390: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 27 14:26:54.394: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Apr 27 14:26:54.394: INFO: ss-0  ip-10-250-14-38.eu-west-1.compute.internal   Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  }]
+Apr 27 14:26:54.394: INFO: ss-1  ip-10-250-12-147.eu-west-1.compute.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:54.394: INFO: ss-2  ip-10-250-14-38.eu-west-1.compute.internal   Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:39 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:54.394: INFO: 
+Apr 27 14:26:54.394: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 27 14:26:55.398: INFO: POD   NODE                                        PHASE    GRACE  CONDITIONS
+Apr 27 14:26:55.398: INFO: ss-0  ip-10-250-14-38.eu-west-1.compute.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:25:47 +0000 UTC  }]
+Apr 27 14:26:55.398: INFO: ss-2  ip-10-250-14-38.eu-west-1.compute.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:39 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:26:16 +0000 UTC  }]
+Apr 27 14:26:55.398: INFO: 
+Apr 27 14:26:55.398: INFO: StatefulSet ss has not reached scale 0, at 2
+Apr 27 14:26:56.401: INFO: Verifying statefulset ss doesn't scale past 0 for another 1.969586652s
+Apr 27 14:26:57.404: INFO: Verifying statefulset ss doesn't scale past 0 for another 966.101108ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-8vz45
+Apr 27 14:26:58.408: INFO: Scaling statefulset ss to 0
+Apr 27 14:26:58.416: INFO: Waiting for statefulset status.replicas updated to 0
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:26:58.419: INFO: Deleting all statefulset in ns e2e-tests-statefulset-8vz45
+Apr 27 14:26:58.422: INFO: Scaling statefulset ss to 0
+Apr 27 14:26:58.431: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:26:58.433: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:26:58.442: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-8vz45" for this suite.
+Apr 27 14:27:04.455: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:27:04.502: INFO: namespace: e2e-tests-statefulset-8vz45, resource: bindings, ignored listing per whitelist
+Apr 27 14:27:04.583: INFO: namespace e2e-tests-statefulset-8vz45 deletion completed in 6.137083026s
+
+• [SLOW TEST:77.018 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Burst scaling should run to completion even with unhealthy pods [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:27:04.583: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:27:04.718: INFO: Waiting up to 5m0s for pod "downwardapi-volume-0eca5e1d-4a27-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-g8tzm" to be "success or failure"
+Apr 27 14:27:04.722: INFO: Pod "downwardapi-volume-0eca5e1d-4a27-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.602968ms
+Apr 27 14:27:06.725: INFO: Pod "downwardapi-volume-0eca5e1d-4a27-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00679795s
+STEP: Saw pod success
+Apr 27 14:27:06.725: INFO: Pod "downwardapi-volume-0eca5e1d-4a27-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:27:06.728: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-0eca5e1d-4a27-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:27:06.746: INFO: Waiting for pod downwardapi-volume-0eca5e1d-4a27-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:27:06.749: INFO: Pod downwardapi-volume-0eca5e1d-4a27-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:27:06.749: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-g8tzm" for this suite.
+Apr 27 14:27:12.764: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:27:12.859: INFO: namespace: e2e-tests-downward-api-g8tzm, resource: bindings, ignored listing per whitelist
+Apr 27 14:27:12.892: INFO: namespace e2e-tests-downward-api-g8tzm deletion completed in 6.140089512s
+
+• [SLOW TEST:8.309 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:27:12.892: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-lr4d8
+I0427 14:27:12.980351      13 runners.go:175] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-lr4d8, replica count: 1
+I0427 14:27:13.980831      13 runners.go:175] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0427 14:27:14.981064      13 runners.go:175] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Apr 27 14:27:15.090: INFO: Created: latency-svc-flnv2
+Apr 27 14:27:15.096: INFO: Got endpoints: latency-svc-flnv2 [15.029472ms]
+Apr 27 14:27:15.109: INFO: Created: latency-svc-hgmm8
+Apr 27 14:27:15.115: INFO: Created: latency-svc-jnt56
+Apr 27 14:27:15.120: INFO: Created: latency-svc-ptqq4
+Apr 27 14:27:15.120: INFO: Got endpoints: latency-svc-jnt56 [23.355448ms]
+Apr 27 14:27:15.120: INFO: Got endpoints: latency-svc-hgmm8 [23.870043ms]
+Apr 27 14:27:15.124: INFO: Got endpoints: latency-svc-ptqq4 [26.85992ms]
+Apr 27 14:27:15.125: INFO: Created: latency-svc-46lks
+Apr 27 14:27:15.132: INFO: Got endpoints: latency-svc-46lks [35.310079ms]
+Apr 27 14:27:15.138: INFO: Created: latency-svc-h7ptb
+Apr 27 14:27:15.138: INFO: Got endpoints: latency-svc-h7ptb [41.236937ms]
+Apr 27 14:27:15.146: INFO: Created: latency-svc-nkhgq
+Apr 27 14:27:15.148: INFO: Created: latency-svc-4qrqq
+Apr 27 14:27:15.148: INFO: Got endpoints: latency-svc-4qrqq [51.373645ms]
+Apr 27 14:27:15.149: INFO: Created: latency-svc-qpl8q
+Apr 27 14:27:15.149: INFO: Got endpoints: latency-svc-nkhgq [51.906172ms]
+Apr 27 14:27:15.150: INFO: Got endpoints: latency-svc-qpl8q [53.111717ms]
+Apr 27 14:27:15.153: INFO: Created: latency-svc-b42db
+Apr 27 14:27:15.155: INFO: Got endpoints: latency-svc-b42db [58.193011ms]
+Apr 27 14:27:15.161: INFO: Created: latency-svc-bw2zb
+Apr 27 14:27:15.162: INFO: Got endpoints: latency-svc-bw2zb [65.027563ms]
+Apr 27 14:27:15.165: INFO: Created: latency-svc-5sf6v
+Apr 27 14:27:15.170: INFO: Created: latency-svc-7dh7d
+Apr 27 14:27:15.171: INFO: Got endpoints: latency-svc-5sf6v [73.595186ms]
+Apr 27 14:27:15.177: INFO: Got endpoints: latency-svc-7dh7d [79.260327ms]
+Apr 27 14:27:15.178: INFO: Created: latency-svc-qkg6g
+Apr 27 14:27:15.182: INFO: Got endpoints: latency-svc-qkg6g [84.22875ms]
+Apr 27 14:27:15.186: INFO: Created: latency-svc-pkv45
+Apr 27 14:27:15.190: INFO: Got endpoints: latency-svc-pkv45 [93.69514ms]
+Apr 27 14:27:15.194: INFO: Created: latency-svc-wkgt6
+Apr 27 14:27:15.194: INFO: Got endpoints: latency-svc-wkgt6 [97.076881ms]
+Apr 27 14:27:15.194: INFO: Created: latency-svc-g6pr6
+Apr 27 14:27:15.198: INFO: Got endpoints: latency-svc-g6pr6 [76.836289ms]
+Apr 27 14:27:15.213: INFO: Created: latency-svc-5dk4r
+Apr 27 14:27:15.213: INFO: Got endpoints: latency-svc-5dk4r [92.00117ms]
+Apr 27 14:27:15.214: INFO: Created: latency-svc-d84fm
+Apr 27 14:27:15.214: INFO: Got endpoints: latency-svc-d84fm [89.936281ms]
+Apr 27 14:27:15.217: INFO: Created: latency-svc-j8pnt
+Apr 27 14:27:15.222: INFO: Got endpoints: latency-svc-j8pnt [89.760854ms]
+Apr 27 14:27:15.222: INFO: Created: latency-svc-qplwh
+Apr 27 14:27:15.226: INFO: Got endpoints: latency-svc-qplwh [87.878367ms]
+Apr 27 14:27:15.229: INFO: Created: latency-svc-5txmt
+Apr 27 14:27:15.230: INFO: Got endpoints: latency-svc-5txmt [81.499969ms]
+Apr 27 14:27:15.239: INFO: Created: latency-svc-5rhm7
+Apr 27 14:27:15.244: INFO: Got endpoints: latency-svc-5rhm7 [94.805592ms]
+Apr 27 14:27:15.245: INFO: Created: latency-svc-rsvqq
+Apr 27 14:27:15.259: INFO: Created: latency-svc-7k9zl
+Apr 27 14:27:15.259: INFO: Got endpoints: latency-svc-rsvqq [108.975482ms]
+Apr 27 14:27:15.262: INFO: Created: latency-svc-msfdk
+Apr 27 14:27:15.263: INFO: Got endpoints: latency-svc-7k9zl [107.120861ms]
+Apr 27 14:27:15.264: INFO: Got endpoints: latency-svc-msfdk [101.572988ms]
+Apr 27 14:27:15.268: INFO: Created: latency-svc-m4xr4
+Apr 27 14:27:15.273: INFO: Got endpoints: latency-svc-m4xr4 [101.975134ms]
+Apr 27 14:27:15.274: INFO: Created: latency-svc-qsvz7
+Apr 27 14:27:15.294: INFO: Created: latency-svc-zpgwt
+Apr 27 14:27:15.298: INFO: Created: latency-svc-t22vr
+Apr 27 14:27:15.302: INFO: Got endpoints: latency-svc-zpgwt [120.418118ms]
+Apr 27 14:27:15.303: INFO: Got endpoints: latency-svc-qsvz7 [125.742329ms]
+Apr 27 14:27:15.303: INFO: Got endpoints: latency-svc-t22vr [105.828974ms]
+Apr 27 14:27:15.304: INFO: Created: latency-svc-jfk5w
+Apr 27 14:27:15.306: INFO: Got endpoints: latency-svc-jfk5w [93.167921ms]
+Apr 27 14:27:15.310: INFO: Created: latency-svc-tb8fd
+Apr 27 14:27:15.315: INFO: Created: latency-svc-7mc9x
+Apr 27 14:27:15.315: INFO: Got endpoints: latency-svc-tb8fd [101.740457ms]
+Apr 27 14:27:15.317: INFO: Got endpoints: latency-svc-7mc9x [126.77474ms]
+Apr 27 14:27:15.322: INFO: Created: latency-svc-fdwwb
+Apr 27 14:27:15.325: INFO: Got endpoints: latency-svc-fdwwb [110.66501ms]
+Apr 27 14:27:15.327: INFO: Created: latency-svc-zbm28
+Apr 27 14:27:15.331: INFO: Created: latency-svc-7fv9w
+Apr 27 14:27:15.336: INFO: Created: latency-svc-mmqww
+Apr 27 14:27:15.348: INFO: Got endpoints: latency-svc-zbm28 [125.946523ms]
+Apr 27 14:27:15.349: INFO: Created: latency-svc-sn29g
+Apr 27 14:27:15.354: INFO: Created: latency-svc-qhdx2
+Apr 27 14:27:15.361: INFO: Created: latency-svc-ckqcj
+Apr 27 14:27:15.364: INFO: Created: latency-svc-df2lt
+Apr 27 14:27:15.368: INFO: Created: latency-svc-tlpz6
+Apr 27 14:27:15.376: INFO: Created: latency-svc-tzw5h
+Apr 27 14:27:15.379: INFO: Created: latency-svc-fgl6c
+Apr 27 14:27:15.385: INFO: Created: latency-svc-qrnlh
+Apr 27 14:27:15.393: INFO: Got endpoints: latency-svc-7fv9w [162.815562ms]
+Apr 27 14:27:15.394: INFO: Created: latency-svc-htt4s
+Apr 27 14:27:15.397: INFO: Created: latency-svc-shz5w
+Apr 27 14:27:15.408: INFO: Created: latency-svc-77vph
+Apr 27 14:27:15.411: INFO: Created: latency-svc-z6k8m
+Apr 27 14:27:15.416: INFO: Created: latency-svc-t6cxv
+Apr 27 14:27:15.428: INFO: Created: latency-svc-v7kz8
+Apr 27 14:27:15.444: INFO: Got endpoints: latency-svc-mmqww [215.243733ms]
+Apr 27 14:27:15.459: INFO: Created: latency-svc-2rqrr
+Apr 27 14:27:15.494: INFO: Got endpoints: latency-svc-sn29g [249.675892ms]
+Apr 27 14:27:15.505: INFO: Created: latency-svc-bkmgm
+Apr 27 14:27:15.543: INFO: Got endpoints: latency-svc-qhdx2 [283.594723ms]
+Apr 27 14:27:15.553: INFO: Created: latency-svc-drk87
+Apr 27 14:27:15.593: INFO: Got endpoints: latency-svc-ckqcj [330.686389ms]
+Apr 27 14:27:15.602: INFO: Created: latency-svc-t946s
+Apr 27 14:27:15.645: INFO: Got endpoints: latency-svc-df2lt [381.081395ms]
+Apr 27 14:27:15.654: INFO: Created: latency-svc-5vrp5
+Apr 27 14:27:15.693: INFO: Got endpoints: latency-svc-tlpz6 [419.760852ms]
+Apr 27 14:27:15.704: INFO: Created: latency-svc-5tvx6
+Apr 27 14:27:15.744: INFO: Got endpoints: latency-svc-tzw5h [441.503818ms]
+Apr 27 14:27:15.759: INFO: Created: latency-svc-k7fk7
+Apr 27 14:27:15.792: INFO: Got endpoints: latency-svc-fgl6c [489.954138ms]
+Apr 27 14:27:15.803: INFO: Created: latency-svc-88crb
+Apr 27 14:27:15.843: INFO: Got endpoints: latency-svc-qrnlh [539.724298ms]
+Apr 27 14:27:15.852: INFO: Created: latency-svc-nxf2r
+Apr 27 14:27:15.893: INFO: Got endpoints: latency-svc-htt4s [587.1795ms]
+Apr 27 14:27:15.902: INFO: Created: latency-svc-vfbmd
+Apr 27 14:27:15.943: INFO: Got endpoints: latency-svc-shz5w [627.8721ms]
+Apr 27 14:27:15.952: INFO: Created: latency-svc-7j5k8
+Apr 27 14:27:15.995: INFO: Got endpoints: latency-svc-77vph [678.23424ms]
+Apr 27 14:27:16.003: INFO: Created: latency-svc-dw94m
+Apr 27 14:27:16.043: INFO: Got endpoints: latency-svc-z6k8m [717.502225ms]
+Apr 27 14:27:16.052: INFO: Created: latency-svc-2522v
+Apr 27 14:27:16.093: INFO: Got endpoints: latency-svc-t6cxv [744.922389ms]
+Apr 27 14:27:16.101: INFO: Created: latency-svc-ck9h5
+Apr 27 14:27:16.145: INFO: Got endpoints: latency-svc-v7kz8 [751.610733ms]
+Apr 27 14:27:16.158: INFO: Created: latency-svc-999tc
+Apr 27 14:27:16.193: INFO: Got endpoints: latency-svc-2rqrr [748.566433ms]
+Apr 27 14:27:16.201: INFO: Created: latency-svc-98t9l
+Apr 27 14:27:16.243: INFO: Got endpoints: latency-svc-bkmgm [748.918697ms]
+Apr 27 14:27:16.250: INFO: Created: latency-svc-5hhjp
+Apr 27 14:27:16.293: INFO: Got endpoints: latency-svc-drk87 [747.688439ms]
+Apr 27 14:27:16.309: INFO: Created: latency-svc-grfsf
+Apr 27 14:27:16.344: INFO: Got endpoints: latency-svc-t946s [750.144892ms]
+Apr 27 14:27:16.353: INFO: Created: latency-svc-45v6c
+Apr 27 14:27:16.395: INFO: Got endpoints: latency-svc-5vrp5 [750.175639ms]
+Apr 27 14:27:16.403: INFO: Created: latency-svc-wq8pv
+Apr 27 14:27:16.465: INFO: Got endpoints: latency-svc-5tvx6 [771.43801ms]
+Apr 27 14:27:16.492: INFO: Created: latency-svc-kzsj5
+Apr 27 14:27:16.503: INFO: Got endpoints: latency-svc-k7fk7 [758.941698ms]
+Apr 27 14:27:16.518: INFO: Created: latency-svc-mzcfr
+Apr 27 14:27:16.543: INFO: Got endpoints: latency-svc-88crb [750.554742ms]
+Apr 27 14:27:16.552: INFO: Created: latency-svc-rf9tl
+Apr 27 14:27:16.593: INFO: Got endpoints: latency-svc-nxf2r [749.751668ms]
+Apr 27 14:27:16.608: INFO: Created: latency-svc-725q9
+Apr 27 14:27:16.644: INFO: Got endpoints: latency-svc-vfbmd [750.295201ms]
+Apr 27 14:27:16.657: INFO: Created: latency-svc-8xmh8
+Apr 27 14:27:16.692: INFO: Got endpoints: latency-svc-7j5k8 [749.477399ms]
+Apr 27 14:27:16.702: INFO: Created: latency-svc-r5ns5
+Apr 27 14:27:16.743: INFO: Got endpoints: latency-svc-dw94m [748.344565ms]
+Apr 27 14:27:16.763: INFO: Created: latency-svc-gtk6k
+Apr 27 14:27:16.794: INFO: Got endpoints: latency-svc-2522v [750.99172ms]
+Apr 27 14:27:16.803: INFO: Created: latency-svc-rqz9s
+Apr 27 14:27:16.843: INFO: Got endpoints: latency-svc-ck9h5 [749.92191ms]
+Apr 27 14:27:16.851: INFO: Created: latency-svc-2zl5b
+Apr 27 14:27:16.893: INFO: Got endpoints: latency-svc-999tc [748.083826ms]
+Apr 27 14:27:16.901: INFO: Created: latency-svc-w7m6p
+Apr 27 14:27:16.943: INFO: Got endpoints: latency-svc-98t9l [749.885969ms]
+Apr 27 14:27:16.951: INFO: Created: latency-svc-n7k9j
+Apr 27 14:27:16.994: INFO: Got endpoints: latency-svc-5hhjp [751.132348ms]
+Apr 27 14:27:17.003: INFO: Created: latency-svc-pkzwp
+Apr 27 14:27:17.050: INFO: Got endpoints: latency-svc-grfsf [756.913927ms]
+Apr 27 14:27:17.071: INFO: Created: latency-svc-w5t4t
+Apr 27 14:27:17.092: INFO: Got endpoints: latency-svc-45v6c [748.611193ms]
+Apr 27 14:27:17.101: INFO: Created: latency-svc-gm9v8
+Apr 27 14:27:17.143: INFO: Got endpoints: latency-svc-wq8pv [747.140475ms]
+Apr 27 14:27:17.151: INFO: Created: latency-svc-zzf4b
+Apr 27 14:27:17.193: INFO: Got endpoints: latency-svc-kzsj5 [727.932601ms]
+Apr 27 14:27:17.201: INFO: Created: latency-svc-mkbt8
+Apr 27 14:27:17.248: INFO: Got endpoints: latency-svc-mzcfr [744.889607ms]
+Apr 27 14:27:17.260: INFO: Created: latency-svc-rxb4g
+Apr 27 14:27:17.292: INFO: Got endpoints: latency-svc-rf9tl [749.304192ms]
+Apr 27 14:27:17.301: INFO: Created: latency-svc-cf7mj
+Apr 27 14:27:17.343: INFO: Got endpoints: latency-svc-725q9 [750.214474ms]
+Apr 27 14:27:17.351: INFO: Created: latency-svc-6g2hm
+Apr 27 14:27:17.393: INFO: Got endpoints: latency-svc-8xmh8 [749.325509ms]
+Apr 27 14:27:17.401: INFO: Created: latency-svc-9x647
+Apr 27 14:27:17.443: INFO: Got endpoints: latency-svc-r5ns5 [750.425491ms]
+Apr 27 14:27:17.454: INFO: Created: latency-svc-947l6
+Apr 27 14:27:17.496: INFO: Got endpoints: latency-svc-gtk6k [752.918549ms]
+Apr 27 14:27:17.508: INFO: Created: latency-svc-cgsjn
+Apr 27 14:27:17.545: INFO: Got endpoints: latency-svc-rqz9s [751.573507ms]
+Apr 27 14:27:17.563: INFO: Created: latency-svc-22qts
+Apr 27 14:27:17.593: INFO: Got endpoints: latency-svc-2zl5b [749.969263ms]
+Apr 27 14:27:17.601: INFO: Created: latency-svc-jl894
+Apr 27 14:27:17.646: INFO: Got endpoints: latency-svc-w7m6p [753.01643ms]
+Apr 27 14:27:17.654: INFO: Created: latency-svc-f8w4j
+Apr 27 14:27:17.693: INFO: Got endpoints: latency-svc-n7k9j [750.1041ms]
+Apr 27 14:27:17.707: INFO: Created: latency-svc-ndbdq
+Apr 27 14:27:17.743: INFO: Got endpoints: latency-svc-pkzwp [748.88377ms]
+Apr 27 14:27:17.765: INFO: Created: latency-svc-jjtv7
+Apr 27 14:27:17.794: INFO: Got endpoints: latency-svc-w5t4t [743.747195ms]
+Apr 27 14:27:17.804: INFO: Created: latency-svc-cf29f
+Apr 27 14:27:17.847: INFO: Got endpoints: latency-svc-gm9v8 [754.29481ms]
+Apr 27 14:27:17.855: INFO: Created: latency-svc-8mlgk
+Apr 27 14:27:17.893: INFO: Got endpoints: latency-svc-zzf4b [750.025868ms]
+Apr 27 14:27:17.901: INFO: Created: latency-svc-tjgxg
+Apr 27 14:27:17.944: INFO: Got endpoints: latency-svc-mkbt8 [750.670395ms]
+Apr 27 14:27:17.951: INFO: Created: latency-svc-ncv5b
+Apr 27 14:27:17.992: INFO: Got endpoints: latency-svc-rxb4g [744.290536ms]
+Apr 27 14:27:18.000: INFO: Created: latency-svc-4b7jj
+Apr 27 14:27:18.049: INFO: Got endpoints: latency-svc-cf7mj [755.981757ms]
+Apr 27 14:27:18.059: INFO: Created: latency-svc-54t2d
+Apr 27 14:27:18.095: INFO: Got endpoints: latency-svc-6g2hm [750.982594ms]
+Apr 27 14:27:18.104: INFO: Created: latency-svc-bcc5w
+Apr 27 14:27:18.144: INFO: Got endpoints: latency-svc-9x647 [750.746365ms]
+Apr 27 14:27:18.152: INFO: Created: latency-svc-gb96h
+Apr 27 14:27:18.193: INFO: Got endpoints: latency-svc-947l6 [750.41006ms]
+Apr 27 14:27:18.202: INFO: Created: latency-svc-rqmsr
+Apr 27 14:27:18.253: INFO: Got endpoints: latency-svc-cgsjn [745.964771ms]
+Apr 27 14:27:18.261: INFO: Created: latency-svc-62ns7
+Apr 27 14:27:18.294: INFO: Got endpoints: latency-svc-22qts [748.22667ms]
+Apr 27 14:27:18.301: INFO: Created: latency-svc-nvqbl
+Apr 27 14:27:18.342: INFO: Got endpoints: latency-svc-jl894 [748.487083ms]
+Apr 27 14:27:18.350: INFO: Created: latency-svc-bscv4
+Apr 27 14:27:18.393: INFO: Got endpoints: latency-svc-f8w4j [747.284372ms]
+Apr 27 14:27:18.405: INFO: Created: latency-svc-l2vgf
+Apr 27 14:27:18.443: INFO: Got endpoints: latency-svc-ndbdq [744.276875ms]
+Apr 27 14:27:18.451: INFO: Created: latency-svc-dwq2j
+Apr 27 14:27:18.493: INFO: Got endpoints: latency-svc-jjtv7 [749.854954ms]
+Apr 27 14:27:18.501: INFO: Created: latency-svc-wlq6z
+Apr 27 14:27:18.543: INFO: Got endpoints: latency-svc-cf29f [749.836812ms]
+Apr 27 14:27:18.551: INFO: Created: latency-svc-cgcgx
+Apr 27 14:27:18.593: INFO: Got endpoints: latency-svc-8mlgk [746.499062ms]
+Apr 27 14:27:18.601: INFO: Created: latency-svc-dpm6g
+Apr 27 14:27:18.642: INFO: Got endpoints: latency-svc-tjgxg [749.333801ms]
+Apr 27 14:27:18.654: INFO: Created: latency-svc-vk9lp
+Apr 27 14:27:18.695: INFO: Got endpoints: latency-svc-ncv5b [751.13005ms]
+Apr 27 14:27:18.703: INFO: Created: latency-svc-w2x62
+Apr 27 14:27:18.742: INFO: Got endpoints: latency-svc-4b7jj [750.044701ms]
+Apr 27 14:27:18.750: INFO: Created: latency-svc-r4mpz
+Apr 27 14:27:18.793: INFO: Got endpoints: latency-svc-54t2d [744.129255ms]
+Apr 27 14:27:18.801: INFO: Created: latency-svc-h6fdn
+Apr 27 14:27:18.842: INFO: Got endpoints: latency-svc-bcc5w [747.670657ms]
+Apr 27 14:27:18.850: INFO: Created: latency-svc-7qpzt
+Apr 27 14:27:18.904: INFO: Got endpoints: latency-svc-gb96h [759.889028ms]
+Apr 27 14:27:18.924: INFO: Created: latency-svc-frh8z
+Apr 27 14:27:18.964: INFO: Got endpoints: latency-svc-rqmsr [770.014784ms]
+Apr 27 14:27:18.984: INFO: Created: latency-svc-94p8j
+Apr 27 14:27:18.994: INFO: Got endpoints: latency-svc-62ns7 [740.864573ms]
+Apr 27 14:27:19.005: INFO: Created: latency-svc-bp867
+Apr 27 14:27:19.043: INFO: Got endpoints: latency-svc-nvqbl [749.334666ms]
+Apr 27 14:27:19.103: INFO: Got endpoints: latency-svc-bscv4 [760.574251ms]
+Apr 27 14:27:19.116: INFO: Created: latency-svc-bn98j
+Apr 27 14:27:19.126: INFO: Created: latency-svc-wsp2f
+Apr 27 14:27:19.142: INFO: Got endpoints: latency-svc-l2vgf [748.811453ms]
+Apr 27 14:27:19.150: INFO: Created: latency-svc-pcds5
+Apr 27 14:27:19.192: INFO: Got endpoints: latency-svc-dwq2j [749.161881ms]
+Apr 27 14:27:19.201: INFO: Created: latency-svc-gptrr
+Apr 27 14:27:19.243: INFO: Got endpoints: latency-svc-wlq6z [749.928827ms]
+Apr 27 14:27:19.251: INFO: Created: latency-svc-7z2w5
+Apr 27 14:27:19.292: INFO: Got endpoints: latency-svc-cgcgx [748.841277ms]
+Apr 27 14:27:19.300: INFO: Created: latency-svc-b7bbr
+Apr 27 14:27:19.344: INFO: Got endpoints: latency-svc-dpm6g [751.037199ms]
+Apr 27 14:27:19.357: INFO: Created: latency-svc-5g8vk
+Apr 27 14:27:19.394: INFO: Got endpoints: latency-svc-vk9lp [751.592955ms]
+Apr 27 14:27:19.417: INFO: Created: latency-svc-bqlv9
+Apr 27 14:27:19.443: INFO: Got endpoints: latency-svc-w2x62 [748.054416ms]
+Apr 27 14:27:19.455: INFO: Created: latency-svc-xszzx
+Apr 27 14:27:19.497: INFO: Got endpoints: latency-svc-r4mpz [754.606671ms]
+Apr 27 14:27:19.509: INFO: Created: latency-svc-pbnwq
+Apr 27 14:27:19.543: INFO: Got endpoints: latency-svc-h6fdn [749.726237ms]
+Apr 27 14:27:19.550: INFO: Created: latency-svc-pwf54
+Apr 27 14:27:19.593: INFO: Got endpoints: latency-svc-7qpzt [750.436677ms]
+Apr 27 14:27:19.601: INFO: Created: latency-svc-wbr6s
+Apr 27 14:27:19.644: INFO: Got endpoints: latency-svc-frh8z [740.323448ms]
+Apr 27 14:27:19.654: INFO: Created: latency-svc-pxm9z
+Apr 27 14:27:19.694: INFO: Got endpoints: latency-svc-94p8j [730.203176ms]
+Apr 27 14:27:19.704: INFO: Created: latency-svc-vshgq
+Apr 27 14:27:19.743: INFO: Got endpoints: latency-svc-bp867 [748.872317ms]
+Apr 27 14:27:19.750: INFO: Created: latency-svc-b8gwq
+Apr 27 14:27:19.795: INFO: Got endpoints: latency-svc-bn98j [691.724747ms]
+Apr 27 14:27:19.807: INFO: Created: latency-svc-vbjql
+Apr 27 14:27:19.849: INFO: Got endpoints: latency-svc-wsp2f [802.635256ms]
+Apr 27 14:27:19.861: INFO: Created: latency-svc-rbnhv
+Apr 27 14:27:19.894: INFO: Got endpoints: latency-svc-pcds5 [752.098008ms]
+Apr 27 14:27:19.903: INFO: Created: latency-svc-2gwmq
+Apr 27 14:27:19.943: INFO: Got endpoints: latency-svc-gptrr [750.378757ms]
+Apr 27 14:27:19.953: INFO: Created: latency-svc-kn56x
+Apr 27 14:27:20.012: INFO: Got endpoints: latency-svc-7z2w5 [768.567177ms]
+Apr 27 14:27:20.030: INFO: Created: latency-svc-5r79s
+Apr 27 14:27:20.045: INFO: Got endpoints: latency-svc-b7bbr [752.824933ms]
+Apr 27 14:27:20.055: INFO: Created: latency-svc-xstzw
+Apr 27 14:27:20.093: INFO: Got endpoints: latency-svc-5g8vk [746.743462ms]
+Apr 27 14:27:20.102: INFO: Created: latency-svc-zhkpt
+Apr 27 14:27:20.144: INFO: Got endpoints: latency-svc-bqlv9 [749.677845ms]
+Apr 27 14:27:20.157: INFO: Created: latency-svc-bp4n4
+Apr 27 14:27:20.209: INFO: Got endpoints: latency-svc-xszzx [765.81318ms]
+Apr 27 14:27:20.230: INFO: Created: latency-svc-2ph8h
+Apr 27 14:27:20.244: INFO: Got endpoints: latency-svc-pbnwq [746.174934ms]
+Apr 27 14:27:20.255: INFO: Created: latency-svc-phbnw
+Apr 27 14:27:20.293: INFO: Got endpoints: latency-svc-pwf54 [750.046408ms]
+Apr 27 14:27:20.302: INFO: Created: latency-svc-tj9vf
+Apr 27 14:27:20.343: INFO: Got endpoints: latency-svc-wbr6s [749.742228ms]
+Apr 27 14:27:20.352: INFO: Created: latency-svc-t8tvc
+Apr 27 14:27:20.393: INFO: Got endpoints: latency-svc-pxm9z [748.344732ms]
+Apr 27 14:27:20.403: INFO: Created: latency-svc-8z468
+Apr 27 14:27:20.445: INFO: Got endpoints: latency-svc-vshgq [750.773835ms]
+Apr 27 14:27:20.456: INFO: Created: latency-svc-5wmgv
+Apr 27 14:27:20.494: INFO: Got endpoints: latency-svc-b8gwq [751.235765ms]
+Apr 27 14:27:20.503: INFO: Created: latency-svc-m97mh
+Apr 27 14:27:20.543: INFO: Got endpoints: latency-svc-vbjql [748.193676ms]
+Apr 27 14:27:20.550: INFO: Created: latency-svc-cdh7q
+Apr 27 14:27:20.594: INFO: Got endpoints: latency-svc-rbnhv [744.564889ms]
+Apr 27 14:27:20.617: INFO: Created: latency-svc-7z8xf
+Apr 27 14:27:20.643: INFO: Got endpoints: latency-svc-2gwmq [748.324952ms]
+Apr 27 14:27:20.651: INFO: Created: latency-svc-x9z49
+Apr 27 14:27:20.694: INFO: Got endpoints: latency-svc-kn56x [750.753085ms]
+Apr 27 14:27:20.703: INFO: Created: latency-svc-5xgwg
+Apr 27 14:27:20.745: INFO: Got endpoints: latency-svc-5r79s [733.321778ms]
+Apr 27 14:27:20.753: INFO: Created: latency-svc-krmff
+Apr 27 14:27:20.792: INFO: Got endpoints: latency-svc-xstzw [747.148301ms]
+Apr 27 14:27:20.806: INFO: Created: latency-svc-nz42j
+Apr 27 14:27:20.843: INFO: Got endpoints: latency-svc-zhkpt [749.48183ms]
+Apr 27 14:27:20.850: INFO: Created: latency-svc-2vwxq
+Apr 27 14:27:20.894: INFO: Got endpoints: latency-svc-bp4n4 [750.001591ms]
+Apr 27 14:27:20.902: INFO: Created: latency-svc-dkttn
+Apr 27 14:27:20.944: INFO: Got endpoints: latency-svc-2ph8h [735.094254ms]
+Apr 27 14:27:20.954: INFO: Created: latency-svc-4wx4f
+Apr 27 14:27:20.994: INFO: Got endpoints: latency-svc-phbnw [750.019065ms]
+Apr 27 14:27:21.014: INFO: Created: latency-svc-fpt8f
+Apr 27 14:27:21.047: INFO: Got endpoints: latency-svc-tj9vf [753.634934ms]
+Apr 27 14:27:21.065: INFO: Created: latency-svc-cfjpx
+Apr 27 14:27:21.093: INFO: Got endpoints: latency-svc-t8tvc [750.232931ms]
+Apr 27 14:27:21.103: INFO: Created: latency-svc-j6dp5
+Apr 27 14:27:21.143: INFO: Got endpoints: latency-svc-8z468 [750.845931ms]
+Apr 27 14:27:21.152: INFO: Created: latency-svc-zd29s
+Apr 27 14:27:21.192: INFO: Got endpoints: latency-svc-5wmgv [747.458288ms]
+Apr 27 14:27:21.200: INFO: Created: latency-svc-hxnfp
+Apr 27 14:27:21.243: INFO: Got endpoints: latency-svc-m97mh [749.188697ms]
+Apr 27 14:27:21.254: INFO: Created: latency-svc-mzd79
+Apr 27 14:27:21.294: INFO: Got endpoints: latency-svc-cdh7q [750.952333ms]
+Apr 27 14:27:21.303: INFO: Created: latency-svc-rqx7w
+Apr 27 14:27:21.343: INFO: Got endpoints: latency-svc-7z8xf [748.668703ms]
+Apr 27 14:27:21.350: INFO: Created: latency-svc-phqnj
+Apr 27 14:27:21.393: INFO: Got endpoints: latency-svc-x9z49 [750.333147ms]
+Apr 27 14:27:21.405: INFO: Created: latency-svc-pq4gz
+Apr 27 14:27:21.444: INFO: Got endpoints: latency-svc-5xgwg [750.077186ms]
+Apr 27 14:27:21.452: INFO: Created: latency-svc-mmkrc
+Apr 27 14:27:21.494: INFO: Got endpoints: latency-svc-krmff [748.553648ms]
+Apr 27 14:27:21.508: INFO: Created: latency-svc-ngx47
+Apr 27 14:27:21.545: INFO: Got endpoints: latency-svc-nz42j [750.243385ms]
+Apr 27 14:27:21.554: INFO: Created: latency-svc-r8zfp
+Apr 27 14:27:21.593: INFO: Got endpoints: latency-svc-2vwxq [750.352534ms]
+Apr 27 14:27:21.603: INFO: Created: latency-svc-8p6qn
+Apr 27 14:27:21.644: INFO: Got endpoints: latency-svc-dkttn [749.738756ms]
+Apr 27 14:27:21.654: INFO: Created: latency-svc-zhh8j
+Apr 27 14:27:21.694: INFO: Got endpoints: latency-svc-4wx4f [749.270488ms]
+Apr 27 14:27:21.701: INFO: Created: latency-svc-t9p58
+Apr 27 14:27:21.746: INFO: Got endpoints: latency-svc-fpt8f [751.682534ms]
+Apr 27 14:27:21.754: INFO: Created: latency-svc-hv9kd
+Apr 27 14:27:21.799: INFO: Got endpoints: latency-svc-cfjpx [749.160447ms]
+Apr 27 14:27:21.817: INFO: Created: latency-svc-qg259
+Apr 27 14:27:21.843: INFO: Got endpoints: latency-svc-j6dp5 [749.588961ms]
+Apr 27 14:27:21.851: INFO: Created: latency-svc-hctk5
+Apr 27 14:27:21.893: INFO: Got endpoints: latency-svc-zd29s [749.306335ms]
+Apr 27 14:27:21.901: INFO: Created: latency-svc-smhcj
+Apr 27 14:27:21.944: INFO: Got endpoints: latency-svc-hxnfp [750.892274ms]
+Apr 27 14:27:21.953: INFO: Created: latency-svc-qs266
+Apr 27 14:27:21.993: INFO: Got endpoints: latency-svc-mzd79 [749.898398ms]
+Apr 27 14:27:22.001: INFO: Created: latency-svc-hllpj
+Apr 27 14:27:22.043: INFO: Got endpoints: latency-svc-rqx7w [748.245508ms]
+Apr 27 14:27:22.051: INFO: Created: latency-svc-24xht
+Apr 27 14:27:22.093: INFO: Got endpoints: latency-svc-phqnj [749.716701ms]
+Apr 27 14:27:22.102: INFO: Created: latency-svc-jcdkg
+Apr 27 14:27:22.143: INFO: Got endpoints: latency-svc-pq4gz [749.85736ms]
+Apr 27 14:27:22.155: INFO: Created: latency-svc-2pcg4
+Apr 27 14:27:22.193: INFO: Got endpoints: latency-svc-mmkrc [748.448595ms]
+Apr 27 14:27:22.202: INFO: Created: latency-svc-vcx27
+Apr 27 14:27:22.243: INFO: Got endpoints: latency-svc-ngx47 [749.055385ms]
+Apr 27 14:27:22.251: INFO: Created: latency-svc-fnj5j
+Apr 27 14:27:22.293: INFO: Got endpoints: latency-svc-r8zfp [748.12144ms]
+Apr 27 14:27:22.308: INFO: Created: latency-svc-9ftkg
+Apr 27 14:27:22.348: INFO: Got endpoints: latency-svc-8p6qn [754.540452ms]
+Apr 27 14:27:22.357: INFO: Created: latency-svc-kqbbx
+Apr 27 14:27:22.393: INFO: Got endpoints: latency-svc-zhh8j [748.949333ms]
+Apr 27 14:27:22.403: INFO: Created: latency-svc-k25hn
+Apr 27 14:27:22.444: INFO: Got endpoints: latency-svc-t9p58 [750.679671ms]
+Apr 27 14:27:22.463: INFO: Created: latency-svc-47ksm
+Apr 27 14:27:22.493: INFO: Got endpoints: latency-svc-hv9kd [747.610012ms]
+Apr 27 14:27:22.502: INFO: Created: latency-svc-2fxs8
+Apr 27 14:27:22.543: INFO: Got endpoints: latency-svc-qg259 [743.060811ms]
+Apr 27 14:27:22.551: INFO: Created: latency-svc-sffvv
+Apr 27 14:27:22.593: INFO: Got endpoints: latency-svc-hctk5 [749.847575ms]
+Apr 27 14:27:22.601: INFO: Created: latency-svc-p82qc
+Apr 27 14:27:22.643: INFO: Got endpoints: latency-svc-smhcj [749.297053ms]
+Apr 27 14:27:22.651: INFO: Created: latency-svc-5llss
+Apr 27 14:27:22.693: INFO: Got endpoints: latency-svc-qs266 [749.02658ms]
+Apr 27 14:27:22.705: INFO: Created: latency-svc-fpw97
+Apr 27 14:27:22.754: INFO: Got endpoints: latency-svc-hllpj [760.591535ms]
+Apr 27 14:27:22.764: INFO: Created: latency-svc-662fh
+Apr 27 14:27:22.793: INFO: Got endpoints: latency-svc-24xht [750.216735ms]
+Apr 27 14:27:22.802: INFO: Created: latency-svc-kxl9h
+Apr 27 14:27:22.844: INFO: Got endpoints: latency-svc-jcdkg [751.082231ms]
+Apr 27 14:27:22.854: INFO: Created: latency-svc-p48wn
+Apr 27 14:27:22.894: INFO: Got endpoints: latency-svc-2pcg4 [750.401705ms]
+Apr 27 14:27:22.902: INFO: Created: latency-svc-xskv2
+Apr 27 14:27:22.943: INFO: Got endpoints: latency-svc-vcx27 [749.951033ms]
+Apr 27 14:27:22.993: INFO: Got endpoints: latency-svc-fnj5j [749.472249ms]
+Apr 27 14:27:23.044: INFO: Got endpoints: latency-svc-9ftkg [750.713353ms]
+Apr 27 14:27:23.094: INFO: Got endpoints: latency-svc-kqbbx [746.207365ms]
+Apr 27 14:27:23.143: INFO: Got endpoints: latency-svc-k25hn [749.153401ms]
+Apr 27 14:27:23.193: INFO: Got endpoints: latency-svc-47ksm [748.603746ms]
+Apr 27 14:27:23.243: INFO: Got endpoints: latency-svc-2fxs8 [749.131318ms]
+Apr 27 14:27:23.292: INFO: Got endpoints: latency-svc-sffvv [749.41165ms]
+Apr 27 14:27:23.343: INFO: Got endpoints: latency-svc-p82qc [749.347265ms]
+Apr 27 14:27:23.394: INFO: Got endpoints: latency-svc-5llss [751.371314ms]
+Apr 27 14:27:23.443: INFO: Got endpoints: latency-svc-fpw97 [750.263778ms]
+Apr 27 14:27:23.494: INFO: Got endpoints: latency-svc-662fh [740.571577ms]
+Apr 27 14:27:23.544: INFO: Got endpoints: latency-svc-kxl9h [750.341777ms]
+Apr 27 14:27:23.599: INFO: Got endpoints: latency-svc-p48wn [755.53383ms]
+Apr 27 14:27:23.644: INFO: Got endpoints: latency-svc-xskv2 [749.650666ms]
+Apr 27 14:27:23.644: INFO: Latencies: [23.355448ms 23.870043ms 26.85992ms 35.310079ms 41.236937ms 51.373645ms 51.906172ms 53.111717ms 58.193011ms 65.027563ms 73.595186ms 76.836289ms 79.260327ms 81.499969ms 84.22875ms 87.878367ms 89.760854ms 89.936281ms 92.00117ms 93.167921ms 93.69514ms 94.805592ms 97.076881ms 101.572988ms 101.740457ms 101.975134ms 105.828974ms 107.120861ms 108.975482ms 110.66501ms 120.418118ms 125.742329ms 125.946523ms 126.77474ms 162.815562ms 215.243733ms 249.675892ms 283.594723ms 330.686389ms 381.081395ms 419.760852ms 441.503818ms 489.954138ms 539.724298ms 587.1795ms 627.8721ms 678.23424ms 691.724747ms 717.502225ms 727.932601ms 730.203176ms 733.321778ms 735.094254ms 740.323448ms 740.571577ms 740.864573ms 743.060811ms 743.747195ms 744.129255ms 744.276875ms 744.290536ms 744.564889ms 744.889607ms 744.922389ms 745.964771ms 746.174934ms 746.207365ms 746.499062ms 746.743462ms 747.140475ms 747.148301ms 747.284372ms 747.458288ms 747.610012ms 747.670657ms 747.688439ms 748.054416ms 748.083826ms 748.12144ms 748.193676ms 748.22667ms 748.245508ms 748.324952ms 748.344565ms 748.344732ms 748.448595ms 748.487083ms 748.553648ms 748.566433ms 748.603746ms 748.611193ms 748.668703ms 748.811453ms 748.841277ms 748.872317ms 748.88377ms 748.918697ms 748.949333ms 749.02658ms 749.055385ms 749.131318ms 749.153401ms 749.160447ms 749.161881ms 749.188697ms 749.270488ms 749.297053ms 749.304192ms 749.306335ms 749.325509ms 749.333801ms 749.334666ms 749.347265ms 749.41165ms 749.472249ms 749.477399ms 749.48183ms 749.588961ms 749.650666ms 749.677845ms 749.716701ms 749.726237ms 749.738756ms 749.742228ms 749.751668ms 749.836812ms 749.847575ms 749.854954ms 749.85736ms 749.885969ms 749.898398ms 749.92191ms 749.928827ms 749.951033ms 749.969263ms 750.001591ms 750.019065ms 750.025868ms 750.044701ms 750.046408ms 750.077186ms 750.1041ms 750.144892ms 750.175639ms 750.214474ms 750.216735ms 750.232931ms 750.243385ms 750.263778ms 750.295201ms 750.333147ms 750.341777ms 750.352534ms 750.378757ms 750.401705ms 750.41006ms 750.425491ms 750.436677ms 750.554742ms 750.670395ms 750.679671ms 750.713353ms 750.746365ms 750.753085ms 750.773835ms 750.845931ms 750.892274ms 750.952333ms 750.982594ms 750.99172ms 751.037199ms 751.082231ms 751.13005ms 751.132348ms 751.235765ms 751.371314ms 751.573507ms 751.592955ms 751.610733ms 751.682534ms 752.098008ms 752.824933ms 752.918549ms 753.01643ms 753.634934ms 754.29481ms 754.540452ms 754.606671ms 755.53383ms 755.981757ms 756.913927ms 758.941698ms 759.889028ms 760.574251ms 760.591535ms 765.81318ms 768.567177ms 770.014784ms 771.43801ms 802.635256ms]
+Apr 27 14:27:23.647: INFO: 50 %ile: 749.131318ms
+Apr 27 14:27:23.647: INFO: 90 %ile: 752.098008ms
+Apr 27 14:27:23.647: INFO: 99 %ile: 771.43801ms
+Apr 27 14:27:23.647: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:27:23.647: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-lr4d8" for this suite.
+Apr 27 14:27:33.663: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:27:33.737: INFO: namespace: e2e-tests-svc-latency-lr4d8, resource: bindings, ignored listing per whitelist
+Apr 27 14:27:33.782: INFO: namespace e2e-tests-svc-latency-lr4d8 deletion completed in 10.131314198s
+
+• [SLOW TEST:20.890 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:27:33.782: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-j5gc4
+[It] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Initializing watcher for selector baz=blah,foo=bar
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-j5gc4
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-j5gc4
+Apr 27 14:27:33.878: INFO: Found 0 stateful pods, waiting for 1
+Apr 27 14:27:43.882: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will halt with unhealthy stateful pod
+Apr 27 14:27:43.885: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-j5gc4 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:27:44.152: INFO: stderr: ""
+Apr 27 14:27:44.152: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:27:44.156: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Apr 27 14:27:54.168: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:27:54.168: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:27:54.180: INFO: Verifying statefulset ss doesn't scale past 1 for another 9.999998898s
+Apr 27 14:27:55.184: INFO: Verifying statefulset ss doesn't scale past 1 for another 8.99654541s
+Apr 27 14:27:56.188: INFO: Verifying statefulset ss doesn't scale past 1 for another 7.99305246s
+Apr 27 14:27:57.192: INFO: Verifying statefulset ss doesn't scale past 1 for another 6.989342293s
+Apr 27 14:27:58.196: INFO: Verifying statefulset ss doesn't scale past 1 for another 5.985261427s
+Apr 27 14:27:59.200: INFO: Verifying statefulset ss doesn't scale past 1 for another 4.981244053s
+Apr 27 14:28:00.204: INFO: Verifying statefulset ss doesn't scale past 1 for another 3.976941116s
+Apr 27 14:28:01.208: INFO: Verifying statefulset ss doesn't scale past 1 for another 2.973023895s
+Apr 27 14:28:02.211: INFO: Verifying statefulset ss doesn't scale past 1 for another 1.969428072s
+Apr 27 14:28:03.215: INFO: Verifying statefulset ss doesn't scale past 1 for another 965.727776ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-j5gc4
+Apr 27 14:28:04.219: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-j5gc4 ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:28:04.503: INFO: stderr: ""
+Apr 27 14:28:04.504: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:28:04.507: INFO: Found 1 stateful pods, waiting for 3
+Apr 27 14:28:14.511: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:28:14.511: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:28:14.511: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Verifying that stateful set ss was scaled up in order
+STEP: Scale down will halt with unhealthy stateful pod
+Apr 27 14:28:14.516: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-j5gc4 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:28:14.767: INFO: stderr: ""
+Apr 27 14:28:14.767: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:28:14.767: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-j5gc4 ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:30:25.620: INFO: rc: 1
+Apr 27 14:30:25.620: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-j5gc4 ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true] []  <nil>  Error from server: error dialing backend: dial tcp 10.250.12.147:10250: getsockopt: connection timed out
+ [] <nil> 0xc4219f37d0 exit status 1 <nil> <nil> true [0xc420ff34c0 0xc420ff34d8 0xc420ff34f0] [0xc420ff34c0 0xc420ff34d8 0xc420ff34f0] [0xc420ff34d0 0xc420ff34e8] [0x94d8e0 0x94d8e0] 0xc4211ecf60 <nil>}:
+Command stdout:
+
+stderr:
+Error from server: error dialing backend: dial tcp 10.250.12.147:10250: getsockopt: connection timed out
+
+error:
+exit status 1
+
+Apr 27 14:30:35.621: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-j5gc4 ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:30:35.948: INFO: stderr: ""
+Apr 27 14:30:35.948: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:30:35.948: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-j5gc4 ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:30:36.304: INFO: stderr: ""
+Apr 27 14:30:36.304: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:30:36.304: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:30:36.309: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 2
+Apr 27 14:30:46.315: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:30:46.315: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:30:46.315: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:30:46.326: INFO: Verifying statefulset ss doesn't scale past 3 for another 9.999998911s
+Apr 27 14:30:47.329: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.996871751s
+Apr 27 14:30:48.333: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.993159264s
+Apr 27 14:30:49.336: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.989753923s
+Apr 27 14:30:50.340: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.986049117s
+Apr 27 14:30:51.344: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.982516997s
+Apr 27 14:30:52.348: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.97870416s
+Apr 27 14:30:53.352: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.974125051s
+Apr 27 14:30:54.356: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.970064799s
+Apr 27 14:30:55.362: INFO: Verifying statefulset ss doesn't scale past 3 for another 965.965392ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-j5gc4
+Apr 27 14:30:56.370: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-j5gc4 ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:30:56.749: INFO: stderr: ""
+Apr 27 14:30:56.749: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:30:56.750: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-j5gc4 ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:30:57.012: INFO: stderr: ""
+Apr 27 14:30:57.012: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:30:57.012: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-j5gc4 ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:30:57.368: INFO: stderr: ""
+Apr 27 14:30:57.368: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:30:57.368: INFO: Scaling statefulset ss to 0
+STEP: Verifying that stateful set ss was scaled down in reverse order
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:31:27.381: INFO: Deleting all statefulset in ns e2e-tests-statefulset-j5gc4
+Apr 27 14:31:27.384: INFO: Scaling statefulset ss to 0
+Apr 27 14:31:27.391: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:31:27.394: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:31:27.403: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-j5gc4" for this suite.
+Apr 27 14:31:33.416: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:31:33.528: INFO: namespace: e2e-tests-statefulset-j5gc4, resource: bindings, ignored listing per whitelist
+Apr 27 14:31:33.547: INFO: namespace e2e-tests-statefulset-j5gc4 deletion completed in 6.140330097s
+
+• [SLOW TEST:239.764 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:31:33.547: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test use defaults
+Apr 27 14:31:33.643: INFO: Waiting up to 5m0s for pod "client-containers-af148d39-4a27-11e8-a1f3-0206690d449d" in namespace "e2e-tests-containers-7b4jg" to be "success or failure"
+Apr 27 14:31:33.647: INFO: Pod "client-containers-af148d39-4a27-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.405128ms
+Apr 27 14:31:35.651: INFO: Pod "client-containers-af148d39-4a27-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008114683s
+STEP: Saw pod success
+Apr 27 14:31:35.652: INFO: Pod "client-containers-af148d39-4a27-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:31:35.654: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod client-containers-af148d39-4a27-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:31:35.671: INFO: Waiting for pod client-containers-af148d39-4a27-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:31:35.674: INFO: Pod client-containers-af148d39-4a27-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:31:35.674: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-7b4jg" for this suite.
+Apr 27 14:31:41.687: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:31:41.785: INFO: namespace: e2e-tests-containers-7b4jg, resource: bindings, ignored listing per whitelist
+Apr 27 14:31:41.811: INFO: namespace e2e-tests-containers-7b4jg deletion completed in 6.133758362s
+
+• [SLOW TEST:8.264 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:31:41.811: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:31:41.901: INFO: Waiting up to 5m0s for pod "downwardapi-volume-b4013ccc-4a27-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-l94fg" to be "success or failure"
+Apr 27 14:31:41.903: INFO: Pod "downwardapi-volume-b4013ccc-4a27-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.382904ms
+Apr 27 14:31:43.907: INFO: Pod "downwardapi-volume-b4013ccc-4a27-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005931908s
+STEP: Saw pod success
+Apr 27 14:31:43.907: INFO: Pod "downwardapi-volume-b4013ccc-4a27-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:31:43.909: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-b4013ccc-4a27-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:31:43.928: INFO: Waiting for pod downwardapi-volume-b4013ccc-4a27-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:31:43.931: INFO: Pod downwardapi-volume-b4013ccc-4a27-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:31:43.931: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-l94fg" for this suite.
+Apr 27 14:31:49.943: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:31:50.055: INFO: namespace: e2e-tests-projected-l94fg, resource: bindings, ignored listing per whitelist
+Apr 27 14:31:50.080: INFO: namespace e2e-tests-projected-l94fg deletion completed in 6.146174206s
+
+• [SLOW TEST:8.269 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:31:50.081: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:31:50.172: INFO: Waiting up to 5m0s for pod "downward-api-b8ef8628-4a27-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-2s59w" to be "success or failure"
+Apr 27 14:31:50.177: INFO: Pod "downward-api-b8ef8628-4a27-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.607469ms
+Apr 27 14:31:52.180: INFO: Pod "downward-api-b8ef8628-4a27-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00753282s
+Apr 27 14:31:54.183: INFO: Pod "downward-api-b8ef8628-4a27-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010761899s
+STEP: Saw pod success
+Apr 27 14:31:54.183: INFO: Pod "downward-api-b8ef8628-4a27-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:31:54.186: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downward-api-b8ef8628-4a27-11e8-a1f3-0206690d449d container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:31:54.201: INFO: Waiting for pod downward-api-b8ef8628-4a27-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:31:54.204: INFO: Pod downward-api-b8ef8628-4a27-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:31:54.204: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-2s59w" for this suite.
+Apr 27 14:32:00.242: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:32:00.366: INFO: namespace: e2e-tests-downward-api-2s59w, resource: bindings, ignored listing per whitelist
+Apr 27 14:32:00.384: INFO: namespace e2e-tests-downward-api-2s59w deletion completed in 6.17269543s
+
+• [SLOW TEST:10.304 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:32:00.384: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-hw2lg
+[It] should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a new StatefulSet
+Apr 27 14:32:00.503: INFO: Found 0 stateful pods, waiting for 3
+Apr 27 14:32:10.507: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:32:10.507: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:32:10.507: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:32:10.517: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-hw2lg ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:32:10.811: INFO: stderr: ""
+Apr 27 14:32:10.811: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+STEP: Updating StatefulSet template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Apr 27 14:32:20.843: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Updating Pods in reverse ordinal order
+Apr 27 14:32:30.858: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-hw2lg ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:32:31.185: INFO: stderr: ""
+Apr 27 14:32:31.185: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:32:41.206: INFO: Waiting for StatefulSet e2e-tests-statefulset-hw2lg/ss2 to complete update
+Apr 27 14:32:41.206: INFO: Waiting for Pod e2e-tests-statefulset-hw2lg/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 27 14:32:41.206: INFO: Waiting for Pod e2e-tests-statefulset-hw2lg/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 27 14:32:51.243: INFO: Waiting for StatefulSet e2e-tests-statefulset-hw2lg/ss2 to complete update
+Apr 27 14:32:51.243: INFO: Waiting for Pod e2e-tests-statefulset-hw2lg/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Rolling back to a previous revision
+Apr 27 14:33:01.212: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-hw2lg ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:33:01.584: INFO: stderr: ""
+Apr 27 14:33:01.584: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:33:11.613: INFO: Updating stateful set ss2
+STEP: Rolling back update in reverse ordinal order
+Apr 27 14:33:21.628: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-892884186 exec --namespace=e2e-tests-statefulset-hw2lg ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:33:28.553: INFO: stderr: ""
+Apr 27 14:33:28.553: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:33:48.571: INFO: Waiting for StatefulSet e2e-tests-statefulset-hw2lg/ss2 to complete update
+Apr 27 14:33:48.571: INFO: Waiting for Pod e2e-tests-statefulset-hw2lg/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:33:58.577: INFO: Deleting all statefulset in ns e2e-tests-statefulset-hw2lg
+Apr 27 14:33:58.579: INFO: Scaling statefulset ss2 to 0
+Apr 27 14:34:28.592: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:34:28.595: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:34:28.605: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-hw2lg" for this suite.
+Apr 27 14:34:34.618: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:34:34.712: INFO: namespace: e2e-tests-statefulset-hw2lg, resource: bindings, ignored listing per whitelist
+Apr 27 14:34:34.761: INFO: namespace e2e-tests-statefulset-hw2lg deletion completed in 6.151370601s
+
+• [SLOW TEST:154.377 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should perform rolling updates and roll backs of template modifications [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:34:34.765: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:34:34.871: INFO: Waiting up to 5m0s for pod "downwardapi-volume-1b1a6d43-4a28-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-l6sr6" to be "success or failure"
+Apr 27 14:34:34.887: INFO: Pod "downwardapi-volume-1b1a6d43-4a28-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 15.976925ms
+Apr 27 14:34:36.891: INFO: Pod "downwardapi-volume-1b1a6d43-4a28-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.020051853s
+STEP: Saw pod success
+Apr 27 14:34:36.891: INFO: Pod "downwardapi-volume-1b1a6d43-4a28-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:34:36.894: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-1b1a6d43-4a28-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:34:36.909: INFO: Waiting for pod downwardapi-volume-1b1a6d43-4a28-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:34:36.913: INFO: Pod downwardapi-volume-1b1a6d43-4a28-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:34:36.913: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-l6sr6" for this suite.
+Apr 27 14:34:42.927: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:34:43.010: INFO: namespace: e2e-tests-projected-l6sr6, resource: bindings, ignored listing per whitelist
+Apr 27 14:34:43.066: INFO: namespace e2e-tests-projected-l6sr6 deletion completed in 6.14805322s
+
+• [SLOW TEST:8.302 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:34:43.066: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Apr 27 14:34:43.154: INFO: Waiting up to 5m0s for pod "pod-200a6fda-4a28-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-v2nj4" to be "success or failure"
+Apr 27 14:34:43.158: INFO: Pod "pod-200a6fda-4a28-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.915839ms
+Apr 27 14:34:45.161: INFO: Pod "pod-200a6fda-4a28-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005803104s
+STEP: Saw pod success
+Apr 27 14:34:45.161: INFO: Pod "pod-200a6fda-4a28-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:34:45.163: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-200a6fda-4a28-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:34:45.183: INFO: Waiting for pod pod-200a6fda-4a28-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:34:45.185: INFO: Pod pod-200a6fda-4a28-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:34:45.186: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-v2nj4" for this suite.
+Apr 27 14:34:51.198: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:34:51.264: INFO: namespace: e2e-tests-emptydir-v2nj4, resource: bindings, ignored listing per whitelist
+Apr 27 14:34:51.321: INFO: namespace e2e-tests-emptydir-v2nj4 deletion completed in 6.132290359s
+
+• [SLOW TEST:8.255 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:34:51.321: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test env composition
+Apr 27 14:34:51.440: INFO: Waiting up to 5m0s for pod "var-expansion-24f9fcb7-4a28-11e8-a1f3-0206690d449d" in namespace "e2e-tests-var-expansion-sh7bp" to be "success or failure"
+Apr 27 14:34:51.444: INFO: Pod "var-expansion-24f9fcb7-4a28-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.229029ms
+Apr 27 14:34:53.447: INFO: Pod "var-expansion-24f9fcb7-4a28-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007090279s
+Apr 27 14:34:55.450: INFO: Pod "var-expansion-24f9fcb7-4a28-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010314977s
+STEP: Saw pod success
+Apr 27 14:34:55.450: INFO: Pod "var-expansion-24f9fcb7-4a28-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:34:55.453: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod var-expansion-24f9fcb7-4a28-11e8-a1f3-0206690d449d container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:34:55.467: INFO: Waiting for pod var-expansion-24f9fcb7-4a28-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:34:55.470: INFO: Pod var-expansion-24f9fcb7-4a28-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:34:55.470: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-sh7bp" for this suite.
+Apr 27 14:35:01.484: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:35:01.771: INFO: namespace: e2e-tests-var-expansion-sh7bp, resource: bindings, ignored listing per whitelist
+Apr 27 14:35:01.803: INFO: namespace e2e-tests-var-expansion-sh7bp deletion completed in 6.330138407s
+
+• [SLOW TEST:10.482 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:35:01.803: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-2b44039d-4a28-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:35:01.994: INFO: Waiting up to 5m0s for pod "pod-secrets-2b450214-4a28-11e8-a1f3-0206690d449d" in namespace "e2e-tests-secrets-bd9mc" to be "success or failure"
+Apr 27 14:35:02.000: INFO: Pod "pod-secrets-2b450214-4a28-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 5.907249ms
+Apr 27 14:35:04.004: INFO: Pod "pod-secrets-2b450214-4a28-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009697152s
+STEP: Saw pod success
+Apr 27 14:35:04.004: INFO: Pod "pod-secrets-2b450214-4a28-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:35:04.007: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-secrets-2b450214-4a28-11e8-a1f3-0206690d449d container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:35:04.022: INFO: Waiting for pod pod-secrets-2b450214-4a28-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:35:04.025: INFO: Pod pod-secrets-2b450214-4a28-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:35:04.025: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-bd9mc" for this suite.
+Apr 27 14:35:10.038: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:35:10.117: INFO: namespace: e2e-tests-secrets-bd9mc, resource: bindings, ignored listing per whitelist
+Apr 27 14:35:10.162: INFO: namespace e2e-tests-secrets-bd9mc deletion completed in 6.134460405s
+
+• [SLOW TEST:8.359 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:35:10.163: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name projected-secret-test-30316054-4a28-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:35:10.257: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-3031d968-4a28-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-gdngv" to be "success or failure"
+Apr 27 14:35:10.261: INFO: Pod "pod-projected-secrets-3031d968-4a28-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.65908ms
+Apr 27 14:35:12.264: INFO: Pod "pod-projected-secrets-3031d968-4a28-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00764041s
+Apr 27 14:35:14.268: INFO: Pod "pod-projected-secrets-3031d968-4a28-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010866148s
+STEP: Saw pod success
+Apr 27 14:35:14.268: INFO: Pod "pod-projected-secrets-3031d968-4a28-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:35:14.270: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-secrets-3031d968-4a28-11e8-a1f3-0206690d449d container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:35:14.295: INFO: Waiting for pod pod-projected-secrets-3031d968-4a28-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:35:14.298: INFO: Pod pod-projected-secrets-3031d968-4a28-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:35:14.298: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-gdngv" for this suite.
+Apr 27 14:35:20.310: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:35:20.375: INFO: namespace: e2e-tests-projected-gdngv, resource: bindings, ignored listing per whitelist
+Apr 27 14:35:20.447: INFO: namespace e2e-tests-projected-gdngv deletion completed in 6.145775439s
+
+• [SLOW TEST:10.284 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:35:20.447: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name cm-test-opt-del-3654c154-4a28-11e8-a1f3-0206690d449d
+STEP: Creating configMap with name cm-test-opt-upd-3654c194-4a28-11e8-a1f3-0206690d449d
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-3654c154-4a28-11e8-a1f3-0206690d449d
+STEP: Updating configmap cm-test-opt-upd-3654c194-4a28-11e8-a1f3-0206690d449d
+STEP: Creating configMap with name cm-test-opt-create-3654c264-4a28-11e8-a1f3-0206690d449d
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:36:27.096: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-b6p5b" for this suite.
+Apr 27 14:36:49.117: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:36:49.193: INFO: namespace: e2e-tests-configmap-b6p5b, resource: bindings, ignored listing per whitelist
+Apr 27 14:36:49.239: INFO: namespace e2e-tests-configmap-b6p5b deletion completed in 22.136767697s
+
+• [SLOW TEST:88.792 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:36:49.239: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Apr 27 14:36:49.356: INFO: Waiting up to 5m0s for pod "pod-6b435b03-4a28-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-sm8b8" to be "success or failure"
+Apr 27 14:36:49.359: INFO: Pod "pod-6b435b03-4a28-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.385001ms
+Apr 27 14:36:51.363: INFO: Pod "pod-6b435b03-4a28-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006263883s
+STEP: Saw pod success
+Apr 27 14:36:51.363: INFO: Pod "pod-6b435b03-4a28-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:36:51.365: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-6b435b03-4a28-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:36:51.381: INFO: Waiting for pod pod-6b435b03-4a28-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:36:51.383: INFO: Pod pod-6b435b03-4a28-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:36:51.383: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-sm8b8" for this suite.
+Apr 27 14:36:57.396: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:36:57.523: INFO: namespace: e2e-tests-emptydir-sm8b8, resource: bindings, ignored listing per whitelist
+Apr 27 14:36:57.540: INFO: namespace e2e-tests-emptydir-sm8b8 deletion completed in 6.153098471s
+
+• [SLOW TEST:8.301 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:36:57.540: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:36:57.642: INFO: (0) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.194305ms)
+Apr 27 14:36:57.645: INFO: (1) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.837402ms)
+Apr 27 14:36:57.649: INFO: (2) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.61642ms)
+Apr 27 14:36:57.653: INFO: (3) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.942681ms)
+Apr 27 14:36:57.657: INFO: (4) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.939427ms)
+Apr 27 14:36:57.661: INFO: (5) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.133361ms)
+Apr 27 14:36:57.666: INFO: (6) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.476922ms)
+Apr 27 14:36:57.670: INFO: (7) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.849067ms)
+Apr 27 14:36:57.673: INFO: (8) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.762334ms)
+Apr 27 14:36:57.677: INFO: (9) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.692112ms)
+Apr 27 14:36:57.681: INFO: (10) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.060205ms)
+Apr 27 14:36:57.685: INFO: (11) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.696194ms)
+Apr 27 14:36:57.689: INFO: (12) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.844083ms)
+Apr 27 14:36:57.693: INFO: (13) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.9765ms)
+Apr 27 14:36:57.697: INFO: (14) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.169484ms)
+Apr 27 14:36:57.701: INFO: (15) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.466267ms)
+Apr 27 14:36:57.705: INFO: (16) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.008277ms)
+Apr 27 14:36:57.710: INFO: (17) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.680025ms)
+Apr 27 14:36:57.715: INFO: (18) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.621697ms)
+Apr 27 14:36:57.719: INFO: (19) /api/v1/nodes/ip-10-250-12-147.eu-west-1.compute.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.94159ms)
+[AfterEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:36:57.719: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-7p5cs" for this suite.
+Apr 27 14:37:03.731: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:37:03.840: INFO: namespace: e2e-tests-proxy-7p5cs, resource: bindings, ignored listing per whitelist
+Apr 27 14:37:03.885: INFO: namespace e2e-tests-proxy-7p5cs deletion completed in 6.162657891s
+
+• [SLOW TEST:6.345 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:37:03.885: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-73fdc721-4a28-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:37:04.004: INFO: Waiting up to 5m0s for pod "pod-configmaps-73fe40c9-4a28-11e8-a1f3-0206690d449d" in namespace "e2e-tests-configmap-hplcv" to be "success or failure"
+Apr 27 14:37:04.007: INFO: Pod "pod-configmaps-73fe40c9-4a28-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.565219ms
+Apr 27 14:37:06.011: INFO: Pod "pod-configmaps-73fe40c9-4a28-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007170027s
+STEP: Saw pod success
+Apr 27 14:37:06.011: INFO: Pod "pod-configmaps-73fe40c9-4a28-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:37:06.014: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-configmaps-73fe40c9-4a28-11e8-a1f3-0206690d449d container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:37:06.029: INFO: Waiting for pod pod-configmaps-73fe40c9-4a28-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:37:06.032: INFO: Pod pod-configmaps-73fe40c9-4a28-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:37:06.032: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-hplcv" for this suite.
+Apr 27 14:37:12.046: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:37:12.139: INFO: namespace: e2e-tests-configmap-hplcv, resource: bindings, ignored listing per whitelist
+Apr 27 14:37:12.177: INFO: namespace e2e-tests-configmap-hplcv deletion completed in 6.140579196s
+
+• [SLOW TEST:8.292 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:37:12.177: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-r5hb7
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 27 14:37:12.264: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 27 14:37:28.321: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.110:8080/dial?request=hostName&protocol=udp&host=100.96.1.109&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-r5hb7 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:37:28.321: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:37:33.957: INFO: Waiting for endpoints: map[]
+Apr 27 14:37:33.960: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.110:8080/dial?request=hostName&protocol=udp&host=100.96.0.27&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-r5hb7 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:37:33.960: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:37:34.115: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:37:34.115: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-r5hb7" for this suite.
+Apr 27 14:37:56.129: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:37:56.169: INFO: namespace: e2e-tests-pod-network-test-r5hb7, resource: bindings, ignored listing per whitelist
+Apr 27 14:37:56.252: INFO: namespace e2e-tests-pod-network-test-r5hb7 deletion completed in 22.133311821s
+
+• [SLOW TEST:44.075 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:37:56.253: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:37:56.356: INFO: Waiting up to 5m0s for pod "downwardapi-volume-93326544-4a28-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-7znnn" to be "success or failure"
+Apr 27 14:37:56.360: INFO: Pod "downwardapi-volume-93326544-4a28-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.340052ms
+Apr 27 14:37:58.363: INFO: Pod "downwardapi-volume-93326544-4a28-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006266088s
+STEP: Saw pod success
+Apr 27 14:37:58.363: INFO: Pod "downwardapi-volume-93326544-4a28-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:37:58.365: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-93326544-4a28-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:37:58.404: INFO: Waiting for pod downwardapi-volume-93326544-4a28-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:37:58.407: INFO: Pod downwardapi-volume-93326544-4a28-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:37:58.407: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-7znnn" for this suite.
+Apr 27 14:38:04.421: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:38:04.526: INFO: namespace: e2e-tests-downward-api-7znnn, resource: bindings, ignored listing per whitelist
+Apr 27 14:38:04.550: INFO: namespace e2e-tests-downward-api-7znnn deletion completed in 6.139155637s
+
+• [SLOW TEST:8.297 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:38:04.550: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-2bk5n
+Apr 27 14:38:06.662: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-2bk5n
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:38:06.665: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:06.875: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-2bk5n" for this suite.
+Apr 27 14:40:12.889: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:13.013: INFO: namespace: e2e-tests-container-probe-2bk5n, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:13.061: INFO: namespace e2e-tests-container-probe-2bk5n deletion completed in 6.182213291s
+
+• [SLOW TEST:128.510 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:13.061: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:40:13.177: INFO: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:13.178: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-spmp6" for this suite.
+Apr 27 14:40:19.191: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:19.314: INFO: namespace: e2e-tests-container-probe-spmp6, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:19.314: INFO: namespace e2e-tests-container-probe-spmp6 deletion completed in 6.133179486s
+
+S [SKIPPING] [6.254 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a docker exec liveness probe with timeout  [Conformance] [It]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+
+  Apr 27 14:40:13.177: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:296
+------------------------------
+SSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:19.315: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:40:19.408: INFO: Creating daemon "daemon-set" with a node selector
+STEP: Initially, daemon pods should not be running on any nodes.
+Apr 27 14:40:19.415: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:19.415: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Change node label to blue, check that daemon pod is launched.
+Apr 27 14:40:19.440: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:19.440: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:20.443: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:20.443: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:21.443: INFO: Number of nodes with available pods: 1
+Apr 27 14:40:21.443: INFO: Number of running nodes: 1, number of available pods: 1
+STEP: Update the node label to green, and wait for daemons to be unscheduled
+Apr 27 14:40:21.464: INFO: Number of nodes with available pods: 1
+Apr 27 14:40:21.464: INFO: Number of running nodes: 0, number of available pods: 1
+Apr 27 14:40:22.468: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:22.468: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Update DaemonSet node selector to green, and change its update strategy to RollingUpdate
+Apr 27 14:40:22.476: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:22.476: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:23.480: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:23.480: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:24.480: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:24.480: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:25.480: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:25.480: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:26.481: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:26.481: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:27.481: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:27.481: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:28.480: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:28.480: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:29.480: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:29.480: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:30.480: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:30.480: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:31.480: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:31.480: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:32.480: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:32.480: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:33.481: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:33.481: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:34.480: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:34.480: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:35.480: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:35.480: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:36.480: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:36.480: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:40:37.482: INFO: Number of nodes with available pods: 1
+Apr 27 14:40:37.482: INFO: Number of running nodes: 1, number of available pods: 1
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 27 14:40:45.526: INFO: Number of nodes with available pods: 0
+Apr 27 14:40:45.526: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 27 14:40:45.532: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-nvhkz/daemonsets","resourceVersion":"8298"},"items":null}
+
+Apr 27 14:40:45.535: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-nvhkz/pods","resourceVersion":"8299"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:45.549: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-nvhkz" for this suite.
+Apr 27 14:40:51.562: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:51.686: INFO: namespace: e2e-tests-daemonsets-nvhkz, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:51.699: INFO: namespace e2e-tests-daemonsets-nvhkz deletion completed in 6.145911779s
+
+• [SLOW TEST:32.384 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:51.699: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Apr 27 14:40:51.803: INFO: Waiting up to 5m0s for pod "pod-fbc58df3-4a28-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-ksfnd" to be "success or failure"
+Apr 27 14:40:51.805: INFO: Pod "pod-fbc58df3-4a28-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.338122ms
+Apr 27 14:40:53.809: INFO: Pod "pod-fbc58df3-4a28-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005372714s
+STEP: Saw pod success
+Apr 27 14:40:53.809: INFO: Pod "pod-fbc58df3-4a28-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:40:53.811: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-fbc58df3-4a28-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:40:53.827: INFO: Waiting for pod pod-fbc58df3-4a28-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:40:53.830: INFO: Pod pod-fbc58df3-4a28-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:53.830: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-ksfnd" for this suite.
+Apr 27 14:40:59.841: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:59.929: INFO: namespace: e2e-tests-emptydir-ksfnd, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:59.981: INFO: namespace e2e-tests-emptydir-ksfnd deletion completed in 6.148152065s
+
+• [SLOW TEST:8.283 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:59.981: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-00b6011c-4a29-11e8-a1f3-0206690d449d
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-00b6011c-4a29-11e8-a1f3-0206690d449d
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:41:04.175: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rlr48" for this suite.
+Apr 27 14:41:26.189: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:41:26.253: INFO: namespace: e2e-tests-projected-rlr48, resource: bindings, ignored listing per whitelist
+Apr 27 14:41:26.320: INFO: namespace e2e-tests-projected-rlr48 deletion completed in 22.139545806s
+
+• [SLOW TEST:26.339 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:41:26.320: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:41:26.432: INFO: Creating ReplicaSet my-hostname-basic-106a6759-4a29-11e8-a1f3-0206690d449d
+Apr 27 14:41:26.438: INFO: Pod name my-hostname-basic-106a6759-4a29-11e8-a1f3-0206690d449d: Found 0 pods out of 1
+Apr 27 14:41:31.442: INFO: Pod name my-hostname-basic-106a6759-4a29-11e8-a1f3-0206690d449d: Found 1 pods out of 1
+Apr 27 14:41:31.442: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-106a6759-4a29-11e8-a1f3-0206690d449d" is running
+Apr 27 14:41:31.445: INFO: Pod "my-hostname-basic-106a6759-4a29-11e8-a1f3-0206690d449d-dgmqc" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:41:26 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:41:28 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:41:26 +0000 UTC Reason: Message:}])
+Apr 27 14:41:31.445: INFO: Trying to dial the pod
+Apr 27 14:41:36.494: INFO: Controller my-hostname-basic-106a6759-4a29-11e8-a1f3-0206690d449d: Got expected result from replica 1 [my-hostname-basic-106a6759-4a29-11e8-a1f3-0206690d449d-dgmqc]: "my-hostname-basic-106a6759-4a29-11e8-a1f3-0206690d449d-dgmqc", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:41:36.494: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-9f6tz" for this suite.
+Apr 27 14:41:42.508: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:41:42.616: INFO: namespace: e2e-tests-replicaset-9f6tz, resource: bindings, ignored listing per whitelist
+Apr 27 14:41:42.653: INFO: namespace e2e-tests-replicaset-9f6tz deletion completed in 6.154802757s
+
+• [SLOW TEST:16.333 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:41:42.653: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: getting the auto-created API token
+Apr 27 14:41:43.264: INFO: created pod pod-service-account-defaultsa
+Apr 27 14:41:43.264: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Apr 27 14:41:43.268: INFO: created pod pod-service-account-mountsa
+Apr 27 14:41:43.268: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Apr 27 14:41:43.275: INFO: created pod pod-service-account-nomountsa
+Apr 27 14:41:43.275: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Apr 27 14:41:43.281: INFO: created pod pod-service-account-defaultsa-mountspec
+Apr 27 14:41:43.281: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Apr 27 14:41:43.287: INFO: created pod pod-service-account-mountsa-mountspec
+Apr 27 14:41:43.287: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Apr 27 14:41:43.295: INFO: created pod pod-service-account-nomountsa-mountspec
+Apr 27 14:41:43.295: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Apr 27 14:41:43.301: INFO: created pod pod-service-account-defaultsa-nomountspec
+Apr 27 14:41:43.301: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Apr 27 14:41:43.307: INFO: created pod pod-service-account-mountsa-nomountspec
+Apr 27 14:41:43.307: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Apr 27 14:41:43.313: INFO: created pod pod-service-account-nomountsa-nomountspec
+Apr 27 14:41:43.313: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:41:43.313: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-78zg5" for this suite.
+Apr 27 14:41:49.339: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:41:49.403: INFO: namespace: e2e-tests-svcaccounts-78zg5, resource: bindings, ignored listing per whitelist
+Apr 27 14:41:49.472: INFO: namespace e2e-tests-svcaccounts-78zg5 deletion completed in 6.149999271s
+
+• [SLOW TEST:6.818 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:41:49.472: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:37
+[It] should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test hostPath mode
+Apr 27 14:41:49.574: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-5bhmw" to be "success or failure"
+Apr 27 14:41:49.579: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 4.456778ms
+Apr 27 14:41:51.582: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007694196s
+STEP: Saw pod success
+Apr 27 14:41:51.582: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Apr 27 14:41:51.585: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Apr 27 14:41:51.599: INFO: Waiting for pod pod-host-path-test to disappear
+Apr 27 14:41:51.602: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:41:51.602: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-5bhmw" for this suite.
+Apr 27 14:41:57.614: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:41:57.718: INFO: namespace: e2e-tests-hostpath-5bhmw, resource: bindings, ignored listing per whitelist
+Apr 27 14:41:57.743: INFO: namespace e2e-tests-hostpath-5bhmw deletion completed in 6.137717809s
+
+• [SLOW TEST:8.271 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:34
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:41:57.743: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-2321a013-4a29-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:41:57.841: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-232243d8-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-fb79s" to be "success or failure"
+Apr 27 14:41:57.843: INFO: Pod "pod-projected-configmaps-232243d8-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.80067ms
+Apr 27 14:41:59.847: INFO: Pod "pod-projected-configmaps-232243d8-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005866906s
+STEP: Saw pod success
+Apr 27 14:41:59.847: INFO: Pod "pod-projected-configmaps-232243d8-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:41:59.849: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-configmaps-232243d8-4a29-11e8-a1f3-0206690d449d container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:41:59.873: INFO: Waiting for pod pod-projected-configmaps-232243d8-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:41:59.875: INFO: Pod pod-projected-configmaps-232243d8-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:41:59.875: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fb79s" for this suite.
+Apr 27 14:42:05.890: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:42:06.036: INFO: namespace: e2e-tests-projected-fb79s, resource: bindings, ignored listing per whitelist
+Apr 27 14:42:06.075: INFO: namespace e2e-tests-projected-fb79s deletion completed in 6.19650047s
+
+• [SLOW TEST:8.332 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:42:06.075: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-map-281978d1-4a29-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:42:06.175: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-2819eeb2-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-lrvds" to be "success or failure"
+Apr 27 14:42:06.180: INFO: Pod "pod-projected-secrets-2819eeb2-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.625638ms
+Apr 27 14:42:08.184: INFO: Pod "pod-projected-secrets-2819eeb2-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008479068s
+STEP: Saw pod success
+Apr 27 14:42:08.184: INFO: Pod "pod-projected-secrets-2819eeb2-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:42:08.193: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-secrets-2819eeb2-4a29-11e8-a1f3-0206690d449d container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:42:08.211: INFO: Waiting for pod pod-projected-secrets-2819eeb2-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:42:08.215: INFO: Pod pod-projected-secrets-2819eeb2-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:42:08.215: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lrvds" for this suite.
+Apr 27 14:42:14.228: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:42:14.356: INFO: namespace: e2e-tests-projected-lrvds, resource: bindings, ignored listing per whitelist
+Apr 27 14:42:14.380: INFO: namespace e2e-tests-projected-lrvds deletion completed in 6.160728362s
+
+• [SLOW TEST:8.305 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:42:14.380: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:42:16.497: INFO: Waiting up to 5m0s for pod "client-envvars-2e41010c-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-pods-2xgjg" to be "success or failure"
+Apr 27 14:42:16.501: INFO: Pod "client-envvars-2e41010c-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.656316ms
+Apr 27 14:42:18.505: INFO: Pod "client-envvars-2e41010c-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007286035s
+Apr 27 14:42:20.508: INFO: Pod "client-envvars-2e41010c-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010945178s
+STEP: Saw pod success
+Apr 27 14:42:20.508: INFO: Pod "client-envvars-2e41010c-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:42:20.513: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod client-envvars-2e41010c-4a29-11e8-a1f3-0206690d449d container env3cont: <nil>
+STEP: delete the pod
+Apr 27 14:42:20.532: INFO: Waiting for pod client-envvars-2e41010c-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:42:20.536: INFO: Pod client-envvars-2e41010c-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:42:20.536: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-2xgjg" for this suite.
+Apr 27 14:42:42.554: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:42:42.613: INFO: namespace: e2e-tests-pods-2xgjg, resource: bindings, ignored listing per whitelist
+Apr 27 14:42:42.703: INFO: namespace e2e-tests-pods-2xgjg deletion completed in 22.160424433s
+
+• [SLOW TEST:28.323 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:42:42.704: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-map-3defb7e7-4a29-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:42:42.810: INFO: Waiting up to 5m0s for pod "pod-secrets-3df02d74-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-secrets-qxx8m" to be "success or failure"
+Apr 27 14:42:42.813: INFO: Pod "pod-secrets-3df02d74-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.603575ms
+Apr 27 14:42:44.816: INFO: Pod "pod-secrets-3df02d74-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006021632s
+STEP: Saw pod success
+Apr 27 14:42:44.816: INFO: Pod "pod-secrets-3df02d74-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:42:44.819: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-secrets-3df02d74-4a29-11e8-a1f3-0206690d449d container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:42:44.840: INFO: Waiting for pod pod-secrets-3df02d74-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:42:44.843: INFO: Pod pod-secrets-3df02d74-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:42:44.843: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-qxx8m" for this suite.
+Apr 27 14:42:50.855: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:42:50.908: INFO: namespace: e2e-tests-secrets-qxx8m, resource: bindings, ignored listing per whitelist
+Apr 27 14:42:50.975: INFO: namespace e2e-tests-secrets-qxx8m deletion completed in 6.128601041s
+
+• [SLOW TEST:8.271 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:42:50.976: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap e2e-tests-configmap-g6vqd/configmap-test-42de25a8-4a29-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:42:51.085: INFO: Waiting up to 5m0s for pod "pod-configmaps-42de9bbf-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-configmap-g6vqd" to be "success or failure"
+Apr 27 14:42:51.087: INFO: Pod "pod-configmaps-42de9bbf-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.663478ms
+Apr 27 14:42:53.090: INFO: Pod "pod-configmaps-42de9bbf-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00578689s
+Apr 27 14:42:55.093: INFO: Pod "pod-configmaps-42de9bbf-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008817831s
+STEP: Saw pod success
+Apr 27 14:42:55.093: INFO: Pod "pod-configmaps-42de9bbf-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:42:55.096: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-configmaps-42de9bbf-4a29-11e8-a1f3-0206690d449d container env-test: <nil>
+STEP: delete the pod
+Apr 27 14:42:55.111: INFO: Waiting for pod pod-configmaps-42de9bbf-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:42:55.114: INFO: Pod pod-configmaps-42de9bbf-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:42:55.114: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-g6vqd" for this suite.
+Apr 27 14:43:01.127: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:43:01.173: INFO: namespace: e2e-tests-configmap-g6vqd, resource: bindings, ignored listing per whitelist
+Apr 27 14:43:01.253: INFO: namespace e2e-tests-configmap-g6vqd deletion completed in 6.135241007s
+
+• [SLOW TEST:10.277 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:43:01.253: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:43:01.348: INFO: Waiting up to 5m0s for pod "downwardapi-volume-48fcac83-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-5zk97" to be "success or failure"
+Apr 27 14:43:01.351: INFO: Pod "downwardapi-volume-48fcac83-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.945291ms
+Apr 27 14:43:03.354: INFO: Pod "downwardapi-volume-48fcac83-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005819612s
+STEP: Saw pod success
+Apr 27 14:43:03.354: INFO: Pod "downwardapi-volume-48fcac83-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:43:03.357: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-48fcac83-4a29-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:43:03.372: INFO: Waiting for pod downwardapi-volume-48fcac83-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:43:03.375: INFO: Pod downwardapi-volume-48fcac83-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:43:03.375: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-5zk97" for this suite.
+Apr 27 14:43:09.386: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:43:09.456: INFO: namespace: e2e-tests-downward-api-5zk97, resource: bindings, ignored listing per whitelist
+Apr 27 14:43:09.506: INFO: namespace e2e-tests-downward-api-5zk97 deletion completed in 6.12838526s
+
+• [SLOW TEST:8.253 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:43:09.507: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-4de7c086-4a29-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:43:09.603: INFO: Waiting up to 5m0s for pod "pod-secrets-4de837d4-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-secrets-kwgpz" to be "success or failure"
+Apr 27 14:43:09.606: INFO: Pod "pod-secrets-4de837d4-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.09003ms
+Apr 27 14:43:11.609: INFO: Pod "pod-secrets-4de837d4-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006566783s
+STEP: Saw pod success
+Apr 27 14:43:11.609: INFO: Pod "pod-secrets-4de837d4-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:43:11.612: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-secrets-4de837d4-4a29-11e8-a1f3-0206690d449d container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:43:11.629: INFO: Waiting for pod pod-secrets-4de837d4-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:43:11.631: INFO: Pod pod-secrets-4de837d4-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:43:11.631: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-kwgpz" for this suite.
+Apr 27 14:43:17.643: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:43:17.749: INFO: namespace: e2e-tests-secrets-kwgpz, resource: bindings, ignored listing per whitelist
+Apr 27 14:43:17.763: INFO: namespace e2e-tests-secrets-kwgpz deletion completed in 6.128942079s
+
+• [SLOW TEST:8.257 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:43:17.764: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-projected-all-test-volume-52d3cb61-4a29-11e8-a1f3-0206690d449d
+STEP: Creating secret with name secret-projected-all-test-volume-52d3cb37-4a29-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Apr 27 14:43:17.865: INFO: Waiting up to 5m0s for pod "projected-volume-52d3c948-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-jzq6l" to be "success or failure"
+Apr 27 14:43:17.868: INFO: Pod "projected-volume-52d3c948-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.870771ms
+Apr 27 14:43:19.871: INFO: Pod "projected-volume-52d3c948-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006078591s
+Apr 27 14:43:21.873: INFO: Pod "projected-volume-52d3c948-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008664065s
+STEP: Saw pod success
+Apr 27 14:43:21.874: INFO: Pod "projected-volume-52d3c948-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:43:21.876: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod projected-volume-52d3c948-4a29-11e8-a1f3-0206690d449d container projected-all-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:43:21.890: INFO: Waiting for pod projected-volume-52d3c948-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:43:21.893: INFO: Pod projected-volume-52d3c948-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:43:21.893: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jzq6l" for this suite.
+Apr 27 14:43:27.905: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:43:27.950: INFO: namespace: e2e-tests-projected-jzq6l, resource: bindings, ignored listing per whitelist
+Apr 27 14:43:28.028: INFO: namespace e2e-tests-projected-jzq6l deletion completed in 6.131417997s
+
+• [SLOW TEST:10.264 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:43:28.028: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for all pods to be garbage collected
+STEP: Gathering metrics
+W0427 14:43:38.155006      13 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:43:38.155: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:43:38.155: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-m77pv" for this suite.
+Apr 27 14:43:44.177: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:43:44.275: INFO: namespace: e2e-tests-gc-m77pv, resource: bindings, ignored listing per whitelist
+Apr 27 14:43:44.308: INFO: namespace e2e-tests-gc-m77pv deletion completed in 6.150360719s
+
+• [SLOW TEST:16.280 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:43:44.309: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Apr 27 14:43:44.406: INFO: Waiting up to 5m0s for pod "pod-62a6c319-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-q5jvv" to be "success or failure"
+Apr 27 14:43:44.408: INFO: Pod "pod-62a6c319-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.163643ms
+Apr 27 14:43:46.412: INFO: Pod "pod-62a6c319-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006129816s
+STEP: Saw pod success
+Apr 27 14:43:46.412: INFO: Pod "pod-62a6c319-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:43:46.415: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-62a6c319-4a29-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:43:46.434: INFO: Waiting for pod pod-62a6c319-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:43:46.437: INFO: Pod pod-62a6c319-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:43:46.437: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-q5jvv" for this suite.
+Apr 27 14:43:52.448: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:43:52.532: INFO: namespace: e2e-tests-emptydir-q5jvv, resource: bindings, ignored listing per whitelist
+Apr 27 14:43:52.590: INFO: namespace e2e-tests-emptydir-q5jvv deletion completed in 6.14968098s
+
+• [SLOW TEST:8.281 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:43:52.590: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Apr 27 14:43:52.678: INFO: Waiting up to 1m0s for all nodes to be ready
+Apr 27 14:44:52.699: INFO: Waiting for terminating namespaces to be deleted...
+Apr 27 14:44:52.704: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 27 14:44:52.715: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 27 14:44:52.715: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 27 14:44:52.718: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 27 14:44:52.719: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-12-147.eu-west-1.compute.internal before test
+Apr 27 14:44:52.730: INFO: kube-proxy-cz98z from kube-system started at 2018-04-27 13:49:28 +0000 UTC (1 container statuses recorded)
+Apr 27 14:44:52.730: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:44:52.730: INFO: calico-node-6q8fw from kube-system started at 2018-04-27 13:49:28 +0000 UTC (2 container statuses recorded)
+Apr 27 14:44:52.730: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:44:52.730: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:44:52.730: INFO: kube-dns-67b49bdfd8-lbm4c from kube-system started at 2018-04-27 13:51:05 +0000 UTC (3 container statuses recorded)
+Apr 27 14:44:52.731: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:44:52.731: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:44:52.731: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:44:52.731: INFO: sonobuoy-e2e-job-2ded2f49b96d41b5 from sonobuoy started at 2018-04-27 14:03:23 +0000 UTC (2 container statuses recorded)
+Apr 27 14:44:52.731: INFO: 	Container e2e ready: true, restart count 0
+Apr 27 14:44:52.731: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Apr 27 14:44:52.731: INFO: node-exporter-pnnmw from kube-system started at 2018-04-27 13:49:28 +0000 UTC (1 container statuses recorded)
+Apr 27 14:44:52.731: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:44:52.731: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-bfjjd from kube-system started at 2018-04-27 13:50:35 +0000 UTC (1 container statuses recorded)
+Apr 27 14:44:52.731: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Apr 27 14:44:52.731: INFO: addons-heapster-e3b0c-5c98c994fc-qvtf9 from kube-system started at 2018-04-27 13:50:36 +0000 UTC (2 container statuses recorded)
+Apr 27 14:44:52.731: INFO: 	Container heapster ready: true, restart count 0
+Apr 27 14:44:52.731: INFO: 	Container heapster-nanny ready: true, restart count 0
+Apr 27 14:44:52.731: INFO: addons-kubernetes-dashboard-8478f49fbf-f642m from kube-system started at 2018-04-27 13:50:37 +0000 UTC (1 container statuses recorded)
+Apr 27 14:44:52.731: INFO: 	Container main ready: true, restart count 0
+Apr 27 14:44:52.731: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-14-38.eu-west-1.compute.internal before test
+Apr 27 14:44:52.740: INFO: node-exporter-2gxj5 from kube-system started at 2018-04-27 13:49:29 +0000 UTC (1 container statuses recorded)
+Apr 27 14:44:52.740: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:44:52.740: INFO: calico-node-qmckv from kube-system started at 2018-04-27 13:49:29 +0000 UTC (2 container statuses recorded)
+Apr 27 14:44:52.740: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:44:52.740: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:44:52.740: INFO: kube-proxy-pnptq from kube-system started at 2018-04-27 13:49:29 +0000 UTC (1 container statuses recorded)
+Apr 27 14:44:52.740: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:44:52.740: INFO: vpn-shoot-8c58cd4d6-xjrwf from kube-system started at 2018-04-27 13:50:35 +0000 UTC (1 container statuses recorded)
+Apr 27 14:44:52.740: INFO: 	Container vpn-shoot ready: true, restart count 1
+Apr 27 14:44:52.740: INFO: addons-nginx-ingress-controller-858f4fc5d7-x27vt from kube-system started at 2018-04-27 13:50:36 +0000 UTC (1 container statuses recorded)
+Apr 27 14:44:52.740: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Apr 27 14:44:52.740: INFO: kube-dns-autoscaler-699b4b55c4-sxgbp from kube-system started at 2018-04-27 13:50:37 +0000 UTC (1 container statuses recorded)
+Apr 27 14:44:52.740: INFO: 	Container autoscaler ready: true, restart count 0
+Apr 27 14:44:52.740: INFO: kube-dns-67b49bdfd8-hm6sf from kube-system started at 2018-04-27 13:50:38 +0000 UTC (3 container statuses recorded)
+Apr 27 14:44:52.740: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:44:52.740: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:44:52.740: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:44:52.740: INFO: sonobuoy from sonobuoy started at 2018-04-27 14:03:03 +0000 UTC (1 container statuses recorded)
+Apr 27 14:44:52.740: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.1529522ad540f0f6], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 node(s) didn't match node selector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:44:53.763: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-r68fs" for this suite.
+Apr 27 14:45:15.775: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:45:15.857: INFO: namespace: e2e-tests-sched-pred-r68fs, resource: bindings, ignored listing per whitelist
+Apr 27 14:45:15.908: INFO: namespace e2e-tests-sched-pred-r68fs deletion completed in 22.14169487s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.318 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:45:15.909: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:45:16.011: INFO: Waiting up to 5m0s for pod "downwardapi-volume-99407cfe-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-tzg92" to be "success or failure"
+Apr 27 14:45:16.013: INFO: Pod "downwardapi-volume-99407cfe-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.370492ms
+Apr 27 14:45:18.016: INFO: Pod "downwardapi-volume-99407cfe-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005345892s
+STEP: Saw pod success
+Apr 27 14:45:18.016: INFO: Pod "downwardapi-volume-99407cfe-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:45:18.018: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-99407cfe-4a29-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:45:18.037: INFO: Waiting for pod downwardapi-volume-99407cfe-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:45:18.040: INFO: Pod downwardapi-volume-99407cfe-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:45:18.040: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-tzg92" for this suite.
+Apr 27 14:45:24.053: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:45:24.174: INFO: namespace: e2e-tests-downward-api-tzg92, resource: bindings, ignored listing per whitelist
+Apr 27 14:45:24.192: INFO: namespace e2e-tests-downward-api-tzg92 deletion completed in 6.149195023s
+
+• [SLOW TEST:8.283 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:45:24.193: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-map-9e2e9e35-4a29-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:45:24.284: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-9e2f14ab-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-4c2v6" to be "success or failure"
+Apr 27 14:45:24.287: INFO: Pod "pod-projected-secrets-9e2f14ab-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.582752ms
+Apr 27 14:45:26.290: INFO: Pod "pod-projected-secrets-9e2f14ab-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005873338s
+STEP: Saw pod success
+Apr 27 14:45:26.290: INFO: Pod "pod-projected-secrets-9e2f14ab-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:45:26.293: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-projected-secrets-9e2f14ab-4a29-11e8-a1f3-0206690d449d container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:45:26.310: INFO: Waiting for pod pod-projected-secrets-9e2f14ab-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:45:26.313: INFO: Pod pod-projected-secrets-9e2f14ab-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:45:26.313: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4c2v6" for this suite.
+Apr 27 14:45:32.328: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:45:32.386: INFO: namespace: e2e-tests-projected-4c2v6, resource: bindings, ignored listing per whitelist
+Apr 27 14:45:32.479: INFO: namespace e2e-tests-projected-4c2v6 deletion completed in 6.162683026s
+
+• [SLOW TEST:8.286 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:45:32.479: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override command
+Apr 27 14:45:32.575: INFO: Waiting up to 5m0s for pod "client-containers-a3201dc2-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-containers-zcgs4" to be "success or failure"
+Apr 27 14:45:32.577: INFO: Pod "client-containers-a3201dc2-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.425409ms
+Apr 27 14:45:34.584: INFO: Pod "client-containers-a3201dc2-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009057037s
+STEP: Saw pod success
+Apr 27 14:45:34.584: INFO: Pod "client-containers-a3201dc2-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:45:34.586: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod client-containers-a3201dc2-4a29-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:45:34.604: INFO: Waiting for pod client-containers-a3201dc2-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:45:34.607: INFO: Pod client-containers-a3201dc2-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:45:34.607: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-zcgs4" for this suite.
+Apr 27 14:45:40.619: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:45:40.673: INFO: namespace: e2e-tests-containers-zcgs4, resource: bindings, ignored listing per whitelist
+Apr 27 14:45:40.756: INFO: namespace e2e-tests-containers-zcgs4 deletion completed in 6.146010298s
+
+• [SLOW TEST:8.277 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:45:40.757: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the pods
+STEP: Gathering metrics
+W0427 14:46:20.880054      13 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:46:20.880: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:46:20.880: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-qblpj" for this suite.
+Apr 27 14:46:26.900: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:46:27.128: INFO: namespace: e2e-tests-gc-qblpj, resource: bindings, ignored listing per whitelist
+Apr 27 14:46:27.224: INFO: namespace e2e-tests-gc-qblpj deletion completed in 6.340569134s
+
+• [SLOW TEST:46.467 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:46:27.224: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-hmbxm
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-hmbxm to expose endpoints map[]
+Apr 27 14:46:27.561: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-hmbxm exposes endpoints map[] (28.75727ms elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-hmbxm
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-hmbxm to expose endpoints map[pod1:[80]]
+Apr 27 14:46:31.618: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-hmbxm exposes endpoints map[pod1:[80]] (4.028225021s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-hmbxm
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-hmbxm to expose endpoints map[pod2:[80] pod1:[80]]
+Apr 27 14:46:33.649: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-hmbxm exposes endpoints map[pod1:[80] pod2:[80]] (2.026155084s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-hmbxm
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-hmbxm to expose endpoints map[pod2:[80]]
+Apr 27 14:46:34.664: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-hmbxm exposes endpoints map[pod2:[80]] (1.011627213s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-hmbxm
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-hmbxm to expose endpoints map[]
+Apr 27 14:46:34.676: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-hmbxm exposes endpoints map[] (3.558529ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:46:34.685: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-hmbxm" for this suite.
+Apr 27 14:46:56.703: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:46:56.822: INFO: namespace: e2e-tests-services-hmbxm, resource: bindings, ignored listing per whitelist
+Apr 27 14:46:56.842: INFO: namespace e2e-tests-services-hmbxm deletion completed in 22.153318091s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:29.618 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:46:56.842: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name cm-test-opt-del-d56a93c9-4a29-11e8-a1f3-0206690d449d
+STEP: Creating configMap with name cm-test-opt-upd-d56a940f-4a29-11e8-a1f3-0206690d449d
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-d56a93c9-4a29-11e8-a1f3-0206690d449d
+STEP: Updating configmap cm-test-opt-upd-d56a940f-4a29-11e8-a1f3-0206690d449d
+STEP: Creating configMap with name cm-test-opt-create-d56a942c-4a29-11e8-a1f3-0206690d449d
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:01.219: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lz6jf" for this suite.
+Apr 27 14:47:23.231: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:23.353: INFO: namespace: e2e-tests-projected-lz6jf, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:23.353: INFO: namespace e2e-tests-projected-lz6jf deletion completed in 22.130904931s
+
+• [SLOW TEST:26.511 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:23.353: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir volume type on node default medium
+Apr 27 14:47:23.470: INFO: Waiting up to 5m0s for pod "pod-e5393bb9-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-hj6ql" to be "success or failure"
+Apr 27 14:47:23.473: INFO: Pod "pod-e5393bb9-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.373459ms
+Apr 27 14:47:25.476: INFO: Pod "pod-e5393bb9-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00590753s
+STEP: Saw pod success
+Apr 27 14:47:25.476: INFO: Pod "pod-e5393bb9-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:47:25.479: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-e5393bb9-4a29-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:47:25.500: INFO: Waiting for pod pod-e5393bb9-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:47:25.503: INFO: Pod pod-e5393bb9-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:25.503: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-hj6ql" for this suite.
+Apr 27 14:47:31.518: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:31.612: INFO: namespace: e2e-tests-emptydir-hj6ql, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:31.642: INFO: namespace e2e-tests-emptydir-hj6ql deletion completed in 6.135308559s
+
+• [SLOW TEST:8.289 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:31.643: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Apr 27 14:47:31.730: INFO: Waiting up to 5m0s for pod "pod-ea25a0de-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-emptydir-b7d9t" to be "success or failure"
+Apr 27 14:47:31.735: INFO: Pod "pod-ea25a0de-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.663672ms
+Apr 27 14:47:33.738: INFO: Pod "pod-ea25a0de-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008099228s
+STEP: Saw pod success
+Apr 27 14:47:33.738: INFO: Pod "pod-ea25a0de-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:47:33.741: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-ea25a0de-4a29-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:47:33.754: INFO: Waiting for pod pod-ea25a0de-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:47:33.756: INFO: Pod pod-ea25a0de-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:33.757: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-b7d9t" for this suite.
+Apr 27 14:47:39.768: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:39.887: INFO: namespace: e2e-tests-emptydir-b7d9t, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:39.914: INFO: namespace e2e-tests-emptydir-b7d9t deletion completed in 6.154469026s
+
+• [SLOW TEST:8.271 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:39.914: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-ef145505-4a29-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume secrets
+Apr 27 14:47:40.008: INFO: Waiting up to 5m0s for pod "pod-secrets-ef14d0b9-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-secrets-9zqtr" to be "success or failure"
+Apr 27 14:47:40.010: INFO: Pod "pod-secrets-ef14d0b9-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.323711ms
+Apr 27 14:47:42.013: INFO: Pod "pod-secrets-ef14d0b9-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005307161s
+Apr 27 14:47:44.016: INFO: Pod "pod-secrets-ef14d0b9-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008408595s
+STEP: Saw pod success
+Apr 27 14:47:44.016: INFO: Pod "pod-secrets-ef14d0b9-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:47:44.019: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-secrets-ef14d0b9-4a29-11e8-a1f3-0206690d449d container secret-env-test: <nil>
+STEP: delete the pod
+Apr 27 14:47:44.033: INFO: Waiting for pod pod-secrets-ef14d0b9-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:47:44.036: INFO: Pod pod-secrets-ef14d0b9-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:44.037: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-9zqtr" for this suite.
+Apr 27 14:47:50.048: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:50.097: INFO: namespace: e2e-tests-secrets-9zqtr, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:50.173: INFO: namespace e2e-tests-secrets-9zqtr deletion completed in 6.133636306s
+
+• [SLOW TEST:10.259 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:50.174: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test substitution in container's args
+Apr 27 14:47:50.267: INFO: Waiting up to 5m0s for pod "var-expansion-f5324703-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-var-expansion-sjb2n" to be "success or failure"
+Apr 27 14:47:50.270: INFO: Pod "var-expansion-f5324703-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.900265ms
+Apr 27 14:47:52.273: INFO: Pod "var-expansion-f5324703-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005794785s
+Apr 27 14:47:54.277: INFO: Pod "var-expansion-f5324703-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009290303s
+STEP: Saw pod success
+Apr 27 14:47:54.277: INFO: Pod "var-expansion-f5324703-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:47:54.279: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod var-expansion-f5324703-4a29-11e8-a1f3-0206690d449d container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:47:54.302: INFO: Waiting for pod var-expansion-f5324703-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:47:54.304: INFO: Pod var-expansion-f5324703-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:54.305: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-sjb2n" for this suite.
+Apr 27 14:48:00.315: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:48:00.391: INFO: namespace: e2e-tests-var-expansion-sjb2n, resource: bindings, ignored listing per whitelist
+Apr 27 14:48:00.464: INFO: namespace e2e-tests-var-expansion-sjb2n deletion completed in 6.156631687s
+
+• [SLOW TEST:10.291 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:48:00.465: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override arguments
+Apr 27 14:48:00.572: INFO: Waiting up to 5m0s for pod "client-containers-fb56a8a7-4a29-11e8-a1f3-0206690d449d" in namespace "e2e-tests-containers-nlwhk" to be "success or failure"
+Apr 27 14:48:00.574: INFO: Pod "client-containers-fb56a8a7-4a29-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.156927ms
+Apr 27 14:48:02.577: INFO: Pod "client-containers-fb56a8a7-4a29-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005146923s
+STEP: Saw pod success
+Apr 27 14:48:02.577: INFO: Pod "client-containers-fb56a8a7-4a29-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:48:02.579: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod client-containers-fb56a8a7-4a29-11e8-a1f3-0206690d449d container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:48:02.594: INFO: Waiting for pod client-containers-fb56a8a7-4a29-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:48:02.596: INFO: Pod client-containers-fb56a8a7-4a29-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:48:02.596: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-nlwhk" for this suite.
+Apr 27 14:48:08.608: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:48:08.708: INFO: namespace: e2e-tests-containers-nlwhk, resource: bindings, ignored listing per whitelist
+Apr 27 14:48:08.727: INFO: namespace e2e-tests-containers-nlwhk deletion completed in 6.12669426s
+
+• [SLOW TEST:8.262 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:48:08.727: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 27 14:48:11.345: INFO: Successfully updated pod "labelsupdate00410324-4a2a-11e8-a1f3-0206690d449d"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:48:13.367: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wdqwl" for this suite.
+Apr 27 14:48:35.379: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:48:35.464: INFO: namespace: e2e-tests-projected-wdqwl, resource: bindings, ignored listing per whitelist
+Apr 27 14:48:35.516: INFO: namespace e2e-tests-projected-wdqwl deletion completed in 22.145597536s
+
+• [SLOW TEST:26.790 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:48:35.517: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-p4sxk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-p4sxk to expose endpoints map[]
+Apr 27 14:48:35.619: INFO: Get endpoints failed (2.094498ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Apr 27 14:48:36.622: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-p4sxk exposes endpoints map[] (1.004818801s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-p4sxk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-p4sxk to expose endpoints map[pod1:[100]]
+Apr 27 14:48:38.645: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-p4sxk exposes endpoints map[pod1:[100]] (2.015749498s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-p4sxk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-p4sxk to expose endpoints map[pod1:[100] pod2:[101]]
+Apr 27 14:48:39.670: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-p4sxk exposes endpoints map[pod1:[100] pod2:[101]] (1.02072427s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-p4sxk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-p4sxk to expose endpoints map[pod2:[101]]
+Apr 27 14:48:40.684: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-p4sxk exposes endpoints map[pod2:[101]] (1.010033634s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-p4sxk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-p4sxk to expose endpoints map[]
+Apr 27 14:48:40.698: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-p4sxk exposes endpoints map[] (2.592388ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:48:40.707: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-p4sxk" for this suite.
+Apr 27 14:49:02.724: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:49:02.792: INFO: namespace: e2e-tests-services-p4sxk, resource: bindings, ignored listing per whitelist
+Apr 27 14:49:02.868: INFO: namespace e2e-tests-services-p4sxk deletion completed in 22.156482711s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:27.351 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:49:02.868: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test substitution in container's command
+Apr 27 14:49:02.965: INFO: Waiting up to 5m0s for pod "var-expansion-20870d95-4a2a-11e8-a1f3-0206690d449d" in namespace "e2e-tests-var-expansion-kmbxm" to be "success or failure"
+Apr 27 14:49:02.968: INFO: Pod "var-expansion-20870d95-4a2a-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.786878ms
+Apr 27 14:49:04.972: INFO: Pod "var-expansion-20870d95-4a2a-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007405244s
+Apr 27 14:49:06.975: INFO: Pod "var-expansion-20870d95-4a2a-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010525735s
+STEP: Saw pod success
+Apr 27 14:49:06.975: INFO: Pod "var-expansion-20870d95-4a2a-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:49:06.978: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod var-expansion-20870d95-4a2a-11e8-a1f3-0206690d449d container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:49:07.017: INFO: Waiting for pod var-expansion-20870d95-4a2a-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:49:07.024: INFO: Pod var-expansion-20870d95-4a2a-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:49:07.024: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-kmbxm" for this suite.
+Apr 27 14:49:13.037: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:49:13.149: INFO: namespace: e2e-tests-var-expansion-kmbxm, resource: bindings, ignored listing per whitelist
+Apr 27 14:49:13.161: INFO: namespace e2e-tests-var-expansion-kmbxm deletion completed in 6.133176012s
+
+• [SLOW TEST:10.293 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:49:13.161: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Apr 27 14:49:17.270: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vtrv6 PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:49:17.270: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:49:17.385: INFO: Exec stderr: ""
+Apr 27 14:49:17.385: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vtrv6 PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:49:17.385: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:49:17.612: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Apr 27 14:49:17.612: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vtrv6 PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:49:17.612: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:49:17.802: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Apr 27 14:49:17.802: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vtrv6 PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:49:17.802: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:49:17.942: INFO: Exec stderr: ""
+Apr 27 14:49:17.942: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vtrv6 PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:49:17.942: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:49:24.929: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:49:24.929: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-vtrv6" for this suite.
+Apr 27 14:50:08.942: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:50:09.038: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-vtrv6, resource: bindings, ignored listing per whitelist
+Apr 27 14:50:09.083: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-vtrv6 deletion completed in 44.150603662s
+
+• [SLOW TEST:55.922 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:50:09.083: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Apr 27 14:50:11.703: INFO: Successfully updated pod "pod-update-activedeadlineseconds-47ff533e-4a2a-11e8-a1f3-0206690d449d"
+Apr 27 14:50:11.703: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-47ff533e-4a2a-11e8-a1f3-0206690d449d" in namespace "e2e-tests-pods-pn7kk" to be "terminated due to deadline exceeded"
+Apr 27 14:50:11.706: INFO: Pod "pod-update-activedeadlineseconds-47ff533e-4a2a-11e8-a1f3-0206690d449d": Phase="Running", Reason="", readiness=true. Elapsed: 2.526134ms
+Apr 27 14:50:13.709: INFO: Pod "pod-update-activedeadlineseconds-47ff533e-4a2a-11e8-a1f3-0206690d449d": Phase="Running", Reason="", readiness=true. Elapsed: 2.005980967s
+Apr 27 14:50:15.712: INFO: Pod "pod-update-activedeadlineseconds-47ff533e-4a2a-11e8-a1f3-0206690d449d": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 4.009004093s
+Apr 27 14:50:15.712: INFO: Pod "pod-update-activedeadlineseconds-47ff533e-4a2a-11e8-a1f3-0206690d449d" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:50:15.712: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-pn7kk" for this suite.
+Apr 27 14:50:21.724: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:50:21.839: INFO: namespace: e2e-tests-pods-pn7kk, resource: bindings, ignored listing per whitelist
+Apr 27 14:50:21.849: INFO: namespace e2e-tests-pods-pn7kk deletion completed in 6.132946799s
+
+• [SLOW TEST:12.766 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:50:21.849: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:50:21.949: INFO: Waiting up to 5m0s for pod "downwardapi-volume-4f9b0925-4a2a-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-g92zc" to be "success or failure"
+Apr 27 14:50:21.952: INFO: Pod "downwardapi-volume-4f9b0925-4a2a-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.812937ms
+Apr 27 14:50:23.967: INFO: Pod "downwardapi-volume-4f9b0925-4a2a-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.018326704s
+STEP: Saw pod success
+Apr 27 14:50:23.967: INFO: Pod "downwardapi-volume-4f9b0925-4a2a-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:50:23.977: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-4f9b0925-4a2a-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:50:23.995: INFO: Waiting for pod downwardapi-volume-4f9b0925-4a2a-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:50:24.001: INFO: Pod downwardapi-volume-4f9b0925-4a2a-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:50:24.001: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-g92zc" for this suite.
+Apr 27 14:50:30.022: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:50:30.071: INFO: namespace: e2e-tests-downward-api-g92zc, resource: bindings, ignored listing per whitelist
+Apr 27 14:50:30.146: INFO: namespace e2e-tests-downward-api-g92zc deletion completed in 6.13867424s
+
+• [SLOW TEST:8.297 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:50:30.146: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap e2e-tests-configmap-g6tl4/configmap-test-548b2be9-4a2a-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:50:30.236: INFO: Waiting up to 5m0s for pod "pod-configmaps-548badfb-4a2a-11e8-a1f3-0206690d449d" in namespace "e2e-tests-configmap-g6tl4" to be "success or failure"
+Apr 27 14:50:30.239: INFO: Pod "pod-configmaps-548badfb-4a2a-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.009415ms
+Apr 27 14:50:32.243: INFO: Pod "pod-configmaps-548badfb-4a2a-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006183153s
+Apr 27 14:50:34.246: INFO: Pod "pod-configmaps-548badfb-4a2a-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009587369s
+STEP: Saw pod success
+Apr 27 14:50:34.246: INFO: Pod "pod-configmaps-548badfb-4a2a-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:50:34.249: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-configmaps-548badfb-4a2a-11e8-a1f3-0206690d449d container env-test: <nil>
+STEP: delete the pod
+Apr 27 14:50:34.264: INFO: Waiting for pod pod-configmaps-548badfb-4a2a-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:50:34.267: INFO: Pod pod-configmaps-548badfb-4a2a-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:50:34.267: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-g6tl4" for this suite.
+Apr 27 14:50:40.281: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:50:40.366: INFO: namespace: e2e-tests-configmap-g6tl4, resource: bindings, ignored listing per whitelist
+Apr 27 14:50:40.418: INFO: namespace e2e-tests-configmap-g6tl4 deletion completed in 6.14783343s
+
+• [SLOW TEST:10.271 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:50:40.418: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Apr 27 14:50:41.022: INFO: Waiting up to 5m0s for pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-mj2cf" in namespace "e2e-tests-svcaccounts-v9mwh" to be "success or failure"
+Apr 27 14:50:41.025: INFO: Pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-mj2cf": Phase="Pending", Reason="", readiness=false. Elapsed: 3.082196ms
+Apr 27 14:50:43.028: INFO: Pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-mj2cf": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006210617s
+Apr 27 14:50:45.032: INFO: Pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-mj2cf": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009714635s
+STEP: Saw pod success
+Apr 27 14:50:45.032: INFO: Pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-mj2cf" satisfied condition "success or failure"
+Apr 27 14:50:45.034: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-mj2cf container token-test: <nil>
+STEP: delete the pod
+Apr 27 14:50:45.050: INFO: Waiting for pod pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-mj2cf to disappear
+Apr 27 14:50:45.053: INFO: Pod pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-mj2cf no longer exists
+STEP: Creating a pod to test consume service account root CA
+Apr 27 14:50:45.057: INFO: Waiting up to 5m0s for pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-czjdj" in namespace "e2e-tests-svcaccounts-v9mwh" to be "success or failure"
+Apr 27 14:50:45.061: INFO: Pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-czjdj": Phase="Pending", Reason="", readiness=false. Elapsed: 3.933955ms
+Apr 27 14:50:47.067: INFO: Pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-czjdj": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010042077s
+Apr 27 14:50:49.070: INFO: Pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-czjdj": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013105016s
+STEP: Saw pod success
+Apr 27 14:50:49.070: INFO: Pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-czjdj" satisfied condition "success or failure"
+Apr 27 14:50:49.073: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-czjdj container root-ca-test: <nil>
+STEP: delete the pod
+Apr 27 14:50:49.087: INFO: Waiting for pod pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-czjdj to disappear
+Apr 27 14:50:49.089: INFO: Pod pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-czjdj no longer exists
+STEP: Creating a pod to test consume service account namespace
+Apr 27 14:50:49.093: INFO: Waiting up to 5m0s for pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-bknnd" in namespace "e2e-tests-svcaccounts-v9mwh" to be "success or failure"
+Apr 27 14:50:49.097: INFO: Pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-bknnd": Phase="Pending", Reason="", readiness=false. Elapsed: 3.495989ms
+Apr 27 14:50:51.100: INFO: Pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-bknnd": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006745891s
+STEP: Saw pod success
+Apr 27 14:50:51.100: INFO: Pod "pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-bknnd" satisfied condition "success or failure"
+Apr 27 14:50:51.102: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-bknnd container namespace-test: <nil>
+STEP: delete the pod
+Apr 27 14:50:51.117: INFO: Waiting for pod pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-bknnd to disappear
+Apr 27 14:50:51.120: INFO: Pod pod-service-account-5af924e5-4a2a-11e8-a1f3-0206690d449d-bknnd no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:50:51.120: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-v9mwh" for this suite.
+Apr 27 14:50:57.136: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:50:57.267: INFO: namespace: e2e-tests-svcaccounts-v9mwh, resource: bindings, ignored listing per whitelist
+Apr 27 14:50:57.267: INFO: namespace e2e-tests-svcaccounts-v9mwh deletion completed in 6.144381854s
+
+• [SLOW TEST:16.850 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:50:57.268: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-bz2dt
+Apr 27 14:50:59.368: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-bz2dt
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:50:59.370: INFO: Initial restart count of pod liveness-http is 0
+Apr 27 14:51:19.404: INFO: Restart count of pod e2e-tests-container-probe-bz2dt/liveness-http is now 1 (20.033977516s elapsed)
+Apr 27 14:51:39.438: INFO: Restart count of pod e2e-tests-container-probe-bz2dt/liveness-http is now 2 (40.067299087s elapsed)
+Apr 27 14:51:59.471: INFO: Restart count of pod e2e-tests-container-probe-bz2dt/liveness-http is now 3 (1m0.101030465s elapsed)
+Apr 27 14:52:19.515: INFO: Restart count of pod e2e-tests-container-probe-bz2dt/liveness-http is now 4 (1m20.144862841s elapsed)
+Apr 27 14:53:19.636: INFO: Restart count of pod e2e-tests-container-probe-bz2dt/liveness-http is now 5 (2m20.266089545s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:53:19.643: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-bz2dt" for this suite.
+Apr 27 14:53:25.655: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:53:25.725: INFO: namespace: e2e-tests-container-probe-bz2dt, resource: bindings, ignored listing per whitelist
+Apr 27 14:53:25.774: INFO: namespace e2e-tests-container-probe-bz2dt deletion completed in 6.127749465s
+
+• [SLOW TEST:148.506 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:53:25.774: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:53:25.864: INFO: Waiting up to 5m0s for pod "downwardapi-volume-bd3a2f3a-4a2a-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-w57n4" to be "success or failure"
+Apr 27 14:53:25.866: INFO: Pod "downwardapi-volume-bd3a2f3a-4a2a-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.790705ms
+Apr 27 14:53:27.870: INFO: Pod "downwardapi-volume-bd3a2f3a-4a2a-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006132641s
+STEP: Saw pod success
+Apr 27 14:53:27.870: INFO: Pod "downwardapi-volume-bd3a2f3a-4a2a-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:53:27.872: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-bd3a2f3a-4a2a-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:53:27.892: INFO: Waiting for pod downwardapi-volume-bd3a2f3a-4a2a-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:53:27.894: INFO: Pod downwardapi-volume-bd3a2f3a-4a2a-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:53:27.894: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-w57n4" for this suite.
+Apr 27 14:53:33.907: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:53:34.002: INFO: namespace: e2e-tests-projected-w57n4, resource: bindings, ignored listing per whitelist
+Apr 27 14:53:34.033: INFO: namespace e2e-tests-projected-w57n4 deletion completed in 6.135759866s
+
+• [SLOW TEST:8.259 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:53:34.034: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:53:58.153: INFO: Container started at 2018-04-27 14:53:35 +0000 UTC, pod became ready at 2018-04-27 14:53:56 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:53:58.153: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-h6846" for this suite.
+Apr 27 14:54:20.167: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:54:20.277: INFO: namespace: e2e-tests-container-probe-h6846, resource: bindings, ignored listing per whitelist
+Apr 27 14:54:20.292: INFO: namespace e2e-tests-container-probe-h6846 deletion completed in 22.13479372s
+
+• [SLOW TEST:46.258 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:54:20.292: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-v25x8
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 27 14:54:20.389: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 27 14:54:42.457: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.0.40:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-v25x8 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:54:42.457: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:54:42.612: INFO: Found all expected endpoints: [netserver-0]
+Apr 27 14:54:42.615: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.1.163:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-v25x8 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:54:42.615: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+Apr 27 14:54:42.789: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:54:42.791: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-v25x8" for this suite.
+Apr 27 14:54:56.806: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:54:56.918: INFO: namespace: e2e-tests-pod-network-test-v25x8, resource: bindings, ignored listing per whitelist
+Apr 27 14:54:56.927: INFO: namespace e2e-tests-pod-network-test-v25x8 deletion completed in 14.129406082s
+
+• [SLOW TEST:36.635 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:54:56.927: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-w8xjf.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-w8xjf.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-w8xjf.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-w8xjf.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-w8xjf.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-w8xjf.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Apr 27 14:55:09.917: INFO: DNS probes using dns-test-f38f8ce0-4a2a-11e8-a1f3-0206690d449d succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:55:09.928: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-w8xjf" for this suite.
+Apr 27 14:55:15.941: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:55:16.055: INFO: namespace: e2e-tests-dns-w8xjf, resource: bindings, ignored listing per whitelist
+Apr 27 14:55:16.077: INFO: namespace e2e-tests-dns-w8xjf deletion completed in 6.145663912s
+
+• [SLOW TEST:19.150 seconds]
+[sig-network] DNS
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:55:16.077: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Apr 27 14:55:16.182: INFO: Number of nodes with available pods: 0
+Apr 27 14:55:16.182: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:55:17.189: INFO: Number of nodes with available pods: 0
+Apr 27 14:55:17.189: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:55:18.190: INFO: Number of nodes with available pods: 2
+Apr 27 14:55:18.190: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.
+Apr 27 14:55:18.215: INFO: Number of nodes with available pods: 1
+Apr 27 14:55:18.215: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:55:19.222: INFO: Number of nodes with available pods: 1
+Apr 27 14:55:19.222: INFO: Node ip-10-250-12-147.eu-west-1.compute.internal is running more than one daemon pod
+Apr 27 14:55:20.222: INFO: Number of nodes with available pods: 2
+Apr 27 14:55:20.222: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Wait for the failed daemon pod to be completely deleted.
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 27 14:55:27.246: INFO: Number of nodes with available pods: 0
+Apr 27 14:55:27.246: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 27 14:55:27.250: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-4hxzl/daemonsets","resourceVersion":"10503"},"items":null}
+
+Apr 27 14:55:27.253: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-4hxzl/pods","resourceVersion":"10504"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:55:27.261: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-4hxzl" for this suite.
+Apr 27 14:55:33.274: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:55:33.335: INFO: namespace: e2e-tests-daemonsets-4hxzl, resource: bindings, ignored listing per whitelist
+Apr 27 14:55:33.394: INFO: namespace e2e-tests-daemonsets-4hxzl deletion completed in 6.129387943s
+
+• [SLOW TEST:17.317 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:55:33.394: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-glhkd
+[It] should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a new StaefulSet
+Apr 27 14:55:33.500: INFO: Found 0 stateful pods, waiting for 3
+Apr 27 14:55:43.504: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:55:43.504: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:55:43.504: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Updating stateful set template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Apr 27 14:55:43.529: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Not applying an update when the partition is greater than the number of replicas
+STEP: Performing a canary update
+Apr 27 14:55:53.561: INFO: Updating stateful set ss2
+Apr 27 14:55:53.566: INFO: Waiting for Pod e2e-tests-statefulset-glhkd/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 27 14:56:03.572: INFO: Waiting for Pod e2e-tests-statefulset-glhkd/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Restoring Pods to the correct revision when they are deleted
+Apr 27 14:56:13.588: INFO: Found 1 stateful pods, waiting for 3
+Apr 27 14:56:23.592: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:56:23.592: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:56:23.592: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Performing a phased rolling update
+Apr 27 14:56:23.618: INFO: Updating stateful set ss2
+Apr 27 14:56:23.627: INFO: Waiting for Pod e2e-tests-statefulset-glhkd/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 27 14:56:33.650: INFO: Updating stateful set ss2
+Apr 27 14:56:33.656: INFO: Waiting for StatefulSet e2e-tests-statefulset-glhkd/ss2 to complete update
+Apr 27 14:56:33.656: INFO: Waiting for Pod e2e-tests-statefulset-glhkd/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 27 14:56:43.662: INFO: Waiting for StatefulSet e2e-tests-statefulset-glhkd/ss2 to complete update
+Apr 27 14:56:43.662: INFO: Waiting for Pod e2e-tests-statefulset-glhkd/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:56:53.662: INFO: Deleting all statefulset in ns e2e-tests-statefulset-glhkd
+Apr 27 14:56:53.664: INFO: Scaling statefulset ss2 to 0
+Apr 27 14:57:33.675: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:57:33.678: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:57:33.687: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-glhkd" for this suite.
+Apr 27 14:57:39.701: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:57:39.802: INFO: namespace: e2e-tests-statefulset-glhkd, resource: bindings, ignored listing per whitelist
+Apr 27 14:57:39.854: INFO: namespace e2e-tests-statefulset-glhkd deletion completed in 6.16353443s
+
+• [SLOW TEST:126.460 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should perform canary updates and phased rolling updates of template modifications [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:57:39.854: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:57:39.959: INFO: Waiting up to 5m0s for pod "downwardapi-volume-54ae0ece-4a2b-11e8-a1f3-0206690d449d" in namespace "e2e-tests-projected-r6hcm" to be "success or failure"
+Apr 27 14:57:39.963: INFO: Pod "downwardapi-volume-54ae0ece-4a2b-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.813558ms
+Apr 27 14:57:41.967: INFO: Pod "downwardapi-volume-54ae0ece-4a2b-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007033006s
+STEP: Saw pod success
+Apr 27 14:57:41.967: INFO: Pod "downwardapi-volume-54ae0ece-4a2b-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:57:41.969: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downwardapi-volume-54ae0ece-4a2b-11e8-a1f3-0206690d449d container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:57:41.985: INFO: Waiting for pod downwardapi-volume-54ae0ece-4a2b-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:57:41.987: INFO: Pod downwardapi-volume-54ae0ece-4a2b-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:57:41.987: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-r6hcm" for this suite.
+Apr 27 14:57:47.999: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:57:48.076: INFO: namespace: e2e-tests-projected-r6hcm, resource: bindings, ignored listing per whitelist
+Apr 27 14:57:48.135: INFO: namespace e2e-tests-projected-r6hcm deletion completed in 6.144535743s
+
+• [SLOW TEST:8.280 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[k8s.io] Pods 
+  should be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:57:48.135: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Apr 27 14:57:50.751: INFO: Successfully updated pod "pod-update-599b9ebe-4a2b-11e8-a1f3-0206690d449d"
+STEP: verifying the updated pod is in kubernetes
+Apr 27 14:57:50.757: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:57:50.758: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-qppks" for this suite.
+Apr 27 14:58:12.776: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:58:12.840: INFO: namespace: e2e-tests-pods-qppks, resource: bindings, ignored listing per whitelist
+Apr 27 14:58:12.898: INFO: namespace e2e-tests-pods-qppks deletion completed in 22.133670364s
+
+• [SLOW TEST:24.763 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:58:12.898: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:58:12.990: INFO: Waiting up to 5m0s for pod "downward-api-685e5007-4a2b-11e8-a1f3-0206690d449d" in namespace "e2e-tests-downward-api-vhq55" to be "success or failure"
+Apr 27 14:58:12.994: INFO: Pod "downward-api-685e5007-4a2b-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 3.309891ms
+Apr 27 14:58:14.997: INFO: Pod "downward-api-685e5007-4a2b-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006531611s
+Apr 27 14:58:17.001: INFO: Pod "downward-api-685e5007-4a2b-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010290684s
+STEP: Saw pod success
+Apr 27 14:58:17.001: INFO: Pod "downward-api-685e5007-4a2b-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:58:17.004: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod downward-api-685e5007-4a2b-11e8-a1f3-0206690d449d container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:58:17.020: INFO: Waiting for pod downward-api-685e5007-4a2b-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:58:17.023: INFO: Pod downward-api-685e5007-4a2b-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:58:17.023: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-vhq55" for this suite.
+Apr 27 14:58:23.037: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:58:23.142: INFO: namespace: e2e-tests-downward-api-vhq55, resource: bindings, ignored listing per whitelist
+Apr 27 14:58:23.179: INFO: namespace e2e-tests-downward-api-vhq55 deletion completed in 6.152132955s
+
+• [SLOW TEST:10.281 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:58:23.180: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-6e7fd6ec-4a2b-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:58:23.281: INFO: Waiting up to 5m0s for pod "pod-configmaps-6e805b37-4a2b-11e8-a1f3-0206690d449d" in namespace "e2e-tests-configmap-lvrbd" to be "success or failure"
+Apr 27 14:58:23.287: INFO: Pod "pod-configmaps-6e805b37-4a2b-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 5.106353ms
+Apr 27 14:58:25.290: INFO: Pod "pod-configmaps-6e805b37-4a2b-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008137458s
+STEP: Saw pod success
+Apr 27 14:58:25.290: INFO: Pod "pod-configmaps-6e805b37-4a2b-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:58:25.292: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-configmaps-6e805b37-4a2b-11e8-a1f3-0206690d449d container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:58:25.307: INFO: Waiting for pod pod-configmaps-6e805b37-4a2b-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:58:25.309: INFO: Pod pod-configmaps-6e805b37-4a2b-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:58:25.310: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-lvrbd" for this suite.
+Apr 27 14:58:31.322: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:58:31.413: INFO: namespace: e2e-tests-configmap-lvrbd, resource: bindings, ignored listing per whitelist
+Apr 27 14:58:31.472: INFO: namespace e2e-tests-configmap-lvrbd deletion completed in 6.159829522s
+
+• [SLOW TEST:8.293 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:58:31.473: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:58:31.594: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-zksnk" for this suite.
+Apr 27 14:58:37.607: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:58:37.667: INFO: namespace: e2e-tests-services-zksnk, resource: bindings, ignored listing per whitelist
+Apr 27 14:58:37.727: INFO: namespace e2e-tests-services-zksnk deletion completed in 6.129184579s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:6.254 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:58:37.727: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-772b6045-4a2b-11e8-a1f3-0206690d449d
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:58:37.826: INFO: Waiting up to 5m0s for pod "pod-configmaps-772bd748-4a2b-11e8-a1f3-0206690d449d" in namespace "e2e-tests-configmap-bjpct" to be "success or failure"
+Apr 27 14:58:37.829: INFO: Pod "pod-configmaps-772bd748-4a2b-11e8-a1f3-0206690d449d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.697175ms
+Apr 27 14:58:39.832: INFO: Pod "pod-configmaps-772bd748-4a2b-11e8-a1f3-0206690d449d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005740091s
+STEP: Saw pod success
+Apr 27 14:58:39.832: INFO: Pod "pod-configmaps-772bd748-4a2b-11e8-a1f3-0206690d449d" satisfied condition "success or failure"
+Apr 27 14:58:39.834: INFO: Trying to get logs from node ip-10-250-14-38.eu-west-1.compute.internal pod pod-configmaps-772bd748-4a2b-11e8-a1f3-0206690d449d container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:58:39.850: INFO: Waiting for pod pod-configmaps-772bd748-4a2b-11e8-a1f3-0206690d449d to disappear
+Apr 27 14:58:39.852: INFO: Pod pod-configmaps-772bd748-4a2b-11e8-a1f3-0206690d449d no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:58:39.852: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-bjpct" for this suite.
+Apr 27 14:58:45.865: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:58:45.987: INFO: namespace: e2e-tests-configmap-bjpct, resource: bindings, ignored listing per whitelist
+Apr 27 14:58:45.999: INFO: namespace e2e-tests-configmap-bjpct deletion completed in 6.143083801s
+
+• [SLOW TEST:8.272 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:58:45.999: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:59:46.112: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-rlcmz" for this suite.
+Apr 27 15:00:08.127: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:00:08.239: INFO: namespace: e2e-tests-container-probe-rlcmz, resource: bindings, ignored listing per whitelist
+Apr 27 15:00:08.254: INFO: namespace e2e-tests-container-probe-rlcmz deletion completed in 22.138622092s
+
+• [SLOW TEST:82.255 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:00:08.255: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating replication controller my-hostname-basic-ad228ece-4a2b-11e8-a1f3-0206690d449d
+Apr 27 15:00:08.364: INFO: Pod name my-hostname-basic-ad228ece-4a2b-11e8-a1f3-0206690d449d: Found 0 pods out of 1
+Apr 27 15:00:13.367: INFO: Pod name my-hostname-basic-ad228ece-4a2b-11e8-a1f3-0206690d449d: Found 1 pods out of 1
+Apr 27 15:00:13.367: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-ad228ece-4a2b-11e8-a1f3-0206690d449d" are running
+Apr 27 15:00:13.371: INFO: Pod "my-hostname-basic-ad228ece-4a2b-11e8-a1f3-0206690d449d-fnp47" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 15:00:08 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 15:00:09 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 15:00:08 +0000 UTC Reason: Message:}])
+Apr 27 15:00:13.371: INFO: Trying to dial the pod
+Apr 27 15:00:18.422: INFO: Controller my-hostname-basic-ad228ece-4a2b-11e8-a1f3-0206690d449d: Got expected result from replica 1 [my-hostname-basic-ad228ece-4a2b-11e8-a1f3-0206690d449d-fnp47]: "my-hostname-basic-ad228ece-4a2b-11e8-a1f3-0206690d449d-fnp47", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:00:18.422: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-4czq7" for this suite.
+Apr 27 15:00:24.433: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:00:24.556: INFO: namespace: e2e-tests-replication-controller-4czq7, resource: bindings, ignored listing per whitelist
+Apr 27 15:00:24.564: INFO: namespace e2e-tests-replication-controller-4czq7 deletion completed in 6.138780596s
+
+• [SLOW TEST:16.309 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:00:24.565: INFO: >>> kubeConfig: /tmp/kubeconfig-892884186
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-ts2fq
+[It] Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Looking for a node to schedule stateful set and pod
+STEP: Creating pod with conflicting port in namespace e2e-tests-statefulset-ts2fq
+STEP: Creating statefulset with conflicting port in namespace e2e-tests-statefulset-ts2fq
+STEP: Waiting until pod test-pod will start running in namespace e2e-tests-statefulset-ts2fq
+STEP: Waiting until stateful pod ss-0 will be recreated and deleted at least once in namespace e2e-tests-statefulset-ts2fq
+Apr 27 15:00:28.692: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-ts2fq, name: ss-0, uid: b9062cba-4a2b-11e8-aa31-6e07c8c44ecd, status phase: Pending. Waiting for statefulset controller to delete.
+Apr 27 15:00:28.890: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-ts2fq, name: ss-0, uid: b9062cba-4a2b-11e8-aa31-6e07c8c44ecd, status phase: Failed. Waiting for statefulset controller to delete.
+Apr 27 15:00:28.894: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-ts2fq, name: ss-0, uid: b9062cba-4a2b-11e8-aa31-6e07c8c44ecd, status phase: Failed. Waiting for statefulset controller to delete.
+Apr 27 15:00:28.897: INFO: Observed delete event for stateful pod ss-0 in namespace e2e-tests-statefulset-ts2fq
+STEP: Removing pod with conflicting port in namespace e2e-tests-statefulset-ts2fq
+STEP: Waiting when stateful pod ss-0 will be recreated in namespace e2e-tests-statefulset-ts2fq and will be in running state
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 15:00:32.951: INFO: Deleting all statefulset in ns e2e-tests-statefulset-ts2fq
+Apr 27 15:00:32.955: INFO: Scaling statefulset ss to 0
+Apr 27 15:00:42.967: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 15:00:42.969: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:00:42.984: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-ts2fq" for this suite.
+Apr 27 15:00:48.996: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:00:49.044: INFO: namespace: e2e-tests-statefulset-ts2fq, resource: bindings, ignored listing per whitelist
+Apr 27 15:00:49.129: INFO: namespace e2e-tests-statefulset-ts2fq deletion completed in 6.141256788s
+
+• [SLOW TEST:24.564 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Should recreate evicted statefulset [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSApr 27 15:00:49.129: INFO: Running AfterSuite actions on all node
+Apr 27 15:00:49.129: INFO: Running AfterSuite actions on node 1
+Apr 27 15:00:49.129: INFO: Skipping dumping logs from cluster
+
+Ran 139 of 836 Specs in 3429.436 seconds
+SUCCESS! -- 139 Passed | 0 Failed | 0 Pending | 697 Skipped PASS
+
+Ginkgo ran 1 suite in 57m9.895722508s
+Test Suite Passed

--- a/v1.10/sap-cp-aws/junit_01.xml
+++ b/v1.10/sap-cp-aws/junit_01.xml
@@ -1,0 +1,2233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="139" failures="0" time="3429.435857385">
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.347192406"></testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="10.287187354"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="21.937010884"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.299584214"></testcase>
+      <testcase name="[k8s.io] Sysctls should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request  [Conformance]" classname="Kubernetes e2e suite" time="10.263255173"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.295054477"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha docker/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.294391135"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with secret pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.309391709"></testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="7.29777925"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="85.440703425"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.273829764"></testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="62.3495791"></testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.289091341"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.300873986"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [Conformance]" classname="Kubernetes e2e suite" time="10.320369254"></testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.302408545"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="8.258706592"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.29804535"></testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.53019444"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.31068375"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]" classname="Kubernetes e2e suite" time="12.272566884"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]" classname="Kubernetes e2e suite" time="8.325406331"></testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.290141943"></testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="86.459270272"></testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted [Conformance]" classname="Kubernetes e2e suite" time="16.297484632"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]" classname="Kubernetes e2e suite" time="11.803017796"></testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [Conformance]" classname="Kubernetes e2e suite" time="28.7897242"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap binary data should be reflected in volume " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.268581243"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit  [Conformance]" classname="Kubernetes e2e suite" time="8.274728151"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.285356964"></testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [Conformance]" classname="Kubernetes e2e suite" time="8.28314668"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP  [Conformance]" classname="Kubernetes e2e suite" time="24.264862179"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="42.720245544"></testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="29.268983377"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.364248922"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="30.321477007"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="30.269848807"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.2551114"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.245137897"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [DisabledForLargeClusters] kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.304317177"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that a pod with an invalid NodeAffinity is rejected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [Conformance]" classname="Kubernetes e2e suite" time="8.292752276"></testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification  [Conformance]" classname="Kubernetes e2e suite" time="26.811679713"></testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with downward pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="22.142066205"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should not be able to prevent deleting validating-webhook-configurations or mutating-webhook-configurations" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]" classname="Kubernetes e2e suite" time="30.394882266"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.309544754"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.267906831"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="36.635552693"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="51.322096909"></testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Downgrade [Feature:IngressDowngrade] ingress downgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files  [Conformance]" classname="Kubernetes e2e suite" time="8.303449238"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="130.473520761"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existent secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify &#34;immediate&#34; deletion of a PV that is not bound to a PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set  [Conformance]" classname="Kubernetes e2e suite" time="8.293857631"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]" classname="Kubernetes e2e suite" time="8.258726369"></testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var  [Conformance]" classname="Kubernetes e2e suite" time="10.289248071"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]" classname="Kubernetes e2e suite" time="38.390672356"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification  [Conformance]" classname="Kubernetes e2e suite" time="26.788909613"></testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive] node unregister" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor using proxy subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments  [Conformance]" classname="Kubernetes e2e suite" time="10.460700094"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.255955936"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="29.544736145999998"></testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes [Feature:CSI] Sanity CSI plugin test using hostPath CSI driver should provision storage with a hostPath CSI driver" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [Conformance]" classname="Kubernetes e2e suite" time="8.278006411"></testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle [Conformance]" classname="Kubernetes e2e suite" time="11.264011231"></testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.353168684"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pvc count metrics for pvc controller after creating pvc only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.300830544"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  StatefulSet with pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with backside re-encryption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.265802991"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="15.286248664"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.589669011"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.243191627">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.268364907"></testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="8.284617487"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods [Conformance]" classname="Kubernetes e2e suite" time="77.018292737"></testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file  [Conformance]" classname="Kubernetes e2e suite" time="8.309073452"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="20.889534551"></testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should update ingress while sync failures occur on other ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pv count metrics for pvc controller after creating pv only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with projected pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]" classname="Kubernetes e2e suite" time="239.764431395"></testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank  [Conformance]" classname="Kubernetes e2e suite" time="8.26424507"></testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.268960667"></testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable  [Conformance]" classname="Kubernetes e2e suite" time="10.303586459"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance]" classname="Kubernetes e2e suite" time="154.37722714"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [Conformance]" classname="Kubernetes e2e suite" time="8.301605964"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.254846090000001"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.481579109"></testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.359364692"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [Conformance]" classname="Kubernetes e2e suite" time="10.284203763"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="88.792114439"></testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.300593446"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates lower priority pod preemption by critical pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.344673338"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.292082586"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Stress with local volume provisioner [Serial] should use be able to process many pods and reuse local volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="44.075217167"></testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit  [Conformance]" classname="Kubernetes e2e suite" time="8.297016716"></testcase>
+      <testcase name="[sig-storage] Regional PD [Feature:RegionalPD] RegionalPD should provision storage [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="128.510414113"></testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout  [Conformance]" classname="Kubernetes e2e suite" time="6.253621673">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]" classname="Kubernetes e2e suite" time="32.383822279"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.282510318"></testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.338627409"></testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.33305518"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="6.818437744"></testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.271070277"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [Conformance]" classname="Kubernetes e2e suite" time="8.331639946"></testcase>
+      <testcase name="[sig-storage] PVC Protection Verify &#34;immediate&#34; deletion of a PVC that is not in active use by a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.305092083"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner deletion should be idempotent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services  [Conformance]" classname="Kubernetes e2e suite" time="28.322829823"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume expand [Feature:ExpandPersistentVolumes] [Slow] Verify if editing PVC allows resize" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Upgrade [Feature:IngressUpgrade] ingress upgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create none metrics for pvc controller before creating any PV or PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.271297132"></testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD [Feature:RegionalPD] RegionalPD should failover to a different zone when all nodes in one zone become unreachable [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable  [Conformance]" classname="Kubernetes e2e suite" time="10.276832455"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Mounted volume expand [Feature:ExpandPersistentVolumes] [Slow] Should verify mounted devices can be resized" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate crd" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.25316602"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPU] run Nvidia GPU tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod  [Conformance]" classname="Kubernetes e2e suite" time="8.256675432"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection] [Conformance]" classname="Kubernetes e2e suite" time="10.263978202"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should support configurable pod resolv.conf" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="16.280355416"></testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.281184468"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.317927409"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only  [Conformance]" classname="Kubernetes e2e suite" time="8.283421269"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [Conformance]" classname="Kubernetes e2e suite" time="8.285836713"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command (docker entrypoint)  [Conformance]" classname="Kubernetes e2e suite" time="8.27746343"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so [Conformance]" classname="Kubernetes e2e suite" time="46.46730389"></testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="29.617941735"></testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.510643526"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.289045"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.271491592"></testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.25913979"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args  [Conformance]" classname="Kubernetes e2e suite" time="10.290525282"></testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd)  [Conformance]" classname="Kubernetes e2e suite" time="8.262030337"></testcase>
+      <testcase name="[k8s.io] PrivilegedPod should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [Conformance]" classname="Kubernetes e2e suite" time="26.789603496"></testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="27.350924441"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command  [Conformance]" classname="Kubernetes e2e suite" time="10.293445097"></testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file  [Conformance]" classname="Kubernetes e2e suite" time="55.921581779"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated  [Conformance]" classname="Kubernetes e2e suite" time="12.765512919"></testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request  [Conformance]" classname="Kubernetes e2e suite" time="8.297156289"></testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.271389928"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="16.849607894000002"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count  [Slow] [Conformance]" classname="Kubernetes e2e suite" time="148.505932246"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [Conformance]" classname="Kubernetes e2e suite" time="8.259497553"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart  [Conformance]" classname="Kubernetes e2e suite" time="46.258169414"></testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that PVC in active use by a pod is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="36.634727673"></testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="19.149835294"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods [Conformance]" classname="Kubernetes e2e suite" time="17.31659433"></testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications [Conformance]" classname="Kubernetes e2e suite" time="126.460021029"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [Conformance]" classname="Kubernetes e2e suite" time="8.280383904"></testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated  [Conformance]" classname="Kubernetes e2e suite" time="24.762813541"></testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.280856287"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support proportional scaling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should not reconcile manually modified health check for ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.2928956"></testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.2540433570000005"></testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify that PV bound to a PVC is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod  [Conformance]" classname="Kubernetes e2e suite" time="8.271686189"></testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart  [Conformance]" classname="Kubernetes e2e suite" time="82.254741063"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 Scalability GCE [Slow] [Serial] [Feature:IngressScale] Creating and updating ingresses should happen promptly with small/medium/large amount of ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.30934919"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset [Conformance]" classname="Kubernetes e2e suite" time="24.564177099"></testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have accelerator metrics [Feature:StackdriverAcceleratorMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.10/sap-cp-aws/version.txt
+++ b/v1.10/sap-cp-aws/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.1", GitCommit:"d4ab47518836c750f9949b9e0d387f20fb92260b", GitTreeState:"clean", BuildDate:"2018-04-12T14:26:04Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.2", GitCommit:"81753b10df112992bf51bbc2c2f85208aad78335", GitTreeState:"clean", BuildDate:"2018-04-27T09:10:24Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}

--- a/v1.10/sap-cp-azure/PRODUCT.yaml
+++ b/v1.10/sap-cp-azure/PRODUCT.yaml
@@ -1,0 +1,6 @@
+vendor: SAP
+name: Cloud Platform - Gardener (https://github.com/gardener/gardener) shoot cluster deployed on Microsoft Azure
+version: 0.4.0
+website_url: https://cloudplatform.sap.com/index.html
+documentation_url: https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/
+product_logo_url: https://www.sap.com/dam/application/shared/logos/sap-logo-svg.svg

--- a/v1.10/sap-cp-azure/README.md
+++ b/v1.10/sap-cp-azure/README.md
@@ -1,0 +1,43 @@
+# To reproduce:
+
+## Create Kubernetes Cluster
+
+Login to SAP Gardener Dashboard to create a Kubernetes Clusters on Amazon Web Services, Microsoft Azure, Google Cloud Platform, or OpenStack cloud provider.
+
+After the creation completed, copy the cluster's kubeconfig, which is provided by the Gardener Dashboard in the cluster's detail view, to ~/.kube/config and launch the Kubernetes E2E conformance tests.
+
+## Launch E2E Conformance Tests
+1. Launch e2e pod and sonobuoy master under namespace `sonobuoy`   
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+    ```
+
+2. Check logs of `sonobuoy` pod to see when test can be finished   
+Run
+
+    ```shell
+    kubectl logs -f -n sonobuoy sonobuoy
+    ```
+    and wait for line `no-exit was specified, sonobuoy is now blocking`.
+
+3. Use `kubectl cp` to copy the results to the client   
+Get the name of the <result archive> from the log output in step 2.
+
+    ```shell
+    kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy/<result archive> /home/result
+    ```
+
+4. Delete the conformance test resources
+
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl delete -f -
+    ```
+
+5. Untar the tarball
+
+    ```shell
+    cd /home/result
+    tar -xzf *_sonobuoy_*.tar.gz
+    ```
+
+    The result files `e2e.log` and `junit_01.xml` are located in the in the directory `plugins/e2e/results/`.

--- a/v1.10/sap-cp-azure/e2e.log
+++ b/v1.10/sap-cp-azure/e2e.log
@@ -1,0 +1,7087 @@
+Apr 24 07:31:20.461: INFO: Overriding default scale value of zero to 1
+Apr 24 07:31:20.461: INFO: Overriding default milliseconds value of zero to 5000
+I0424 07:31:20.598901      14 test_context.go:358] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-403291544
+I0424 07:31:20.599035      14 e2e.go:333] Starting e2e run "7b92b0e6-4791-11e8-bf16-a2a292742988" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1524555080 - Will randomize all specs
+Will run 141 of 836 specs
+
+Apr 24 07:31:20.661: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 07:31:20.663: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
+Apr 24 07:31:20.678: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 24 07:31:20.743: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 24 07:31:20.743: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 24 07:31:20.747: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 24 07:31:20.747: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Apr 24 07:31:20.750: INFO: e2e test version: v1.10.0
+Apr 24 07:31:20.751: INFO: kube-apiserver version: v1.10.1
+SSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:31:20.752: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+Apr 24 07:31:20.862: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-7bdbf8a5-4791-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 07:31:20.875: INFO: Waiting up to 5m0s for pod "pod-configmaps-7bdcdb6c-4791-11e8-bf16-a2a292742988" in namespace "e2e-tests-configmap-z5n7k" to be "success or failure"
+Apr 24 07:31:20.883: INFO: Pod "pod-configmaps-7bdcdb6c-4791-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 7.890576ms
+Apr 24 07:31:22.886: INFO: Pod "pod-configmaps-7bdcdb6c-4791-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010915329s
+Apr 24 07:31:24.889: INFO: Pod "pod-configmaps-7bdcdb6c-4791-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01465006s
+STEP: Saw pod success
+Apr 24 07:31:24.889: INFO: Pod "pod-configmaps-7bdcdb6c-4791-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:31:24.892: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-configmaps-7bdcdb6c-4791-11e8-bf16-a2a292742988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:31:24.973: INFO: Waiting for pod pod-configmaps-7bdcdb6c-4791-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:31:24.977: INFO: Pod pod-configmaps-7bdcdb6c-4791-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:31:24.977: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-z5n7k" for this suite.
+Apr 24 07:31:30.991: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:31:31.088: INFO: namespace: e2e-tests-configmap-z5n7k, resource: bindings, ignored listing per whitelist
+Apr 24 07:31:31.126: INFO: namespace e2e-tests-configmap-z5n7k deletion completed in 6.145541859s
+
+• [SLOW TEST:10.374 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:31:31.126: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-qtnvw
+[It] should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a new StaefulSet
+Apr 24 07:31:31.270: INFO: Found 0 stateful pods, waiting for 3
+Apr 24 07:31:41.274: INFO: Found 1 stateful pods, waiting for 3
+Apr 24 07:31:51.274: INFO: Found 2 stateful pods, waiting for 3
+Apr 24 07:32:01.274: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 24 07:32:01.274: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 24 07:32:01.275: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Updating stateful set template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Apr 24 07:32:01.304: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Not applying an update when the partition is greater than the number of replicas
+STEP: Performing a canary update
+Apr 24 07:32:11.336: INFO: Updating stateful set ss2
+Apr 24 07:32:11.347: INFO: Waiting for Pod e2e-tests-statefulset-qtnvw/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Restoring Pods to the correct revision when they are deleted
+Apr 24 07:32:21.420: INFO: Found 2 stateful pods, waiting for 3
+Apr 24 07:32:31.424: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 24 07:32:31.424: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 24 07:32:31.424: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Performing a phased rolling update
+Apr 24 07:32:31.446: INFO: Updating stateful set ss2
+Apr 24 07:32:31.453: INFO: Waiting for Pod e2e-tests-statefulset-qtnvw/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 24 07:32:41.479: INFO: Updating stateful set ss2
+Apr 24 07:32:41.494: INFO: Waiting for StatefulSet e2e-tests-statefulset-qtnvw/ss2 to complete update
+Apr 24 07:32:41.494: INFO: Waiting for Pod e2e-tests-statefulset-qtnvw/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 24 07:32:51.501: INFO: Deleting all statefulset in ns e2e-tests-statefulset-qtnvw
+Apr 24 07:32:51.503: INFO: Scaling statefulset ss2 to 0
+Apr 24 07:33:11.516: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 24 07:33:11.519: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:33:11.531: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-qtnvw" for this suite.
+Apr 24 07:33:17.552: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:33:17.628: INFO: namespace: e2e-tests-statefulset-qtnvw, resource: bindings, ignored listing per whitelist
+Apr 24 07:33:17.687: INFO: namespace e2e-tests-statefulset-qtnvw deletion completed in 6.153290308s
+
+• [SLOW TEST:106.561 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should perform canary updates and phased rolling updates of template modifications [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:33:17.687: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 07:33:17.783: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c18ba09e-4791-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-j7c9d" to be "success or failure"
+Apr 24 07:33:17.792: INFO: Pod "downwardapi-volume-c18ba09e-4791-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 8.662104ms
+Apr 24 07:33:19.796: INFO: Pod "downwardapi-volume-c18ba09e-4791-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.013614168s
+STEP: Saw pod success
+Apr 24 07:33:19.797: INFO: Pod "downwardapi-volume-c18ba09e-4791-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:33:19.799: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-c18ba09e-4791-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 07:33:19.819: INFO: Waiting for pod downwardapi-volume-c18ba09e-4791-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:33:19.837: INFO: Pod downwardapi-volume-c18ba09e-4791-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:33:19.839: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-j7c9d" for this suite.
+Apr 24 07:33:25.854: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:33:25.954: INFO: namespace: e2e-tests-projected-j7c9d, resource: bindings, ignored listing per whitelist
+Apr 24 07:33:26.011: INFO: namespace e2e-tests-projected-j7c9d deletion completed in 6.168739377s
+
+• [SLOW TEST:8.323 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:33:26.011: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-map-c6822ae2-4791-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 07:33:26.113: INFO: Waiting up to 5m0s for pod "pod-secrets-c682910e-4791-11e8-bf16-a2a292742988" in namespace "e2e-tests-secrets-cxq2g" to be "success or failure"
+Apr 24 07:33:26.123: INFO: Pod "pod-secrets-c682910e-4791-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 9.89691ms
+Apr 24 07:33:28.126: INFO: Pod "pod-secrets-c682910e-4791-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.012931569s
+Apr 24 07:33:30.129: INFO: Pod "pod-secrets-c682910e-4791-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016275894s
+STEP: Saw pod success
+Apr 24 07:33:30.129: INFO: Pod "pod-secrets-c682910e-4791-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:33:30.132: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-secrets-c682910e-4791-11e8-bf16-a2a292742988 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:33:30.153: INFO: Waiting for pod pod-secrets-c682910e-4791-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:33:30.164: INFO: Pod pod-secrets-c682910e-4791-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:33:30.164: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-cxq2g" for this suite.
+Apr 24 07:33:36.177: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:33:36.288: INFO: namespace: e2e-tests-secrets-cxq2g, resource: bindings, ignored listing per whitelist
+Apr 24 07:33:36.311: INFO: namespace e2e-tests-secrets-cxq2g deletion completed in 6.144137321s
+
+• [SLOW TEST:10.300 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:33:36.312: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-qxhqp
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 24 07:33:36.446: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 24 07:34:06.640: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.1.13:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-qxhqp PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 07:34:06.640: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 07:34:06.858: INFO: Found all expected endpoints: [netserver-0]
+Apr 24 07:34:06.861: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.0.12:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-qxhqp PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 07:34:06.861: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 07:34:07.098: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:34:07.098: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-qxhqp" for this suite.
+Apr 24 07:34:29.112: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:34:29.159: INFO: namespace: e2e-tests-pod-network-test-qxhqp, resource: bindings, ignored listing per whitelist
+Apr 24 07:34:29.239: INFO: namespace e2e-tests-pod-network-test-qxhqp deletion completed in 22.137220832s
+
+• [SLOW TEST:52.927 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:34:29.239: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:34:29.339: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-n8m6w" for this suite.
+Apr 24 07:34:35.351: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:34:35.464: INFO: namespace: e2e-tests-services-n8m6w, resource: bindings, ignored listing per whitelist
+Apr 24 07:34:35.487: INFO: namespace e2e-tests-services-n8m6w deletion completed in 6.145866628s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:6.248 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:34:35.489: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 24 07:34:35.583: INFO: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:34:35.584: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-qg9kw" for this suite.
+Apr 24 07:34:41.600: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:34:41.712: INFO: namespace: e2e-tests-container-probe-qg9kw, resource: bindings, ignored listing per whitelist
+Apr 24 07:34:41.749: INFO: namespace e2e-tests-container-probe-qg9kw deletion completed in 6.158649692s
+
+S [SKIPPING] [6.261 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a docker exec liveness probe with timeout  [Conformance] [It]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+
+  Apr 24 07:34:35.583: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:296
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:34:41.750: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-f3a79eee-4791-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 07:34:41.857: INFO: Waiting up to 5m0s for pod "pod-secrets-f3a82db2-4791-11e8-bf16-a2a292742988" in namespace "e2e-tests-secrets-hptpv" to be "success or failure"
+Apr 24 07:34:41.865: INFO: Pod "pod-secrets-f3a82db2-4791-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 7.68481ms
+Apr 24 07:34:43.869: INFO: Pod "pod-secrets-f3a82db2-4791-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01126489s
+Apr 24 07:34:46.015: INFO: Pod "pod-secrets-f3a82db2-4791-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.157513374s
+STEP: Saw pod success
+Apr 24 07:34:46.015: INFO: Pod "pod-secrets-f3a82db2-4791-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:34:46.018: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-secrets-f3a82db2-4791-11e8-bf16-a2a292742988 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:34:46.093: INFO: Waiting for pod pod-secrets-f3a82db2-4791-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:34:46.118: INFO: Pod pod-secrets-f3a82db2-4791-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:34:46.118: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-hptpv" for this suite.
+Apr 24 07:34:52.135: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:34:52.193: INFO: namespace: e2e-tests-secrets-hptpv, resource: bindings, ignored listing per whitelist
+Apr 24 07:34:52.271: INFO: namespace e2e-tests-secrets-hptpv deletion completed in 6.147187679s
+
+• [SLOW TEST:10.521 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:34:52.273: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-upd-f9efb569-4791-11e8-bf16-a2a292742988
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-f9efb569-4791-11e8-bf16-a2a292742988
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:34:56.489: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-tc9gc" for this suite.
+Apr 24 07:35:18.502: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:35:18.571: INFO: namespace: e2e-tests-configmap-tc9gc, resource: bindings, ignored listing per whitelist
+Apr 24 07:35:18.640: INFO: namespace e2e-tests-configmap-tc9gc deletion completed in 22.147924506s
+
+• [SLOW TEST:26.368 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:35:18.640: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Apr 24 07:35:21.264: INFO: Successfully updated pod "pod-update-activedeadlineseconds-09a4c84f-4792-11e8-bf16-a2a292742988"
+Apr 24 07:35:21.264: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-09a4c84f-4792-11e8-bf16-a2a292742988" in namespace "e2e-tests-pods-x6lgb" to be "terminated due to deadline exceeded"
+Apr 24 07:35:21.280: INFO: Pod "pod-update-activedeadlineseconds-09a4c84f-4792-11e8-bf16-a2a292742988": Phase="Running", Reason="", readiness=true. Elapsed: 15.777222ms
+Apr 24 07:35:23.283: INFO: Pod "pod-update-activedeadlineseconds-09a4c84f-4792-11e8-bf16-a2a292742988": Phase="Running", Reason="", readiness=true. Elapsed: 2.018792827s
+Apr 24 07:35:25.286: INFO: Pod "pod-update-activedeadlineseconds-09a4c84f-4792-11e8-bf16-a2a292742988": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 4.02149698s
+Apr 24 07:35:25.286: INFO: Pod "pod-update-activedeadlineseconds-09a4c84f-4792-11e8-bf16-a2a292742988" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:35:25.286: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-x6lgb" for this suite.
+Apr 24 07:35:31.302: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:35:31.403: INFO: namespace: e2e-tests-pods-x6lgb, resource: bindings, ignored listing per whitelist
+Apr 24 07:35:31.445: INFO: namespace e2e-tests-pods-x6lgb deletion completed in 6.157030803s
+
+• [SLOW TEST:12.805 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:35:31.446: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 24 07:35:31.598: INFO: Creating simple daemon set daemon-set
+STEP: Check that daemon pods launch on every node of the cluster.
+Apr 24 07:35:31.615: INFO: Number of nodes with available pods: 0
+Apr 24 07:35:31.615: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:35:32.622: INFO: Number of nodes with available pods: 0
+Apr 24 07:35:32.622: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:35:33.645: INFO: Number of nodes with available pods: 0
+Apr 24 07:35:33.645: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:35:34.621: INFO: Number of nodes with available pods: 0
+Apr 24 07:35:34.621: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:35:35.626: INFO: Number of nodes with available pods: 2
+Apr 24 07:35:35.626: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Update daemon pods image.
+STEP: Check that daemon pods images are updated.
+Apr 24 07:35:35.646: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:35.646: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:36.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:36.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:37.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:37.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:38.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:38.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:39.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:39.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:40.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:40.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:41.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:41.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:42.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:42.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:43.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:43.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:44.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:44.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:45.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:45.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:46.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:46.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:47.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:47.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:48.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:48.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:49.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:49.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:50.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:50.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:51.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:51.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:52.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:52.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:53.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:53.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:54.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:54.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:55.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:55.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:56.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:56.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:57.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:57.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:58.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:58.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:59.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:35:59.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:00.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:00.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:01.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:01.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:02.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:02.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:03.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:03.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:04.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:04.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:05.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:05.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:06.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:06.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:07.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:07.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:08.659: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:08.659: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:09.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:09.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:10.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:10.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:11.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:11.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:12.660: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:12.660: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:13.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:13.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:14.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:14.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:15.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:15.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:16.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:16.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:17.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:17.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:18.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:18.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:19.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:19.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:20.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:20.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:21.659: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:21.659: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:22.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:22.658: INFO: Pod daemon-set-6m5tn is not available
+Apr 24 07:36:22.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:23.659: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:23.659: INFO: Pod daemon-set-6m5tn is not available
+Apr 24 07:36:23.659: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:24.658: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:24.658: INFO: Pod daemon-set-6m5tn is not available
+Apr 24 07:36:24.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:25.657: INFO: Wrong image for pod: daemon-set-6m5tn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:25.658: INFO: Pod daemon-set-6m5tn is not available
+Apr 24 07:36:25.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:26.658: INFO: Pod daemon-set-26v4q is not available
+Apr 24 07:36:26.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:27.662: INFO: Pod daemon-set-26v4q is not available
+Apr 24 07:36:27.663: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:28.659: INFO: Pod daemon-set-26v4q is not available
+Apr 24 07:36:28.659: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:29.657: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:30.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:31.659: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:32.658: INFO: Wrong image for pod: daemon-set-dqpc7. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 24 07:36:32.658: INFO: Pod daemon-set-dqpc7 is not available
+Apr 24 07:36:33.658: INFO: Pod daemon-set-72msz is not available
+STEP: Check that daemon pods are still running on every node of the cluster.
+Apr 24 07:36:33.666: INFO: Number of nodes with available pods: 1
+Apr 24 07:36:33.666: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:36:34.672: INFO: Number of nodes with available pods: 1
+Apr 24 07:36:34.672: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:36:35.672: INFO: Number of nodes with available pods: 1
+Apr 24 07:36:35.672: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:36:36.673: INFO: Number of nodes with available pods: 2
+Apr 24 07:36:36.674: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 24 07:36:48.706: INFO: Number of nodes with available pods: 0
+Apr 24 07:36:48.706: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 24 07:36:48.712: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-2dw7j/daemonsets","resourceVersion":"2027"},"items":null}
+
+Apr 24 07:36:48.717: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-2dw7j/pods","resourceVersion":"2030"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:36:48.725: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-2dw7j" for this suite.
+Apr 24 07:36:54.738: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:36:54.822: INFO: namespace: e2e-tests-daemonsets-2dw7j, resource: bindings, ignored listing per whitelist
+Apr 24 07:36:54.862: INFO: namespace e2e-tests-daemonsets-2dw7j deletion completed in 6.134312836s
+
+• [SLOW TEST:83.417 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:36:54.864: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Apr 24 07:36:54.974: INFO: Waiting up to 1m0s for all nodes to be ready
+Apr 24 07:37:55.004: INFO: Waiting for terminating namespaces to be deleted...
+Apr 24 07:37:55.009: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 24 07:37:55.019: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 24 07:37:55.019: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 24 07:37:55.022: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 24 07:37:55.022: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz before test
+Apr 24 07:37:55.063: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-z9qrd from kube-system started at 2018-04-24 07:27:24 +0000 UTC (1 container statuses recorded)
+Apr 24 07:37:55.063: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Apr 24 07:37:55.063: INFO: addons-nginx-ingress-controller-7c8749685-zcr5c from kube-system started at 2018-04-24 07:27:25 +0000 UTC (1 container statuses recorded)
+Apr 24 07:37:55.063: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Apr 24 07:37:55.063: INFO: kube-dns-autoscaler-699b4b55c4-2b2qj from kube-system started at 2018-04-24 07:27:25 +0000 UTC (1 container statuses recorded)
+Apr 24 07:37:55.063: INFO: 	Container autoscaler ready: true, restart count 0
+Apr 24 07:37:55.063: INFO: kube-dns-67b49bdfd8-mxmlq from kube-system started at 2018-04-24 07:27:25 +0000 UTC (3 container statuses recorded)
+Apr 24 07:37:55.063: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 24 07:37:55.063: INFO: 	Container kubedns ready: true, restart count 0
+Apr 24 07:37:55.064: INFO: 	Container sidecar ready: true, restart count 0
+Apr 24 07:37:55.064: INFO: kube-dns-67b49bdfd8-b6dbb from kube-system started at 2018-04-24 07:27:52 +0000 UTC (3 container statuses recorded)
+Apr 24 07:37:55.064: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 24 07:37:55.064: INFO: 	Container kubedns ready: true, restart count 0
+Apr 24 07:37:55.064: INFO: 	Container sidecar ready: true, restart count 0
+Apr 24 07:37:55.064: INFO: kube-proxy-wstg7 from kube-system started at 2018-04-24 07:26:48 +0000 UTC (1 container statuses recorded)
+Apr 24 07:37:55.064: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 24 07:37:55.064: INFO: node-exporter-whjfj from kube-system started at 2018-04-24 07:26:48 +0000 UTC (1 container statuses recorded)
+Apr 24 07:37:55.064: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 24 07:37:55.064: INFO: addons-heapster-e3b0c-5c98c994fc-gjv8r from kube-system started at 2018-04-24 07:27:25 +0000 UTC (2 container statuses recorded)
+Apr 24 07:37:55.064: INFO: 	Container heapster ready: true, restart count 0
+Apr 24 07:37:55.065: INFO: 	Container heapster-nanny ready: true, restart count 0
+Apr 24 07:37:55.065: INFO: addons-kubernetes-dashboard-8478f49fbf-4f9h7 from kube-system started at 2018-04-24 07:27:25 +0000 UTC (1 container statuses recorded)
+Apr 24 07:37:55.065: INFO: 	Container main ready: true, restart count 0
+Apr 24 07:37:55.065: INFO: calico-node-zqnlp from kube-system started at 2018-04-24 07:26:48 +0000 UTC (2 container statuses recorded)
+Apr 24 07:37:55.065: INFO: 	Container calico-node ready: true, restart count 0
+Apr 24 07:37:55.065: INFO: 	Container install-cni ready: true, restart count 0
+Apr 24 07:37:55.065: INFO: vpn-shoot-6d7b66b496-7qwch from kube-system started at 2018-04-24 07:27:24 +0000 UTC (1 container statuses recorded)
+Apr 24 07:37:55.065: INFO: 	Container vpn-shoot ready: true, restart count 1
+Apr 24 07:37:55.065: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 before test
+Apr 24 07:37:55.081: INFO: node-exporter-9zwr8 from kube-system started at 2018-04-24 07:27:19 +0000 UTC (1 container statuses recorded)
+Apr 24 07:37:55.081: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 24 07:37:55.081: INFO: sonobuoy from sonobuoy started at 2018-04-24 07:30:41 +0000 UTC (1 container statuses recorded)
+Apr 24 07:37:55.081: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Apr 24 07:37:55.081: INFO: sonobuoy-e2e-job-34f29dcaad2e487d from sonobuoy started at 2018-04-24 07:30:58 +0000 UTC (2 container statuses recorded)
+Apr 24 07:37:55.081: INFO: 	Container e2e ready: true, restart count 0
+Apr 24 07:37:55.081: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Apr 24 07:37:55.081: INFO: calico-node-jzkbx from kube-system started at 2018-04-24 07:27:19 +0000 UTC (2 container statuses recorded)
+Apr 24 07:37:55.081: INFO: 	Container calico-node ready: true, restart count 0
+Apr 24 07:37:55.081: INFO: 	Container install-cni ready: true, restart count 0
+Apr 24 07:37:55.081: INFO: kube-proxy-vg59j from kube-system started at 2018-04-24 07:27:19 +0000 UTC (1 container statuses recorded)
+Apr 24 07:37:55.081: INFO: 	Container kube-proxy ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: verifying the node has the label node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+STEP: verifying the node has the label node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7
+Apr 24 07:37:55.119: INFO: Pod addons-heapster-e3b0c-5c98c994fc-gjv8r requesting resource cpu=50m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+Apr 24 07:37:55.120: INFO: Pod addons-kubernetes-dashboard-8478f49fbf-4f9h7 requesting resource cpu=100m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+Apr 24 07:37:55.120: INFO: Pod addons-nginx-ingress-controller-7c8749685-zcr5c requesting resource cpu=0m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+Apr 24 07:37:55.120: INFO: Pod addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-z9qrd requesting resource cpu=0m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+Apr 24 07:37:55.120: INFO: Pod calico-node-jzkbx requesting resource cpu=250m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7
+Apr 24 07:37:55.120: INFO: Pod calico-node-zqnlp requesting resource cpu=250m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+Apr 24 07:37:55.120: INFO: Pod kube-dns-67b49bdfd8-b6dbb requesting resource cpu=260m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+Apr 24 07:37:55.120: INFO: Pod kube-dns-67b49bdfd8-mxmlq requesting resource cpu=260m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+Apr 24 07:37:55.120: INFO: Pod kube-dns-autoscaler-699b4b55c4-2b2qj requesting resource cpu=20m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+Apr 24 07:37:55.121: INFO: Pod kube-proxy-vg59j requesting resource cpu=100m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7
+Apr 24 07:37:55.121: INFO: Pod kube-proxy-wstg7 requesting resource cpu=100m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+Apr 24 07:37:55.121: INFO: Pod node-exporter-9zwr8 requesting resource cpu=100m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7
+Apr 24 07:37:55.121: INFO: Pod node-exporter-whjfj requesting resource cpu=100m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+Apr 24 07:37:55.121: INFO: Pod vpn-shoot-6d7b66b496-7qwch requesting resource cpu=100m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+Apr 24 07:37:55.121: INFO: Pod sonobuoy requesting resource cpu=0m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7
+Apr 24 07:37:55.121: INFO: Pod sonobuoy-e2e-job-34f29dcaad2e487d requesting resource cpu=0m on Node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-66daec12-4792-11e8-bf16-a2a292742988.15284f208fd42f6a], Reason = [Scheduled], Message = [Successfully assigned filler-pod-66daec12-4792-11e8-bf16-a2a292742988 to shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-66daec12-4792-11e8-bf16-a2a292742988.15284f209c442de1], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-jndvw" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-66daec12-4792-11e8-bf16-a2a292742988.15284f20cedc9594], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause-amd64:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-66daec12-4792-11e8-bf16-a2a292742988.15284f20d63ac610], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-66daec12-4792-11e8-bf16-a2a292742988.15284f20e312d8aa], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-66dc28b9-4792-11e8-bf16-a2a292742988.15284f20909511a7], Reason = [Scheduled], Message = [Successfully assigned filler-pod-66dc28b9-4792-11e8-bf16-a2a292742988 to shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-66dc28b9-4792-11e8-bf16-a2a292742988.15284f20986bf495], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-jndvw" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-66dc28b9-4792-11e8-bf16-a2a292742988.15284f20ced684a7], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause-amd64:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-66dc28b9-4792-11e8-bf16-a2a292742988.15284f20d6fbac2e], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-66dc28b9-4792-11e8-bf16-a2a292742988.15284f20e634d9a9], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.15284f2189b7bb00], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 Insufficient cpu.]
+STEP: removing the label node off the node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:38:00.362: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-vpdvv" for this suite.
+Apr 24 07:38:22.413: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:38:22.472: INFO: namespace: e2e-tests-sched-pred-vpdvv, resource: bindings, ignored listing per whitelist
+Apr 24 07:38:22.537: INFO: namespace e2e-tests-sched-pred-vpdvv deletion completed in 22.17207053s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:87.673 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:38:22.540: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating secret e2e-tests-secrets-hr5ht/secret-test-7740b4ca-4792-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 07:38:22.640: INFO: Waiting up to 5m0s for pod "pod-configmaps-77411d86-4792-11e8-bf16-a2a292742988" in namespace "e2e-tests-secrets-hr5ht" to be "success or failure"
+Apr 24 07:38:22.644: INFO: Pod "pod-configmaps-77411d86-4792-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.980207ms
+Apr 24 07:38:24.647: INFO: Pod "pod-configmaps-77411d86-4792-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006282888s
+Apr 24 07:38:26.650: INFO: Pod "pod-configmaps-77411d86-4792-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.009317414s
+Apr 24 07:38:28.654: INFO: Pod "pod-configmaps-77411d86-4792-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.013719339s
+STEP: Saw pod success
+Apr 24 07:38:28.655: INFO: Pod "pod-configmaps-77411d86-4792-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:38:28.657: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-configmaps-77411d86-4792-11e8-bf16-a2a292742988 container env-test: <nil>
+STEP: delete the pod
+Apr 24 07:38:28.708: INFO: Waiting for pod pod-configmaps-77411d86-4792-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:38:28.725: INFO: Pod pod-configmaps-77411d86-4792-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:38:28.726: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-hr5ht" for this suite.
+Apr 24 07:38:34.741: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:38:34.788: INFO: namespace: e2e-tests-secrets-hr5ht, resource: bindings, ignored listing per whitelist
+Apr 24 07:38:34.864: INFO: namespace e2e-tests-secrets-hr5ht deletion completed in 6.134790266s
+
+• [SLOW TEST:12.325 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:38:34.867: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 24 07:38:34.977: INFO: Requires at least 2 nodes (not -1)
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+Apr 24 07:38:34.983: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-ntwvz/daemonsets","resourceVersion":"2231"},"items":null}
+
+Apr 24 07:38:34.986: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-ntwvz/pods","resourceVersion":"2231"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:38:34.992: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-ntwvz" for this suite.
+Apr 24 07:38:41.005: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:38:41.124: INFO: namespace: e2e-tests-daemonsets-ntwvz, resource: bindings, ignored listing per whitelist
+Apr 24 07:38:41.129: INFO: namespace e2e-tests-daemonsets-ntwvz deletion completed in 6.13395352s
+
+S [SKIPPING] [6.262 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should rollback without unnecessary restarts [Conformance] [It]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+
+  Apr 24 07:38:34.977: Requires at least 2 nodes (not -1)
+
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:296
+------------------------------
+S
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:38:41.129: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 24 07:38:41.311: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:38:41.855: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-l8b2x" for this suite.
+Apr 24 07:38:47.874: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:38:47.948: INFO: namespace: e2e-tests-custom-resource-definition-l8b2x, resource: bindings, ignored listing per whitelist
+Apr 24 07:38:47.992: INFO: namespace e2e-tests-custom-resource-definition-l8b2x deletion completed in 6.13320385s
+
+• [SLOW TEST:6.863 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:38:47.993: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Apr 24 07:38:48.110: INFO: Waiting up to 5m0s for pod "pod-866eee9c-4792-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-wnxzj" to be "success or failure"
+Apr 24 07:38:48.115: INFO: Pod "pod-866eee9c-4792-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 5.245313ms
+Apr 24 07:38:50.118: INFO: Pod "pod-866eee9c-4792-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008131286s
+Apr 24 07:38:52.122: INFO: Pod "pod-866eee9c-4792-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01217036s
+STEP: Saw pod success
+Apr 24 07:38:52.122: INFO: Pod "pod-866eee9c-4792-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:38:52.124: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-866eee9c-4792-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 07:38:52.147: INFO: Waiting for pod pod-866eee9c-4792-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:38:52.157: INFO: Pod pod-866eee9c-4792-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:38:52.159: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-wnxzj" for this suite.
+Apr 24 07:38:58.178: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:38:58.253: INFO: namespace: e2e-tests-emptydir-wnxzj, resource: bindings, ignored listing per whitelist
+Apr 24 07:38:58.324: INFO: namespace e2e-tests-emptydir-wnxzj deletion completed in 6.161330052s
+
+• [SLOW TEST:10.331 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:38:58.324: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-m2b4s
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 24 07:38:58.421: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 24 07:39:20.514: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.24:8080/dial?request=hostName&protocol=udp&host=100.96.0.16&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-m2b4s PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 07:39:20.514: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 07:39:20.913: INFO: Waiting for endpoints: map[]
+Apr 24 07:39:20.916: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.24:8080/dial?request=hostName&protocol=udp&host=100.96.1.23&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-m2b4s PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 07:39:20.916: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 07:39:21.302: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:39:21.302: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-m2b4s" for this suite.
+Apr 24 07:39:43.316: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:39:43.423: INFO: namespace: e2e-tests-pod-network-test-m2b4s, resource: bindings, ignored listing per whitelist
+Apr 24 07:39:43.449: INFO: namespace e2e-tests-pod-network-test-m2b4s deletion completed in 22.14244842s
+
+• [SLOW TEST:45.125 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:39:43.452: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 07:39:43.555: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a77be026-4792-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-6xf6t" to be "success or failure"
+Apr 24 07:39:43.564: INFO: Pod "downwardapi-volume-a77be026-4792-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 8.936321ms
+Apr 24 07:39:45.567: INFO: Pod "downwardapi-volume-a77be026-4792-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.012045344s
+Apr 24 07:39:47.570: INFO: Pod "downwardapi-volume-a77be026-4792-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015153839s
+STEP: Saw pod success
+Apr 24 07:39:47.570: INFO: Pod "downwardapi-volume-a77be026-4792-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:39:47.572: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-a77be026-4792-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 07:39:47.607: INFO: Waiting for pod downwardapi-volume-a77be026-4792-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:39:47.612: INFO: Pod downwardapi-volume-a77be026-4792-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:39:47.612: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6xf6t" for this suite.
+Apr 24 07:39:53.627: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:39:53.699: INFO: namespace: e2e-tests-projected-6xf6t, resource: bindings, ignored listing per whitelist
+Apr 24 07:39:53.755: INFO: namespace e2e-tests-projected-6xf6t deletion completed in 6.139808891s
+
+• [SLOW TEST:10.304 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:39:53.756: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0424 07:39:59.884706      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 24 07:39:59.884: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:39:59.884: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-b6g67" for this suite.
+Apr 24 07:40:05.908: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:40:05.968: INFO: namespace: e2e-tests-gc-b6g67, resource: bindings, ignored listing per whitelist
+Apr 24 07:40:06.071: INFO: namespace e2e-tests-gc-b6g67 deletion completed in 6.184040418s
+
+• [SLOW TEST:12.316 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:40:06.072: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test use defaults
+Apr 24 07:40:06.178: INFO: Waiting up to 5m0s for pod "client-containers-b4f7cbdc-4792-11e8-bf16-a2a292742988" in namespace "e2e-tests-containers-z5ps5" to be "success or failure"
+Apr 24 07:40:06.182: INFO: Pod "client-containers-b4f7cbdc-4792-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.320211ms
+Apr 24 07:40:08.185: INFO: Pod "client-containers-b4f7cbdc-4792-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007233344s
+Apr 24 07:40:10.191: INFO: Pod "client-containers-b4f7cbdc-4792-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012943488s
+STEP: Saw pod success
+Apr 24 07:40:10.191: INFO: Pod "client-containers-b4f7cbdc-4792-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:40:10.198: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod client-containers-b4f7cbdc-4792-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 07:40:10.240: INFO: Waiting for pod client-containers-b4f7cbdc-4792-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:40:10.258: INFO: Pod client-containers-b4f7cbdc-4792-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:40:10.258: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-z5ps5" for this suite.
+Apr 24 07:40:16.282: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:40:16.405: INFO: namespace: e2e-tests-containers-z5ps5, resource: bindings, ignored listing per whitelist
+Apr 24 07:40:16.417: INFO: namespace e2e-tests-containers-z5ps5 deletion completed in 6.148755282s
+
+• [SLOW TEST:10.346 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:40:16.418: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating server pod server in namespace e2e-tests-prestop-q9d4p
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-q9d4p
+STEP: Deleting pre-stop pod
+Apr 24 07:40:33.620: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:40:33.637: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-q9d4p" for this suite.
+Apr 24 07:41:11.659: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:41:11.766: INFO: namespace: e2e-tests-prestop-q9d4p, resource: bindings, ignored listing per whitelist
+Apr 24 07:41:11.781: INFO: namespace e2e-tests-prestop-q9d4p deletion completed in 38.13970725s
+
+• [SLOW TEST:55.363 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:41:11.781: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 24 07:41:14.408: INFO: Successfully updated pod "labelsupdatedc20429e-4792-11e8-bf16-a2a292742988"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:41:16.437: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-xjf59" for this suite.
+Apr 24 07:41:38.453: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:41:38.552: INFO: namespace: e2e-tests-downward-api-xjf59, resource: bindings, ignored listing per whitelist
+Apr 24 07:41:38.569: INFO: namespace e2e-tests-downward-api-xjf59 deletion completed in 22.126558999s
+
+• [SLOW TEST:26.788 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:41:38.572: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Apr 24 07:41:38.664: INFO: Waiting up to 1m0s for all nodes to be ready
+Apr 24 07:42:38.684: INFO: Waiting for terminating namespaces to be deleted...
+Apr 24 07:42:38.689: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 24 07:42:38.699: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 24 07:42:38.699: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 24 07:42:38.702: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 24 07:42:38.703: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz before test
+Apr 24 07:42:38.791: INFO: kube-proxy-wstg7 from kube-system started at 2018-04-24 07:26:48 +0000 UTC (1 container statuses recorded)
+Apr 24 07:42:38.791: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 24 07:42:38.791: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-z9qrd from kube-system started at 2018-04-24 07:27:24 +0000 UTC (1 container statuses recorded)
+Apr 24 07:42:38.791: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Apr 24 07:42:38.791: INFO: kube-dns-67b49bdfd8-mxmlq from kube-system started at 2018-04-24 07:27:25 +0000 UTC (3 container statuses recorded)
+Apr 24 07:42:38.792: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 24 07:42:38.792: INFO: 	Container kubedns ready: true, restart count 0
+Apr 24 07:42:38.792: INFO: 	Container sidecar ready: true, restart count 0
+Apr 24 07:42:38.792: INFO: calico-node-zqnlp from kube-system started at 2018-04-24 07:26:48 +0000 UTC (2 container statuses recorded)
+Apr 24 07:42:38.792: INFO: 	Container calico-node ready: true, restart count 0
+Apr 24 07:42:38.792: INFO: 	Container install-cni ready: true, restart count 0
+Apr 24 07:42:38.792: INFO: node-exporter-whjfj from kube-system started at 2018-04-24 07:26:48 +0000 UTC (1 container statuses recorded)
+Apr 24 07:42:38.793: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 24 07:42:38.793: INFO: addons-nginx-ingress-controller-7c8749685-zcr5c from kube-system started at 2018-04-24 07:27:25 +0000 UTC (1 container statuses recorded)
+Apr 24 07:42:38.793: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Apr 24 07:42:38.793: INFO: kube-dns-autoscaler-699b4b55c4-2b2qj from kube-system started at 2018-04-24 07:27:25 +0000 UTC (1 container statuses recorded)
+Apr 24 07:42:38.793: INFO: 	Container autoscaler ready: true, restart count 0
+Apr 24 07:42:38.793: INFO: kube-dns-67b49bdfd8-b6dbb from kube-system started at 2018-04-24 07:27:52 +0000 UTC (3 container statuses recorded)
+Apr 24 07:42:38.793: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 24 07:42:38.794: INFO: 	Container kubedns ready: true, restart count 0
+Apr 24 07:42:38.794: INFO: 	Container sidecar ready: true, restart count 0
+Apr 24 07:42:38.794: INFO: vpn-shoot-6d7b66b496-7qwch from kube-system started at 2018-04-24 07:27:24 +0000 UTC (1 container statuses recorded)
+Apr 24 07:42:38.794: INFO: 	Container vpn-shoot ready: true, restart count 1
+Apr 24 07:42:38.794: INFO: addons-heapster-e3b0c-5c98c994fc-gjv8r from kube-system started at 2018-04-24 07:27:25 +0000 UTC (2 container statuses recorded)
+Apr 24 07:42:38.794: INFO: 	Container heapster ready: true, restart count 0
+Apr 24 07:42:38.794: INFO: 	Container heapster-nanny ready: true, restart count 0
+Apr 24 07:42:38.795: INFO: addons-kubernetes-dashboard-8478f49fbf-4f9h7 from kube-system started at 2018-04-24 07:27:25 +0000 UTC (1 container statuses recorded)
+Apr 24 07:42:38.795: INFO: 	Container main ready: true, restart count 0
+Apr 24 07:42:38.795: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 before test
+Apr 24 07:42:38.828: INFO: calico-node-jzkbx from kube-system started at 2018-04-24 07:27:19 +0000 UTC (2 container statuses recorded)
+Apr 24 07:42:38.828: INFO: 	Container calico-node ready: true, restart count 0
+Apr 24 07:42:38.829: INFO: 	Container install-cni ready: true, restart count 0
+Apr 24 07:42:38.829: INFO: node-exporter-9zwr8 from kube-system started at 2018-04-24 07:27:19 +0000 UTC (1 container statuses recorded)
+Apr 24 07:42:38.829: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 24 07:42:38.829: INFO: sonobuoy from sonobuoy started at 2018-04-24 07:30:41 +0000 UTC (1 container statuses recorded)
+Apr 24 07:42:38.829: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Apr 24 07:42:38.829: INFO: sonobuoy-e2e-job-34f29dcaad2e487d from sonobuoy started at 2018-04-24 07:30:58 +0000 UTC (2 container statuses recorded)
+Apr 24 07:42:38.830: INFO: 	Container e2e ready: true, restart count 0
+Apr 24 07:42:38.830: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Apr 24 07:42:38.830: INFO: kube-proxy-vg59j from kube-system started at 2018-04-24 07:27:19 +0000 UTC (1 container statuses recorded)
+Apr 24 07:42:38.830: INFO: 	Container kube-proxy ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-126031c7-4793-11e8-bf16-a2a292742988 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-126031c7-4793-11e8-bf16-a2a292742988 off the node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-126031c7-4793-11e8-bf16-a2a292742988
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:42:46.960: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-s7nql" for this suite.
+Apr 24 07:43:09.027: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:43:09.101: INFO: namespace: e2e-tests-sched-pred-s7nql, resource: bindings, ignored listing per whitelist
+Apr 24 07:43:09.159: INFO: namespace e2e-tests-sched-pred-s7nql deletion completed in 22.19429778s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:90.588 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:43:09.161: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Apr 24 07:43:09.770: INFO: Waiting up to 5m0s for pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-66x6d" in namespace "e2e-tests-svcaccounts-cnxqt" to be "success or failure"
+Apr 24 07:43:09.774: INFO: Pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-66x6d": Phase="Pending", Reason="", readiness=false. Elapsed: 4.129512ms
+Apr 24 07:43:11.777: INFO: Pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-66x6d": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007108346s
+Apr 24 07:43:13.780: INFO: Pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-66x6d": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010172195s
+STEP: Saw pod success
+Apr 24 07:43:13.780: INFO: Pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-66x6d" satisfied condition "success or failure"
+Apr 24 07:43:13.784: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-66x6d container token-test: <nil>
+STEP: delete the pod
+Apr 24 07:43:13.809: INFO: Waiting for pod pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-66x6d to disappear
+Apr 24 07:43:13.824: INFO: Pod pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-66x6d no longer exists
+STEP: Creating a pod to test consume service account root CA
+Apr 24 07:43:13.834: INFO: Waiting up to 5m0s for pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9pqgt" in namespace "e2e-tests-svcaccounts-cnxqt" to be "success or failure"
+Apr 24 07:43:13.844: INFO: Pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9pqgt": Phase="Pending", Reason="", readiness=false. Elapsed: 10.108434ms
+Apr 24 07:43:15.848: INFO: Pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9pqgt": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013571946s
+Apr 24 07:43:17.851: INFO: Pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9pqgt": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016724138s
+STEP: Saw pod success
+Apr 24 07:43:17.851: INFO: Pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9pqgt" satisfied condition "success or failure"
+Apr 24 07:43:17.853: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9pqgt container root-ca-test: <nil>
+STEP: delete the pod
+Apr 24 07:43:17.883: INFO: Waiting for pod pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9pqgt to disappear
+Apr 24 07:43:17.885: INFO: Pod pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9pqgt no longer exists
+STEP: Creating a pod to test consume service account namespace
+Apr 24 07:43:17.894: INFO: Waiting up to 5m0s for pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9rfnd" in namespace "e2e-tests-svcaccounts-cnxqt" to be "success or failure"
+Apr 24 07:43:17.909: INFO: Pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9rfnd": Phase="Pending", Reason="", readiness=false. Elapsed: 15.075653ms
+Apr 24 07:43:19.913: INFO: Pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9rfnd": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01885836s
+Apr 24 07:43:21.916: INFO: Pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9rfnd": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.022285413s
+STEP: Saw pod success
+Apr 24 07:43:21.917: INFO: Pod "pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9rfnd" satisfied condition "success or failure"
+Apr 24 07:43:21.919: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9rfnd container namespace-test: <nil>
+STEP: delete the pod
+Apr 24 07:43:21.963: INFO: Waiting for pod pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9rfnd to disappear
+Apr 24 07:43:21.977: INFO: Pod pod-service-account-2265a56d-4793-11e8-bf16-a2a292742988-9rfnd no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:43:21.977: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-cnxqt" for this suite.
+Apr 24 07:43:27.991: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:43:28.097: INFO: namespace: e2e-tests-svcaccounts-cnxqt, resource: bindings, ignored listing per whitelist
+Apr 24 07:43:28.133: INFO: namespace e2e-tests-svcaccounts-cnxqt deletion completed in 6.153085104s
+
+• [SLOW TEST:18.972 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:43:28.135: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Apr 24 07:43:28.262: INFO: Waiting up to 5m0s for pod "pod-2d6add7f-4793-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-2dhwb" to be "success or failure"
+Apr 24 07:43:28.274: INFO: Pod "pod-2d6add7f-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 11.991939ms
+Apr 24 07:43:30.277: INFO: Pod "pod-2d6add7f-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.014484553s
+Apr 24 07:43:32.280: INFO: Pod "pod-2d6add7f-4793-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017721873s
+STEP: Saw pod success
+Apr 24 07:43:32.280: INFO: Pod "pod-2d6add7f-4793-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:43:32.282: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-2d6add7f-4793-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 07:43:32.390: INFO: Waiting for pod pod-2d6add7f-4793-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:43:32.393: INFO: Pod pod-2d6add7f-4793-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:43:32.393: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-2dhwb" for this suite.
+Apr 24 07:43:38.406: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:43:38.474: INFO: namespace: e2e-tests-emptydir-2dhwb, resource: bindings, ignored listing per whitelist
+Apr 24 07:43:38.534: INFO: namespace e2e-tests-emptydir-2dhwb deletion completed in 6.137254734s
+
+• [SLOW TEST:10.399 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:43:38.536: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-339aedba-4793-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 07:43:38.647: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-339b6f32-4793-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-m4knz" to be "success or failure"
+Apr 24 07:43:38.651: INFO: Pod "pod-projected-configmaps-339b6f32-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.265014ms
+Apr 24 07:43:40.654: INFO: Pod "pod-projected-configmaps-339b6f32-4793-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007117458s
+STEP: Saw pod success
+Apr 24 07:43:40.654: INFO: Pod "pod-projected-configmaps-339b6f32-4793-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:43:40.656: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-configmaps-339b6f32-4793-11e8-bf16-a2a292742988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:43:40.687: INFO: Waiting for pod pod-projected-configmaps-339b6f32-4793-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:43:40.711: INFO: Pod pod-projected-configmaps-339b6f32-4793-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:43:40.712: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-m4knz" for this suite.
+Apr 24 07:43:46.730: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:43:46.819: INFO: namespace: e2e-tests-projected-m4knz, resource: bindings, ignored listing per whitelist
+Apr 24 07:43:46.853: INFO: namespace e2e-tests-projected-m4knz deletion completed in 6.134902355s
+
+• [SLOW TEST:8.318 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:43:46.854: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 24 07:43:49.495: INFO: Successfully updated pod "annotationupdate388fbe7c-4793-11e8-bf16-a2a292742988"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:43:51.527: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wjfn7" for this suite.
+Apr 24 07:44:13.544: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:44:13.602: INFO: namespace: e2e-tests-projected-wjfn7, resource: bindings, ignored listing per whitelist
+Apr 24 07:44:13.669: INFO: namespace e2e-tests-projected-wjfn7 deletion completed in 22.138435796s
+
+• [SLOW TEST:26.815 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:44:13.669: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 07:44:13.784: INFO: Waiting up to 5m0s for pod "downwardapi-volume-488d5ca1-4793-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-7dvf4" to be "success or failure"
+Apr 24 07:44:13.793: INFO: Pod "downwardapi-volume-488d5ca1-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 8.90153ms
+Apr 24 07:44:15.796: INFO: Pod "downwardapi-volume-488d5ca1-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.012266157s
+Apr 24 07:44:17.823: INFO: Pod "downwardapi-volume-488d5ca1-4793-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.039695921s
+STEP: Saw pod success
+Apr 24 07:44:17.824: INFO: Pod "downwardapi-volume-488d5ca1-4793-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:44:17.827: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-488d5ca1-4793-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 07:44:17.850: INFO: Waiting for pod downwardapi-volume-488d5ca1-4793-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:44:17.860: INFO: Pod downwardapi-volume-488d5ca1-4793-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:44:17.860: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-7dvf4" for this suite.
+Apr 24 07:44:23.886: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:44:23.996: INFO: namespace: e2e-tests-downward-api-7dvf4, resource: bindings, ignored listing per whitelist
+Apr 24 07:44:24.016: INFO: namespace e2e-tests-downward-api-7dvf4 deletion completed in 6.146131229s
+
+• [SLOW TEST:10.347 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:44:24.017: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Apr 24 07:44:24.144: INFO: Number of nodes with available pods: 0
+Apr 24 07:44:24.144: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:44:25.150: INFO: Number of nodes with available pods: 0
+Apr 24 07:44:25.150: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:44:26.150: INFO: Number of nodes with available pods: 1
+Apr 24 07:44:26.150: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 is running more than one daemon pod
+Apr 24 07:44:27.150: INFO: Number of nodes with available pods: 2
+Apr 24 07:44:27.150: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Stop a daemon pod, check that the daemon pod is revived.
+Apr 24 07:44:27.177: INFO: Number of nodes with available pods: 1
+Apr 24 07:44:27.177: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 is running more than one daemon pod
+Apr 24 07:44:28.187: INFO: Number of nodes with available pods: 1
+Apr 24 07:44:28.187: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 is running more than one daemon pod
+Apr 24 07:44:29.184: INFO: Number of nodes with available pods: 1
+Apr 24 07:44:29.184: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 is running more than one daemon pod
+Apr 24 07:44:30.184: INFO: Number of nodes with available pods: 1
+Apr 24 07:44:30.184: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 is running more than one daemon pod
+Apr 24 07:44:31.185: INFO: Number of nodes with available pods: 1
+Apr 24 07:44:31.185: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 is running more than one daemon pod
+Apr 24 07:44:32.184: INFO: Number of nodes with available pods: 1
+Apr 24 07:44:32.184: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 is running more than one daemon pod
+Apr 24 07:44:33.183: INFO: Number of nodes with available pods: 2
+Apr 24 07:44:33.183: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 24 07:44:46.234: INFO: Number of nodes with available pods: 0
+Apr 24 07:44:46.234: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 24 07:44:46.236: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-z9vfl/daemonsets","resourceVersion":"3153"},"items":null}
+
+Apr 24 07:44:46.244: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-z9vfl/pods","resourceVersion":"3154"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:44:46.257: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-z9vfl" for this suite.
+Apr 24 07:44:52.270: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:44:52.349: INFO: namespace: e2e-tests-daemonsets-z9vfl, resource: bindings, ignored listing per whitelist
+Apr 24 07:44:52.394: INFO: namespace e2e-tests-daemonsets-z9vfl deletion completed in 6.134124598s
+
+• [SLOW TEST:28.378 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:44:52.395: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-5fa18548-4793-11e8-bf16-a2a292742988
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-5fa18548-4793-11e8-bf16-a2a292742988
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:46:07.067: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-tdll4" for this suite.
+Apr 24 07:46:29.085: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:46:29.134: INFO: namespace: e2e-tests-projected-tdll4, resource: bindings, ignored listing per whitelist
+Apr 24 07:46:29.208: INFO: namespace e2e-tests-projected-tdll4 deletion completed in 22.138668655s
+
+• [SLOW TEST:96.814 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:46:29.213: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Apr 24 07:46:38.799: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-j576k PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 07:46:38.799: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 07:46:45.626: INFO: Exec stderr: ""
+Apr 24 07:46:45.626: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-j576k PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 07:46:45.626: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 07:46:45.854: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Apr 24 07:46:45.854: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-j576k PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 07:46:45.854: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 07:46:45.986: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Apr 24 07:46:45.986: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-j576k PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 07:46:45.986: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 07:46:46.175: INFO: Exec stderr: ""
+Apr 24 07:46:46.175: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-j576k PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 07:46:46.175: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 07:46:46.363: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:46:46.364: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-j576k" for this suite.
+Apr 24 07:47:48.378: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:47:48.461: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-j576k, resource: bindings, ignored listing per whitelist
+Apr 24 07:47:48.508: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-j576k deletion completed in 1m2.140556129s
+
+• [SLOW TEST:79.295 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:47:48.509: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-map-c8992eea-4793-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 07:47:48.614: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-c899b225-4793-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-kq27t" to be "success or failure"
+Apr 24 07:47:48.624: INFO: Pod "pod-projected-secrets-c899b225-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 9.726334ms
+Apr 24 07:47:50.627: INFO: Pod "pod-projected-secrets-c899b225-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01275705s
+Apr 24 07:47:52.630: INFO: Pod "pod-projected-secrets-c899b225-4793-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015965892s
+STEP: Saw pod success
+Apr 24 07:47:52.630: INFO: Pod "pod-projected-secrets-c899b225-4793-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:47:52.632: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-secrets-c899b225-4793-11e8-bf16-a2a292742988 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:47:52.691: INFO: Waiting for pod pod-projected-secrets-c899b225-4793-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:47:52.697: INFO: Pod pod-projected-secrets-c899b225-4793-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:47:52.697: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-kq27t" for this suite.
+Apr 24 07:47:58.738: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:47:58.840: INFO: namespace: e2e-tests-projected-kq27t, resource: bindings, ignored listing per whitelist
+Apr 24 07:47:58.875: INFO: namespace e2e-tests-projected-kq27t deletion completed in 6.155525058s
+
+• [SLOW TEST:10.366 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:47:58.875: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 24 07:48:03.020: INFO: Waiting up to 5m0s for pod "client-envvars-d12fec2a-4793-11e8-bf16-a2a292742988" in namespace "e2e-tests-pods-b75bz" to be "success or failure"
+Apr 24 07:48:03.027: INFO: Pod "client-envvars-d12fec2a-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 7.328928ms
+Apr 24 07:48:05.030: INFO: Pod "client-envvars-d12fec2a-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01030326s
+Apr 24 07:48:07.033: INFO: Pod "client-envvars-d12fec2a-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.012938223s
+Apr 24 07:48:09.038: INFO: Pod "client-envvars-d12fec2a-4793-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.018655923s
+STEP: Saw pod success
+Apr 24 07:48:09.038: INFO: Pod "client-envvars-d12fec2a-4793-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:48:09.040: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod client-envvars-d12fec2a-4793-11e8-bf16-a2a292742988 container env3cont: <nil>
+STEP: delete the pod
+Apr 24 07:48:09.063: INFO: Waiting for pod client-envvars-d12fec2a-4793-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:48:09.071: INFO: Pod client-envvars-d12fec2a-4793-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:48:09.071: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-b75bz" for this suite.
+Apr 24 07:48:31.085: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:48:31.192: INFO: namespace: e2e-tests-pods-b75bz, resource: bindings, ignored listing per whitelist
+Apr 24 07:48:31.210: INFO: namespace e2e-tests-pods-b75bz deletion completed in 22.136312679s
+
+• [SLOW TEST:32.336 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:48:31.212: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 07:48:31.316: INFO: Waiting up to 5m0s for pod "downwardapi-volume-e20d64d8-4793-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-kz2xm" to be "success or failure"
+Apr 24 07:48:31.320: INFO: Pod "downwardapi-volume-e20d64d8-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.919615ms
+Apr 24 07:48:33.323: INFO: Pod "downwardapi-volume-e20d64d8-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006993868s
+Apr 24 07:48:35.326: INFO: Pod "downwardapi-volume-e20d64d8-4793-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009968083s
+STEP: Saw pod success
+Apr 24 07:48:35.326: INFO: Pod "downwardapi-volume-e20d64d8-4793-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:48:35.329: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-e20d64d8-4793-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 07:48:35.349: INFO: Waiting for pod downwardapi-volume-e20d64d8-4793-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:48:35.355: INFO: Pod downwardapi-volume-e20d64d8-4793-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:48:35.355: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-kz2xm" for this suite.
+Apr 24 07:48:41.378: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:48:41.431: INFO: namespace: e2e-tests-downward-api-kz2xm, resource: bindings, ignored listing per whitelist
+Apr 24 07:48:41.511: INFO: namespace e2e-tests-downward-api-kz2xm deletion completed in 6.142067431s
+
+• [SLOW TEST:10.299 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:48:41.512: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name cm-test-opt-del-e83202f8-4793-11e8-bf16-a2a292742988
+STEP: Creating configMap with name cm-test-opt-upd-e8320327-4793-11e8-bf16-a2a292742988
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-e83202f8-4793-11e8-bf16-a2a292742988
+STEP: Updating configmap cm-test-opt-upd-e8320327-4793-11e8-bf16-a2a292742988
+STEP: Creating configMap with name cm-test-opt-create-e8320338-4793-11e8-bf16-a2a292742988
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:48:48.391: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-tw5fb" for this suite.
+Apr 24 07:49:10.404: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:49:10.487: INFO: namespace: e2e-tests-projected-tw5fb, resource: bindings, ignored listing per whitelist
+Apr 24 07:49:10.531: INFO: namespace e2e-tests-projected-tw5fb deletion completed in 22.137751202s
+
+• [SLOW TEST:29.020 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:49:10.532: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-f97e0097-4793-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 07:49:10.643: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-f97e6b4e-4793-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-6t9q9" to be "success or failure"
+Apr 24 07:49:10.651: INFO: Pod "pod-projected-secrets-f97e6b4e-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 7.475127ms
+Apr 24 07:49:12.654: INFO: Pod "pod-projected-secrets-f97e6b4e-4793-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011129775s
+STEP: Saw pod success
+Apr 24 07:49:12.654: INFO: Pod "pod-projected-secrets-f97e6b4e-4793-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:49:12.656: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-secrets-f97e6b4e-4793-11e8-bf16-a2a292742988 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:49:12.698: INFO: Waiting for pod pod-projected-secrets-f97e6b4e-4793-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:49:12.704: INFO: Pod pod-projected-secrets-f97e6b4e-4793-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:49:12.704: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6t9q9" for this suite.
+Apr 24 07:49:18.719: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:49:18.828: INFO: namespace: e2e-tests-projected-6t9q9, resource: bindings, ignored listing per whitelist
+Apr 24 07:49:18.846: INFO: namespace e2e-tests-projected-6t9q9 deletion completed in 6.139198247s
+
+• [SLOW TEST:8.314 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:49:18.846: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-fe712502-4793-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 07:49:18.952: INFO: Waiting up to 5m0s for pod "pod-secrets-fe719ba9-4793-11e8-bf16-a2a292742988" in namespace "e2e-tests-secrets-rz6qm" to be "success or failure"
+Apr 24 07:49:18.976: INFO: Pod "pod-secrets-fe719ba9-4793-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 24.290594ms
+Apr 24 07:49:20.980: INFO: Pod "pod-secrets-fe719ba9-4793-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.028217993s
+STEP: Saw pod success
+Apr 24 07:49:20.980: INFO: Pod "pod-secrets-fe719ba9-4793-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:49:20.982: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-secrets-fe719ba9-4793-11e8-bf16-a2a292742988 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:49:21.006: INFO: Waiting for pod pod-secrets-fe719ba9-4793-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:49:21.015: INFO: Pod pod-secrets-fe719ba9-4793-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:49:21.015: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-rz6qm" for this suite.
+Apr 24 07:49:27.047: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:49:27.208: INFO: namespace: e2e-tests-secrets-rz6qm, resource: bindings, ignored listing per whitelist
+Apr 24 07:49:27.227: INFO: namespace e2e-tests-secrets-rz6qm deletion completed in 6.20939684s
+
+• [SLOW TEST:8.381 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:49:27.227: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 07:49:27.341: INFO: Waiting up to 5m0s for pod "downwardapi-volume-03729e9d-4794-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-ksf5q" to be "success or failure"
+Apr 24 07:49:27.347: INFO: Pod "downwardapi-volume-03729e9d-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 5.942527ms
+Apr 24 07:49:29.351: INFO: Pod "downwardapi-volume-03729e9d-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009034497s
+Apr 24 07:49:31.354: INFO: Pod "downwardapi-volume-03729e9d-4794-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012643933s
+STEP: Saw pod success
+Apr 24 07:49:31.354: INFO: Pod "downwardapi-volume-03729e9d-4794-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:49:31.356: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-03729e9d-4794-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 07:49:31.393: INFO: Waiting for pod downwardapi-volume-03729e9d-4794-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:49:31.402: INFO: Pod downwardapi-volume-03729e9d-4794-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:49:31.402: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-ksf5q" for this suite.
+Apr 24 07:49:37.416: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:49:37.477: INFO: namespace: e2e-tests-projected-ksf5q, resource: bindings, ignored listing per whitelist
+Apr 24 07:49:37.563: INFO: namespace e2e-tests-projected-ksf5q deletion completed in 6.157009271s
+
+• [SLOW TEST:10.336 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:49:37.566: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-5rc25
+[It] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Initializing watcher for selector baz=blah,foo=bar
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-5rc25
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-5rc25
+Apr 24 07:49:37.751: INFO: Found 0 stateful pods, waiting for 1
+Apr 24 07:49:47.754: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will halt with unhealthy stateful pod
+Apr 24 07:49:47.757: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-5rc25 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 24 07:49:48.061: INFO: stderr: ""
+Apr 24 07:49:48.061: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 24 07:49:48.067: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Apr 24 07:49:58.070: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 24 07:49:58.070: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 24 07:49:58.082: INFO: Verifying statefulset ss doesn't scale past 1 for another 9.9999998s
+Apr 24 07:49:59.086: INFO: Verifying statefulset ss doesn't scale past 1 for another 8.995695296s
+Apr 24 07:50:00.089: INFO: Verifying statefulset ss doesn't scale past 1 for another 7.992441607s
+Apr 24 07:50:01.093: INFO: Verifying statefulset ss doesn't scale past 1 for another 6.988737326s
+Apr 24 07:50:02.097: INFO: Verifying statefulset ss doesn't scale past 1 for another 5.985347457s
+Apr 24 07:50:03.101: INFO: Verifying statefulset ss doesn't scale past 1 for another 4.980890794s
+Apr 24 07:50:04.104: INFO: Verifying statefulset ss doesn't scale past 1 for another 3.977449245s
+Apr 24 07:50:05.108: INFO: Verifying statefulset ss doesn't scale past 1 for another 2.973909306s
+Apr 24 07:50:06.111: INFO: Verifying statefulset ss doesn't scale past 1 for another 1.970354077s
+Apr 24 07:50:07.114: INFO: Verifying statefulset ss doesn't scale past 1 for another 966.827359ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-5rc25
+Apr 24 07:50:08.118: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-5rc25 ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 24 07:50:08.468: INFO: stderr: ""
+Apr 24 07:50:08.468: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 24 07:50:08.471: INFO: Found 1 stateful pods, waiting for 3
+Apr 24 07:50:18.479: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 24 07:50:18.479: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 24 07:50:18.479: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Verifying that stateful set ss was scaled up in order
+STEP: Scale down will halt with unhealthy stateful pod
+Apr 24 07:50:18.484: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-5rc25 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 24 07:50:18.830: INFO: stderr: ""
+Apr 24 07:50:18.830: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 24 07:50:18.830: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-5rc25 ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 24 07:50:25.577: INFO: stderr: ""
+Apr 24 07:50:25.577: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 24 07:50:25.577: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-5rc25 ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 24 07:50:25.936: INFO: stderr: ""
+Apr 24 07:50:25.936: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 24 07:50:25.936: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 24 07:50:25.939: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 1
+Apr 24 07:50:35.945: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 24 07:50:35.945: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Apr 24 07:50:35.945: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Apr 24 07:50:35.982: INFO: Verifying statefulset ss doesn't scale past 3 for another 9.9999998s
+Apr 24 07:50:36.986: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.967982755s
+Apr 24 07:50:37.990: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.963776823s
+Apr 24 07:50:38.993: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.960453506s
+Apr 24 07:50:39.997: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.956991498s
+Apr 24 07:50:41.000: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.9534717s
+Apr 24 07:50:42.004: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.949851512s
+Apr 24 07:50:43.007: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.946203435s
+Apr 24 07:50:44.011: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.942871869s
+Apr 24 07:50:45.014: INFO: Verifying statefulset ss doesn't scale past 3 for another 939.473913ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-5rc25
+Apr 24 07:50:46.017: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-5rc25 ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 24 07:50:46.444: INFO: stderr: ""
+Apr 24 07:50:46.444: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 24 07:50:46.444: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-5rc25 ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 24 07:50:46.787: INFO: stderr: ""
+Apr 24 07:50:46.787: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 24 07:50:46.787: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-5rc25 ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 24 07:50:47.107: INFO: stderr: ""
+Apr 24 07:50:47.107: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 24 07:50:47.107: INFO: Scaling statefulset ss to 0
+STEP: Verifying that stateful set ss was scaled down in reverse order
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 24 07:51:17.124: INFO: Deleting all statefulset in ns e2e-tests-statefulset-5rc25
+Apr 24 07:51:17.126: INFO: Scaling statefulset ss to 0
+Apr 24 07:51:17.134: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 24 07:51:17.136: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:51:17.213: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-5rc25" for this suite.
+Apr 24 07:51:23.241: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:51:23.291: INFO: namespace: e2e-tests-statefulset-5rc25, resource: bindings, ignored listing per whitelist
+Apr 24 07:51:23.367: INFO: namespace e2e-tests-statefulset-5rc25 deletion completed in 6.145191876s
+
+• [SLOW TEST:105.801 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:51:23.367: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir volume type on node default medium
+Apr 24 07:51:23.468: INFO: Waiting up to 5m0s for pod "pod-48aa0778-4794-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-5xlrm" to be "success or failure"
+Apr 24 07:51:23.477: INFO: Pod "pod-48aa0778-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 9.495637ms
+Apr 24 07:51:25.482: INFO: Pod "pod-48aa0778-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013554181s
+Apr 24 07:51:27.485: INFO: Pod "pod-48aa0778-4794-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016569477s
+STEP: Saw pod success
+Apr 24 07:51:27.485: INFO: Pod "pod-48aa0778-4794-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:51:27.488: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-48aa0778-4794-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 07:51:27.506: INFO: Waiting for pod pod-48aa0778-4794-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:51:27.523: INFO: Pod pod-48aa0778-4794-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:51:27.523: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-5xlrm" for this suite.
+Apr 24 07:51:33.538: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:51:33.630: INFO: namespace: e2e-tests-emptydir-5xlrm, resource: bindings, ignored listing per whitelist
+Apr 24 07:51:33.670: INFO: namespace e2e-tests-emptydir-5xlrm deletion completed in 6.145078511s
+
+• [SLOW TEST:10.304 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:51:33.672: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-4ecf0e30-4794-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 07:51:33.781: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-4ecf7fc9-4794-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-2v9wp" to be "success or failure"
+Apr 24 07:51:33.783: INFO: Pod "pod-projected-configmaps-4ecf7fc9-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.649509ms
+Apr 24 07:51:35.787: INFO: Pod "pod-projected-configmaps-4ecf7fc9-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006028933s
+Apr 24 07:51:37.790: INFO: Pod "pod-projected-configmaps-4ecf7fc9-4794-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.00902651s
+STEP: Saw pod success
+Apr 24 07:51:37.790: INFO: Pod "pod-projected-configmaps-4ecf7fc9-4794-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:51:37.792: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-configmaps-4ecf7fc9-4794-11e8-bf16-a2a292742988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:51:37.819: INFO: Waiting for pod pod-projected-configmaps-4ecf7fc9-4794-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:51:37.831: INFO: Pod pod-projected-configmaps-4ecf7fc9-4794-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:51:37.831: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2v9wp" for this suite.
+Apr 24 07:51:43.844: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:51:43.945: INFO: namespace: e2e-tests-projected-2v9wp, resource: bindings, ignored listing per whitelist
+Apr 24 07:51:43.967: INFO: namespace e2e-tests-projected-2v9wp deletion completed in 6.133453741s
+
+• [SLOW TEST:10.296 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:51:43.968: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-54f2ed57-4794-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 07:51:44.082: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-54f36563-4794-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-zngft" to be "success or failure"
+Apr 24 07:51:44.086: INFO: Pod "pod-projected-configmaps-54f36563-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.173216ms
+Apr 24 07:51:46.090: INFO: Pod "pod-projected-configmaps-54f36563-4794-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008195584s
+STEP: Saw pod success
+Apr 24 07:51:46.090: INFO: Pod "pod-projected-configmaps-54f36563-4794-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:51:46.093: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-configmaps-54f36563-4794-11e8-bf16-a2a292742988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:51:46.118: INFO: Waiting for pod pod-projected-configmaps-54f36563-4794-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:51:46.130: INFO: Pod pod-projected-configmaps-54f36563-4794-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:51:46.135: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-zngft" for this suite.
+Apr 24 07:51:52.149: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:51:52.280: INFO: namespace: e2e-tests-projected-zngft, resource: bindings, ignored listing per whitelist
+Apr 24 07:51:52.280: INFO: namespace e2e-tests-projected-zngft deletion completed in 6.140503516s
+
+• [SLOW TEST:8.313 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:51:52.281: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name s-test-opt-del-59e54729-4794-11e8-bf16-a2a292742988
+STEP: Creating secret with name s-test-opt-upd-59e54816-4794-11e8-bf16-a2a292742988
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-59e54729-4794-11e8-bf16-a2a292742988
+STEP: Updating secret s-test-opt-upd-59e54816-4794-11e8-bf16-a2a292742988
+STEP: Creating secret with name s-test-opt-create-59e5482b-4794-11e8-bf16-a2a292742988
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:53:28.128: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-l76mr" for this suite.
+Apr 24 07:53:50.142: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:53:50.229: INFO: namespace: e2e-tests-secrets-l76mr, resource: bindings, ignored listing per whitelist
+Apr 24 07:53:50.277: INFO: namespace e2e-tests-secrets-l76mr deletion completed in 22.145848567s
+
+• [SLOW TEST:117.996 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:53:50.277: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-a03e6a0f-4794-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 07:53:50.406: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-a03ee2bc-4794-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-ldqbf" to be "success or failure"
+Apr 24 07:53:50.411: INFO: Pod "pod-projected-configmaps-a03ee2bc-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.732219ms
+Apr 24 07:53:52.414: INFO: Pod "pod-projected-configmaps-a03ee2bc-4794-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007780823s
+STEP: Saw pod success
+Apr 24 07:53:52.414: INFO: Pod "pod-projected-configmaps-a03ee2bc-4794-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:53:52.416: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-configmaps-a03ee2bc-4794-11e8-bf16-a2a292742988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:53:52.458: INFO: Waiting for pod pod-projected-configmaps-a03ee2bc-4794-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:53:52.468: INFO: Pod pod-projected-configmaps-a03ee2bc-4794-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:53:52.468: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-ldqbf" for this suite.
+Apr 24 07:53:58.482: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:53:58.578: INFO: namespace: e2e-tests-projected-ldqbf, resource: bindings, ignored listing per whitelist
+Apr 24 07:53:58.605: INFO: namespace e2e-tests-projected-ldqbf deletion completed in 6.133957372s
+
+• [SLOW TEST:8.328 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:53:58.606: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-projected-all-test-volume-a5337de1-4794-11e8-bf16-a2a292742988
+STEP: Creating secret with name secret-projected-all-test-volume-a5337dd2-4794-11e8-bf16-a2a292742988
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Apr 24 07:53:58.764: INFO: Waiting up to 5m0s for pod "projected-volume-a5337d9c-4794-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-f2psz" to be "success or failure"
+Apr 24 07:53:58.766: INFO: Pod "projected-volume-a5337d9c-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007408ms
+Apr 24 07:54:00.770: INFO: Pod "projected-volume-a5337d9c-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005515538s
+Apr 24 07:54:02.792: INFO: Pod "projected-volume-a5337d9c-4794-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.027281824s
+STEP: Saw pod success
+Apr 24 07:54:02.792: INFO: Pod "projected-volume-a5337d9c-4794-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:54:02.802: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod projected-volume-a5337d9c-4794-11e8-bf16-a2a292742988 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:54:02.860: INFO: Waiting for pod projected-volume-a5337d9c-4794-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:54:02.875: INFO: Pod projected-volume-a5337d9c-4794-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:54:02.878: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-f2psz" for this suite.
+Apr 24 07:54:08.896: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:54:09.014: INFO: namespace: e2e-tests-projected-f2psz, resource: bindings, ignored listing per whitelist
+Apr 24 07:54:09.022: INFO: namespace e2e-tests-projected-f2psz deletion completed in 6.140660324s
+
+• [SLOW TEST:10.416 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:54:09.022: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-ab667d8f-4794-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 07:54:09.125: INFO: Waiting up to 5m0s for pod "pod-configmaps-ab66eb61-4794-11e8-bf16-a2a292742988" in namespace "e2e-tests-configmap-m2rg2" to be "success or failure"
+Apr 24 07:54:09.146: INFO: Pod "pod-configmaps-ab66eb61-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 21.225289ms
+Apr 24 07:54:11.150: INFO: Pod "pod-configmaps-ab66eb61-4794-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.025109372s
+STEP: Saw pod success
+Apr 24 07:54:11.150: INFO: Pod "pod-configmaps-ab66eb61-4794-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:54:11.154: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-configmaps-ab66eb61-4794-11e8-bf16-a2a292742988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:54:11.185: INFO: Waiting for pod pod-configmaps-ab66eb61-4794-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:54:11.195: INFO: Pod pod-configmaps-ab66eb61-4794-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:54:11.195: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-m2rg2" for this suite.
+Apr 24 07:54:17.217: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:54:17.303: INFO: namespace: e2e-tests-configmap-m2rg2, resource: bindings, ignored listing per whitelist
+Apr 24 07:54:17.342: INFO: namespace e2e-tests-configmap-m2rg2 deletion completed in 6.138386807s
+
+• [SLOW TEST:8.319 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:54:17.344: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name cm-test-opt-del-b05e0efd-4794-11e8-bf16-a2a292742988
+STEP: Creating configMap with name cm-test-opt-upd-b05e0f30-4794-11e8-bf16-a2a292742988
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-b05e0efd-4794-11e8-bf16-a2a292742988
+STEP: Updating configmap cm-test-opt-upd-b05e0f30-4794-11e8-bf16-a2a292742988
+STEP: Creating configMap with name cm-test-opt-create-b05e0f42-4794-11e8-bf16-a2a292742988
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:55:40.469: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-mvpg2" for this suite.
+Apr 24 07:56:02.483: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:56:02.585: INFO: namespace: e2e-tests-configmap-mvpg2, resource: bindings, ignored listing per whitelist
+Apr 24 07:56:02.616: INFO: namespace e2e-tests-configmap-mvpg2 deletion completed in 22.143521307s
+
+• [SLOW TEST:105.272 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:56:02.616: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override command
+Apr 24 07:56:02.713: INFO: Waiting up to 5m0s for pod "client-containers-ef1b6d85-4794-11e8-bf16-a2a292742988" in namespace "e2e-tests-containers-7dts2" to be "success or failure"
+Apr 24 07:56:02.717: INFO: Pod "client-containers-ef1b6d85-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.781615ms
+Apr 24 07:56:04.720: INFO: Pod "client-containers-ef1b6d85-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007002079s
+Apr 24 07:56:06.724: INFO: Pod "client-containers-ef1b6d85-4794-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010345851s
+STEP: Saw pod success
+Apr 24 07:56:06.724: INFO: Pod "client-containers-ef1b6d85-4794-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:56:06.726: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod client-containers-ef1b6d85-4794-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 07:56:06.758: INFO: Waiting for pod client-containers-ef1b6d85-4794-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:56:06.761: INFO: Pod client-containers-ef1b6d85-4794-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:56:06.761: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-7dts2" for this suite.
+Apr 24 07:56:12.778: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:56:12.851: INFO: namespace: e2e-tests-containers-7dts2, resource: bindings, ignored listing per whitelist
+Apr 24 07:56:12.917: INFO: namespace e2e-tests-containers-7dts2 deletion completed in 6.149867073s
+
+• [SLOW TEST:10.301 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:56:12.918: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-f541d5ce-4794-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 07:56:13.042: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-f5429ae7-4794-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-f64v8" to be "success or failure"
+Apr 24 07:56:13.062: INFO: Pod "pod-projected-configmaps-f5429ae7-4794-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 19.870478ms
+Apr 24 07:56:15.066: INFO: Pod "pod-projected-configmaps-f5429ae7-4794-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.023143969s
+STEP: Saw pod success
+Apr 24 07:56:15.066: INFO: Pod "pod-projected-configmaps-f5429ae7-4794-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:56:15.068: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-configmaps-f5429ae7-4794-11e8-bf16-a2a292742988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:56:15.094: INFO: Waiting for pod pod-projected-configmaps-f5429ae7-4794-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:56:15.099: INFO: Pod pod-projected-configmaps-f5429ae7-4794-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:56:15.100: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-f64v8" for this suite.
+Apr 24 07:56:21.124: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:56:21.245: INFO: namespace: e2e-tests-projected-f64v8, resource: bindings, ignored listing per whitelist
+Apr 24 07:56:21.265: INFO: namespace e2e-tests-projected-f64v8 deletion completed in 6.15822855s
+
+• [SLOW TEST:8.347 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:56:21.266: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 24 07:56:21.380: INFO: Creating daemon "daemon-set" with a node selector
+STEP: Initially, daemon pods should not be running on any nodes.
+Apr 24 07:56:21.386: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:21.386: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Change node label to blue, check that daemon pod is launched.
+Apr 24 07:56:21.408: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:21.408: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:22.412: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:22.412: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:23.412: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:23.412: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:24.411: INFO: Number of nodes with available pods: 1
+Apr 24 07:56:24.411: INFO: Number of running nodes: 1, number of available pods: 1
+STEP: Update the node label to green, and wait for daemons to be unscheduled
+Apr 24 07:56:24.432: INFO: Number of nodes with available pods: 1
+Apr 24 07:56:24.432: INFO: Number of running nodes: 0, number of available pods: 1
+Apr 24 07:56:25.436: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:25.436: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Update DaemonSet node selector to green, and change its update strategy to RollingUpdate
+Apr 24 07:56:25.458: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:25.458: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:26.495: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:26.495: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:27.465: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:27.465: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:28.461: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:28.461: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:29.461: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:29.461: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:30.462: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:30.462: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:31.462: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:31.462: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:32.462: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:32.462: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:33.462: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:33.462: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:34.461: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:34.461: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:35.461: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:35.461: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:36.465: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:36.465: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:37.462: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:37.462: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:38.462: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:38.462: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:39.462: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:39.462: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:40.461: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:40.461: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 07:56:41.464: INFO: Number of nodes with available pods: 1
+Apr 24 07:56:41.464: INFO: Number of running nodes: 1, number of available pods: 1
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 24 07:56:49.489: INFO: Number of nodes with available pods: 0
+Apr 24 07:56:49.489: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 24 07:56:49.501: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-pfp78/daemonsets","resourceVersion":"4652"},"items":null}
+
+Apr 24 07:56:49.504: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-pfp78/pods","resourceVersion":"4652"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:56:49.529: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-pfp78" for this suite.
+Apr 24 07:56:55.543: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:56:55.634: INFO: namespace: e2e-tests-daemonsets-pfp78, resource: bindings, ignored listing per whitelist
+Apr 24 07:56:55.666: INFO: namespace e2e-tests-daemonsets-pfp78 deletion completed in 6.133630604s
+
+• [SLOW TEST:34.400 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:56:55.667: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test env composition
+Apr 24 07:56:55.768: INFO: Waiting up to 5m0s for pod "var-expansion-0ebb3330-4795-11e8-bf16-a2a292742988" in namespace "e2e-tests-var-expansion-kx5d8" to be "success or failure"
+Apr 24 07:56:55.772: INFO: Pod "var-expansion-0ebb3330-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.611114ms
+Apr 24 07:56:57.776: INFO: Pod "var-expansion-0ebb3330-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007129301s
+Apr 24 07:56:59.944: INFO: Pod "var-expansion-0ebb3330-4795-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.175263911s
+STEP: Saw pod success
+Apr 24 07:56:59.944: INFO: Pod "var-expansion-0ebb3330-4795-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:56:59.951: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod var-expansion-0ebb3330-4795-11e8-bf16-a2a292742988 container dapi-container: <nil>
+STEP: delete the pod
+Apr 24 07:57:00.022: INFO: Waiting for pod var-expansion-0ebb3330-4795-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:57:00.029: INFO: Pod var-expansion-0ebb3330-4795-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:57:00.029: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-kx5d8" for this suite.
+Apr 24 07:57:06.079: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:57:06.154: INFO: namespace: e2e-tests-var-expansion-kx5d8, resource: bindings, ignored listing per whitelist
+Apr 24 07:57:06.211: INFO: namespace e2e-tests-var-expansion-kx5d8 deletion completed in 6.178291604s
+
+• [SLOW TEST:10.544 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:57:06.213: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-15063828-4795-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 07:57:06.336: INFO: Waiting up to 5m0s for pod "pod-secrets-1506af9c-4795-11e8-bf16-a2a292742988" in namespace "e2e-tests-secrets-4xw5w" to be "success or failure"
+Apr 24 07:57:06.355: INFO: Pod "pod-secrets-1506af9c-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 18.487879ms
+Apr 24 07:57:08.358: INFO: Pod "pod-secrets-1506af9c-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.021224783s
+Apr 24 07:57:10.366: INFO: Pod "pod-secrets-1506af9c-4795-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.029894274s
+STEP: Saw pod success
+Apr 24 07:57:10.366: INFO: Pod "pod-secrets-1506af9c-4795-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:57:10.369: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-secrets-1506af9c-4795-11e8-bf16-a2a292742988 container secret-env-test: <nil>
+STEP: delete the pod
+Apr 24 07:57:10.406: INFO: Waiting for pod pod-secrets-1506af9c-4795-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:57:10.450: INFO: Pod pod-secrets-1506af9c-4795-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:57:10.450: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-4xw5w" for this suite.
+Apr 24 07:57:16.474: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:57:16.543: INFO: namespace: e2e-tests-secrets-4xw5w, resource: bindings, ignored listing per whitelist
+Apr 24 07:57:16.607: INFO: namespace e2e-tests-secrets-4xw5w deletion completed in 6.15092341s
+
+• [SLOW TEST:10.394 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:57:16.608: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-52zjq
+Apr 24 07:57:20.759: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-52zjq
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 24 07:57:20.765: INFO: Initial restart count of pod liveness-exec is 0
+Apr 24 07:58:10.855: INFO: Restart count of pod e2e-tests-container-probe-52zjq/liveness-exec is now 1 (50.090050409s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:58:10.875: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-52zjq" for this suite.
+Apr 24 07:58:16.897: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:58:17.024: INFO: namespace: e2e-tests-container-probe-52zjq, resource: bindings, ignored listing per whitelist
+Apr 24 07:58:17.029: INFO: namespace e2e-tests-container-probe-52zjq deletion completed in 6.149938684s
+
+• [SLOW TEST:60.421 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:58:17.029: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-3f397d73-4795-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 07:58:17.145: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-3f3a6128-4795-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-s2lrd" to be "success or failure"
+Apr 24 07:58:17.153: INFO: Pod "pod-projected-secrets-3f3a6128-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 8.411135ms
+Apr 24 07:58:19.157: INFO: Pod "pod-projected-secrets-3f3a6128-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011542317s
+Apr 24 07:58:21.160: INFO: Pod "pod-projected-secrets-3f3a6128-4795-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014957156s
+STEP: Saw pod success
+Apr 24 07:58:21.160: INFO: Pod "pod-projected-secrets-3f3a6128-4795-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:58:21.162: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-secrets-3f3a6128-4795-11e8-bf16-a2a292742988 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 24 07:58:21.180: INFO: Waiting for pod pod-projected-secrets-3f3a6128-4795-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:58:21.184: INFO: Pod pod-projected-secrets-3f3a6128-4795-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:58:21.184: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-s2lrd" for this suite.
+Apr 24 07:58:27.201: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:58:27.245: INFO: namespace: e2e-tests-projected-s2lrd, resource: bindings, ignored listing per whitelist
+Apr 24 07:58:27.320: INFO: namespace e2e-tests-projected-s2lrd deletion completed in 6.13278406s
+
+• [SLOW TEST:10.291 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:58:27.321: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 24 07:58:27.439: INFO: Waiting up to 5m0s for pod "downward-api-455eb7b1-4795-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-nxq99" to be "success or failure"
+Apr 24 07:58:27.442: INFO: Pod "downward-api-455eb7b1-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.690211ms
+Apr 24 07:58:29.445: INFO: Pod "downward-api-455eb7b1-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006370766s
+Apr 24 07:58:31.453: INFO: Pod "downward-api-455eb7b1-4795-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013645895s
+STEP: Saw pod success
+Apr 24 07:58:31.453: INFO: Pod "downward-api-455eb7b1-4795-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 07:58:31.458: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downward-api-455eb7b1-4795-11e8-bf16-a2a292742988 container dapi-container: <nil>
+STEP: delete the pod
+Apr 24 07:58:31.910: INFO: Waiting for pod downward-api-455eb7b1-4795-11e8-bf16-a2a292742988 to disappear
+Apr 24 07:58:31.949: INFO: Pod downward-api-455eb7b1-4795-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:58:31.949: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-nxq99" for this suite.
+Apr 24 07:58:37.963: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 07:58:38.050: INFO: namespace: e2e-tests-downward-api-nxq99, resource: bindings, ignored listing per whitelist
+Apr 24 07:58:38.111: INFO: namespace e2e-tests-downward-api-nxq99 deletion completed in 6.158102186s
+
+• [SLOW TEST:10.791 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 07:58:38.112: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 07:59:38.214: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-t6cq2" for this suite.
+Apr 24 08:00:00.227: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:00:00.307: INFO: namespace: e2e-tests-container-probe-t6cq2, resource: bindings, ignored listing per whitelist
+Apr 24 08:00:00.355: INFO: namespace e2e-tests-container-probe-t6cq2 deletion completed in 22.138048218s
+
+• [SLOW TEST:82.243 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:00:00.356: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:00:00.466: INFO: Waiting up to 5m0s for pod "downwardapi-volume-7cd1b899-4795-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-mvrhs" to be "success or failure"
+Apr 24 08:00:00.476: INFO: Pod "downwardapi-volume-7cd1b899-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 9.72074ms
+Apr 24 08:00:02.482: INFO: Pod "downwardapi-volume-7cd1b899-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.015490323s
+Apr 24 08:00:04.485: INFO: Pod "downwardapi-volume-7cd1b899-4795-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.018834605s
+STEP: Saw pod success
+Apr 24 08:00:04.485: INFO: Pod "downwardapi-volume-7cd1b899-4795-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:00:04.488: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-7cd1b899-4795-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:00:04.516: INFO: Waiting for pod downwardapi-volume-7cd1b899-4795-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:00:04.519: INFO: Pod downwardapi-volume-7cd1b899-4795-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:00:04.519: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-mvrhs" for this suite.
+Apr 24 08:00:10.546: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:00:10.659: INFO: namespace: e2e-tests-projected-mvrhs, resource: bindings, ignored listing per whitelist
+Apr 24 08:00:10.676: INFO: namespace e2e-tests-projected-mvrhs deletion completed in 6.15269298s
+
+• [SLOW TEST:10.321 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:00:10.676: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-82f8da23-4795-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 08:00:10.793: INFO: Waiting up to 5m0s for pod "pod-configmaps-82f96e59-4795-11e8-bf16-a2a292742988" in namespace "e2e-tests-configmap-lgh9l" to be "success or failure"
+Apr 24 08:00:10.800: INFO: Pod "pod-configmaps-82f96e59-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 6.840027ms
+Apr 24 08:00:12.806: INFO: Pod "pod-configmaps-82f96e59-4795-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.013410476s
+STEP: Saw pod success
+Apr 24 08:00:12.806: INFO: Pod "pod-configmaps-82f96e59-4795-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:00:12.810: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-configmaps-82f96e59-4795-11e8-bf16-a2a292742988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:00:12.828: INFO: Waiting for pod pod-configmaps-82f96e59-4795-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:00:12.832: INFO: Pod pod-configmaps-82f96e59-4795-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:00:12.833: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-lgh9l" for this suite.
+Apr 24 08:00:18.875: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:00:18.941: INFO: namespace: e2e-tests-configmap-lgh9l, resource: bindings, ignored listing per whitelist
+Apr 24 08:00:19.136: INFO: namespace e2e-tests-configmap-lgh9l deletion completed in 6.296253363s
+
+• [SLOW TEST:8.460 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:00:19.136: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Apr 24 08:00:22.027: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-88455a1d-4795-11e8-bf16-a2a292742988", GenerateName:"", Namespace:"e2e-tests-pods-lx24b", SelfLink:"/api/v1/namespaces/e2e-tests-pods-lx24b/pods/pod-submit-remove-88455a1d-4795-11e8-bf16-a2a292742988", UID:"884df74e-4795-11e8-a903-52bf91b907ea", ResourceVersion:"5096", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63660153619, loc:(*time.Location)(0x65972e0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"674625567"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"100.96.1.78/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-64hb5", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc420b92980), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"k8s.gcr.io/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-64hb5", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc421b1d0e8), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7", HostNetwork:false, HostPID:false, HostIPC:false, ShareProcessNamespace:(*bool)(nil), SecurityContext:(*v1.PodSecurityContext)(0xc420b92a00), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc421b1d130)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc421b1d150)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63660153619, loc:(*time.Location)(0x65972e0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63660153621, loc:(*time.Location)(0x65972e0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63660153619, loc:(*time.Location)(0x65972e0)}}, Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"10.250.0.4", PodIP:"100.96.1.78", StartTime:(*v1.Time)(0xc4215f6460), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc4215f6480), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"k8s.gcr.io/nginx-slim-amd64:0.20", ImageID:"docker-pullable://k8s.gcr.io/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://b8972dc3fd32cb509de3164380b3210f8c2e8026490f4f2b92c2181924de45e9"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+Apr 24 08:00:27.052: INFO: no pod exists with the name we were looking for, assuming the termination request was observed and completed
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:00:27.055: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-lx24b" for this suite.
+Apr 24 08:00:33.069: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:00:33.159: INFO: namespace: e2e-tests-pods-lx24b, resource: bindings, ignored listing per whitelist
+Apr 24 08:00:33.192: INFO: namespace e2e-tests-pods-lx24b deletion completed in 6.133733228s
+
+• [SLOW TEST:14.056 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:00:33.192: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 24 08:00:33.314: INFO: (0) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 9.120142ms)
+Apr 24 08:00:33.319: INFO: (1) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.988823ms)
+Apr 24 08:00:33.324: INFO: (2) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.067224ms)
+Apr 24 08:00:33.328: INFO: (3) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.929719ms)
+Apr 24 08:00:33.334: INFO: (4) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.330425ms)
+Apr 24 08:00:33.339: INFO: (5) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.180425ms)
+Apr 24 08:00:33.343: INFO: (6) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.15082ms)
+Apr 24 08:00:33.348: INFO: (7) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.377425ms)
+Apr 24 08:00:33.354: INFO: (8) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.475125ms)
+Apr 24 08:00:33.358: INFO: (9) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.24422ms)
+Apr 24 08:00:33.364: INFO: (10) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.147224ms)
+Apr 24 08:00:33.368: INFO: (11) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.808723ms)
+Apr 24 08:00:33.373: INFO: (12) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.539021ms)
+Apr 24 08:00:33.378: INFO: (13) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.005324ms)
+Apr 24 08:00:33.383: INFO: (14) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.450721ms)
+Apr 24 08:00:33.387: INFO: (15) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.43132ms)
+Apr 24 08:00:33.392: INFO: (16) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.868423ms)
+Apr 24 08:00:33.396: INFO: (17) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.102119ms)
+Apr 24 08:00:33.401: INFO: (18) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.482821ms)
+Apr 24 08:00:33.411: INFO: (19) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 10.046247ms)
+[AfterEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:00:33.411: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-tldbf" for this suite.
+Apr 24 08:00:39.423: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:00:39.506: INFO: namespace: e2e-tests-proxy-tldbf, resource: bindings, ignored listing per whitelist
+Apr 24 08:00:39.549: INFO: namespace e2e-tests-proxy-tldbf deletion completed in 6.135240792s
+
+• [SLOW TEST:6.357 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:00:39.550: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:00:39.671: INFO: Waiting up to 5m0s for pod "downwardapi-volume-942b7087-4795-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-4pgs7" to be "success or failure"
+Apr 24 08:00:39.673: INFO: Pod "downwardapi-volume-942b7087-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 1.97681ms
+Apr 24 08:00:41.676: INFO: Pod "downwardapi-volume-942b7087-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00536765s
+Apr 24 08:00:43.679: INFO: Pod "downwardapi-volume-942b7087-4795-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008391023s
+STEP: Saw pod success
+Apr 24 08:00:43.679: INFO: Pod "downwardapi-volume-942b7087-4795-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:00:43.681: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-942b7087-4795-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:00:43.715: INFO: Waiting for pod downwardapi-volume-942b7087-4795-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:00:43.722: INFO: Pod downwardapi-volume-942b7087-4795-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:00:43.725: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-4pgs7" for this suite.
+Apr 24 08:00:49.742: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:00:49.866: INFO: namespace: e2e-tests-downward-api-4pgs7, resource: bindings, ignored listing per whitelist
+Apr 24 08:00:49.869: INFO: namespace e2e-tests-downward-api-4pgs7 deletion completed in 6.140456354s
+
+• [SLOW TEST:10.319 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:00:49.869: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: getting the auto-created API token
+Apr 24 08:00:50.486: INFO: created pod pod-service-account-defaultsa
+Apr 24 08:00:50.486: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Apr 24 08:00:50.498: INFO: created pod pod-service-account-mountsa
+Apr 24 08:00:50.498: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Apr 24 08:00:50.502: INFO: created pod pod-service-account-nomountsa
+Apr 24 08:00:50.502: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Apr 24 08:00:50.505: INFO: created pod pod-service-account-defaultsa-mountspec
+Apr 24 08:00:50.505: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Apr 24 08:00:50.517: INFO: created pod pod-service-account-mountsa-mountspec
+Apr 24 08:00:50.517: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Apr 24 08:00:50.528: INFO: created pod pod-service-account-nomountsa-mountspec
+Apr 24 08:00:50.528: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Apr 24 08:00:50.535: INFO: created pod pod-service-account-defaultsa-nomountspec
+Apr 24 08:00:50.535: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Apr 24 08:00:50.543: INFO: created pod pod-service-account-mountsa-nomountspec
+Apr 24 08:00:50.543: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Apr 24 08:00:50.552: INFO: created pod pod-service-account-nomountsa-nomountspec
+Apr 24 08:00:50.552: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:00:50.552: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-2nlzw" for this suite.
+Apr 24 08:01:12.571: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:01:12.637: INFO: namespace: e2e-tests-svcaccounts-2nlzw, resource: bindings, ignored listing per whitelist
+Apr 24 08:01:12.692: INFO: namespace e2e-tests-svcaccounts-2nlzw deletion completed in 22.136031476s
+
+• [SLOW TEST:22.823 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:01:12.692: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:01:12.800: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a7eeeb99-4795-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-68sxr" to be "success or failure"
+Apr 24 08:01:12.803: INFO: Pod "downwardapi-volume-a7eeeb99-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.984712ms
+Apr 24 08:01:14.806: INFO: Pod "downwardapi-volume-a7eeeb99-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006298702s
+Apr 24 08:01:16.809: INFO: Pod "downwardapi-volume-a7eeeb99-4795-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009607136s
+STEP: Saw pod success
+Apr 24 08:01:16.810: INFO: Pod "downwardapi-volume-a7eeeb99-4795-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:01:16.812: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-a7eeeb99-4795-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:01:16.835: INFO: Waiting for pod downwardapi-volume-a7eeeb99-4795-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:01:16.842: INFO: Pod downwardapi-volume-a7eeeb99-4795-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:01:16.842: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-68sxr" for this suite.
+Apr 24 08:01:22.869: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:01:22.961: INFO: namespace: e2e-tests-downward-api-68sxr, resource: bindings, ignored listing per whitelist
+Apr 24 08:01:23.010: INFO: namespace e2e-tests-downward-api-68sxr deletion completed in 6.164414454s
+
+• [SLOW TEST:10.318 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:01:23.011: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-ae18c436-4795-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 08:01:23.146: INFO: Waiting up to 5m0s for pod "pod-secrets-ae19361a-4795-11e8-bf16-a2a292742988" in namespace "e2e-tests-secrets-l6qqd" to be "success or failure"
+Apr 24 08:01:23.150: INFO: Pod "pod-secrets-ae19361a-4795-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.668616ms
+Apr 24 08:01:25.154: INFO: Pod "pod-secrets-ae19361a-4795-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007913797s
+STEP: Saw pod success
+Apr 24 08:01:25.154: INFO: Pod "pod-secrets-ae19361a-4795-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:01:25.157: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-secrets-ae19361a-4795-11e8-bf16-a2a292742988 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:01:25.179: INFO: Waiting for pod pod-secrets-ae19361a-4795-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:01:25.190: INFO: Pod pod-secrets-ae19361a-4795-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:01:25.190: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-l6qqd" for this suite.
+Apr 24 08:01:31.213: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:01:31.269: INFO: namespace: e2e-tests-secrets-l6qqd, resource: bindings, ignored listing per whitelist
+Apr 24 08:01:31.346: INFO: namespace e2e-tests-secrets-l6qqd deletion completed in 6.146484457s
+
+• [SLOW TEST:8.336 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:01:31.347: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Apr 24 08:01:31.439: INFO: Waiting up to 1m0s for all nodes to be ready
+Apr 24 08:02:31.460: INFO: Waiting for terminating namespaces to be deleted...
+Apr 24 08:02:31.465: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 24 08:02:31.477: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 24 08:02:31.477: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 24 08:02:31.480: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 24 08:02:31.480: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz before test
+Apr 24 08:02:31.534: INFO: kube-dns-67b49bdfd8-mxmlq from kube-system started at 2018-04-24 07:27:25 +0000 UTC (3 container statuses recorded)
+Apr 24 08:02:31.534: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 24 08:02:31.534: INFO: 	Container kubedns ready: true, restart count 0
+Apr 24 08:02:31.534: INFO: 	Container sidecar ready: true, restart count 0
+Apr 24 08:02:31.534: INFO: kube-proxy-wstg7 from kube-system started at 2018-04-24 07:26:48 +0000 UTC (1 container statuses recorded)
+Apr 24 08:02:31.534: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 24 08:02:31.534: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-z9qrd from kube-system started at 2018-04-24 07:27:24 +0000 UTC (1 container statuses recorded)
+Apr 24 08:02:31.534: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Apr 24 08:02:31.534: INFO: calico-node-zqnlp from kube-system started at 2018-04-24 07:26:48 +0000 UTC (2 container statuses recorded)
+Apr 24 08:02:31.535: INFO: 	Container calico-node ready: true, restart count 0
+Apr 24 08:02:31.535: INFO: 	Container install-cni ready: true, restart count 0
+Apr 24 08:02:31.535: INFO: kube-dns-autoscaler-699b4b55c4-2b2qj from kube-system started at 2018-04-24 07:27:25 +0000 UTC (1 container statuses recorded)
+Apr 24 08:02:31.535: INFO: 	Container autoscaler ready: true, restart count 0
+Apr 24 08:02:31.535: INFO: kube-dns-67b49bdfd8-b6dbb from kube-system started at 2018-04-24 07:27:52 +0000 UTC (3 container statuses recorded)
+Apr 24 08:02:31.535: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 24 08:02:31.535: INFO: 	Container kubedns ready: true, restart count 0
+Apr 24 08:02:31.535: INFO: 	Container sidecar ready: true, restart count 0
+Apr 24 08:02:31.535: INFO: node-exporter-whjfj from kube-system started at 2018-04-24 07:26:48 +0000 UTC (1 container statuses recorded)
+Apr 24 08:02:31.535: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 24 08:02:31.535: INFO: addons-nginx-ingress-controller-7c8749685-zcr5c from kube-system started at 2018-04-24 07:27:25 +0000 UTC (1 container statuses recorded)
+Apr 24 08:02:31.535: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Apr 24 08:02:31.535: INFO: addons-kubernetes-dashboard-8478f49fbf-4f9h7 from kube-system started at 2018-04-24 07:27:25 +0000 UTC (1 container statuses recorded)
+Apr 24 08:02:31.535: INFO: 	Container main ready: true, restart count 0
+Apr 24 08:02:31.535: INFO: vpn-shoot-6d7b66b496-7qwch from kube-system started at 2018-04-24 07:27:24 +0000 UTC (1 container statuses recorded)
+Apr 24 08:02:31.535: INFO: 	Container vpn-shoot ready: true, restart count 1
+Apr 24 08:02:31.535: INFO: addons-heapster-e3b0c-5c98c994fc-gjv8r from kube-system started at 2018-04-24 07:27:25 +0000 UTC (2 container statuses recorded)
+Apr 24 08:02:31.535: INFO: 	Container heapster ready: true, restart count 0
+Apr 24 08:02:31.535: INFO: 	Container heapster-nanny ready: true, restart count 0
+Apr 24 08:02:31.535: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 before test
+Apr 24 08:02:31.587: INFO: sonobuoy from sonobuoy started at 2018-04-24 07:30:41 +0000 UTC (1 container statuses recorded)
+Apr 24 08:02:31.587: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Apr 24 08:02:31.587: INFO: sonobuoy-e2e-job-34f29dcaad2e487d from sonobuoy started at 2018-04-24 07:30:58 +0000 UTC (2 container statuses recorded)
+Apr 24 08:02:31.587: INFO: 	Container e2e ready: true, restart count 0
+Apr 24 08:02:31.587: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Apr 24 08:02:31.587: INFO: calico-node-jzkbx from kube-system started at 2018-04-24 07:27:19 +0000 UTC (2 container statuses recorded)
+Apr 24 08:02:31.587: INFO: 	Container calico-node ready: true, restart count 0
+Apr 24 08:02:31.587: INFO: 	Container install-cni ready: true, restart count 0
+Apr 24 08:02:31.587: INFO: node-exporter-9zwr8 from kube-system started at 2018-04-24 07:27:19 +0000 UTC (1 container statuses recorded)
+Apr 24 08:02:31.587: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 24 08:02:31.587: INFO: kube-proxy-vg59j from kube-system started at 2018-04-24 07:27:19 +0000 UTC (1 container statuses recorded)
+Apr 24 08:02:31.587: INFO: 	Container kube-proxy ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.15285078547354eb], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 node(s) didn't match node selector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:02:32.609: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-fb285" for this suite.
+Apr 24 08:02:54.622: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:02:54.731: INFO: namespace: e2e-tests-sched-pred-fb285, resource: bindings, ignored listing per whitelist
+Apr 24 08:02:54.778: INFO: namespace e2e-tests-sched-pred-fb285 deletion completed in 22.165845084s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.431 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:02:54.778: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-ww4wm
+Apr 24 08:02:56.905: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-ww4wm
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 24 08:02:56.908: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:04:57.122: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-ww4wm" for this suite.
+Apr 24 08:05:03.145: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:05:03.194: INFO: namespace: e2e-tests-container-probe-ww4wm, resource: bindings, ignored listing per whitelist
+Apr 24 08:05:03.287: INFO: namespace e2e-tests-container-probe-ww4wm deletion completed in 6.157841762s
+
+• [SLOW TEST:128.509 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:05:03.288: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override arguments
+Apr 24 08:05:03.420: INFO: Waiting up to 5m0s for pod "client-containers-3164d226-4796-11e8-bf16-a2a292742988" in namespace "e2e-tests-containers-wxngp" to be "success or failure"
+Apr 24 08:05:03.426: INFO: Pod "client-containers-3164d226-4796-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 5.785825ms
+Apr 24 08:05:05.429: INFO: Pod "client-containers-3164d226-4796-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008930488s
+Apr 24 08:05:07.432: INFO: Pod "client-containers-3164d226-4796-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012274567s
+STEP: Saw pod success
+Apr 24 08:05:07.432: INFO: Pod "client-containers-3164d226-4796-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:05:07.434: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod client-containers-3164d226-4796-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:05:07.462: INFO: Waiting for pod client-containers-3164d226-4796-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:05:07.473: INFO: Pod client-containers-3164d226-4796-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:05:07.473: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-wxngp" for this suite.
+Apr 24 08:05:13.487: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:05:13.554: INFO: namespace: e2e-tests-containers-wxngp, resource: bindings, ignored listing per whitelist
+Apr 24 08:05:13.637: INFO: namespace e2e-tests-containers-wxngp deletion completed in 6.161117615s
+
+• [SLOW TEST:10.350 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:05:13.638: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Apr 24 08:05:13.761: INFO: Waiting up to 5m0s for pod "pod-378e31b1-4796-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-hkhz2" to be "success or failure"
+Apr 24 08:05:13.763: INFO: Pod "pod-378e31b1-4796-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.31941ms
+Apr 24 08:05:15.767: INFO: Pod "pod-378e31b1-4796-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005740048s
+Apr 24 08:05:17.770: INFO: Pod "pod-378e31b1-4796-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008776104s
+STEP: Saw pod success
+Apr 24 08:05:17.770: INFO: Pod "pod-378e31b1-4796-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:05:17.773: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-378e31b1-4796-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:05:17.795: INFO: Waiting for pod pod-378e31b1-4796-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:05:17.812: INFO: Pod pod-378e31b1-4796-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:05:17.812: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-hkhz2" for this suite.
+Apr 24 08:05:23.836: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:05:23.876: INFO: namespace: e2e-tests-emptydir-hkhz2, resource: bindings, ignored listing per whitelist
+Apr 24 08:05:23.954: INFO: namespace e2e-tests-emptydir-hkhz2 deletion completed in 6.130706661s
+
+• [SLOW TEST:10.316 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:05:23.954: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-map-3db24c5c-4796-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 08:05:24.063: INFO: Waiting up to 5m0s for pod "pod-secrets-3db2b4c4-4796-11e8-bf16-a2a292742988" in namespace "e2e-tests-secrets-pg7nb" to be "success or failure"
+Apr 24 08:05:24.067: INFO: Pod "pod-secrets-3db2b4c4-4796-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.714117ms
+Apr 24 08:05:26.070: INFO: Pod "pod-secrets-3db2b4c4-4796-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006918926s
+Apr 24 08:05:28.073: INFO: Pod "pod-secrets-3db2b4c4-4796-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.00999914s
+STEP: Saw pod success
+Apr 24 08:05:28.073: INFO: Pod "pod-secrets-3db2b4c4-4796-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:05:28.076: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-secrets-3db2b4c4-4796-11e8-bf16-a2a292742988 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:05:28.093: INFO: Waiting for pod pod-secrets-3db2b4c4-4796-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:05:28.097: INFO: Pod pod-secrets-3db2b4c4-4796-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:05:28.108: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-pg7nb" for this suite.
+Apr 24 08:05:34.124: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:05:34.229: INFO: namespace: e2e-tests-secrets-pg7nb, resource: bindings, ignored listing per whitelist
+Apr 24 08:05:34.257: INFO: namespace e2e-tests-secrets-pg7nb deletion completed in 6.146306638s
+
+• [SLOW TEST:10.303 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:05:34.258: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test substitution in container's args
+Apr 24 08:05:34.354: INFO: Waiting up to 5m0s for pod "var-expansion-43d50fcd-4796-11e8-bf16-a2a292742988" in namespace "e2e-tests-var-expansion-6z5xp" to be "success or failure"
+Apr 24 08:05:34.358: INFO: Pod "var-expansion-43d50fcd-4796-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.803517ms
+Apr 24 08:05:36.364: INFO: Pod "var-expansion-43d50fcd-4796-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009407232s
+Apr 24 08:05:38.368: INFO: Pod "var-expansion-43d50fcd-4796-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.013238038s
+Apr 24 08:05:40.371: INFO: Pod "var-expansion-43d50fcd-4796-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.016512583s
+STEP: Saw pod success
+Apr 24 08:05:40.371: INFO: Pod "var-expansion-43d50fcd-4796-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:05:40.373: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod var-expansion-43d50fcd-4796-11e8-bf16-a2a292742988 container dapi-container: <nil>
+STEP: delete the pod
+Apr 24 08:05:40.395: INFO: Waiting for pod var-expansion-43d50fcd-4796-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:05:40.399: INFO: Pod var-expansion-43d50fcd-4796-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:05:40.399: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-6z5xp" for this suite.
+Apr 24 08:05:46.418: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:05:46.471: INFO: namespace: e2e-tests-var-expansion-6z5xp, resource: bindings, ignored listing per whitelist
+Apr 24 08:05:46.550: INFO: namespace e2e-tests-var-expansion-6z5xp deletion completed in 6.14187002s
+
+• [SLOW TEST:12.292 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:05:46.551: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-4b2b2528-4796-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 08:05:46.667: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-4b2ba8e9-4796-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-p9k7l" to be "success or failure"
+Apr 24 08:05:46.677: INFO: Pod "pod-projected-configmaps-4b2ba8e9-4796-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 9.886643ms
+Apr 24 08:05:48.680: INFO: Pod "pod-projected-configmaps-4b2ba8e9-4796-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.01303364s
+STEP: Saw pod success
+Apr 24 08:05:48.680: INFO: Pod "pod-projected-configmaps-4b2ba8e9-4796-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:05:48.683: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-configmaps-4b2ba8e9-4796-11e8-bf16-a2a292742988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:05:48.710: INFO: Waiting for pod pod-projected-configmaps-4b2ba8e9-4796-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:05:48.713: INFO: Pod pod-projected-configmaps-4b2ba8e9-4796-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:05:48.713: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-p9k7l" for this suite.
+Apr 24 08:05:54.729: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:05:54.774: INFO: namespace: e2e-tests-projected-p9k7l, resource: bindings, ignored listing per whitelist
+Apr 24 08:05:54.866: INFO: namespace e2e-tests-projected-p9k7l deletion completed in 6.147846959s
+
+• [SLOW TEST:8.316 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:05:54.867: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-sbdvn
+[It] Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-sbdvn
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-sbdvn
+Apr 24 08:05:54.974: INFO: Found 0 stateful pods, waiting for 1
+Apr 24 08:06:04.977: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will not halt with unhealthy stateful pod
+Apr 24 08:06:04.980: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-sbdvn ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 24 08:06:05.329: INFO: stderr: ""
+Apr 24 08:06:05.329: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 24 08:06:05.332: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Apr 24 08:06:15.336: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 24 08:06:15.337: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 24 08:06:15.348: INFO: POD   NODE                                              PHASE    GRACE  CONDITIONS
+Apr 24 08:06:15.348: INFO: ss-0  shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:05:55 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:05 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:05:54 +0000 UTC  }]
+Apr 24 08:06:15.348: INFO: 
+Apr 24 08:06:15.348: INFO: StatefulSet ss has not reached scale 3, at 1
+Apr 24 08:06:16.356: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.996378291s
+Apr 24 08:06:17.360: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.987925226s
+Apr 24 08:06:18.364: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.984774059s
+Apr 24 08:06:19.367: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.980658517s
+Apr 24 08:06:20.371: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.977224789s
+Apr 24 08:06:21.374: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.97363937s
+Apr 24 08:06:22.377: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.970205163s
+Apr 24 08:06:23.381: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.966962867s
+Apr 24 08:06:24.385: INFO: Verifying statefulset ss doesn't scale past 3 for another 963.40648ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-sbdvn
+Apr 24 08:06:25.389: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-sbdvn ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 24 08:06:25.732: INFO: stderr: ""
+Apr 24 08:06:25.732: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 24 08:06:25.732: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-sbdvn ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 24 08:06:35.100: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Apr 24 08:06:35.100: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: 
+Apr 24 08:06:35.100: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-sbdvn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 24 08:06:35.479: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Apr 24 08:06:35.479: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Apr 24 08:06:35.482: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 24 08:06:35.482: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 24 08:06:35.482: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Scale down will not halt with unhealthy stateful pod
+Apr 24 08:06:35.485: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-sbdvn ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 24 08:06:35.821: INFO: stderr: ""
+Apr 24 08:06:35.821: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 24 08:06:35.821: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-sbdvn ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 24 08:06:36.173: INFO: stderr: ""
+Apr 24 08:06:36.173: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 24 08:06:36.173: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-sbdvn ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 24 08:06:36.543: INFO: stderr: ""
+Apr 24 08:06:36.543: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 24 08:06:36.543: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 24 08:06:36.545: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 2
+Apr 24 08:06:46.552: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 24 08:06:46.552: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Apr 24 08:06:46.552: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Apr 24 08:06:46.562: INFO: POD   NODE                                              PHASE    GRACE  CONDITIONS
+Apr 24 08:06:46.562: INFO: ss-0  shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:05:55 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:36 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:05:54 +0000 UTC  }]
+Apr 24 08:06:46.562: INFO: ss-1  shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:36 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:15 +0000 UTC  }]
+Apr 24 08:06:46.562: INFO: ss-2  shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:36 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:15 +0000 UTC  }]
+Apr 24 08:06:46.562: INFO: 
+Apr 24 08:06:46.562: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 24 08:06:47.565: INFO: POD   NODE                                              PHASE    GRACE  CONDITIONS
+Apr 24 08:06:47.565: INFO: ss-0  shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:05:55 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:36 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:05:54 +0000 UTC  }]
+Apr 24 08:06:47.565: INFO: ss-1  shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:36 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:15 +0000 UTC  }]
+Apr 24 08:06:47.565: INFO: ss-2  shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:36 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:15 +0000 UTC  }]
+Apr 24 08:06:47.565: INFO: 
+Apr 24 08:06:47.565: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 24 08:06:48.579: INFO: POD   NODE                                              PHASE    GRACE  CONDITIONS
+Apr 24 08:06:48.580: INFO: ss-0  shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:05:55 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:36 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:05:54 +0000 UTC  }]
+Apr 24 08:06:48.580: INFO: ss-1  shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:36 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:15 +0000 UTC  }]
+Apr 24 08:06:48.580: INFO: ss-2  shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:36 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:06:15 +0000 UTC  }]
+Apr 24 08:06:48.580: INFO: 
+Apr 24 08:06:48.580: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 24 08:06:49.735: INFO: Verifying statefulset ss doesn't scale past 0 for another 6.825577489s
+Apr 24 08:06:50.738: INFO: Verifying statefulset ss doesn't scale past 0 for another 5.822380686s
+Apr 24 08:06:51.741: INFO: Verifying statefulset ss doesn't scale past 0 for another 4.819539495s
+Apr 24 08:06:52.744: INFO: Verifying statefulset ss doesn't scale past 0 for another 3.816192211s
+Apr 24 08:06:53.750: INFO: Verifying statefulset ss doesn't scale past 0 for another 2.812949038s
+Apr 24 08:06:54.753: INFO: Verifying statefulset ss doesn't scale past 0 for another 1.806904063s
+Apr 24 08:06:55.756: INFO: Verifying statefulset ss doesn't scale past 0 for another 803.947911ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-sbdvn
+Apr 24 08:06:56.766: INFO: Scaling statefulset ss to 0
+Apr 24 08:06:56.778: INFO: Waiting for statefulset status.replicas updated to 0
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 24 08:06:56.782: INFO: Deleting all statefulset in ns e2e-tests-statefulset-sbdvn
+Apr 24 08:06:56.792: INFO: Scaling statefulset ss to 0
+Apr 24 08:06:56.799: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 24 08:06:56.801: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:06:56.813: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-sbdvn" for this suite.
+Apr 24 08:07:02.835: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:07:02.875: INFO: namespace: e2e-tests-statefulset-sbdvn, resource: bindings, ignored listing per whitelist
+Apr 24 08:07:02.986: INFO: namespace e2e-tests-statefulset-sbdvn deletion completed in 6.162629733s
+
+• [SLOW TEST:68.120 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Burst scaling should run to completion even with unhealthy pods [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:07:02.991: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-78ba4588-4796-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 08:07:03.107: INFO: Waiting up to 5m0s for pod "pod-configmaps-78baf7d7-4796-11e8-bf16-a2a292742988" in namespace "e2e-tests-configmap-k54z6" to be "success or failure"
+Apr 24 08:07:03.113: INFO: Pod "pod-configmaps-78baf7d7-4796-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 5.513723ms
+Apr 24 08:07:05.116: INFO: Pod "pod-configmaps-78baf7d7-4796-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008891771s
+STEP: Saw pod success
+Apr 24 08:07:05.116: INFO: Pod "pod-configmaps-78baf7d7-4796-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:07:05.118: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-configmaps-78baf7d7-4796-11e8-bf16-a2a292742988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:07:05.166: INFO: Waiting for pod pod-configmaps-78baf7d7-4796-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:07:05.169: INFO: Pod pod-configmaps-78baf7d7-4796-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:07:05.169: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-k54z6" for this suite.
+Apr 24 08:07:11.183: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:07:11.272: INFO: namespace: e2e-tests-configmap-k54z6, resource: bindings, ignored listing per whitelist
+Apr 24 08:07:11.327: INFO: namespace e2e-tests-configmap-k54z6 deletion completed in 6.155108733s
+
+• [SLOW TEST:8.336 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:07:11.329: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-9gghh in namespace e2e-tests-proxy-t2ffk
+I0424 08:07:11.521489      14 runners.go:175] Created replication controller with name: proxy-service-9gghh, namespace: e2e-tests-proxy-t2ffk, replica count: 1
+I0424 08:07:12.522070      14 runners.go:175] proxy-service-9gghh Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0424 08:07:13.522249      14 runners.go:175] proxy-service-9gghh Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0424 08:07:14.522490      14 runners.go:175] proxy-service-9gghh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0424 08:07:15.522690      14 runners.go:175] proxy-service-9gghh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0424 08:07:16.522980      14 runners.go:175] proxy-service-9gghh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0424 08:07:17.523186      14 runners.go:175] proxy-service-9gghh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0424 08:07:18.523467      14 runners.go:175] proxy-service-9gghh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0424 08:07:19.523731      14 runners.go:175] proxy-service-9gghh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0424 08:07:20.524044      14 runners.go:175] proxy-service-9gghh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0424 08:07:21.524345      14 runners.go:175] proxy-service-9gghh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0424 08:07:22.524540      14 runners.go:175] proxy-service-9gghh Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Apr 24 08:07:22.527: INFO: setup took 11.047178313s, starting test cases
+STEP: running 16 cases, 20 attempts per case, 320 total attempts
+Apr 24 08:07:22.541: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 13.132359ms)
+Apr 24 08:07:22.541: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 13.724762ms)
+Apr 24 08:07:22.551: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 23.280504ms)
+Apr 24 08:07:22.552: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 23.323904ms)
+Apr 24 08:07:22.552: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 24.70461ms)
+Apr 24 08:07:22.552: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 25.237512ms)
+Apr 24 08:07:22.552: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 25.176712ms)
+Apr 24 08:07:22.553: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 24.77441ms)
+Apr 24 08:07:22.553: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 25.177613ms)
+Apr 24 08:07:22.553: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 25.554014ms)
+Apr 24 08:07:22.553: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 25.848815ms)
+Apr 24 08:07:22.566: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 38.10767ms)
+Apr 24 08:07:22.567: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 39.019774ms)
+Apr 24 08:07:22.567: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 39.359675ms)
+Apr 24 08:07:22.567: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 39.190574ms)
+Apr 24 08:07:22.571: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 43.383393ms)
+Apr 24 08:07:22.576: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 3.955518ms)
+Apr 24 08:07:22.578: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 5.160623ms)
+Apr 24 08:07:22.579: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 6.85243ms)
+Apr 24 08:07:22.579: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 7.367433ms)
+Apr 24 08:07:22.579: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 6.480129ms)
+Apr 24 08:07:22.579: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 7.984936ms)
+Apr 24 08:07:22.580: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 7.666034ms)
+Apr 24 08:07:22.580: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 6.338328ms)
+Apr 24 08:07:22.580: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 7.572134ms)
+Apr 24 08:07:22.580: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 7.359333ms)
+Apr 24 08:07:22.580: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 6.639729ms)
+Apr 24 08:07:22.580: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 7.135732ms)
+Apr 24 08:07:22.580: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 7.434233ms)
+Apr 24 08:07:22.581: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 8.589839ms)
+Apr 24 08:07:22.583: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 10.268546ms)
+Apr 24 08:07:22.583: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 10.698448ms)
+Apr 24 08:07:22.592: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 8.634538ms)
+Apr 24 08:07:22.592: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 9.114441ms)
+Apr 24 08:07:22.593: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 9.239242ms)
+Apr 24 08:07:22.593: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 9.867544ms)
+Apr 24 08:07:22.596: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 12.044054ms)
+Apr 24 08:07:22.596: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 12.025754ms)
+Apr 24 08:07:22.596: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 12.191354ms)
+Apr 24 08:07:22.596: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 12.283155ms)
+Apr 24 08:07:22.596: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 12.232054ms)
+Apr 24 08:07:22.596: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 12.347355ms)
+Apr 24 08:07:22.599: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 15.79017ms)
+Apr 24 08:07:22.599: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 16.171972ms)
+Apr 24 08:07:22.599: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 15.65057ms)
+Apr 24 08:07:22.602: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 18.332581ms)
+Apr 24 08:07:22.602: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 18.603283ms)
+Apr 24 08:07:22.604: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 19.893689ms)
+Apr 24 08:07:22.609: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 5.558025ms)
+Apr 24 08:07:22.612: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 7.597234ms)
+Apr 24 08:07:22.613: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 8.509338ms)
+Apr 24 08:07:22.613: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 8.261037ms)
+Apr 24 08:07:22.613: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 9.07494ms)
+Apr 24 08:07:22.613: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 9.00604ms)
+Apr 24 08:07:22.613: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 9.11474ms)
+Apr 24 08:07:22.614: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 10.135245ms)
+Apr 24 08:07:22.614: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 10.066545ms)
+Apr 24 08:07:22.614: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 10.295546ms)
+Apr 24 08:07:22.615: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 10.231845ms)
+Apr 24 08:07:22.615: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 10.297346ms)
+Apr 24 08:07:22.615: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 10.811148ms)
+Apr 24 08:07:22.615: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 11.02995ms)
+Apr 24 08:07:22.616: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 12.056654ms)
+Apr 24 08:07:22.619: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 14.850266ms)
+Apr 24 08:07:22.628: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 7.717134ms)
+Apr 24 08:07:22.628: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 8.534638ms)
+Apr 24 08:07:22.628: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 8.712439ms)
+Apr 24 08:07:22.628: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 8.374138ms)
+Apr 24 08:07:22.628: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 8.509738ms)
+Apr 24 08:07:22.628: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 7.844135ms)
+Apr 24 08:07:22.629: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 9.101341ms)
+Apr 24 08:07:22.630: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 10.267046ms)
+Apr 24 08:07:22.630: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 9.373242ms)
+Apr 24 08:07:22.630: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 9.734244ms)
+Apr 24 08:07:22.630: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 9.788243ms)
+Apr 24 08:07:22.630: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 10.500847ms)
+Apr 24 08:07:22.631: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 10.975649ms)
+Apr 24 08:07:22.631: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 11.597252ms)
+Apr 24 08:07:22.632: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 11.661552ms)
+Apr 24 08:07:22.635: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 15.148467ms)
+Apr 24 08:07:22.645: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 8.203237ms)
+Apr 24 08:07:22.645: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 9.743643ms)
+Apr 24 08:07:22.646: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 9.836044ms)
+Apr 24 08:07:22.646: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 10.102045ms)
+Apr 24 08:07:22.646: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 10.010845ms)
+Apr 24 08:07:22.647: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 10.075645ms)
+Apr 24 08:07:22.647: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 10.982549ms)
+Apr 24 08:07:22.647: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 10.622147ms)
+Apr 24 08:07:22.647: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 11.041949ms)
+Apr 24 08:07:22.647: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 10.728648ms)
+Apr 24 08:07:22.647: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 11.462751ms)
+Apr 24 08:07:22.647: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 11.32025ms)
+Apr 24 08:07:22.650: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 14.448465ms)
+Apr 24 08:07:22.651: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 15.589769ms)
+Apr 24 08:07:22.651: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 15.948571ms)
+Apr 24 08:07:22.651: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 15.259668ms)
+Apr 24 08:07:22.658: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 6.045727ms)
+Apr 24 08:07:22.658: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 5.833826ms)
+Apr 24 08:07:22.658: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 6.156528ms)
+Apr 24 08:07:22.658: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 6.352029ms)
+Apr 24 08:07:22.658: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 6.518829ms)
+Apr 24 08:07:22.658: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 6.259228ms)
+Apr 24 08:07:22.659: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 6.415929ms)
+Apr 24 08:07:22.659: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 7.297533ms)
+Apr 24 08:07:22.659: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 6.775031ms)
+Apr 24 08:07:22.659: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 7.468834ms)
+Apr 24 08:07:22.659: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 7.308133ms)
+Apr 24 08:07:22.660: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 8.098536ms)
+Apr 24 08:07:22.661: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 8.788839ms)
+Apr 24 08:07:22.663: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 10.454747ms)
+Apr 24 08:07:22.663: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 10.586347ms)
+Apr 24 08:07:22.663: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 10.807548ms)
+Apr 24 08:07:22.670: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 7.322233ms)
+Apr 24 08:07:22.671: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 6.71303ms)
+Apr 24 08:07:22.671: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 7.637934ms)
+Apr 24 08:07:22.671: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 7.739735ms)
+Apr 24 08:07:22.672: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 8.274537ms)
+Apr 24 08:07:22.672: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 7.975536ms)
+Apr 24 08:07:22.672: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 8.188137ms)
+Apr 24 08:07:22.672: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 9.04964ms)
+Apr 24 08:07:22.672: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 8.611238ms)
+Apr 24 08:07:22.673: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 9.072841ms)
+Apr 24 08:07:22.673: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 8.683439ms)
+Apr 24 08:07:22.673: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 9.938644ms)
+Apr 24 08:07:22.674: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 10.130245ms)
+Apr 24 08:07:22.674: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 11.004449ms)
+Apr 24 08:07:22.675: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 10.884149ms)
+Apr 24 08:07:22.675: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 11.748552ms)
+Apr 24 08:07:22.685: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 7.014531ms)
+Apr 24 08:07:22.685: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 7.913335ms)
+Apr 24 08:07:22.685: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 8.114436ms)
+Apr 24 08:07:22.685: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 8.820039ms)
+Apr 24 08:07:22.687: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 9.708343ms)
+Apr 24 08:07:22.687: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 10.136045ms)
+Apr 24 08:07:22.687: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 9.694344ms)
+Apr 24 08:07:22.688: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 10.341946ms)
+Apr 24 08:07:22.688: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 10.136145ms)
+Apr 24 08:07:22.688: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 11.755353ms)
+Apr 24 08:07:22.689: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 11.807053ms)
+Apr 24 08:07:22.689: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 12.994858ms)
+Apr 24 08:07:22.689: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 11.248851ms)
+Apr 24 08:07:22.690: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 12.491855ms)
+Apr 24 08:07:22.696: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 19.553187ms)
+Apr 24 08:07:22.696: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 19.848789ms)
+Apr 24 08:07:22.704: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 6.757131ms)
+Apr 24 08:07:22.704: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 7.568034ms)
+Apr 24 08:07:22.705: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 7.475233ms)
+Apr 24 08:07:22.705: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 8.043136ms)
+Apr 24 08:07:22.705: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 7.952236ms)
+Apr 24 08:07:22.707: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 10.445047ms)
+Apr 24 08:07:22.707: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 10.146746ms)
+Apr 24 08:07:22.707: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 10.406247ms)
+Apr 24 08:07:22.708: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 10.177546ms)
+Apr 24 08:07:22.708: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 11.053549ms)
+Apr 24 08:07:22.708: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 11.745052ms)
+Apr 24 08:07:22.709: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 10.807048ms)
+Apr 24 08:07:22.710: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 12.627857ms)
+Apr 24 08:07:22.715: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 17.373678ms)
+Apr 24 08:07:22.715: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 17.673079ms)
+Apr 24 08:07:22.715: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 17.101076ms)
+Apr 24 08:07:22.726: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 9.210241ms)
+Apr 24 08:07:22.726: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 9.750144ms)
+Apr 24 08:07:22.726: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 10.402946ms)
+Apr 24 08:07:22.726: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 10.752848ms)
+Apr 24 08:07:22.726: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 9.479743ms)
+Apr 24 08:07:22.726: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 9.959045ms)
+Apr 24 08:07:22.726: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 10.280546ms)
+Apr 24 08:07:22.726: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 10.570047ms)
+Apr 24 08:07:22.726: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 10.767348ms)
+Apr 24 08:07:22.726: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 9.700543ms)
+Apr 24 08:07:22.726: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 9.692243ms)
+Apr 24 08:07:22.727: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 10.347146ms)
+Apr 24 08:07:22.747: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 29.944434ms)
+Apr 24 08:07:22.747: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 30.344235ms)
+Apr 24 08:07:22.747: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 31.129639ms)
+Apr 24 08:07:22.747: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 30.674837ms)
+Apr 24 08:07:22.757: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 8.693839ms)
+Apr 24 08:07:22.757: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 9.315242ms)
+Apr 24 08:07:22.757: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 8.486438ms)
+Apr 24 08:07:22.757: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 8.553238ms)
+Apr 24 08:07:22.757: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 8.699939ms)
+Apr 24 08:07:22.757: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 9.260841ms)
+Apr 24 08:07:22.757: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 9.333642ms)
+Apr 24 08:07:22.757: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 8.680939ms)
+Apr 24 08:07:22.757: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 8.88884ms)
+Apr 24 08:07:22.757: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 8.728439ms)
+Apr 24 08:07:22.758: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 10.405446ms)
+Apr 24 08:07:22.759: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 10.197945ms)
+Apr 24 08:07:29.873: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 7.124778219s)
+Apr 24 08:07:29.873: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 7.125170621s)
+Apr 24 08:07:29.873: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 7.12489012s)
+Apr 24 08:07:29.873: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 7.124374117s)
+Apr 24 08:07:29.880: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 6.756529ms)
+Apr 24 08:07:29.881: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 7.778034ms)
+Apr 24 08:07:29.882: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 8.543437ms)
+Apr 24 08:07:29.882: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 8.440437ms)
+Apr 24 08:07:29.882: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 8.393636ms)
+Apr 24 08:07:29.882: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 8.694138ms)
+Apr 24 08:07:29.882: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 8.674638ms)
+Apr 24 08:07:29.882: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 8.834639ms)
+Apr 24 08:07:29.882: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 8.873239ms)
+Apr 24 08:07:29.882: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 8.791639ms)
+Apr 24 08:07:29.882: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 8.763939ms)
+Apr 24 08:07:29.882: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 8.741839ms)
+Apr 24 08:07:29.882: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 8.761138ms)
+Apr 24 08:07:29.883: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 10.022744ms)
+Apr 24 08:07:29.883: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 10.179444ms)
+Apr 24 08:07:29.883: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 10.403846ms)
+Apr 24 08:07:29.891: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 6.740929ms)
+Apr 24 08:07:29.891: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 6.865331ms)
+Apr 24 08:07:29.891: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 7.419332ms)
+Apr 24 08:07:29.891: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 7.232431ms)
+Apr 24 08:07:29.891: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 7.709834ms)
+Apr 24 08:07:29.892: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 7.769634ms)
+Apr 24 08:07:29.892: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 7.663234ms)
+Apr 24 08:07:29.893: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 8.933139ms)
+Apr 24 08:07:29.893: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 8.765738ms)
+Apr 24 08:07:29.893: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 9.11724ms)
+Apr 24 08:07:29.893: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 8.978839ms)
+Apr 24 08:07:29.893: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 9.22584ms)
+Apr 24 08:07:29.893: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 9.22614ms)
+Apr 24 08:07:29.893: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 9.400341ms)
+Apr 24 08:07:29.893: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 9.881944ms)
+Apr 24 08:07:29.894: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 10.901648ms)
+Apr 24 08:07:29.901: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 6.417928ms)
+Apr 24 08:07:29.901: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 6.70093ms)
+Apr 24 08:07:29.901: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 6.91173ms)
+Apr 24 08:07:29.902: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 7.296432ms)
+Apr 24 08:07:29.903: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 7.994235ms)
+Apr 24 08:07:29.903: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 7.703534ms)
+Apr 24 08:07:29.903: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 7.700934ms)
+Apr 24 08:07:29.906: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 10.926347ms)
+Apr 24 08:07:29.907: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 10.985349ms)
+Apr 24 08:07:29.907: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 11.27815ms)
+Apr 24 08:07:29.907: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 11.053749ms)
+Apr 24 08:07:29.907: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 11.112949ms)
+Apr 24 08:07:29.907: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 11.117849ms)
+Apr 24 08:07:29.907: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 11.50745ms)
+Apr 24 08:07:29.907: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 11.640751ms)
+Apr 24 08:07:29.907: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 11.39695ms)
+Apr 24 08:07:29.912: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 5.039623ms)
+Apr 24 08:07:29.913: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 5.975226ms)
+Apr 24 08:07:29.913: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 6.119327ms)
+Apr 24 08:07:29.915: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 7.501133ms)
+Apr 24 08:07:29.915: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 7.464733ms)
+Apr 24 08:07:29.916: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 8.591238ms)
+Apr 24 08:07:29.916: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 9.09904ms)
+Apr 24 08:07:29.918: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 10.882647ms)
+Apr 24 08:07:29.919: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 11.101348ms)
+Apr 24 08:07:29.919: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 11.32035ms)
+Apr 24 08:07:29.920: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 12.969257ms)
+Apr 24 08:07:29.920: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 13.079957ms)
+Apr 24 08:07:29.921: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 13.613459ms)
+Apr 24 08:07:29.921: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 13.62156ms)
+Apr 24 08:07:29.921: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 13.65836ms)
+Apr 24 08:07:29.921: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 13.69216ms)
+Apr 24 08:07:29.928: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 6.651429ms)
+Apr 24 08:07:29.928: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 6.534028ms)
+Apr 24 08:07:29.928: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 6.620329ms)
+Apr 24 08:07:29.928: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 6.66413ms)
+Apr 24 08:07:29.929: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 7.620533ms)
+Apr 24 08:07:29.929: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 7.430633ms)
+Apr 24 08:07:29.929: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 7.429932ms)
+Apr 24 08:07:29.929: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 7.482733ms)
+Apr 24 08:07:29.929: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 7.651233ms)
+Apr 24 08:07:29.929: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 7.666734ms)
+Apr 24 08:07:29.929: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 7.785134ms)
+Apr 24 08:07:29.929: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 7.676234ms)
+Apr 24 08:07:29.929: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 8.053935ms)
+Apr 24 08:07:29.929: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 7.993436ms)
+Apr 24 08:07:29.969: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 48.018111ms)
+Apr 24 08:07:29.969: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 48.026311ms)
+Apr 24 08:07:29.978: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 8.405037ms)
+Apr 24 08:07:29.978: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 8.112936ms)
+Apr 24 08:07:29.978: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 8.335236ms)
+Apr 24 08:07:29.979: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 9.363741ms)
+Apr 24 08:07:29.980: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 9.517342ms)
+Apr 24 08:07:29.980: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 9.644442ms)
+Apr 24 08:07:29.980: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 9.615742ms)
+Apr 24 08:07:29.980: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 9.886944ms)
+Apr 24 08:07:29.980: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 10.220445ms)
+Apr 24 08:07:29.980: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 10.072944ms)
+Apr 24 08:07:29.980: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 9.946444ms)
+Apr 24 08:07:29.980: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 10.261445ms)
+Apr 24 08:07:29.980: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 10.491546ms)
+Apr 24 08:07:29.980: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 10.489846ms)
+Apr 24 08:07:29.981: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 10.685847ms)
+Apr 24 08:07:29.982: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 11.576651ms)
+Apr 24 08:07:29.987: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 5.056122ms)
+Apr 24 08:07:29.989: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 6.870131ms)
+Apr 24 08:07:29.989: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 7.411133ms)
+Apr 24 08:07:29.989: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 7.544833ms)
+Apr 24 08:07:29.989: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 7.319632ms)
+Apr 24 08:07:29.991: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 8.484137ms)
+Apr 24 08:07:29.991: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 8.706738ms)
+Apr 24 08:07:29.991: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 8.553837ms)
+Apr 24 08:07:29.991: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 8.627838ms)
+Apr 24 08:07:29.991: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 8.657538ms)
+Apr 24 08:07:29.991: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 8.665638ms)
+Apr 24 08:07:29.991: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 8.568338ms)
+Apr 24 08:07:29.991: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 8.666238ms)
+Apr 24 08:07:30.002: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 20.149189ms)
+Apr 24 08:07:30.002: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 20.128988ms)
+Apr 24 08:07:30.002: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 20.041888ms)
+Apr 24 08:07:30.009: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 6.097327ms)
+Apr 24 08:07:30.010: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname2/proxy/: bar (200; 7.227831ms)
+Apr 24 08:07:30.010: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:462/proxy/: tls qux (200; 7.312932ms)
+Apr 24 08:07:30.010: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:160/proxy/: foo (200; 7.245732ms)
+Apr 24 08:07:30.010: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname1/proxy/: tls baz (200; 7.936735ms)
+Apr 24 08:07:30.010: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h/proxy/rewriteme"... (200; 7.785835ms)
+Apr 24 08:07:30.010: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 7.886435ms)
+Apr 24 08:07:30.013: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname1/proxy/: foo (200; 10.606746ms)
+Apr 24 08:07:30.013: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:460/proxy/: tls baz (200; 10.799547ms)
+Apr 24 08:07:30.013: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:1080/proxy/rewri... (200; 10.592346ms)
+Apr 24 08:07:30.013: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/https:proxy-service-9gghh-wxp8h:443/proxy/... (200; 10.765547ms)
+Apr 24 08:07:30.013: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/proxy-service-9gghh-wxp8h:162/proxy/: bar (200; 10.596647ms)
+Apr 24 08:07:30.013: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-t2ffk/pods/http:proxy-service-9gghh-wxp8h:1080/proxy/... (200; 10.673747ms)
+Apr 24 08:07:30.047: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/proxy-service-9gghh:portname2/proxy/: bar (200; 44.957697ms)
+Apr 24 08:07:30.048: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/https:proxy-service-9gghh:tlsportname2/proxy/: tls qux (200; 45.118998ms)
+Apr 24 08:07:30.048: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-t2ffk/services/http:proxy-service-9gghh:portname1/proxy/: foo (200; 45.192998ms)
+STEP: deleting { ReplicationController} proxy-service-9gghh in namespace e2e-tests-proxy-t2ffk
+Apr 24 08:07:31.221: INFO: Deleting { ReplicationController} proxy-service-9gghh took: 1.070055987s
+Apr 24 08:07:31.221: INFO: Terminating { ReplicationController} proxy-service-9gghh pods took: 77.5µs
+Apr 24 08:07:36.221: INFO: Garbage collecting { ReplicationController} proxy-service-9gghh pods took: 6.070315958s
+[AfterEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:07:36.221: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-t2ffk" for this suite.
+Apr 24 08:07:42.233: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:07:42.333: INFO: namespace: e2e-tests-proxy-t2ffk, resource: bindings, ignored listing per whitelist
+Apr 24 08:07:42.356: INFO: namespace e2e-tests-proxy-t2ffk deletion completed in 6.13204263s
+
+• [SLOW TEST:31.027 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:07:42.358: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-df92r
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-df92r to expose endpoints map[]
+Apr 24 08:07:42.472: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-df92r exposes endpoints map[] (4.569019ms elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-df92r
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-df92r to expose endpoints map[pod1:[100]]
+Apr 24 08:07:45.502: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-df92r exposes endpoints map[pod1:[100]] (3.022740905s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-df92r
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-df92r to expose endpoints map[pod1:[100] pod2:[101]]
+Apr 24 08:07:48.553: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-df92r exposes endpoints map[pod1:[100] pod2:[101]] (3.039681466s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-df92r
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-df92r to expose endpoints map[pod2:[101]]
+Apr 24 08:07:49.615: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-df92r exposes endpoints map[pod2:[101]] (1.058287833s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-df92r
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-df92r to expose endpoints map[]
+Apr 24 08:07:49.624: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-df92r exposes endpoints map[] (4.630121ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:07:49.659: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-df92r" for this suite.
+Apr 24 08:08:11.680: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:08:11.770: INFO: namespace: e2e-tests-services-df92r, resource: bindings, ignored listing per whitelist
+Apr 24 08:08:11.805: INFO: namespace e2e-tests-services-df92r deletion completed in 22.136957015s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:29.447 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:08:11.807: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 24 08:08:11.952: INFO: pod1.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod3", UID:"a1c22ca8-4796-11e8-a903-52bf91b907ea", Controller:(*bool)(0xc4206608e6), BlockOwnerDeletion:(*bool)(0xc4206608e7)}}
+Apr 24 08:08:11.957: INFO: pod2.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod1", UID:"a1c0dc20-4796-11e8-a903-52bf91b907ea", Controller:(*bool)(0xc420660b16), BlockOwnerDeletion:(*bool)(0xc420660b17)}}
+Apr 24 08:08:11.965: INFO: pod3.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod2", UID:"a1c164c3-4796-11e8-a903-52bf91b907ea", Controller:(*bool)(0xc4212e9596), BlockOwnerDeletion:(*bool)(0xc4212e9597)}}
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:08:16.975: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-rmmlk" for this suite.
+Apr 24 08:08:23.002: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:08:23.042: INFO: namespace: e2e-tests-gc-rmmlk, resource: bindings, ignored listing per whitelist
+Apr 24 08:08:23.124: INFO: namespace e2e-tests-gc-rmmlk deletion completed in 6.143463722s
+
+• [SLOW TEST:11.318 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:08:23.125: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-qx4d9
+Apr 24 08:08:27.305: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-qx4d9
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 24 08:08:27.444: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:10:27.733: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-qx4d9" for this suite.
+Apr 24 08:10:33.773: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:10:33.818: INFO: namespace: e2e-tests-container-probe-qx4d9, resource: bindings, ignored listing per whitelist
+Apr 24 08:10:33.891: INFO: namespace e2e-tests-container-probe-qx4d9 deletion completed in 6.129277769s
+
+• [SLOW TEST:130.766 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Pods 
+  should be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:10:33.892: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Apr 24 08:10:36.565: INFO: Successfully updated pod "pod-update-f6744a26-4796-11e8-bf16-a2a292742988"
+STEP: verifying the updated pod is in kubernetes
+Apr 24 08:10:36.580: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:10:36.580: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-sv2pw" for this suite.
+Apr 24 08:10:58.593: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:10:58.692: INFO: namespace: e2e-tests-pods-sv2pw, resource: bindings, ignored listing per whitelist
+Apr 24 08:10:58.723: INFO: namespace e2e-tests-pods-sv2pw deletion completed in 22.139762241s
+
+• [SLOW TEST:24.831 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:10:58.725: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Apr 24 08:10:58.841: INFO: Waiting up to 5m0s for pod "pod-053c5b62-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-xld47" to be "success or failure"
+Apr 24 08:10:58.844: INFO: Pod "pod-053c5b62-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.032312ms
+Apr 24 08:11:00.848: INFO: Pod "pod-053c5b62-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006329733s
+Apr 24 08:11:02.851: INFO: Pod "pod-053c5b62-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009412131s
+STEP: Saw pod success
+Apr 24 08:11:02.851: INFO: Pod "pod-053c5b62-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:11:02.853: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-053c5b62-4797-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:11:02.884: INFO: Waiting for pod pod-053c5b62-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:11:02.888: INFO: Pod pod-053c5b62-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:11:02.888: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-xld47" for this suite.
+Apr 24 08:11:08.903: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:11:08.945: INFO: namespace: e2e-tests-emptydir-xld47, resource: bindings, ignored listing per whitelist
+Apr 24 08:11:09.029: INFO: namespace e2e-tests-emptydir-xld47 deletion completed in 6.138608713s
+
+• [SLOW TEST:10.305 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:11:09.032: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Apr 24 08:11:09.134: INFO: Waiting up to 5m0s for pod "pod-0b603005-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-gtrqh" to be "success or failure"
+Apr 24 08:11:09.151: INFO: Pod "pod-0b603005-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 17.239678ms
+Apr 24 08:11:11.154: INFO: Pod "pod-0b603005-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.019927415s
+Apr 24 08:11:13.157: INFO: Pod "pod-0b603005-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.022544774s
+STEP: Saw pod success
+Apr 24 08:11:13.157: INFO: Pod "pod-0b603005-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:11:13.158: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-0b603005-4797-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:11:13.180: INFO: Waiting for pod pod-0b603005-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:11:13.194: INFO: Pod pod-0b603005-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:11:13.194: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-gtrqh" for this suite.
+Apr 24 08:11:19.208: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:11:19.294: INFO: namespace: e2e-tests-emptydir-gtrqh, resource: bindings, ignored listing per whitelist
+Apr 24 08:11:19.329: INFO: namespace e2e-tests-emptydir-gtrqh deletion completed in 6.1312396s
+
+• [SLOW TEST:10.298 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:11:19.330: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-map-11844c87-4797-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 08:11:19.442: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-1184adf0-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-xj46k" to be "success or failure"
+Apr 24 08:11:19.453: INFO: Pod "pod-projected-secrets-1184adf0-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 11.286747ms
+Apr 24 08:11:21.457: INFO: Pod "pod-projected-secrets-1184adf0-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.01509835s
+STEP: Saw pod success
+Apr 24 08:11:21.457: INFO: Pod "pod-projected-secrets-1184adf0-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:11:21.460: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-secrets-1184adf0-4797-11e8-bf16-a2a292742988 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:11:21.480: INFO: Waiting for pod pod-projected-secrets-1184adf0-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:11:21.484: INFO: Pod pod-projected-secrets-1184adf0-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:11:21.484: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xj46k" for this suite.
+Apr 24 08:11:27.501: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:11:27.549: INFO: namespace: e2e-tests-projected-xj46k, resource: bindings, ignored listing per whitelist
+Apr 24 08:11:27.627: INFO: namespace e2e-tests-projected-xj46k deletion completed in 6.139769058s
+
+• [SLOW TEST:8.297 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:11:27.629: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test substitution in container's command
+Apr 24 08:11:27.724: INFO: Waiting up to 5m0s for pod "var-expansion-1674ea2f-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-var-expansion-225kx" to be "success or failure"
+Apr 24 08:11:27.727: INFO: Pod "var-expansion-1674ea2f-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.145213ms
+Apr 24 08:11:29.730: INFO: Pod "var-expansion-1674ea2f-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006013661s
+Apr 24 08:11:31.733: INFO: Pod "var-expansion-1674ea2f-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009503362s
+STEP: Saw pod success
+Apr 24 08:11:31.733: INFO: Pod "var-expansion-1674ea2f-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:11:31.735: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod var-expansion-1674ea2f-4797-11e8-bf16-a2a292742988 container dapi-container: <nil>
+STEP: delete the pod
+Apr 24 08:11:31.779: INFO: Waiting for pod var-expansion-1674ea2f-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:11:31.788: INFO: Pod var-expansion-1674ea2f-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:11:31.788: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-225kx" for this suite.
+Apr 24 08:11:37.805: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:11:37.879: INFO: namespace: e2e-tests-var-expansion-225kx, resource: bindings, ignored listing per whitelist
+Apr 24 08:11:37.958: INFO: namespace e2e-tests-var-expansion-225kx deletion completed in 6.164295412s
+
+• [SLOW TEST:10.329 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:11:37.959: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name s-test-opt-del-1ca0ac62-4797-11e8-bf16-a2a292742988
+STEP: Creating secret with name s-test-opt-upd-1ca0aca1-4797-11e8-bf16-a2a292742988
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-1ca0ac62-4797-11e8-bf16-a2a292742988
+STEP: Updating secret s-test-opt-upd-1ca0aca1-4797-11e8-bf16-a2a292742988
+STEP: Creating secret with name s-test-opt-create-1ca0acb6-4797-11e8-bf16-a2a292742988
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:13:04.290: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-bhhjv" for this suite.
+Apr 24 08:13:26.308: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:13:26.418: INFO: namespace: e2e-tests-projected-bhhjv, resource: bindings, ignored listing per whitelist
+Apr 24 08:13:26.439: INFO: namespace e2e-tests-projected-bhhjv deletion completed in 22.145454265s
+
+• [SLOW TEST:108.479 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:13:26.439: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:37
+[It] should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test hostPath mode
+Apr 24 08:13:26.542: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-qwszc" to be "success or failure"
+Apr 24 08:13:26.549: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 6.94063ms
+Apr 24 08:13:28.552: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009999338s
+Apr 24 08:13:30.556: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013611427s
+STEP: Saw pod success
+Apr 24 08:13:30.556: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Apr 24 08:13:30.558: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Apr 24 08:13:30.576: INFO: Waiting for pod pod-host-path-test to disappear
+Apr 24 08:13:30.586: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:13:30.589: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-qwszc" for this suite.
+Apr 24 08:13:36.602: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:13:36.645: INFO: namespace: e2e-tests-hostpath-qwszc, resource: bindings, ignored listing per whitelist
+Apr 24 08:13:36.729: INFO: namespace e2e-tests-hostpath-qwszc deletion completed in 6.136591555s
+
+• [SLOW TEST:10.290 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:34
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:13:36.729: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-636a91b7-4797-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 08:13:36.849: INFO: Waiting up to 5m0s for pod "pod-configmaps-636b2dc9-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-configmap-sstvk" to be "success or failure"
+Apr 24 08:13:36.854: INFO: Pod "pod-configmaps-636b2dc9-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 5.067522ms
+Apr 24 08:13:38.857: INFO: Pod "pod-configmaps-636b2dc9-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008150608s
+Apr 24 08:13:40.860: INFO: Pod "pod-configmaps-636b2dc9-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011291167s
+STEP: Saw pod success
+Apr 24 08:13:40.860: INFO: Pod "pod-configmaps-636b2dc9-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:13:40.862: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-configmaps-636b2dc9-4797-11e8-bf16-a2a292742988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:13:40.882: INFO: Waiting for pod pod-configmaps-636b2dc9-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:13:40.899: INFO: Pod pod-configmaps-636b2dc9-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:13:40.899: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-sstvk" for this suite.
+Apr 24 08:13:46.912: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:13:46.960: INFO: namespace: e2e-tests-configmap-sstvk, resource: bindings, ignored listing per whitelist
+Apr 24 08:13:47.050: INFO: namespace e2e-tests-configmap-sstvk deletion completed in 6.14829864s
+
+• [SLOW TEST:10.321 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:13:47.051: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-698fb654-4797-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 08:13:47.157: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-69905464-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-4xb56" to be "success or failure"
+Apr 24 08:13:47.163: INFO: Pod "pod-projected-configmaps-69905464-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 6.283628ms
+Apr 24 08:13:49.170: INFO: Pod "pod-projected-configmaps-69905464-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.013144168s
+STEP: Saw pod success
+Apr 24 08:13:49.170: INFO: Pod "pod-projected-configmaps-69905464-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:13:49.172: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-configmaps-69905464-4797-11e8-bf16-a2a292742988 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:13:49.190: INFO: Waiting for pod pod-projected-configmaps-69905464-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:13:49.195: INFO: Pod pod-projected-configmaps-69905464-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:13:49.195: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4xb56" for this suite.
+Apr 24 08:13:55.224: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:13:55.339: INFO: namespace: e2e-tests-projected-4xb56, resource: bindings, ignored listing per whitelist
+Apr 24 08:13:55.342: INFO: namespace e2e-tests-projected-4xb56 deletion completed in 6.131686738s
+
+• [SLOW TEST:8.291 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:13:55.342: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name projected-secret-test-6e7ff4f6-4797-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 08:13:55.445: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-6e8072b5-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-kmq24" to be "success or failure"
+Apr 24 08:13:55.449: INFO: Pod "pod-projected-secrets-6e8072b5-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.212815ms
+Apr 24 08:13:57.456: INFO: Pod "pod-projected-secrets-6e8072b5-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010179127s
+STEP: Saw pod success
+Apr 24 08:13:57.456: INFO: Pod "pod-projected-secrets-6e8072b5-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:13:57.458: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-secrets-6e8072b5-4797-11e8-bf16-a2a292742988 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:13:57.495: INFO: Waiting for pod pod-projected-secrets-6e8072b5-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:13:57.498: INFO: Pod pod-projected-secrets-6e8072b5-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:13:57.498: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-kmq24" for this suite.
+Apr 24 08:14:03.519: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:14:03.608: INFO: namespace: e2e-tests-projected-kmq24, resource: bindings, ignored listing per whitelist
+Apr 24 08:14:03.642: INFO: namespace e2e-tests-projected-kmq24 deletion completed in 6.134987723s
+
+• [SLOW TEST:8.300 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:14:03.645: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-sgnrc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-sgnrc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-sgnrc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-sgnrc;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-sgnrc.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-sgnrc.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-sgnrc.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-sgnrc.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-sgnrc.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-sgnrc.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-sgnrc.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sgnrc.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-sgnrc.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-sgnrc.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-sgnrc.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-sgnrc.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-sgnrc.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 63.36.69.100.in-addr.arpa. PTR)" && echo OK > /results/100.69.36.63_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 63.36.69.100.in-addr.arpa. PTR)" && echo OK > /results/100.69.36.63_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-sgnrc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-sgnrc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-sgnrc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-sgnrc;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-sgnrc.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-sgnrc.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-sgnrc.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-sgnrc.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-sgnrc.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-sgnrc.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-sgnrc.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sgnrc.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-sgnrc.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-sgnrc.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-sgnrc.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-sgnrc.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-sgnrc.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 63.36.69.100.in-addr.arpa. PTR)" && echo OK > /results/100.69.36.63_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 63.36.69.100.in-addr.arpa. PTR)" && echo OK > /results/100.69.36.63_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Apr 24 08:14:27.095: INFO: DNS probes using dns-test-73787846-4797-11e8-bf16-a2a292742988 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:14:27.171: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-sgnrc" for this suite.
+Apr 24 08:14:33.192: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:14:33.267: INFO: namespace: e2e-tests-dns-sgnrc, resource: bindings, ignored listing per whitelist
+Apr 24 08:14:33.317: INFO: namespace e2e-tests-dns-sgnrc deletion completed in 6.142526732s
+
+• [SLOW TEST:29.673 seconds]
+[sig-network] DNS
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:14:33.317: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Apr 24 08:14:33.472: INFO: Waiting up to 5m0s for pod "pod-852b5c54-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-5xbjn" to be "success or failure"
+Apr 24 08:14:33.478: INFO: Pod "pod-852b5c54-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 5.705626ms
+Apr 24 08:14:35.483: INFO: Pod "pod-852b5c54-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010460646s
+STEP: Saw pod success
+Apr 24 08:14:35.483: INFO: Pod "pod-852b5c54-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:14:35.485: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-852b5c54-4797-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:14:35.508: INFO: Waiting for pod pod-852b5c54-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:14:35.519: INFO: Pod pod-852b5c54-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:14:35.519: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-5xbjn" for this suite.
+Apr 24 08:14:41.536: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:14:41.599: INFO: namespace: e2e-tests-emptydir-5xbjn, resource: bindings, ignored listing per whitelist
+Apr 24 08:14:41.663: INFO: namespace e2e-tests-emptydir-5xbjn deletion completed in 6.140869054s
+
+• [SLOW TEST:8.346 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:14:41.664: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating pod
+Apr 24 08:14:49.772: INFO: Pod pod-hostip-8a1c4111-4797-11e8-bf16-a2a292742988 has hostIP: 10.250.0.4
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:14:49.772: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-v9w46" for this suite.
+Apr 24 08:15:11.785: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:15:11.902: INFO: namespace: e2e-tests-pods-v9w46, resource: bindings, ignored listing per whitelist
+Apr 24 08:15:11.911: INFO: namespace e2e-tests-pods-v9w46 deletion completed in 22.135958523s
+
+• [SLOW TEST:30.248 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:15:11.915: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 24 08:15:12.025: INFO: Waiting up to 5m0s for pod "downward-api-9c26537d-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-chgsv" to be "success or failure"
+Apr 24 08:15:12.035: INFO: Pod "downward-api-9c26537d-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 9.992445ms
+Apr 24 08:15:14.131: INFO: Pod "downward-api-9c26537d-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.10566163s
+Apr 24 08:15:16.223: INFO: Pod "downward-api-9c26537d-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.197950604s
+STEP: Saw pod success
+Apr 24 08:15:16.223: INFO: Pod "downward-api-9c26537d-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:15:16.229: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downward-api-9c26537d-4797-11e8-bf16-a2a292742988 container dapi-container: <nil>
+STEP: delete the pod
+Apr 24 08:15:16.416: INFO: Waiting for pod downward-api-9c26537d-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:15:16.473: INFO: Pod downward-api-9c26537d-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:15:16.473: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-chgsv" for this suite.
+Apr 24 08:15:22.626: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:15:22.760: INFO: namespace: e2e-tests-downward-api-chgsv, resource: bindings, ignored listing per whitelist
+Apr 24 08:15:22.763: INFO: namespace e2e-tests-downward-api-chgsv deletion completed in 6.286438701s
+
+• [SLOW TEST:10.848 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:15:22.763: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the pods
+STEP: Gathering metrics
+W0424 08:16:03.097319      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 24 08:16:03.097: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:16:03.097: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-jdj5r" for this suite.
+Apr 24 08:16:09.119: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:16:09.251: INFO: namespace: e2e-tests-gc-jdj5r, resource: bindings, ignored listing per whitelist
+Apr 24 08:16:09.251: INFO: namespace e2e-tests-gc-jdj5r deletion completed in 6.151879165s
+
+• [SLOW TEST:46.489 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:16:09.251: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 24 08:16:09.377: INFO: (0) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 6.742629ms)
+Apr 24 08:16:09.382: INFO: (1) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.396919ms)
+Apr 24 08:16:09.385: INFO: (2) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.942617ms)
+Apr 24 08:16:09.389: INFO: (3) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.657316ms)
+Apr 24 08:16:09.395: INFO: (4) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.847625ms)
+Apr 24 08:16:09.400: INFO: (5) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.62222ms)
+Apr 24 08:16:09.404: INFO: (6) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.714221ms)
+Apr 24 08:16:09.408: INFO: (7) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.009817ms)
+Apr 24 08:16:09.413: INFO: (8) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.977722ms)
+Apr 24 08:16:09.420: INFO: (9) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 6.297727ms)
+Apr 24 08:16:09.425: INFO: (10) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.969221ms)
+Apr 24 08:16:09.429: INFO: (11) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.282319ms)
+Apr 24 08:16:09.437: INFO: (12) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 7.988635ms)
+Apr 24 08:16:09.442: INFO: (13) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.66952ms)
+Apr 24 08:16:09.446: INFO: (14) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.244018ms)
+Apr 24 08:16:09.450: INFO: (15) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.042018ms)
+Apr 24 08:16:09.457: INFO: (16) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 6.341228ms)
+Apr 24 08:16:09.461: INFO: (17) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.881417ms)
+Apr 24 08:16:09.464: INFO: (18) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.679316ms)
+Apr 24 08:16:09.476: INFO: (19) /api/v1/nodes/shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 11.42075ms)
+[AfterEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:16:09.476: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-jwlrs" for this suite.
+Apr 24 08:16:15.489: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:16:15.583: INFO: namespace: e2e-tests-proxy-jwlrs, resource: bindings, ignored listing per whitelist
+Apr 24 08:16:15.622: INFO: namespace e2e-tests-proxy-jwlrs deletion completed in 6.14289303s
+
+• [SLOW TEST:6.370 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:16:15.622: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 24 08:16:18.353: INFO: Successfully updated pod "labelsupdatec21e5c64-4797-11e8-bf16-a2a292742988"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:16:22.403: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-n2bb4" for this suite.
+Apr 24 08:16:44.433: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:16:44.513: INFO: namespace: e2e-tests-projected-n2bb4, resource: bindings, ignored listing per whitelist
+Apr 24 08:16:44.554: INFO: namespace e2e-tests-projected-n2bb4 deletion completed in 22.148123274s
+
+• [SLOW TEST:28.932 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:16:44.557: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for all pods to be garbage collected
+STEP: Gathering metrics
+W0424 08:16:54.675277      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 24 08:16:54.675: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:16:54.675: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-642r6" for this suite.
+Apr 24 08:17:00.693: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:17:00.783: INFO: namespace: e2e-tests-gc-642r6, resource: bindings, ignored listing per whitelist
+Apr 24 08:17:00.825: INFO: namespace e2e-tests-gc-642r6 deletion completed in 6.147209668s
+
+• [SLOW TEST:16.267 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:17:00.825: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating replication controller my-hostname-basic-dd14eb5d-4797-11e8-bf16-a2a292742988
+Apr 24 08:17:00.968: INFO: Pod name my-hostname-basic-dd14eb5d-4797-11e8-bf16-a2a292742988: Found 0 pods out of 1
+Apr 24 08:17:05.972: INFO: Pod name my-hostname-basic-dd14eb5d-4797-11e8-bf16-a2a292742988: Found 1 pods out of 1
+Apr 24 08:17:05.972: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-dd14eb5d-4797-11e8-bf16-a2a292742988" are running
+Apr 24 08:17:05.974: INFO: Pod "my-hostname-basic-dd14eb5d-4797-11e8-bf16-a2a292742988-422qq" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-24 08:17:00 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-24 08:17:02 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-24 08:17:00 +0000 UTC Reason: Message:}])
+Apr 24 08:17:05.974: INFO: Trying to dial the pod
+Apr 24 08:17:11.028: INFO: Controller my-hostname-basic-dd14eb5d-4797-11e8-bf16-a2a292742988: Got expected result from replica 1 [my-hostname-basic-dd14eb5d-4797-11e8-bf16-a2a292742988-422qq]: "my-hostname-basic-dd14eb5d-4797-11e8-bf16-a2a292742988-422qq", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:17:11.028: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-x4tqw" for this suite.
+Apr 24 08:17:17.044: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:17:17.095: INFO: namespace: e2e-tests-replication-controller-x4tqw, resource: bindings, ignored listing per whitelist
+Apr 24 08:17:17.322: INFO: namespace e2e-tests-replication-controller-x4tqw deletion completed in 6.291652718s
+
+• [SLOW TEST:16.498 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:17:17.323: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-e6e53d5e-4797-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 08:17:17.430: INFO: Waiting up to 5m0s for pod "pod-secrets-e6e5a45b-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-secrets-vjbgg" to be "success or failure"
+Apr 24 08:17:17.440: INFO: Pod "pod-secrets-e6e5a45b-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 10.337044ms
+Apr 24 08:17:19.443: INFO: Pod "pod-secrets-e6e5a45b-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013449734s
+Apr 24 08:17:21.446: INFO: Pod "pod-secrets-e6e5a45b-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015996044s
+STEP: Saw pod success
+Apr 24 08:17:21.446: INFO: Pod "pod-secrets-e6e5a45b-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:17:21.448: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-secrets-e6e5a45b-4797-11e8-bf16-a2a292742988 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:17:27.962: INFO: Waiting for pod pod-secrets-e6e5a45b-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:17:27.967: INFO: Pod pod-secrets-e6e5a45b-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:17:27.967: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-vjbgg" for this suite.
+Apr 24 08:17:33.985: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:17:34.094: INFO: namespace: e2e-tests-secrets-vjbgg, resource: bindings, ignored listing per whitelist
+Apr 24 08:17:34.113: INFO: namespace e2e-tests-secrets-vjbgg deletion completed in 6.138745961s
+
+• [SLOW TEST:16.790 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:17:34.114: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override all
+Apr 24 08:17:34.216: INFO: Waiting up to 5m0s for pod "client-containers-f0e72624-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-containers-dlxgr" to be "success or failure"
+Apr 24 08:17:34.220: INFO: Pod "client-containers-f0e72624-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.18942ms
+Apr 24 08:17:36.224: INFO: Pod "client-containers-f0e72624-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007480233s
+Apr 24 08:17:38.227: INFO: Pod "client-containers-f0e72624-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011298001s
+STEP: Saw pod success
+Apr 24 08:17:38.227: INFO: Pod "client-containers-f0e72624-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:17:38.230: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod client-containers-f0e72624-4797-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:17:38.261: INFO: Waiting for pod client-containers-f0e72624-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:17:38.292: INFO: Pod client-containers-f0e72624-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:17:38.292: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-dlxgr" for this suite.
+Apr 24 08:17:44.307: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:17:44.386: INFO: namespace: e2e-tests-containers-dlxgr, resource: bindings, ignored listing per whitelist
+Apr 24 08:17:44.435: INFO: namespace e2e-tests-containers-dlxgr deletion completed in 6.139279818s
+
+• [SLOW TEST:10.321 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:17:44.435: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Apr 24 08:17:44.544: INFO: Waiting up to 5m0s for pod "pod-f70d620a-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-jprzh" to be "success or failure"
+Apr 24 08:17:44.572: INFO: Pod "pod-f70d620a-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 27.698098ms
+Apr 24 08:17:46.582: INFO: Pod "pod-f70d620a-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.038197276s
+Apr 24 08:17:48.586: INFO: Pod "pod-f70d620a-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.041738682s
+STEP: Saw pod success
+Apr 24 08:17:48.586: INFO: Pod "pod-f70d620a-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:17:48.588: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-f70d620a-4797-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:17:48.609: INFO: Waiting for pod pod-f70d620a-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:17:48.621: INFO: Pod pod-f70d620a-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:17:48.621: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-jprzh" for this suite.
+Apr 24 08:17:54.645: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:17:54.704: INFO: namespace: e2e-tests-emptydir-jprzh, resource: bindings, ignored listing per whitelist
+Apr 24 08:17:54.776: INFO: namespace e2e-tests-emptydir-jprzh deletion completed in 6.152981338s
+
+• [SLOW TEST:10.342 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:17:54.777: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:17:54.888: INFO: Waiting up to 5m0s for pod "downwardapi-volume-fd397f30-4797-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-wkxlz" to be "success or failure"
+Apr 24 08:17:54.895: INFO: Pod "downwardapi-volume-fd397f30-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 7.19513ms
+Apr 24 08:17:56.899: INFO: Pod "downwardapi-volume-fd397f30-4797-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010551588s
+Apr 24 08:17:58.902: INFO: Pod "downwardapi-volume-fd397f30-4797-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014069009s
+STEP: Saw pod success
+Apr 24 08:17:58.902: INFO: Pod "downwardapi-volume-fd397f30-4797-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:17:58.905: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-fd397f30-4797-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:17:58.920: INFO: Waiting for pod downwardapi-volume-fd397f30-4797-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:17:58.926: INFO: Pod downwardapi-volume-fd397f30-4797-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:17:58.927: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wkxlz" for this suite.
+Apr 24 08:18:04.942: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:18:05.021: INFO: namespace: e2e-tests-projected-wkxlz, resource: bindings, ignored listing per whitelist
+Apr 24 08:18:05.076: INFO: namespace e2e-tests-projected-wkxlz deletion completed in 6.143548461s
+
+• [SLOW TEST:10.299 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:18:05.076: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-dk5f4
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 24 08:18:05.173: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 24 08:18:23.236: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.1.131 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-dk5f4 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 08:18:23.236: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 08:18:24.481: INFO: Found all expected endpoints: [netserver-0]
+Apr 24 08:18:24.484: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.0.30 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-dk5f4 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 08:18:24.484: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 08:18:25.668: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:18:25.668: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-dk5f4" for this suite.
+Apr 24 08:18:47.682: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:18:47.747: INFO: namespace: e2e-tests-pod-network-test-dk5f4, resource: bindings, ignored listing per whitelist
+Apr 24 08:18:47.812: INFO: namespace e2e-tests-pod-network-test-dk5f4 deletion completed in 22.140586075s
+
+• [SLOW TEST:42.736 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:18:47.812: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:18:47.923: INFO: Waiting up to 5m0s for pod "downwardapi-volume-1cd542e0-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-4qdgs" to be "success or failure"
+Apr 24 08:18:47.927: INFO: Pod "downwardapi-volume-1cd542e0-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.347617ms
+Apr 24 08:18:49.933: INFO: Pod "downwardapi-volume-1cd542e0-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010082646s
+STEP: Saw pod success
+Apr 24 08:18:49.933: INFO: Pod "downwardapi-volume-1cd542e0-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:18:49.936: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-1cd542e0-4798-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:18:49.969: INFO: Waiting for pod downwardapi-volume-1cd542e0-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:18:49.980: INFO: Pod downwardapi-volume-1cd542e0-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:18:49.980: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-4qdgs" for this suite.
+Apr 24 08:18:56.043: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:18:56.109: INFO: namespace: e2e-tests-downward-api-4qdgs, resource: bindings, ignored listing per whitelist
+Apr 24 08:18:56.172: INFO: namespace e2e-tests-downward-api-4qdgs deletion completed in 6.185419594s
+
+• [SLOW TEST:8.359 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:18:56.172: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:18:56.266: INFO: Waiting up to 5m0s for pod "downwardapi-volume-21cefd20-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-wnkt5" to be "success or failure"
+Apr 24 08:18:56.269: INFO: Pod "downwardapi-volume-21cefd20-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.593115ms
+Apr 24 08:18:58.272: INFO: Pod "downwardapi-volume-21cefd20-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006738287s
+STEP: Saw pod success
+Apr 24 08:18:58.272: INFO: Pod "downwardapi-volume-21cefd20-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:18:58.275: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-21cefd20-4798-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:18:58.333: INFO: Waiting for pod downwardapi-volume-21cefd20-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:18:58.347: INFO: Pod downwardapi-volume-21cefd20-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:18:58.347: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wnkt5" for this suite.
+Apr 24 08:19:04.384: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:19:04.492: INFO: namespace: e2e-tests-projected-wnkt5, resource: bindings, ignored listing per whitelist
+Apr 24 08:19:04.499: INFO: namespace e2e-tests-projected-wnkt5 deletion completed in 6.125861692s
+
+• [SLOW TEST:8.327 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:19:04.499: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 24 08:19:30.613: INFO: Container started at 2018-04-24 08:19:05 +0000 UTC, pod became ready at 2018-04-24 08:19:29 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:19:30.613: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-flj2w" for this suite.
+Apr 24 08:19:52.629: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:19:52.745: INFO: namespace: e2e-tests-container-probe-flj2w, resource: bindings, ignored listing per whitelist
+Apr 24 08:19:52.752: INFO: namespace e2e-tests-container-probe-flj2w deletion completed in 22.135076011s
+
+• [SLOW TEST:48.252 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:19:52.752: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Apr 24 08:19:52.889: INFO: Number of nodes with available pods: 0
+Apr 24 08:19:52.889: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 08:19:53.905: INFO: Number of nodes with available pods: 0
+Apr 24 08:19:53.905: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 08:19:54.897: INFO: Number of nodes with available pods: 0
+Apr 24 08:19:54.897: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 08:19:55.898: INFO: Number of nodes with available pods: 2
+Apr 24 08:19:55.898: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.
+Apr 24 08:19:55.923: INFO: Number of nodes with available pods: 1
+Apr 24 08:19:55.923: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 08:19:56.930: INFO: Number of nodes with available pods: 1
+Apr 24 08:19:56.930: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 08:19:57.930: INFO: Number of nodes with available pods: 1
+Apr 24 08:19:57.930: INFO: Node shoot-core-cncf-az-worker-gumvp-7bdb694675-2s2mz is running more than one daemon pod
+Apr 24 08:19:58.929: INFO: Number of nodes with available pods: 2
+Apr 24 08:19:58.929: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Wait for the failed daemon pod to be completely deleted.
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 24 08:20:08.954: INFO: Number of nodes with available pods: 0
+Apr 24 08:20:08.954: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 24 08:20:08.957: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-42rcw/daemonsets","resourceVersion":"7828"},"items":null}
+
+Apr 24 08:20:08.959: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-42rcw/pods","resourceVersion":"7828"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:20:08.970: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-42rcw" for this suite.
+Apr 24 08:20:14.984: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:20:15.089: INFO: namespace: e2e-tests-daemonsets-42rcw, resource: bindings, ignored listing per whitelist
+Apr 24 08:20:15.131: INFO: namespace e2e-tests-daemonsets-42rcw deletion completed in 6.157716278s
+
+• [SLOW TEST:22.379 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:20:15.131: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Apr 24 08:20:15.235: INFO: Waiting up to 5m0s for pod "pod-50e0e561-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-5vxkj" to be "success or failure"
+Apr 24 08:20:15.243: INFO: Pod "pod-50e0e561-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 7.405429ms
+Apr 24 08:20:17.246: INFO: Pod "pod-50e0e561-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010532158s
+Apr 24 08:20:19.249: INFO: Pod "pod-50e0e561-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013549226s
+STEP: Saw pod success
+Apr 24 08:20:19.249: INFO: Pod "pod-50e0e561-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:20:19.251: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-50e0e561-4798-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:20:19.286: INFO: Waiting for pod pod-50e0e561-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:20:19.299: INFO: Pod pod-50e0e561-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:20:19.299: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-5vxkj" for this suite.
+Apr 24 08:20:25.350: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:20:25.498: INFO: namespace: e2e-tests-emptydir-5vxkj, resource: bindings, ignored listing per whitelist
+Apr 24 08:20:25.552: INFO: namespace e2e-tests-emptydir-5vxkj deletion completed in 6.249487398s
+
+• [SLOW TEST:10.421 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:20:25.552: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 24 08:20:25.684: INFO: Waiting up to 5m0s for pod "downward-api-5719d049-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-pvzpn" to be "success or failure"
+Apr 24 08:20:25.691: INFO: Pod "downward-api-5719d049-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 7.140031ms
+Apr 24 08:20:27.694: INFO: Pod "downward-api-5719d049-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010347165s
+Apr 24 08:20:29.700: INFO: Pod "downward-api-5719d049-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.0160825s
+Apr 24 08:20:31.703: INFO: Pod "downward-api-5719d049-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.01913454s
+STEP: Saw pod success
+Apr 24 08:20:31.703: INFO: Pod "downward-api-5719d049-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:20:31.705: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downward-api-5719d049-4798-11e8-bf16-a2a292742988 container dapi-container: <nil>
+STEP: delete the pod
+Apr 24 08:20:31.735: INFO: Waiting for pod downward-api-5719d049-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:20:31.741: INFO: Pod downward-api-5719d049-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:20:31.741: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-pvzpn" for this suite.
+Apr 24 08:20:37.753: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:20:37.852: INFO: namespace: e2e-tests-downward-api-pvzpn, resource: bindings, ignored listing per whitelist
+Apr 24 08:20:37.874: INFO: namespace e2e-tests-downward-api-pvzpn deletion completed in 6.130145819s
+
+• [SLOW TEST:12.322 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:20:37.874: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:20:37.979: INFO: Waiting up to 5m0s for pod "downwardapi-volume-5e6f2e1b-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-vd9ql" to be "success or failure"
+Apr 24 08:20:37.987: INFO: Pod "downwardapi-volume-5e6f2e1b-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 7.653232ms
+Apr 24 08:20:39.990: INFO: Pod "downwardapi-volume-5e6f2e1b-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010976164s
+Apr 24 08:20:41.994: INFO: Pod "downwardapi-volume-5e6f2e1b-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.014093246s
+Apr 24 08:20:44.146: INFO: Pod "downwardapi-volume-5e6f2e1b-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.166440271s
+STEP: Saw pod success
+Apr 24 08:20:44.146: INFO: Pod "downwardapi-volume-5e6f2e1b-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:20:44.155: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-5e6f2e1b-4798-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:20:44.186: INFO: Waiting for pod downwardapi-volume-5e6f2e1b-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:20:44.197: INFO: Pod downwardapi-volume-5e6f2e1b-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:20:44.197: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-vd9ql" for this suite.
+Apr 24 08:20:50.214: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:20:50.280: INFO: namespace: e2e-tests-downward-api-vd9ql, resource: bindings, ignored listing per whitelist
+Apr 24 08:20:50.336: INFO: namespace e2e-tests-downward-api-vd9ql deletion completed in 6.134448635s
+
+• [SLOW TEST:12.462 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:20:50.337: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:20:50.458: INFO: Waiting up to 5m0s for pod "downwardapi-volume-65df7084-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-mvl52" to be "success or failure"
+Apr 24 08:20:50.462: INFO: Pod "downwardapi-volume-65df7084-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.248319ms
+Apr 24 08:20:52.465: INFO: Pod "downwardapi-volume-65df7084-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007424764s
+Apr 24 08:20:54.471: INFO: Pod "downwardapi-volume-65df7084-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013264813s
+STEP: Saw pod success
+Apr 24 08:20:54.471: INFO: Pod "downwardapi-volume-65df7084-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:20:54.474: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-65df7084-4798-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:20:54.495: INFO: Waiting for pod downwardapi-volume-65df7084-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:20:54.503: INFO: Pod downwardapi-volume-65df7084-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:20:54.503: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-mvl52" for this suite.
+Apr 24 08:21:00.525: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:21:00.578: INFO: namespace: e2e-tests-projected-mvl52, resource: bindings, ignored listing per whitelist
+Apr 24 08:21:00.647: INFO: namespace e2e-tests-projected-mvl52 deletion completed in 6.13832322s
+
+• [SLOW TEST:10.310 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:21:00.648: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-6c01c7b9-4798-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 08:21:00.755: INFO: Waiting up to 5m0s for pod "pod-configmaps-6c027e68-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-configmap-c7m9n" to be "success or failure"
+Apr 24 08:21:00.760: INFO: Pod "pod-configmaps-6c027e68-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 5.189021ms
+Apr 24 08:21:02.763: INFO: Pod "pod-configmaps-6c027e68-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008252711s
+STEP: Saw pod success
+Apr 24 08:21:02.763: INFO: Pod "pod-configmaps-6c027e68-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:21:02.765: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-configmaps-6c027e68-4798-11e8-bf16-a2a292742988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:21:02.797: INFO: Waiting for pod pod-configmaps-6c027e68-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:21:02.802: INFO: Pod pod-configmaps-6c027e68-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:21:02.806: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-c7m9n" for this suite.
+Apr 24 08:21:08.828: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:21:08.890: INFO: namespace: e2e-tests-configmap-c7m9n, resource: bindings, ignored listing per whitelist
+Apr 24 08:21:08.940: INFO: namespace e2e-tests-configmap-c7m9n deletion completed in 6.127568257s
+
+• [SLOW TEST:8.293 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:21:08.941: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:21:09.076: INFO: Waiting up to 5m0s for pod "downwardapi-volume-70f38a21-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-9k7s8" to be "success or failure"
+Apr 24 08:21:09.093: INFO: Pod "downwardapi-volume-70f38a21-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 16.688272ms
+Apr 24 08:21:11.096: INFO: Pod "downwardapi-volume-70f38a21-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.020003229s
+Apr 24 08:21:13.108: INFO: Pod "downwardapi-volume-70f38a21-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.032141613s
+STEP: Saw pod success
+Apr 24 08:21:13.108: INFO: Pod "downwardapi-volume-70f38a21-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:21:13.114: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-70f38a21-4798-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:21:13.142: INFO: Waiting for pod downwardapi-volume-70f38a21-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:21:13.150: INFO: Pod downwardapi-volume-70f38a21-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:21:13.150: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-9k7s8" for this suite.
+Apr 24 08:21:19.176: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:21:19.287: INFO: namespace: e2e-tests-projected-9k7s8, resource: bindings, ignored listing per whitelist
+Apr 24 08:21:19.302: INFO: namespace e2e-tests-projected-9k7s8 deletion completed in 6.14887469s
+
+• [SLOW TEST:10.362 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:21:19.303: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:21:19.424: INFO: Waiting up to 5m0s for pod "downwardapi-volume-7722d017-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-dxld5" to be "success or failure"
+Apr 24 08:21:19.433: INFO: Pod "downwardapi-volume-7722d017-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 8.949939ms
+Apr 24 08:21:21.437: INFO: Pod "downwardapi-volume-7722d017-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01229603s
+Apr 24 08:21:23.440: INFO: Pod "downwardapi-volume-7722d017-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01562503s
+STEP: Saw pod success
+Apr 24 08:21:23.440: INFO: Pod "downwardapi-volume-7722d017-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:21:23.442: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-7722d017-4798-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:21:23.476: INFO: Waiting for pod downwardapi-volume-7722d017-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:21:23.485: INFO: Pod downwardapi-volume-7722d017-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:21:23.485: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-dxld5" for this suite.
+Apr 24 08:21:29.506: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:21:29.568: INFO: namespace: e2e-tests-downward-api-dxld5, resource: bindings, ignored listing per whitelist
+Apr 24 08:21:29.632: INFO: namespace e2e-tests-downward-api-dxld5 deletion completed in 6.136370406s
+
+• [SLOW TEST:10.329 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:21:29.632: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for 2 Minute to see if the garbage collector mistakenly deletes the rs
+STEP: expected 0 Deploymentss, got 1 Deployments
+STEP: Gathering metrics
+W0424 08:21:35.286861      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 24 08:21:35.286: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:21:35.287: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-hqgzx" for this suite.
+Apr 24 08:21:41.301: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:21:41.363: INFO: namespace: e2e-tests-gc-hqgzx, resource: bindings, ignored listing per whitelist
+Apr 24 08:21:41.435: INFO: namespace e2e-tests-gc-hqgzx deletion completed in 6.144021947s
+
+• [SLOW TEST:11.803 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:21:41.436: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Apr 24 08:21:41.550: INFO: Waiting up to 5m0s for pod "pod-8453380a-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-4chrm" to be "success or failure"
+Apr 24 08:21:41.557: INFO: Pod "pod-8453380a-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 6.601428ms
+Apr 24 08:21:43.560: INFO: Pod "pod-8453380a-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009623294s
+Apr 24 08:21:45.563: INFO: Pod "pod-8453380a-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013440228s
+STEP: Saw pod success
+Apr 24 08:21:45.563: INFO: Pod "pod-8453380a-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:21:45.566: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-8453380a-4798-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:21:45.593: INFO: Waiting for pod pod-8453380a-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:21:45.602: INFO: Pod pod-8453380a-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:21:45.602: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-4chrm" for this suite.
+Apr 24 08:21:51.615: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:21:51.681: INFO: namespace: e2e-tests-emptydir-4chrm, resource: bindings, ignored listing per whitelist
+Apr 24 08:21:51.743: INFO: namespace e2e-tests-emptydir-4chrm deletion completed in 6.13779031s
+
+• [SLOW TEST:10.307 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:21:51.745: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Apr 24 08:21:51.845: INFO: Waiting up to 5m0s for pod "pod-8a75d789-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-nr9s6" to be "success or failure"
+Apr 24 08:21:51.848: INFO: Pod "pod-8a75d789-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.764011ms
+Apr 24 08:21:53.852: INFO: Pod "pod-8a75d789-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006582091s
+Apr 24 08:21:55.856: INFO: Pod "pod-8a75d789-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010659364s
+STEP: Saw pod success
+Apr 24 08:21:55.856: INFO: Pod "pod-8a75d789-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:21:55.859: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-8a75d789-4798-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:21:55.896: INFO: Waiting for pod pod-8a75d789-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:21:55.901: INFO: Pod pod-8a75d789-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:21:55.901: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-nr9s6" for this suite.
+Apr 24 08:22:01.915: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:22:01.968: INFO: namespace: e2e-tests-emptydir-nr9s6, resource: bindings, ignored listing per whitelist
+Apr 24 08:22:02.051: INFO: namespace e2e-tests-emptydir-nr9s6 deletion completed in 6.147650747s
+
+• [SLOW TEST:10.307 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:22:02.052: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 24 08:22:06.704: INFO: Successfully updated pod "annotationupdate909d226e-4798-11e8-bf16-a2a292742988"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:22:08.725: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-7xk4q" for this suite.
+Apr 24 08:22:30.740: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:22:30.827: INFO: namespace: e2e-tests-downward-api-7xk4q, resource: bindings, ignored listing per whitelist
+Apr 24 08:22:30.857: INFO: namespace e2e-tests-downward-api-7xk4q deletion completed in 22.128428873s
+
+• [SLOW TEST:28.805 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:22:30.859: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for all rs to be garbage collected
+STEP: expected 0 rs, got 1 rs
+STEP: expected 0 Pods, got 2 Pods
+STEP: Gathering metrics
+W0424 08:22:32.039577      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 24 08:22:32.039: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:22:32.040: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-94679" for this suite.
+Apr 24 08:22:38.054: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:22:38.164: INFO: namespace: e2e-tests-gc-94679, resource: bindings, ignored listing per whitelist
+Apr 24 08:22:38.185: INFO: namespace e2e-tests-gc-94679 deletion completed in 6.140228315s
+
+• [SLOW TEST:7.326 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:22:38.186: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc1
+STEP: create the rc2
+STEP: set half of pods created by rc simpletest-rc-to-be-deleted to have rc simpletest-rc-to-stay as owner as well
+STEP: delete the rc simpletest-rc-to-be-deleted
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0424 08:22:48.490673      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 24 08:22:48.490: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:22:48.490: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-4bbnx" for this suite.
+Apr 24 08:22:54.524: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:22:54.592: INFO: namespace: e2e-tests-gc-4bbnx, resource: bindings, ignored listing per whitelist
+Apr 24 08:22:54.688: INFO: namespace e2e-tests-gc-4bbnx deletion completed in 6.192425541s
+
+• [SLOW TEST:16.502 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:22:54.688: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-kbphj
+I0424 08:22:54.809420      14 runners.go:175] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-kbphj, replica count: 1
+I0424 08:22:55.809833      14 runners.go:175] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0424 08:22:56.809989      14 runners.go:175] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0424 08:22:57.811476      14 runners.go:175] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Apr 24 08:22:57.926: INFO: Created: latency-svc-tzdwk
+Apr 24 08:22:57.935: INFO: Got endpoints: latency-svc-tzdwk [22.477896ms]
+Apr 24 08:22:57.998: INFO: Created: latency-svc-284hb
+Apr 24 08:22:57.998: INFO: Got endpoints: latency-svc-284hb [63.47187ms]
+Apr 24 08:22:57.999: INFO: Created: latency-svc-srdqt
+Apr 24 08:22:57.999: INFO: Got endpoints: latency-svc-srdqt [64.317673ms]
+Apr 24 08:22:57.999: INFO: Created: latency-svc-gsht2
+Apr 24 08:22:57.999: INFO: Created: latency-svc-v744r
+Apr 24 08:22:57.999: INFO: Got endpoints: latency-svc-v744r [64.421074ms]
+Apr 24 08:22:58.000: INFO: Got endpoints: latency-svc-gsht2 [64.716775ms]
+Apr 24 08:22:58.008: INFO: Created: latency-svc-gpl9k
+Apr 24 08:22:58.013: INFO: Got endpoints: latency-svc-gpl9k [78.287933ms]
+Apr 24 08:22:58.025: INFO: Created: latency-svc-wfs5r
+Apr 24 08:22:58.025: INFO: Got endpoints: latency-svc-wfs5r [90.378386ms]
+Apr 24 08:22:58.031: INFO: Created: latency-svc-j8grv
+Apr 24 08:22:58.042: INFO: Got endpoints: latency-svc-j8grv [106.770757ms]
+Apr 24 08:22:58.051: INFO: Created: latency-svc-m2cbw
+Apr 24 08:22:58.052: INFO: Got endpoints: latency-svc-m2cbw [116.494799ms]
+Apr 24 08:22:58.061: INFO: Created: latency-svc-69psv
+Apr 24 08:22:58.100: INFO: Got endpoints: latency-svc-69psv [164.390406ms]
+Apr 24 08:22:58.101: INFO: Created: latency-svc-28n4t
+Apr 24 08:22:58.112: INFO: Got endpoints: latency-svc-28n4t [112.278886ms]
+Apr 24 08:22:58.112: INFO: Created: latency-svc-w6vd2
+Apr 24 08:22:58.113: INFO: Got endpoints: latency-svc-w6vd2 [113.490991ms]
+Apr 24 08:22:58.123: INFO: Created: latency-svc-mkpsd
+Apr 24 08:22:58.129: INFO: Got endpoints: latency-svc-mkpsd [193.871834ms]
+Apr 24 08:22:58.139: INFO: Created: latency-svc-c9cks
+Apr 24 08:22:58.148: INFO: Got endpoints: latency-svc-c9cks [212.918416ms]
+Apr 24 08:22:58.157: INFO: Created: latency-svc-wv2k6
+Apr 24 08:22:58.160: INFO: Got endpoints: latency-svc-wv2k6 [161.190797ms]
+Apr 24 08:22:58.174: INFO: Created: latency-svc-gqgf9
+Apr 24 08:22:58.177: INFO: Got endpoints: latency-svc-gqgf9 [241.989842ms]
+Apr 24 08:22:58.188: INFO: Created: latency-svc-zlgkq
+Apr 24 08:22:58.238: INFO: Got endpoints: latency-svc-zlgkq [303.032106ms]
+Apr 24 08:22:58.239: INFO: Created: latency-svc-tgrv5
+Apr 24 08:22:58.245: INFO: Got endpoints: latency-svc-tgrv5 [309.613434ms]
+Apr 24 08:22:58.257: INFO: Created: latency-svc-zmx7v
+Apr 24 08:22:58.273: INFO: Got endpoints: latency-svc-zmx7v [337.337255ms]
+Apr 24 08:22:58.273: INFO: Created: latency-svc-jw5ft
+Apr 24 08:22:58.282: INFO: Got endpoints: latency-svc-jw5ft [284.127629ms]
+Apr 24 08:22:58.289: INFO: Created: latency-svc-fbx5q
+Apr 24 08:22:58.292: INFO: Got endpoints: latency-svc-fbx5q [278.780606ms]
+Apr 24 08:22:58.301: INFO: Created: latency-svc-hxrdz
+Apr 24 08:22:58.304: INFO: Got endpoints: latency-svc-hxrdz [278.572705ms]
+Apr 24 08:22:58.312: INFO: Created: latency-svc-frmxr
+Apr 24 08:22:58.319: INFO: Got endpoints: latency-svc-frmxr [277.052999ms]
+Apr 24 08:22:58.328: INFO: Created: latency-svc-j8mvk
+Apr 24 08:22:58.332: INFO: Got endpoints: latency-svc-j8mvk [280.640614ms]
+Apr 24 08:22:58.357: INFO: Created: latency-svc-gsmdk
+Apr 24 08:22:58.369: INFO: Created: latency-svc-lddj9
+Apr 24 08:22:58.370: INFO: Got endpoints: latency-svc-gsmdk [269.992968ms]
+Apr 24 08:22:58.377: INFO: Got endpoints: latency-svc-lddj9 [265.034946ms]
+Apr 24 08:22:58.388: INFO: Created: latency-svc-m8jlf
+Apr 24 08:22:58.392: INFO: Got endpoints: latency-svc-m8jlf [278.759106ms]
+Apr 24 08:22:58.403: INFO: Created: latency-svc-hvdb2
+Apr 24 08:22:58.407: INFO: Got endpoints: latency-svc-hvdb2 [277.718802ms]
+Apr 24 08:22:58.416: INFO: Created: latency-svc-j46kx
+Apr 24 08:22:58.419: INFO: Got endpoints: latency-svc-j46kx [271.027673ms]
+Apr 24 08:22:58.427: INFO: Created: latency-svc-gg654
+Apr 24 08:22:58.434: INFO: Got endpoints: latency-svc-gg654 [273.640583ms]
+Apr 24 08:22:58.445: INFO: Created: latency-svc-rz4j7
+Apr 24 08:22:58.455: INFO: Got endpoints: latency-svc-rz4j7 [278.033003ms]
+Apr 24 08:22:58.456: INFO: Created: latency-svc-l7n7v
+Apr 24 08:22:58.480: INFO: Got endpoints: latency-svc-l7n7v [241.866847ms]
+Apr 24 08:22:58.481: INFO: Created: latency-svc-zhhqp
+Apr 24 08:22:58.485: INFO: Got endpoints: latency-svc-zhhqp [240.215739ms]
+Apr 24 08:22:58.499: INFO: Created: latency-svc-dfrxt
+Apr 24 08:22:58.504: INFO: Got endpoints: latency-svc-dfrxt [230.914798ms]
+Apr 24 08:22:58.516: INFO: Created: latency-svc-5rv4j
+Apr 24 08:22:58.520: INFO: Got endpoints: latency-svc-5rv4j [237.448428ms]
+Apr 24 08:22:58.529: INFO: Created: latency-svc-pnd6m
+Apr 24 08:22:58.532: INFO: Got endpoints: latency-svc-pnd6m [239.830237ms]
+Apr 24 08:22:58.540: INFO: Created: latency-svc-np76n
+Apr 24 08:22:58.545: INFO: Got endpoints: latency-svc-np76n [240.670941ms]
+Apr 24 08:22:58.559: INFO: Created: latency-svc-56p2j
+Apr 24 08:22:58.565: INFO: Got endpoints: latency-svc-56p2j [245.477562ms]
+Apr 24 08:22:58.576: INFO: Created: latency-svc-rpr6l
+Apr 24 08:22:58.610: INFO: Got endpoints: latency-svc-rpr6l [277.124199ms]
+Apr 24 08:22:58.611: INFO: Created: latency-svc-2glxz
+Apr 24 08:22:58.619: INFO: Got endpoints: latency-svc-2glxz [249.153777ms]
+Apr 24 08:22:58.634: INFO: Created: latency-svc-tqzjg
+Apr 24 08:22:58.641: INFO: Got endpoints: latency-svc-tqzjg [263.45894ms]
+Apr 24 08:22:58.652: INFO: Created: latency-svc-rxz98
+Apr 24 08:22:58.654: INFO: Got endpoints: latency-svc-rxz98 [261.735932ms]
+Apr 24 08:22:58.663: INFO: Created: latency-svc-kwk46
+Apr 24 08:22:58.670: INFO: Got endpoints: latency-svc-kwk46 [263.091739ms]
+Apr 24 08:22:58.682: INFO: Created: latency-svc-t82jz
+Apr 24 08:22:58.689: INFO: Created: latency-svc-2klmm
+Apr 24 08:22:58.689: INFO: Got endpoints: latency-svc-t82jz [269.774067ms]
+Apr 24 08:22:58.694: INFO: Got endpoints: latency-svc-2klmm [259.931225ms]
+Apr 24 08:22:58.703: INFO: Created: latency-svc-8sv92
+Apr 24 08:22:58.751: INFO: Got endpoints: latency-svc-8sv92 [295.149276ms]
+Apr 24 08:22:58.754: INFO: Created: latency-svc-fq7nz
+Apr 24 08:22:58.764: INFO: Created: latency-svc-4scml
+Apr 24 08:22:58.777: INFO: Created: latency-svc-rbs4w
+Apr 24 08:22:58.780: INFO: Got endpoints: latency-svc-fq7nz [299.817697ms]
+Apr 24 08:22:58.789: INFO: Created: latency-svc-hwwx4
+Apr 24 08:22:58.802: INFO: Created: latency-svc-zrv5m
+Apr 24 08:22:58.817: INFO: Created: latency-svc-t4b7v
+Apr 24 08:22:58.829: INFO: Got endpoints: latency-svc-4scml [343.992789ms]
+Apr 24 08:22:58.830: INFO: Created: latency-svc-7c56t
+Apr 24 08:22:58.848: INFO: Created: latency-svc-n7gpc
+Apr 24 08:22:58.878: INFO: Created: latency-svc-hhmxh
+Apr 24 08:22:58.883: INFO: Got endpoints: latency-svc-rbs4w [379.11764ms]
+Apr 24 08:22:58.891: INFO: Created: latency-svc-chl8c
+Apr 24 08:22:58.904: INFO: Created: latency-svc-gckn9
+Apr 24 08:22:58.923: INFO: Created: latency-svc-tnvsb
+Apr 24 08:22:58.930: INFO: Got endpoints: latency-svc-hwwx4 [410.138675ms]
+Apr 24 08:22:58.939: INFO: Created: latency-svc-wxn4s
+Apr 24 08:22:58.956: INFO: Created: latency-svc-rkrbm
+Apr 24 08:22:58.968: INFO: Created: latency-svc-d6zg8
+Apr 24 08:22:59.001: INFO: Got endpoints: latency-svc-zrv5m [469.22783ms]
+Apr 24 08:22:59.002: INFO: Created: latency-svc-rt2t6
+Apr 24 08:22:59.011: INFO: Created: latency-svc-hk7vr
+Apr 24 08:22:59.025: INFO: Created: latency-svc-k6q7n
+Apr 24 08:22:59.030: INFO: Got endpoints: latency-svc-t4b7v [485.4585ms]
+Apr 24 08:22:59.039: INFO: Created: latency-svc-sdr7r
+Apr 24 08:22:59.053: INFO: Created: latency-svc-fr2cq
+Apr 24 08:22:59.065: INFO: Created: latency-svc-szptt
+Apr 24 08:22:59.157: INFO: Got endpoints: latency-svc-n7gpc [546.820964ms]
+Apr 24 08:22:59.157: INFO: Got endpoints: latency-svc-7c56t [592.029659ms]
+Apr 24 08:22:59.171: INFO: Created: latency-svc-vzfkd
+Apr 24 08:22:59.187: INFO: Got endpoints: latency-svc-hhmxh [567.892755ms]
+Apr 24 08:22:59.188: INFO: Created: latency-svc-xlnds
+Apr 24 08:22:59.202: INFO: Created: latency-svc-hkhmg
+Apr 24 08:22:59.241: INFO: Got endpoints: latency-svc-chl8c [600.592796ms]
+Apr 24 08:22:59.269: INFO: Created: latency-svc-7ljbr
+Apr 24 08:22:59.279: INFO: Got endpoints: latency-svc-gckn9 [624.565799ms]
+Apr 24 08:22:59.295: INFO: Created: latency-svc-l9hzs
+Apr 24 08:22:59.342: INFO: Got endpoints: latency-svc-tnvsb [672.084204ms]
+Apr 24 08:22:59.371: INFO: Created: latency-svc-zm7n9
+Apr 24 08:22:59.379: INFO: Got endpoints: latency-svc-wxn4s [689.451779ms]
+Apr 24 08:22:59.397: INFO: Created: latency-svc-gkc9d
+Apr 24 08:22:59.494: INFO: Got endpoints: latency-svc-d6zg8 [743.669613ms]
+Apr 24 08:22:59.495: INFO: Got endpoints: latency-svc-rkrbm [800.587259ms]
+Apr 24 08:22:59.512: INFO: Created: latency-svc-dkk2h
+Apr 24 08:22:59.526: INFO: Created: latency-svc-c7llt
+Apr 24 08:22:59.530: INFO: Got endpoints: latency-svc-rt2t6 [749.236936ms]
+Apr 24 08:22:59.544: INFO: Created: latency-svc-ztsm5
+Apr 24 08:22:59.593: INFO: Got endpoints: latency-svc-hk7vr [763.9248ms]
+Apr 24 08:22:59.610: INFO: Created: latency-svc-zj4mh
+Apr 24 08:22:59.629: INFO: Got endpoints: latency-svc-k6q7n [745.954721ms]
+Apr 24 08:22:59.645: INFO: Created: latency-svc-2459g
+Apr 24 08:22:59.680: INFO: Got endpoints: latency-svc-sdr7r [749.152134ms]
+Apr 24 08:22:59.730: INFO: Got endpoints: latency-svc-fr2cq [728.190343ms]
+Apr 24 08:22:59.730: INFO: Created: latency-svc-l9srm
+Apr 24 08:22:59.778: INFO: Created: latency-svc-rlknz
+Apr 24 08:22:59.785: INFO: Got endpoints: latency-svc-szptt [754.318757ms]
+Apr 24 08:22:59.800: INFO: Created: latency-svc-5cxsh
+Apr 24 08:22:59.843: INFO: Got endpoints: latency-svc-vzfkd [686.327463ms]
+Apr 24 08:22:59.857: INFO: Created: latency-svc-qntq4
+Apr 24 08:22:59.879: INFO: Got endpoints: latency-svc-xlnds [721.317614ms]
+Apr 24 08:22:59.893: INFO: Created: latency-svc-9bm6w
+Apr 24 08:22:59.929: INFO: Got endpoints: latency-svc-hkhmg [741.473501ms]
+Apr 24 08:22:59.958: INFO: Created: latency-svc-l6qz9
+Apr 24 08:22:59.980: INFO: Got endpoints: latency-svc-7ljbr [738.222887ms]
+Apr 24 08:23:00.000: INFO: Created: latency-svc-rzjrt
+Apr 24 08:23:00.029: INFO: Got endpoints: latency-svc-l9hzs [750.328839ms]
+Apr 24 08:23:00.047: INFO: Created: latency-svc-tlzn5
+Apr 24 08:23:00.079: INFO: Got endpoints: latency-svc-zm7n9 [737.290683ms]
+Apr 24 08:23:00.094: INFO: Created: latency-svc-2qrr6
+Apr 24 08:23:00.129: INFO: Got endpoints: latency-svc-gkc9d [750.194238ms]
+Apr 24 08:23:00.143: INFO: Created: latency-svc-zwjvw
+Apr 24 08:23:00.196: INFO: Got endpoints: latency-svc-dkk2h [701.058525ms]
+Apr 24 08:23:00.209: INFO: Created: latency-svc-qhzbl
+Apr 24 08:23:00.230: INFO: Got endpoints: latency-svc-c7llt [734.496669ms]
+Apr 24 08:23:00.243: INFO: Created: latency-svc-bjfdv
+Apr 24 08:23:00.279: INFO: Got endpoints: latency-svc-ztsm5 [749.662934ms]
+Apr 24 08:23:00.294: INFO: Created: latency-svc-x6smq
+Apr 24 08:23:00.330: INFO: Got endpoints: latency-svc-zj4mh [735.212771ms]
+Apr 24 08:23:00.347: INFO: Created: latency-svc-n9sp6
+Apr 24 08:23:00.379: INFO: Got endpoints: latency-svc-2459g [750.289236ms]
+Apr 24 08:23:00.399: INFO: Created: latency-svc-4gv95
+Apr 24 08:23:00.433: INFO: Got endpoints: latency-svc-l9srm [752.792846ms]
+Apr 24 08:23:00.452: INFO: Created: latency-svc-8qw9v
+Apr 24 08:23:00.480: INFO: Got endpoints: latency-svc-rlknz [749.813933ms]
+Apr 24 08:23:00.503: INFO: Created: latency-svc-2jfh4
+Apr 24 08:23:00.543: INFO: Got endpoints: latency-svc-5cxsh [758.215369ms]
+Apr 24 08:23:00.558: INFO: Created: latency-svc-ptf7s
+Apr 24 08:23:00.579: INFO: Got endpoints: latency-svc-qntq4 [735.715371ms]
+Apr 24 08:23:00.595: INFO: Created: latency-svc-7sjfm
+Apr 24 08:23:00.629: INFO: Got endpoints: latency-svc-9bm6w [749.769731ms]
+Apr 24 08:23:00.642: INFO: Created: latency-svc-2dvfv
+Apr 24 08:23:00.679: INFO: Got endpoints: latency-svc-l6qz9 [750.131332ms]
+Apr 24 08:23:00.699: INFO: Created: latency-svc-pm2zl
+Apr 24 08:23:00.729: INFO: Got endpoints: latency-svc-rzjrt [749.340029ms]
+Apr 24 08:23:00.751: INFO: Created: latency-svc-vqbjd
+Apr 24 08:23:00.783: INFO: Got endpoints: latency-svc-tlzn5 [753.905148ms]
+Apr 24 08:23:00.796: INFO: Created: latency-svc-26l7c
+Apr 24 08:23:00.833: INFO: Got endpoints: latency-svc-2qrr6 [753.298745ms]
+Apr 24 08:23:00.857: INFO: Created: latency-svc-lvvhn
+Apr 24 08:23:00.879: INFO: Got endpoints: latency-svc-zwjvw [749.470729ms]
+Apr 24 08:23:00.928: INFO: Created: latency-svc-mjhdm
+Apr 24 08:23:00.934: INFO: Got endpoints: latency-svc-qhzbl [737.98478ms]
+Apr 24 08:23:00.952: INFO: Created: latency-svc-s67zl
+Apr 24 08:23:00.979: INFO: Got endpoints: latency-svc-bjfdv [749.119527ms]
+Apr 24 08:23:01.005: INFO: Created: latency-svc-kp8p2
+Apr 24 08:23:01.030: INFO: Got endpoints: latency-svc-x6smq [750.141131ms]
+Apr 24 08:23:01.044: INFO: Created: latency-svc-44g26
+Apr 24 08:23:01.080: INFO: Got endpoints: latency-svc-n9sp6 [750.054931ms]
+Apr 24 08:23:01.094: INFO: Created: latency-svc-ttcmx
+Apr 24 08:23:01.177: INFO: Got endpoints: latency-svc-4gv95 [797.279034ms]
+Apr 24 08:23:01.179: INFO: Got endpoints: latency-svc-8qw9v [746.554914ms]
+Apr 24 08:23:01.201: INFO: Created: latency-svc-665wx
+Apr 24 08:23:01.219: INFO: Created: latency-svc-cc4db
+Apr 24 08:23:01.229: INFO: Got endpoints: latency-svc-2jfh4 [749.091326ms]
+Apr 24 08:23:01.245: INFO: Created: latency-svc-6nzdj
+Apr 24 08:23:01.299: INFO: Got endpoints: latency-svc-ptf7s [755.243451ms]
+Apr 24 08:23:01.315: INFO: Created: latency-svc-l5fpj
+Apr 24 08:23:01.329: INFO: Got endpoints: latency-svc-7sjfm [750.092628ms]
+Apr 24 08:23:01.346: INFO: Created: latency-svc-2szjt
+Apr 24 08:23:01.379: INFO: Got endpoints: latency-svc-2dvfv [749.782327ms]
+Apr 24 08:23:01.396: INFO: Created: latency-svc-zkjdm
+Apr 24 08:23:01.437: INFO: Got endpoints: latency-svc-pm2zl [758.156563ms]
+Apr 24 08:23:01.452: INFO: Created: latency-svc-w82nw
+Apr 24 08:23:01.479: INFO: Got endpoints: latency-svc-vqbjd [749.745726ms]
+Apr 24 08:23:01.499: INFO: Created: latency-svc-cpk5c
+Apr 24 08:23:01.551: INFO: Got endpoints: latency-svc-26l7c [767.680902ms]
+Apr 24 08:23:01.575: INFO: Created: latency-svc-554pc
+Apr 24 08:23:01.579: INFO: Got endpoints: latency-svc-lvvhn [740.495985ms]
+Apr 24 08:23:01.598: INFO: Created: latency-svc-rb2zq
+Apr 24 08:23:01.629: INFO: Got endpoints: latency-svc-mjhdm [749.942826ms]
+Apr 24 08:23:01.650: INFO: Created: latency-svc-7bv7j
+Apr 24 08:23:01.682: INFO: Got endpoints: latency-svc-s67zl [747.641915ms]
+Apr 24 08:23:01.702: INFO: Created: latency-svc-552ff
+Apr 24 08:23:01.729: INFO: Got endpoints: latency-svc-kp8p2 [749.893125ms]
+Apr 24 08:23:01.745: INFO: Created: latency-svc-pn5tb
+Apr 24 08:23:01.794: INFO: Got endpoints: latency-svc-44g26 [763.999785ms]
+Apr 24 08:23:01.809: INFO: Created: latency-svc-ls8sw
+Apr 24 08:23:01.829: INFO: Got endpoints: latency-svc-ttcmx [749.302222ms]
+Apr 24 08:23:01.846: INFO: Created: latency-svc-55bsf
+Apr 24 08:23:01.879: INFO: Got endpoints: latency-svc-665wx [702.298619ms]
+Apr 24 08:23:01.893: INFO: Created: latency-svc-q5fhk
+Apr 24 08:23:01.930: INFO: Got endpoints: latency-svc-cc4db [750.288526ms]
+Apr 24 08:23:02.579: INFO: Got endpoints: latency-svc-l5fpj [1.279827198s]
+Apr 24 08:23:02.579: INFO: Got endpoints: latency-svc-6nzdj [1.349908199s]
+Apr 24 08:23:02.581: INFO: Got endpoints: latency-svc-zkjdm [1.202239563s]
+Apr 24 08:23:02.582: INFO: Got endpoints: latency-svc-2szjt [1.252449179s]
+Apr 24 08:23:02.585: INFO: Got endpoints: latency-svc-w82nw [1.147018027s]
+Apr 24 08:23:02.647: INFO: Created: latency-svc-v5pmc
+Apr 24 08:23:02.652: INFO: Got endpoints: latency-svc-7bv7j [1.022755491s]
+Apr 24 08:23:02.652: INFO: Got endpoints: latency-svc-554pc [1.101003128s]
+Apr 24 08:23:02.653: INFO: Got endpoints: latency-svc-552ff [966.315948ms]
+Apr 24 08:23:02.653: INFO: Got endpoints: latency-svc-rb2zq [1.073950212s]
+Apr 24 08:23:02.653: INFO: Got endpoints: latency-svc-cpk5c [1.173877141s]
+Apr 24 08:23:02.677: INFO: Got endpoints: latency-svc-q5fhk [798.285226ms]
+Apr 24 08:23:02.678: INFO: Got endpoints: latency-svc-pn5tb [949.127374ms]
+Apr 24 08:23:02.678: INFO: Got endpoints: latency-svc-55bsf [846.896335ms]
+Apr 24 08:23:02.679: INFO: Got endpoints: latency-svc-ls8sw [884.613797ms]
+Apr 24 08:23:02.795: INFO: Got endpoints: latency-svc-v5pmc [864.989012ms]
+Apr 24 08:23:02.810: INFO: Created: latency-svc-l64dh
+Apr 24 08:23:02.815: INFO: Got endpoints: latency-svc-l64dh [135.991583ms]
+Apr 24 08:23:02.830: INFO: Created: latency-svc-2jblh
+Apr 24 08:23:02.835: INFO: Got endpoints: latency-svc-2jblh [253.794389ms]
+Apr 24 08:23:02.845: INFO: Created: latency-svc-trmcg
+Apr 24 08:23:02.850: INFO: Got endpoints: latency-svc-trmcg [268.643552ms]
+Apr 24 08:23:02.861: INFO: Created: latency-svc-mnn5p
+Apr 24 08:23:02.882: INFO: Created: latency-svc-j4m8f
+Apr 24 08:23:02.925: INFO: Got endpoints: latency-svc-mnn5p [346.152385ms]
+Apr 24 08:23:02.926: INFO: Created: latency-svc-qns9m
+Apr 24 08:23:02.932: INFO: Got endpoints: latency-svc-j4m8f [346.994389ms]
+Apr 24 08:23:02.945: INFO: Created: latency-svc-2ptzj
+Apr 24 08:23:02.959: INFO: Created: latency-svc-b28zk
+Apr 24 08:23:02.973: INFO: Created: latency-svc-c2c2r
+Apr 24 08:23:02.984: INFO: Got endpoints: latency-svc-qns9m [306.059213ms]
+Apr 24 08:23:02.985: INFO: Created: latency-svc-k5gnq
+Apr 24 08:23:02.997: INFO: Created: latency-svc-42jms
+Apr 24 08:23:03.015: INFO: Created: latency-svc-t6swf
+Apr 24 08:23:03.063: INFO: Got endpoints: latency-svc-2ptzj [267.384047ms]
+Apr 24 08:23:03.063: INFO: Created: latency-svc-jzmwq
+Apr 24 08:23:03.073: INFO: Created: latency-svc-hkjlh
+Apr 24 08:23:03.088: INFO: Created: latency-svc-zshsv
+Apr 24 08:23:03.088: INFO: Got endpoints: latency-svc-b28zk [409.625457ms]
+Apr 24 08:23:03.101: INFO: Created: latency-svc-sr5nn
+Apr 24 08:23:03.124: INFO: Created: latency-svc-jkt99
+Apr 24 08:23:03.132: INFO: Created: latency-svc-t69qv
+Apr 24 08:23:03.132: INFO: Got endpoints: latency-svc-c2c2r [552.951971ms]
+Apr 24 08:23:03.149: INFO: Created: latency-svc-2s4j7
+Apr 24 08:23:03.184: INFO: Got endpoints: latency-svc-k5gnq [525.985955ms]
+Apr 24 08:23:03.184: INFO: Created: latency-svc-5ffqd
+Apr 24 08:23:03.197: INFO: Created: latency-svc-q4wlf
+Apr 24 08:23:03.210: INFO: Created: latency-svc-t5hg2
+Apr 24 08:23:03.223: INFO: Created: latency-svc-hbvxk
+Apr 24 08:23:03.245: INFO: Created: latency-svc-4bbkr
+Apr 24 08:23:03.245: INFO: Got endpoints: latency-svc-42jms [593.483444ms]
+Apr 24 08:23:03.252: INFO: Created: latency-svc-mv6gv
+Apr 24 08:23:03.267: INFO: Created: latency-svc-56cbq
+Apr 24 08:23:03.280: INFO: Got endpoints: latency-svc-t6swf [602.151781ms]
+Apr 24 08:23:03.321: INFO: Created: latency-svc-28244
+Apr 24 08:23:03.329: INFO: Got endpoints: latency-svc-jzmwq [514.496605ms]
+Apr 24 08:23:03.345: INFO: Created: latency-svc-lgf2l
+Apr 24 08:23:03.379: INFO: Got endpoints: latency-svc-hkjlh [726.508213ms]
+Apr 24 08:23:03.394: INFO: Created: latency-svc-8qnkv
+Apr 24 08:23:03.442: INFO: Got endpoints: latency-svc-zshsv [789.004781ms]
+Apr 24 08:23:03.461: INFO: Created: latency-svc-kl57h
+Apr 24 08:23:03.479: INFO: Got endpoints: latency-svc-sr5nn [826.872543ms]
+Apr 24 08:23:03.495: INFO: Created: latency-svc-kw7nt
+Apr 24 08:23:03.529: INFO: Got endpoints: latency-svc-jkt99 [693.539471ms]
+Apr 24 08:23:03.561: INFO: Created: latency-svc-rcv46
+Apr 24 08:23:03.579: INFO: Got endpoints: latency-svc-t69qv [728.37842ms]
+Apr 24 08:23:03.598: INFO: Created: latency-svc-j8sfw
+Apr 24 08:23:03.629: INFO: Got endpoints: latency-svc-2s4j7 [703.834114ms]
+Apr 24 08:23:03.650: INFO: Created: latency-svc-4zxvx
+Apr 24 08:23:03.679: INFO: Got endpoints: latency-svc-5ffqd [747.641701ms]
+Apr 24 08:23:03.694: INFO: Created: latency-svc-mgn4w
+Apr 24 08:23:03.730: INFO: Got endpoints: latency-svc-q4wlf [745.947994ms]
+Apr 24 08:23:03.752: INFO: Created: latency-svc-frjr4
+Apr 24 08:23:03.810: INFO: Got endpoints: latency-svc-t5hg2 [747.5322ms]
+Apr 24 08:23:03.824: INFO: Created: latency-svc-hvmvb
+Apr 24 08:23:03.833: INFO: Got endpoints: latency-svc-hbvxk [744.189286ms]
+Apr 24 08:23:03.849: INFO: Created: latency-svc-wpdqv
+Apr 24 08:23:03.878: INFO: Got endpoints: latency-svc-4bbkr [746.722397ms]
+Apr 24 08:23:03.896: INFO: Created: latency-svc-p858z
+Apr 24 08:23:03.929: INFO: Got endpoints: latency-svc-mv6gv [745.284491ms]
+Apr 24 08:23:03.944: INFO: Created: latency-svc-g74pf
+Apr 24 08:23:03.979: INFO: Got endpoints: latency-svc-56cbq [733.865342ms]
+Apr 24 08:23:03.998: INFO: Created: latency-svc-sffln
+Apr 24 08:23:04.029: INFO: Got endpoints: latency-svc-28244 [749.464209ms]
+Apr 24 08:23:04.044: INFO: Created: latency-svc-wpfdw
+Apr 24 08:23:04.079: INFO: Got endpoints: latency-svc-lgf2l [749.836309ms]
+Apr 24 08:23:04.116: INFO: Created: latency-svc-z526d
+Apr 24 08:23:04.142: INFO: Got endpoints: latency-svc-8qnkv [763.190766ms]
+Apr 24 08:23:04.156: INFO: Created: latency-svc-jds4b
+Apr 24 08:23:04.179: INFO: Got endpoints: latency-svc-kl57h [737.099354ms]
+Apr 24 08:23:04.194: INFO: Created: latency-svc-f5tdh
+Apr 24 08:23:04.229: INFO: Got endpoints: latency-svc-kw7nt [749.371107ms]
+Apr 24 08:23:04.264: INFO: Created: latency-svc-jc7hp
+Apr 24 08:23:04.279: INFO: Got endpoints: latency-svc-rcv46 [749.604007ms]
+Apr 24 08:23:04.294: INFO: Created: latency-svc-8td27
+Apr 24 08:23:04.329: INFO: Got endpoints: latency-svc-j8sfw [750.183309ms]
+Apr 24 08:23:04.347: INFO: Created: latency-svc-pp7s9
+Apr 24 08:23:04.385: INFO: Got endpoints: latency-svc-4zxvx [755.637832ms]
+Apr 24 08:23:04.400: INFO: Created: latency-svc-z7pf5
+Apr 24 08:23:04.440: INFO: Got endpoints: latency-svc-mgn4w [760.08345ms]
+Apr 24 08:23:04.455: INFO: Created: latency-svc-w4l6c
+Apr 24 08:23:04.501: INFO: Got endpoints: latency-svc-frjr4 [771.077797ms]
+Apr 24 08:23:04.517: INFO: Created: latency-svc-jdz6w
+Apr 24 08:23:04.529: INFO: Got endpoints: latency-svc-hvmvb [718.255871ms]
+Apr 24 08:23:04.559: INFO: Created: latency-svc-np5m4
+Apr 24 08:23:04.579: INFO: Got endpoints: latency-svc-wpdqv [746.039889ms]
+Apr 24 08:23:04.598: INFO: Created: latency-svc-chbc4
+Apr 24 08:23:04.630: INFO: Got endpoints: latency-svc-p858z [751.01921ms]
+Apr 24 08:23:04.655: INFO: Created: latency-svc-98bml
+Apr 24 08:23:04.679: INFO: Got endpoints: latency-svc-g74pf [749.614503ms]
+Apr 24 08:23:04.694: INFO: Created: latency-svc-5ll8h
+Apr 24 08:23:04.741: INFO: Got endpoints: latency-svc-sffln [761.935755ms]
+Apr 24 08:23:04.756: INFO: Created: latency-svc-l6gh2
+Apr 24 08:23:04.779: INFO: Got endpoints: latency-svc-wpfdw [749.449902ms]
+Apr 24 08:23:04.792: INFO: Created: latency-svc-vh797
+Apr 24 08:23:04.829: INFO: Got endpoints: latency-svc-z526d [749.195301ms]
+Apr 24 08:23:04.856: INFO: Created: latency-svc-slpl9
+Apr 24 08:23:04.881: INFO: Got endpoints: latency-svc-jds4b [738.138153ms]
+Apr 24 08:23:04.893: INFO: Created: latency-svc-ksbkc
+Apr 24 08:23:04.929: INFO: Got endpoints: latency-svc-f5tdh [749.939204ms]
+Apr 24 08:23:04.945: INFO: Created: latency-svc-ts9fg
+Apr 24 08:23:04.979: INFO: Got endpoints: latency-svc-jc7hp [750.025005ms]
+Apr 24 08:23:04.994: INFO: Created: latency-svc-gd8b6
+Apr 24 08:23:05.035: INFO: Got endpoints: latency-svc-8td27 [755.699728ms]
+Apr 24 08:23:05.060: INFO: Created: latency-svc-sskwb
+Apr 24 08:23:05.081: INFO: Got endpoints: latency-svc-pp7s9 [751.722111ms]
+Apr 24 08:23:05.095: INFO: Created: latency-svc-xsx4t
+Apr 24 08:23:05.129: INFO: Got endpoints: latency-svc-z7pf5 [743.803176ms]
+Apr 24 08:23:05.144: INFO: Created: latency-svc-lw7n6
+Apr 24 08:23:05.179: INFO: Got endpoints: latency-svc-w4l6c [739.378157ms]
+Apr 24 08:23:05.213: INFO: Created: latency-svc-jcsxd
+Apr 24 08:23:05.230: INFO: Got endpoints: latency-svc-jdz6w [728.38791ms]
+Apr 24 08:23:05.248: INFO: Created: latency-svc-6scpw
+Apr 24 08:23:05.279: INFO: Got endpoints: latency-svc-np5m4 [750.304604ms]
+Apr 24 08:23:05.297: INFO: Created: latency-svc-2tkgg
+Apr 24 08:23:05.329: INFO: Got endpoints: latency-svc-chbc4 [750.197302ms]
+Apr 24 08:23:05.343: INFO: Created: latency-svc-746gz
+Apr 24 08:23:05.379: INFO: Got endpoints: latency-svc-98bml [749.6392ms]
+Apr 24 08:23:05.395: INFO: Created: latency-svc-pxplt
+Apr 24 08:23:05.430: INFO: Got endpoints: latency-svc-5ll8h [750.655003ms]
+Apr 24 08:23:05.450: INFO: Created: latency-svc-rnwbb
+Apr 24 08:23:05.481: INFO: Got endpoints: latency-svc-l6gh2 [739.097954ms]
+Apr 24 08:23:05.501: INFO: Created: latency-svc-6f6jc
+Apr 24 08:23:05.529: INFO: Got endpoints: latency-svc-vh797 [750.1564ms]
+Apr 24 08:23:05.575: INFO: Created: latency-svc-bgsfc
+Apr 24 08:23:05.579: INFO: Got endpoints: latency-svc-slpl9 [750.245ms]
+Apr 24 08:23:05.594: INFO: Created: latency-svc-924pr
+Apr 24 08:23:05.629: INFO: Got endpoints: latency-svc-ksbkc [748.532592ms]
+Apr 24 08:23:05.675: INFO: Created: latency-svc-5g289
+Apr 24 08:23:05.683: INFO: Got endpoints: latency-svc-ts9fg [753.531113ms]
+Apr 24 08:23:05.696: INFO: Created: latency-svc-t29kd
+Apr 24 08:23:05.729: INFO: Got endpoints: latency-svc-gd8b6 [749.692897ms]
+Apr 24 08:23:05.748: INFO: Created: latency-svc-56529
+Apr 24 08:23:05.780: INFO: Got endpoints: latency-svc-sskwb [733.019525ms]
+Apr 24 08:23:05.829: INFO: Got endpoints: latency-svc-xsx4t [747.061285ms]
+Apr 24 08:23:05.880: INFO: Got endpoints: latency-svc-lw7n6 [750.297498ms]
+Apr 24 08:23:05.929: INFO: Got endpoints: latency-svc-jcsxd [749.286395ms]
+Apr 24 08:23:05.979: INFO: Got endpoints: latency-svc-6scpw [748.627992ms]
+Apr 24 08:23:06.029: INFO: Got endpoints: latency-svc-2tkgg [749.834396ms]
+Apr 24 08:23:06.079: INFO: Got endpoints: latency-svc-746gz [749.097793ms]
+Apr 24 08:23:06.129: INFO: Got endpoints: latency-svc-pxplt [749.201193ms]
+Apr 24 08:23:06.179: INFO: Got endpoints: latency-svc-rnwbb [749.060892ms]
+Apr 24 08:23:06.231: INFO: Got endpoints: latency-svc-6f6jc [749.972995ms]
+Apr 24 08:23:06.280: INFO: Got endpoints: latency-svc-bgsfc [750.066795ms]
+Apr 24 08:23:06.329: INFO: Got endpoints: latency-svc-924pr [749.760194ms]
+Apr 24 08:23:06.379: INFO: Got endpoints: latency-svc-5g289 [749.465592ms]
+Apr 24 08:23:06.429: INFO: Got endpoints: latency-svc-t29kd [745.761576ms]
+Apr 24 08:23:06.479: INFO: Got endpoints: latency-svc-56529 [750.021693ms]
+Apr 24 08:23:06.479: INFO: Latencies: [63.47187ms 64.317673ms 64.421074ms 64.716775ms 78.287933ms 90.378386ms 106.770757ms 112.278886ms 113.490991ms 116.494799ms 135.991583ms 161.190797ms 164.390406ms 193.871834ms 212.918416ms 230.914798ms 237.448428ms 239.830237ms 240.215739ms 240.670941ms 241.866847ms 241.989842ms 245.477562ms 249.153777ms 253.794389ms 259.931225ms 261.735932ms 263.091739ms 263.45894ms 265.034946ms 267.384047ms 268.643552ms 269.774067ms 269.992968ms 271.027673ms 273.640583ms 277.052999ms 277.124199ms 277.718802ms 278.033003ms 278.572705ms 278.759106ms 278.780606ms 280.640614ms 284.127629ms 295.149276ms 299.817697ms 303.032106ms 306.059213ms 309.613434ms 337.337255ms 343.992789ms 346.152385ms 346.994389ms 379.11764ms 409.625457ms 410.138675ms 469.22783ms 485.4585ms 514.496605ms 525.985955ms 546.820964ms 552.951971ms 567.892755ms 592.029659ms 593.483444ms 600.592796ms 602.151781ms 624.565799ms 672.084204ms 686.327463ms 689.451779ms 693.539471ms 701.058525ms 702.298619ms 703.834114ms 718.255871ms 721.317614ms 726.508213ms 728.190343ms 728.37842ms 728.38791ms 733.019525ms 733.865342ms 734.496669ms 735.212771ms 735.715371ms 737.099354ms 737.290683ms 737.98478ms 738.138153ms 738.222887ms 739.097954ms 739.378157ms 740.495985ms 741.473501ms 743.669613ms 743.803176ms 744.189286ms 745.284491ms 745.761576ms 745.947994ms 745.954721ms 746.039889ms 746.554914ms 746.722397ms 747.061285ms 747.5322ms 747.641701ms 747.641915ms 748.532592ms 748.627992ms 749.060892ms 749.091326ms 749.097793ms 749.119527ms 749.152134ms 749.195301ms 749.201193ms 749.236936ms 749.286395ms 749.302222ms 749.340029ms 749.371107ms 749.449902ms 749.464209ms 749.465592ms 749.470729ms 749.604007ms 749.614503ms 749.6392ms 749.662934ms 749.692897ms 749.745726ms 749.760194ms 749.769731ms 749.782327ms 749.813933ms 749.834396ms 749.836309ms 749.893125ms 749.939204ms 749.942826ms 749.972995ms 750.021693ms 750.025005ms 750.054931ms 750.066795ms 750.092628ms 750.131332ms 750.141131ms 750.1564ms 750.183309ms 750.194238ms 750.197302ms 750.245ms 750.288526ms 750.289236ms 750.297498ms 750.304604ms 750.328839ms 750.655003ms 751.01921ms 751.722111ms 752.792846ms 753.298745ms 753.531113ms 753.905148ms 754.318757ms 755.243451ms 755.637832ms 755.699728ms 758.156563ms 758.215369ms 760.08345ms 761.935755ms 763.190766ms 763.9248ms 763.999785ms 767.680902ms 771.077797ms 789.004781ms 797.279034ms 798.285226ms 800.587259ms 826.872543ms 846.896335ms 864.989012ms 884.613797ms 949.127374ms 966.315948ms 1.022755491s 1.073950212s 1.101003128s 1.147018027s 1.173877141s 1.202239563s 1.252449179s 1.279827198s 1.349908199s]
+Apr 24 08:23:06.479: INFO: 50 %ile: 745.761576ms
+Apr 24 08:23:06.480: INFO: 90 %ile: 771.077797ms
+Apr 24 08:23:06.480: INFO: 99 %ile: 1.279827198s
+Apr 24 08:23:06.480: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:23:06.480: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-kbphj" for this suite.
+Apr 24 08:23:22.500: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:23:22.549: INFO: namespace: e2e-tests-svc-latency-kbphj, resource: bindings, ignored listing per whitelist
+Apr 24 08:23:22.623: INFO: namespace e2e-tests-svc-latency-kbphj deletion completed in 16.135162731s
+
+• [SLOW TEST:27.935 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:23:22.624: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-wrkb6
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-wrkb6 to expose endpoints map[]
+Apr 24 08:23:22.740: INFO: Get endpoints failed (2.701211ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Apr 24 08:23:23.743: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-wrkb6 exposes endpoints map[] (1.005326539s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-wrkb6
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-wrkb6 to expose endpoints map[pod1:[80]]
+Apr 24 08:23:26.773: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-wrkb6 exposes endpoints map[pod1:[80]] (3.024136033s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-wrkb6
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-wrkb6 to expose endpoints map[pod1:[80] pod2:[80]]
+Apr 24 08:23:29.810: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-wrkb6 exposes endpoints map[pod1:[80] pod2:[80]] (3.032542107s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-wrkb6
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-wrkb6 to expose endpoints map[pod2:[80]]
+Apr 24 08:23:30.103: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-wrkb6 exposes endpoints map[pod2:[80]] (26.834511ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-wrkb6
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-wrkb6 to expose endpoints map[]
+Apr 24 08:23:30.115: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-wrkb6 exposes endpoints map[] (7.32333ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:23:30.133: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-wrkb6" for this suite.
+Apr 24 08:23:52.161: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:23:52.250: INFO: namespace: e2e-tests-services-wrkb6, resource: bindings, ignored listing per whitelist
+Apr 24 08:23:52.284: INFO: namespace e2e-tests-services-wrkb6 deletion completed in 22.141662416s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:29.660 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:23:52.284: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Apr 24 08:23:52.397: INFO: Waiting up to 5m0s for pod "pod-d250af3d-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-thwcg" to be "success or failure"
+Apr 24 08:23:52.407: INFO: Pod "pod-d250af3d-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 9.925439ms
+Apr 24 08:23:54.411: INFO: Pod "pod-d250af3d-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013692883s
+Apr 24 08:23:56.415: INFO: Pod "pod-d250af3d-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017367334s
+STEP: Saw pod success
+Apr 24 08:23:56.415: INFO: Pod "pod-d250af3d-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:23:56.417: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-d250af3d-4798-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:23:56.436: INFO: Waiting for pod pod-d250af3d-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:23:56.442: INFO: Pod pod-d250af3d-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:23:56.442: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-thwcg" for this suite.
+Apr 24 08:24:02.459: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:24:02.529: INFO: namespace: e2e-tests-emptydir-thwcg, resource: bindings, ignored listing per whitelist
+Apr 24 08:24:02.584: INFO: namespace e2e-tests-emptydir-thwcg deletion completed in 6.134108991s
+
+• [SLOW TEST:10.300 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:24:02.584: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-kk76p.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-kk76p.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-kk76p.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-kk76p.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-kk76p.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-kk76p.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Apr 24 08:24:17.758: INFO: DNS probes using dns-test-d873fa48-4798-11e8-bf16-a2a292742988 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:24:17.781: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-kk76p" for this suite.
+Apr 24 08:24:23.808: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:24:23.849: INFO: namespace: e2e-tests-dns-kk76p, resource: bindings, ignored listing per whitelist
+Apr 24 08:24:23.973: INFO: namespace e2e-tests-dns-kk76p deletion completed in 6.175591647s
+
+• [SLOW TEST:21.389 seconds]
+[sig-network] DNS
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:24:23.973: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 24 08:24:24.076: INFO: Waiting up to 5m0s for pod "downward-api-e5329de7-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-mrzls" to be "success or failure"
+Apr 24 08:24:24.084: INFO: Pod "downward-api-e5329de7-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 7.088029ms
+Apr 24 08:24:26.087: INFO: Pod "downward-api-e5329de7-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01017019s
+Apr 24 08:24:28.091: INFO: Pod "downward-api-e5329de7-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014828112s
+STEP: Saw pod success
+Apr 24 08:24:28.091: INFO: Pod "downward-api-e5329de7-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:24:28.094: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downward-api-e5329de7-4798-11e8-bf16-a2a292742988 container dapi-container: <nil>
+STEP: delete the pod
+Apr 24 08:24:28.134: INFO: Waiting for pod downward-api-e5329de7-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:24:28.143: INFO: Pod downward-api-e5329de7-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:24:28.143: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-mrzls" for this suite.
+Apr 24 08:24:34.191: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:24:34.303: INFO: namespace: e2e-tests-downward-api-mrzls, resource: bindings, ignored listing per whitelist
+Apr 24 08:24:34.321: INFO: namespace e2e-tests-downward-api-mrzls deletion completed in 6.174490692s
+
+• [SLOW TEST:10.348 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:24:34.322: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Apr 24 08:24:34.435: INFO: Waiting up to 5m0s for pod "pod-eb5eaceb-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-9lt6f" to be "success or failure"
+Apr 24 08:24:34.438: INFO: Pod "pod-eb5eaceb-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.801812ms
+Apr 24 08:24:36.442: INFO: Pod "pod-eb5eaceb-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006730262s
+STEP: Saw pod success
+Apr 24 08:24:36.442: INFO: Pod "pod-eb5eaceb-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:24:36.445: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-eb5eaceb-4798-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:24:36.472: INFO: Waiting for pod pod-eb5eaceb-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:24:36.478: INFO: Pod pod-eb5eaceb-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:24:36.478: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-9lt6f" for this suite.
+Apr 24 08:24:42.502: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:24:42.576: INFO: namespace: e2e-tests-emptydir-9lt6f, resource: bindings, ignored listing per whitelist
+Apr 24 08:24:42.628: INFO: namespace e2e-tests-emptydir-9lt6f deletion completed in 6.140558109s
+
+• [SLOW TEST:8.306 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:24:42.628: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-f0518620-4798-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume secrets
+Apr 24 08:24:42.739: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-f05286fe-4798-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-s5qcp" to be "success or failure"
+Apr 24 08:24:42.743: INFO: Pod "pod-projected-secrets-f05286fe-4798-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.112412ms
+Apr 24 08:24:44.747: INFO: Pod "pod-projected-secrets-f05286fe-4798-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007994455s
+STEP: Saw pod success
+Apr 24 08:24:44.747: INFO: Pod "pod-projected-secrets-f05286fe-4798-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:24:44.750: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-projected-secrets-f05286fe-4798-11e8-bf16-a2a292742988 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:24:44.768: INFO: Waiting for pod pod-projected-secrets-f05286fe-4798-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:24:44.774: INFO: Pod pod-projected-secrets-f05286fe-4798-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:24:44.774: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-s5qcp" for this suite.
+Apr 24 08:24:50.795: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:24:50.911: INFO: namespace: e2e-tests-projected-s5qcp, resource: bindings, ignored listing per whitelist
+Apr 24 08:24:50.924: INFO: namespace e2e-tests-projected-s5qcp deletion completed in 6.146612895s
+
+• [SLOW TEST:8.295 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:24:50.924: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 24 08:24:51.038: INFO: Creating ReplicaSet my-hostname-basic-f545a9d5-4798-11e8-bf16-a2a292742988
+Apr 24 08:24:51.046: INFO: Pod name my-hostname-basic-f545a9d5-4798-11e8-bf16-a2a292742988: Found 0 pods out of 1
+Apr 24 08:24:56.053: INFO: Pod name my-hostname-basic-f545a9d5-4798-11e8-bf16-a2a292742988: Found 1 pods out of 1
+Apr 24 08:24:56.053: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-f545a9d5-4798-11e8-bf16-a2a292742988" is running
+Apr 24 08:24:56.055: INFO: Pod "my-hostname-basic-f545a9d5-4798-11e8-bf16-a2a292742988-xk4mx" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-24 08:24:51 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-24 08:24:52 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-24 08:24:51 +0000 UTC Reason: Message:}])
+Apr 24 08:24:56.055: INFO: Trying to dial the pod
+Apr 24 08:25:01.117: INFO: Controller my-hostname-basic-f545a9d5-4798-11e8-bf16-a2a292742988: Got expected result from replica 1 [my-hostname-basic-f545a9d5-4798-11e8-bf16-a2a292742988-xk4mx]: "my-hostname-basic-f545a9d5-4798-11e8-bf16-a2a292742988-xk4mx", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:25:01.118: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-fmtnd" for this suite.
+Apr 24 08:25:07.131: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:25:07.181: INFO: namespace: e2e-tests-replicaset-fmtnd, resource: bindings, ignored listing per whitelist
+Apr 24 08:25:07.252: INFO: namespace e2e-tests-replicaset-fmtnd deletion completed in 6.131733697s
+
+• [SLOW TEST:16.329 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:25:07.253: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-fb297
+[It] Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Looking for a node to schedule stateful set and pod
+STEP: Creating pod with conflicting port in namespace e2e-tests-statefulset-fb297
+STEP: Creating statefulset with conflicting port in namespace e2e-tests-statefulset-fb297
+STEP: Waiting until pod test-pod will start running in namespace e2e-tests-statefulset-fb297
+STEP: Waiting until stateful pod ss-0 will be recreated and deleted at least once in namespace e2e-tests-statefulset-fb297
+Apr 24 08:25:11.389: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-fb297, name: ss-0, uid: 00f04386-4799-11e8-a903-52bf91b907ea, status phase: Pending. Waiting for statefulset controller to delete.
+Apr 24 08:25:11.988: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-fb297, name: ss-0, uid: 00f04386-4799-11e8-a903-52bf91b907ea, status phase: Failed. Waiting for statefulset controller to delete.
+Apr 24 08:25:11.993: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-fb297, name: ss-0, uid: 00f04386-4799-11e8-a903-52bf91b907ea, status phase: Failed. Waiting for statefulset controller to delete.
+Apr 24 08:25:12.020: INFO: Observed delete event for stateful pod ss-0 in namespace e2e-tests-statefulset-fb297
+STEP: Removing pod with conflicting port in namespace e2e-tests-statefulset-fb297
+STEP: Waiting when stateful pod ss-0 will be recreated in namespace e2e-tests-statefulset-fb297 and will be in running state
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 24 08:25:16.049: INFO: Deleting all statefulset in ns e2e-tests-statefulset-fb297
+Apr 24 08:25:16.051: INFO: Scaling statefulset ss to 0
+Apr 24 08:25:26.065: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 24 08:25:26.071: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:25:26.089: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-fb297" for this suite.
+Apr 24 08:25:32.103: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:25:32.230: INFO: namespace: e2e-tests-statefulset-fb297, resource: bindings, ignored listing per whitelist
+Apr 24 08:25:32.284: INFO: namespace e2e-tests-statefulset-fb297 deletion completed in 6.191348645s
+
+• [SLOW TEST:25.031 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Should recreate evicted statefulset [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:25:32.284: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:25:32.389: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-47d72" for this suite.
+Apr 24 08:25:54.422: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:25:54.487: INFO: namespace: e2e-tests-pods-47d72, resource: bindings, ignored listing per whitelist
+Apr 24 08:25:54.573: INFO: namespace e2e-tests-pods-47d72 deletion completed in 22.179263726s
+
+• [SLOW TEST:22.290 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:25:54.573: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 24 08:25:54.721: INFO: Waiting up to 5m0s for pod "downward-api-1b3a0cf4-4799-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-2fwvj" to be "success or failure"
+Apr 24 08:25:54.724: INFO: Pod "downward-api-1b3a0cf4-4799-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.345909ms
+Apr 24 08:25:56.727: INFO: Pod "downward-api-1b3a0cf4-4799-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005268548s
+Apr 24 08:25:58.730: INFO: Pod "downward-api-1b3a0cf4-4799-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008529348s
+STEP: Saw pod success
+Apr 24 08:25:58.730: INFO: Pod "downward-api-1b3a0cf4-4799-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:25:58.732: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downward-api-1b3a0cf4-4799-11e8-bf16-a2a292742988 container dapi-container: <nil>
+STEP: delete the pod
+Apr 24 08:25:58.759: INFO: Waiting for pod downward-api-1b3a0cf4-4799-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:25:58.762: INFO: Pod downward-api-1b3a0cf4-4799-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:25:58.762: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-2fwvj" for this suite.
+Apr 24 08:26:04.778: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:26:04.833: INFO: namespace: e2e-tests-downward-api-2fwvj, resource: bindings, ignored listing per whitelist
+Apr 24 08:26:04.913: INFO: namespace e2e-tests-downward-api-2fwvj deletion completed in 6.14705277s
+
+• [SLOW TEST:10.340 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:26:04.915: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-7d9q8
+Apr 24 08:26:09.027: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-7d9q8
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 24 08:26:09.030: INFO: Initial restart count of pod liveness-http is 0
+Apr 24 08:26:27.062: INFO: Restart count of pod e2e-tests-container-probe-7d9q8/liveness-http is now 1 (18.031891842s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:26:27.072: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-7d9q8" for this suite.
+Apr 24 08:26:33.096: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:26:33.156: INFO: namespace: e2e-tests-container-probe-7d9q8, resource: bindings, ignored listing per whitelist
+Apr 24 08:26:33.233: INFO: namespace e2e-tests-container-probe-7d9q8 deletion completed in 6.157743564s
+
+• [SLOW TEST:28.319 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:26:33.235: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-xq4vz
+[It] should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a new StatefulSet
+Apr 24 08:26:33.394: INFO: Found 0 stateful pods, waiting for 3
+Apr 24 08:26:43.397: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 24 08:26:43.398: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 24 08:26:43.398: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+Apr 24 08:26:43.405: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-xq4vz ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 24 08:26:43.743: INFO: stderr: ""
+Apr 24 08:26:43.743: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+STEP: Updating StatefulSet template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Apr 24 08:26:53.793: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Updating Pods in reverse ordinal order
+Apr 24 08:27:03.824: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-xq4vz ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 24 08:27:04.123: INFO: stderr: ""
+Apr 24 08:27:04.123: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 24 08:27:24.139: INFO: Waiting for StatefulSet e2e-tests-statefulset-xq4vz/ss2 to complete update
+Apr 24 08:27:24.139: INFO: Waiting for Pod e2e-tests-statefulset-xq4vz/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Rolling back to a previous revision
+Apr 24 08:27:34.145: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-xq4vz ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 24 08:27:35.132: INFO: stderr: ""
+Apr 24 08:27:35.132: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 24 08:27:45.163: INFO: Updating stateful set ss2
+STEP: Rolling back update in reverse ordinal order
+Apr 24 08:27:55.178: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-403291544 exec --namespace=e2e-tests-statefulset-xq4vz ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 24 08:27:55.504: INFO: stderr: ""
+Apr 24 08:27:55.504: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 24 08:28:15.524: INFO: Waiting for StatefulSet e2e-tests-statefulset-xq4vz/ss2 to complete update
+Apr 24 08:28:15.524: INFO: Waiting for Pod e2e-tests-statefulset-xq4vz/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 24 08:28:25.531: INFO: Deleting all statefulset in ns e2e-tests-statefulset-xq4vz
+Apr 24 08:28:25.533: INFO: Scaling statefulset ss2 to 0
+Apr 24 08:28:55.549: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 24 08:28:55.551: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:28:55.563: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-xq4vz" for this suite.
+Apr 24 08:29:01.578: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:29:01.625: INFO: namespace: e2e-tests-statefulset-xq4vz, resource: bindings, ignored listing per whitelist
+Apr 24 08:29:01.705: INFO: namespace e2e-tests-statefulset-xq4vz deletion completed in 6.137129412s
+
+• [SLOW TEST:148.470 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should perform rolling updates and roll backs of template modifications [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:29:01.707: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-8abce151-4799-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 08:29:01.823: INFO: Waiting up to 5m0s for pod "pod-configmaps-8abf7c70-4799-11e8-bf16-a2a292742988" in namespace "e2e-tests-configmap-spb6z" to be "success or failure"
+Apr 24 08:29:01.827: INFO: Pod "pod-configmaps-8abf7c70-4799-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.627719ms
+Apr 24 08:29:03.830: INFO: Pod "pod-configmaps-8abf7c70-4799-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007434297s
+STEP: Saw pod success
+Apr 24 08:29:03.830: INFO: Pod "pod-configmaps-8abf7c70-4799-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:29:03.832: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-configmaps-8abf7c70-4799-11e8-bf16-a2a292742988 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 24 08:29:03.861: INFO: Waiting for pod pod-configmaps-8abf7c70-4799-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:29:03.872: INFO: Pod pod-configmaps-8abf7c70-4799-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:29:03.872: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-spb6z" for this suite.
+Apr 24 08:29:09.895: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:29:09.949: INFO: namespace: e2e-tests-configmap-spb6z, resource: bindings, ignored listing per whitelist
+Apr 24 08:29:10.023: INFO: namespace e2e-tests-configmap-spb6z deletion completed in 6.142439352s
+
+• [SLOW TEST:8.317 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:29:10.027: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:29:10.137: INFO: Waiting up to 5m0s for pod "downwardapi-volume-8fb443ef-4799-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-zbvbp" to be "success or failure"
+Apr 24 08:29:10.145: INFO: Pod "downwardapi-volume-8fb443ef-4799-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 7.47573ms
+Apr 24 08:29:12.148: INFO: Pod "downwardapi-volume-8fb443ef-4799-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010798375s
+STEP: Saw pod success
+Apr 24 08:29:12.148: INFO: Pod "downwardapi-volume-8fb443ef-4799-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:29:12.153: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-8fb443ef-4799-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:29:12.190: INFO: Waiting for pod downwardapi-volume-8fb443ef-4799-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:29:12.193: INFO: Pod downwardapi-volume-8fb443ef-4799-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:29:12.193: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-zbvbp" for this suite.
+Apr 24 08:29:18.209: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:29:18.337: INFO: namespace: e2e-tests-downward-api-zbvbp, resource: bindings, ignored listing per whitelist
+Apr 24 08:29:18.344: INFO: namespace e2e-tests-downward-api-zbvbp deletion completed in 6.14773988s
+
+• [SLOW TEST:8.318 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:29:18.347: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:29:18.465: INFO: Waiting up to 5m0s for pod "downwardapi-volume-94ab2361-4799-11e8-bf16-a2a292742988" in namespace "e2e-tests-projected-fmgzr" to be "success or failure"
+Apr 24 08:29:18.470: INFO: Pod "downwardapi-volume-94ab2361-4799-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 4.260719ms
+Apr 24 08:29:20.473: INFO: Pod "downwardapi-volume-94ab2361-4799-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007333504s
+STEP: Saw pod success
+Apr 24 08:29:20.473: INFO: Pod "downwardapi-volume-94ab2361-4799-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:29:20.475: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-94ab2361-4799-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:29:20.497: INFO: Waiting for pod downwardapi-volume-94ab2361-4799-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:29:20.500: INFO: Pod downwardapi-volume-94ab2361-4799-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:29:20.508: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fmgzr" for this suite.
+Apr 24 08:29:26.527: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:29:26.634: INFO: namespace: e2e-tests-projected-fmgzr, resource: bindings, ignored listing per whitelist
+Apr 24 08:29:26.648: INFO: namespace e2e-tests-projected-fmgzr deletion completed in 6.132491745s
+
+• [SLOW TEST:8.301 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:29:26.652: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-999ce862-4799-11e8-bf16-a2a292742988,GenerateName:,Namespace:e2e-tests-events-qr9kg,SelfLink:/api/v1/namespaces/e2e-tests-events-qr9kg/pods/send-events-999ce862-4799-11e8-bf16-a2a292742988,UID:999dafbd-4799-11e8-a903-52bf91b907ea,ResourceVersion:10678,Generation:0,CreationTimestamp:2018-04-24 08:29:26 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 756572094,},Annotations:map[string]string{cni.projectcalico.org/podIP: 100.96.1.175/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-zs57c {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-zs57c,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-zs57c true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc421633530} {node.kubernetes.io/unreachable Exists  NoExecute 0xc421633550}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:29:26 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:29:28 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-24 08:29:26 +0000 UTC  }],Message:,Reason:,HostIP:10.250.0.4,PodIP:100.96.1.175,StartTime:2018-04-24 08:29:26 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-04-24 08:29:28 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://6d38ffd794446de39e5d838db6de97860cc2627dc4fa6e36dd1d1e2b08d21694}],QOSClass:BestEffort,InitContainerStatuses:[],NominatedNodeName:,},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:29:32.791: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-qr9kg" for this suite.
+Apr 24 08:29:38.810: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:29:38.878: INFO: namespace: e2e-tests-events-qr9kg, resource: bindings, ignored listing per whitelist
+Apr 24 08:29:38.942: INFO: namespace e2e-tests-events-qr9kg deletion completed in 6.142239077s
+
+• [SLOW TEST:12.290 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:29:38.944: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Apr 24 08:29:39.044: INFO: Waiting up to 5m0s for pod "pod-a0eef1b2-4799-11e8-bf16-a2a292742988" in namespace "e2e-tests-emptydir-tl6tz" to be "success or failure"
+Apr 24 08:29:39.047: INFO: Pod "pod-a0eef1b2-4799-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.446014ms
+Apr 24 08:29:41.053: INFO: Pod "pod-a0eef1b2-4799-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009210969s
+STEP: Saw pod success
+Apr 24 08:29:41.053: INFO: Pod "pod-a0eef1b2-4799-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:29:41.055: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-a0eef1b2-4799-11e8-bf16-a2a292742988 container test-container: <nil>
+STEP: delete the pod
+Apr 24 08:29:41.085: INFO: Waiting for pod pod-a0eef1b2-4799-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:29:41.088: INFO: Pod pod-a0eef1b2-4799-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:29:41.088: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-tl6tz" for this suite.
+Apr 24 08:29:47.103: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:29:47.191: INFO: namespace: e2e-tests-emptydir-tl6tz, resource: bindings, ignored listing per whitelist
+Apr 24 08:29:47.246: INFO: namespace e2e-tests-emptydir-tl6tz deletion completed in 6.156291005s
+
+• [SLOW TEST:8.303 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:29:47.249: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap e2e-tests-configmap-7t6tp/configmap-test-a5e35b2f-4799-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 08:29:47.361: INFO: Waiting up to 5m0s for pod "pod-configmaps-a5e41637-4799-11e8-bf16-a2a292742988" in namespace "e2e-tests-configmap-7t6tp" to be "success or failure"
+Apr 24 08:29:47.365: INFO: Pod "pod-configmaps-a5e41637-4799-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 3.773715ms
+Apr 24 08:29:49.370: INFO: Pod "pod-configmaps-a5e41637-4799-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008850684s
+Apr 24 08:29:51.374: INFO: Pod "pod-configmaps-a5e41637-4799-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012728222s
+STEP: Saw pod success
+Apr 24 08:29:51.374: INFO: Pod "pod-configmaps-a5e41637-4799-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:29:51.377: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-configmaps-a5e41637-4799-11e8-bf16-a2a292742988 container env-test: <nil>
+STEP: delete the pod
+Apr 24 08:29:51.409: INFO: Waiting for pod pod-configmaps-a5e41637-4799-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:29:51.412: INFO: Pod pod-configmaps-a5e41637-4799-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:29:51.412: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-7t6tp" for this suite.
+Apr 24 08:29:57.437: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:29:57.546: INFO: namespace: e2e-tests-configmap-7t6tp, resource: bindings, ignored listing per whitelist
+Apr 24 08:29:57.572: INFO: namespace e2e-tests-configmap-7t6tp deletion completed in 6.146848169s
+
+• [SLOW TEST:10.324 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:29:57.574: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap e2e-tests-configmap-75dc4/configmap-test-ac0b8940-4799-11e8-bf16-a2a292742988
+STEP: Creating a pod to test consume configMaps
+Apr 24 08:29:57.693: INFO: Waiting up to 5m0s for pod "pod-configmaps-ac0c1a74-4799-11e8-bf16-a2a292742988" in namespace "e2e-tests-configmap-75dc4" to be "success or failure"
+Apr 24 08:29:57.699: INFO: Pod "pod-configmaps-ac0c1a74-4799-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 6.317327ms
+Apr 24 08:29:59.702: INFO: Pod "pod-configmaps-ac0c1a74-4799-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009502503s
+Apr 24 08:30:01.706: INFO: Pod "pod-configmaps-ac0c1a74-4799-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012818948s
+STEP: Saw pod success
+Apr 24 08:30:01.706: INFO: Pod "pod-configmaps-ac0c1a74-4799-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:30:01.708: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod pod-configmaps-ac0c1a74-4799-11e8-bf16-a2a292742988 container env-test: <nil>
+STEP: delete the pod
+Apr 24 08:30:01.737: INFO: Waiting for pod pod-configmaps-ac0c1a74-4799-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:30:01.749: INFO: Pod pod-configmaps-ac0c1a74-4799-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:30:01.749: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-75dc4" for this suite.
+Apr 24 08:30:07.785: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:30:07.892: INFO: namespace: e2e-tests-configmap-75dc4, resource: bindings, ignored listing per whitelist
+Apr 24 08:30:07.903: INFO: namespace e2e-tests-configmap-75dc4 deletion completed in 6.150959207s
+
+• [SLOW TEST:10.330 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:30:07.906: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 24 08:30:08.014: INFO: Waiting up to 5m0s for pod "downwardapi-volume-b2320627-4799-11e8-bf16-a2a292742988" in namespace "e2e-tests-downward-api-wb25k" to be "success or failure"
+Apr 24 08:30:08.023: INFO: Pod "downwardapi-volume-b2320627-4799-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 8.753436ms
+Apr 24 08:30:10.039: INFO: Pod "downwardapi-volume-b2320627-4799-11e8-bf16-a2a292742988": Phase="Pending", Reason="", readiness=false. Elapsed: 2.025096378s
+Apr 24 08:30:12.042: INFO: Pod "downwardapi-volume-b2320627-4799-11e8-bf16-a2a292742988": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.027975671s
+STEP: Saw pod success
+Apr 24 08:30:12.042: INFO: Pod "downwardapi-volume-b2320627-4799-11e8-bf16-a2a292742988" satisfied condition "success or failure"
+Apr 24 08:30:12.044: INFO: Trying to get logs from node shoot-core-cncf-az-worker-gumvp-7bdb694675-ml5p7 pod downwardapi-volume-b2320627-4799-11e8-bf16-a2a292742988 container client-container: <nil>
+STEP: delete the pod
+Apr 24 08:30:12.063: INFO: Waiting for pod downwardapi-volume-b2320627-4799-11e8-bf16-a2a292742988 to disappear
+Apr 24 08:30:12.076: INFO: Pod downwardapi-volume-b2320627-4799-11e8-bf16-a2a292742988 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:30:12.076: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-wb25k" for this suite.
+Apr 24 08:30:18.177: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:30:18.276: INFO: namespace: e2e-tests-downward-api-wb25k, resource: bindings, ignored listing per whitelist
+Apr 24 08:30:18.301: INFO: namespace e2e-tests-downward-api-wb25k deletion completed in 6.222055449s
+
+• [SLOW TEST:10.395 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:30:18.304: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-znvqc
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 24 08:30:18.781: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 24 08:30:41.093: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.181:8080/dial?request=hostName&protocol=http&host=100.96.0.43&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-znvqc PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 08:30:41.093: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 08:30:41.510: INFO: Waiting for endpoints: map[]
+Apr 24 08:30:41.512: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.181:8080/dial?request=hostName&protocol=http&host=100.96.1.180&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-znvqc PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 24 08:30:41.512: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+Apr 24 08:30:41.760: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:30:41.760: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-znvqc" for this suite.
+Apr 24 08:31:03.775: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:31:03.892: INFO: namespace: e2e-tests-pod-network-test-znvqc, resource: bindings, ignored listing per whitelist
+Apr 24 08:31:03.901: INFO: namespace e2e-tests-pod-network-test-znvqc deletion completed in 22.138653011s
+
+• [SLOW TEST:45.598 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 24 08:31:03.902: INFO: >>> kubeConfig: /tmp/kubeconfig-403291544
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-4k829
+Apr 24 08:31:06.017: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-4k829
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 24 08:31:06.019: INFO: Initial restart count of pod liveness-http is 0
+Apr 24 08:31:20.050: INFO: Restart count of pod e2e-tests-container-probe-4k829/liveness-http is now 1 (14.03065565s elapsed)
+Apr 24 08:31:40.081: INFO: Restart count of pod e2e-tests-container-probe-4k829/liveness-http is now 2 (34.061859952s elapsed)
+Apr 24 08:32:00.113: INFO: Restart count of pod e2e-tests-container-probe-4k829/liveness-http is now 3 (54.093623323s elapsed)
+Apr 24 08:32:20.145: INFO: Restart count of pod e2e-tests-container-probe-4k829/liveness-http is now 4 (1m14.125327885s elapsed)
+Apr 24 08:32:40.182: INFO: Restart count of pod e2e-tests-container-probe-4k829/liveness-http is now 5 (1m34.162449078s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 24 08:32:40.215: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-4k829" for this suite.
+Apr 24 08:32:46.242: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 24 08:32:46.310: INFO: namespace: e2e-tests-container-probe-4k829, resource: bindings, ignored listing per whitelist
+Apr 24 08:32:46.367: INFO: namespace e2e-tests-container-probe-4k829 deletion completed in 6.138284322s
+
+• [SLOW TEST:102.464 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSApr 24 08:32:46.367: INFO: Running AfterSuite actions on all node
+Apr 24 08:32:46.367: INFO: Running AfterSuite actions on node 1
+Apr 24 08:32:46.367: INFO: Skipping dumping logs from cluster
+
+Ran 139 of 836 Specs in 3685.707 seconds
+SUCCESS! -- 139 Passed | 0 Failed | 0 Pending | 697 Skipped PASS
+
+Ginkgo ran 1 suite in 1h1m26.155410572s
+Test Suite Passed

--- a/v1.10/sap-cp-azure/junit_01.xml
+++ b/v1.10/sap-cp-azure/junit_01.xml
@@ -1,0 +1,2233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="139" failures="0" time="3685.706693806">
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should support configurable pod resolv.conf" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="10.373780033"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications [Conformance]" classname="Kubernetes e2e suite" time="106.561085778"></testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [Conformance]" classname="Kubernetes e2e suite" time="8.323352928"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="10.300025363"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="52.927098922"></testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.24840636"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout  [Conformance]" classname="Kubernetes e2e suite" time="6.260762418">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]" classname="Kubernetes e2e suite" time="10.520798408"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.367559648"></testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated  [Conformance]" classname="Kubernetes e2e suite" time="12.80535974"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]" classname="Kubernetes e2e suite" time="83.416707661"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="87.673342879"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="12.324919833"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support proportional scaling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.261739546">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="6.862837462"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="10.331188289"></testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="45.12456789"></testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="10.303682699"></testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD [Feature:RegionalPD] RegionalPD should failover to a different zone when all nodes in one zone become unreachable [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor using proxy subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]" classname="Kubernetes e2e suite" time="12.315577425"></testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank  [Conformance]" classname="Kubernetes e2e suite" time="10.34560344"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="55.363342285"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify &#34;immediate&#34; deletion of a PVC that is not in active use by a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification  [Conformance]" classname="Kubernetes e2e suite" time="26.788243819"></testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="90.587776117"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="18.972261188"></testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="10.399100107"></testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [Conformance]" classname="Kubernetes e2e suite" time="8.317576797"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [Conformance]" classname="Kubernetes e2e suite" time="26.815147581"></testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request  [Conformance]" classname="Kubernetes e2e suite" time="10.347174887"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner deletion should be idempotent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]" classname="Kubernetes e2e suite" time="28.377620602"></testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="96.813803519"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with downward pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file  [Conformance]" classname="Kubernetes e2e suite" time="79.29495587"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="10.365603852"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services  [Conformance]" classname="Kubernetes e2e suite" time="32.335541139"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="10.299460474"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="29.019740095"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]" classname="Kubernetes e2e suite" time="8.31392653"></testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.380826784"></testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [Conformance]" classname="Kubernetes e2e suite" time="10.335967824"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]" classname="Kubernetes e2e suite" time="105.800550873"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="10.303562031"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [Conformance]" classname="Kubernetes e2e suite" time="10.295797515"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.31252034"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="117.996457482"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that a pod with an invalid NodeAffinity is rejected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.328063554"></testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection] [Conformance]" classname="Kubernetes e2e suite" time="10.41584564"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.319448525"></testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="105.272077519"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command (docker entrypoint)  [Conformance]" classname="Kubernetes e2e suite" time="10.301424078"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.347457092"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]" classname="Kubernetes e2e suite" time="34.400157248"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.54416649"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.39430188"></testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="60.421417817"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="10.291322617"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable  [Conformance]" classname="Kubernetes e2e suite" time="10.790692302"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart  [Conformance]" classname="Kubernetes e2e suite" time="82.243155586"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate crd" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  StatefulSet with pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with projected pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [Conformance]" classname="Kubernetes e2e suite" time="10.320694697"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.459662753"></testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="14.05550895"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.357430231"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file  [Conformance]" classname="Kubernetes e2e suite" time="10.318779637"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Stress with local volume provisioner [Serial] should use be able to process many pods and reuse local volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="22.822928887"></testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="10.317604258"></testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [DisabledForLargeClusters] kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with backside re-encryption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.335642336"></testcase>
+      <testcase name="[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive] node unregister" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pv count metrics for pvc controller after creating pv only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.431246681"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap binary data should be reflected in volume " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="128.508735326"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd)  [Conformance]" classname="Kubernetes e2e suite" time="10.349751655"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="10.315970766"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set  [Conformance]" classname="Kubernetes e2e suite" time="10.303493447"></testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args  [Conformance]" classname="Kubernetes e2e suite" time="12.291882205"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify that PV bound to a PVC is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.315776186"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create none metrics for pvc controller before creating any PV or PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods [Conformance]" classname="Kubernetes e2e suite" time="68.119963027"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.336428211"></testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="31.027318518"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="29.446911442"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle [Conformance]" classname="Kubernetes e2e suite" time="11.317836374"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 Scalability GCE [Slow] [Serial] [Feature:IngressScale] Creating and updating ingresses should happen promptly with small/medium/large amount of ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="130.766448799"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated  [Conformance]" classname="Kubernetes e2e suite" time="24.830598457"></testcase>
+      <testcase name="[sig-storage] Regional PD [Feature:RegionalPD] RegionalPD should provision storage [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="10.304986918"></testcase>
+      <testcase name="[sig-storage] CSI Volumes [Feature:CSI] Sanity CSI plugin test using hostPath CSI driver should provision storage with a hostPath CSI driver" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="10.297601219"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [Conformance]" classname="Kubernetes e2e suite" time="8.296888812"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Upgrade [Feature:IngressUpgrade] ingress upgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command  [Conformance]" classname="Kubernetes e2e suite" time="10.329353545"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume expand [Feature:ExpandPersistentVolumes] [Slow] Verify if editing PVC allows resize" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="108.479325537"></testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existent secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Downgrade [Feature:IngressDowngrade] ingress downgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [Conformance]" classname="Kubernetes e2e suite" time="10.289521194"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod  [Conformance]" classname="Kubernetes e2e suite" time="10.321081621"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.290617457"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [Conformance]" classname="Kubernetes e2e suite" time="8.30041927"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="29.672556706"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.345984768"></testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have accelerator metrics [Feature:StackdriverAcceleratorMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP  [Conformance]" classname="Kubernetes e2e suite" time="30.247731645000002"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.847735692"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so [Conformance]" classname="Kubernetes e2e suite" time="46.488594715"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.370221213"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should not be able to prevent deleting validating-webhook-configurations or mutating-webhook-configurations" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [Conformance]" classname="Kubernetes e2e suite" time="28.931994831"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates lower priority pod preemption by critical pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="16.267456072"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.497763092"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod  [Conformance]" classname="Kubernetes e2e suite" time="16.790408704"></testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments  [Conformance]" classname="Kubernetes e2e suite" time="10.321304537"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="10.341564867"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [Conformance]" classname="Kubernetes e2e suite" time="10.299170273"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="42.736136683"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with secret pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit  [Conformance]" classname="Kubernetes e2e suite" time="8.359393802"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [Conformance]" classname="Kubernetes e2e suite" time="8.327136158"></testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart  [Conformance]" classname="Kubernetes e2e suite" time="48.252473306"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods [Conformance]" classname="Kubernetes e2e suite" time="22.37857524"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="10.420523955"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var  [Conformance]" classname="Kubernetes e2e suite" time="12.321962796"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should not reconcile manually modified health check for ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files  [Conformance]" classname="Kubernetes e2e suite" time="12.461843290000001"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [Conformance]" classname="Kubernetes e2e suite" time="10.310463826"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.292709343"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that PVC in active use by a pod is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="10.36183128"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit  [Conformance]" classname="Kubernetes e2e suite" time="10.328545808"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]" classname="Kubernetes e2e suite" time="11.802600173"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="10.306935897"></testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="10.306882907"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification  [Conformance]" classname="Kubernetes e2e suite" time="28.805244647"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="7.326126982"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted [Conformance]" classname="Kubernetes e2e suite" time="16.501968009"></testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="27.935057605"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="29.660300785"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="10.300095925"></testcase>
+      <testcase name="[sig-storage] Mounted volume expand [Feature:ExpandPersistentVolumes] [Slow] Should verify mounted devices can be resized" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="21.3887354"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should update ingress while sync failures occur on other ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.347525348"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.306260139"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.295411016"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pvc count metrics for pvc controller after creating pvc only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.328677796"></testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset [Conformance]" classname="Kubernetes e2e suite" time="25.030825866"></testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.289555955"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.339787266"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="28.318578074"></testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance]" classname="Kubernetes e2e suite" time="148.470242015"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.316892327"></testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only  [Conformance]" classname="Kubernetes e2e suite" time="8.317639086"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [Conformance]" classname="Kubernetes e2e suite" time="8.300902455"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPU] run Nvidia GPU tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="12.290361506"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha docker/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.303006757"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.323709477"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable  [Conformance]" classname="Kubernetes e2e suite" time="10.329904976"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify &#34;immediate&#34; deletion of a PV that is not bound to a PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request  [Conformance]" classname="Kubernetes e2e suite" time="10.395234923"></testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="45.597934617"></testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count  [Slow] [Conformance]" classname="Kubernetes e2e suite" time="102.464491198"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.10/sap-cp-azure/version.txt
+++ b/v1.10/sap-cp-azure/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.1", GitCommit:"d4ab47518836c750f9949b9e0d387f20fb92260b", GitTreeState:"clean", BuildDate:"2018-04-12T14:26:04Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.1", GitCommit:"d4ab47518836c750f9949b9e0d387f20fb92260b", GitTreeState:"clean", BuildDate:"2018-04-12T14:14:26Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}

--- a/v1.10/sap-cp-gcp/PRODUCT.yaml
+++ b/v1.10/sap-cp-gcp/PRODUCT.yaml
@@ -1,0 +1,6 @@
+vendor: SAP
+name: Cloud Platform - Gardener (https://github.com/gardener/gardener) shoot cluster deployed on Google Cloud Platform
+version: 0.4.0
+website_url: https://cloudplatform.sap.com/index.html
+documentation_url: https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/
+product_logo_url: https://www.sap.com/dam/application/shared/logos/sap-logo-svg.svg

--- a/v1.10/sap-cp-gcp/README.md
+++ b/v1.10/sap-cp-gcp/README.md
@@ -1,0 +1,43 @@
+# To reproduce:
+
+## Create Kubernetes Cluster
+
+Login to SAP Gardener Dashboard to create a Kubernetes Clusters on Amazon Web Services, Microsoft Azure, Google Cloud Platform, or OpenStack cloud provider.
+
+After the creation completed, copy the cluster's kubeconfig, which is provided by the Gardener Dashboard in the cluster's detail view, to ~/.kube/config and launch the Kubernetes E2E conformance tests.
+
+## Launch E2E Conformance Tests
+1. Launch e2e pod and sonobuoy master under namespace `sonobuoy`   
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+    ```
+
+2. Check logs of `sonobuoy` pod to see when test can be finished   
+Run
+
+    ```shell
+    kubectl logs -f -n sonobuoy sonobuoy
+    ```
+    and wait for line `no-exit was specified, sonobuoy is now blocking`.
+
+3. Use `kubectl cp` to copy the results to the client   
+Get the name of the <result archive> from the log output in step 2.
+
+    ```shell
+    kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy/<result archive> /home/result
+    ```
+
+4. Delete the conformance test resources
+
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl delete -f -
+    ```
+
+5. Untar the tarball
+
+    ```shell
+    cd /home/result
+    tar -xzf *_sonobuoy_*.tar.gz
+    ```
+
+    The result files `e2e.log` and `junit_01.xml` are located in the in the directory `plugins/e2e/results/`.

--- a/v1.10/sap-cp-gcp/e2e.log
+++ b/v1.10/sap-cp-gcp/e2e.log
@@ -1,0 +1,6921 @@
+Apr 27 14:04:41.553: INFO: Overriding default scale value of zero to 1
+Apr 27 14:04:41.553: INFO: Overriding default milliseconds value of zero to 5000
+I0427 14:04:41.705034      17 test_context.go:358] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-590915753
+I0427 14:04:41.705169      17 e2e.go:333] Starting e2e run "ee28adb6-4a23-11e8-8194-02aee6f695c9" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1524837881 - Will randomize all specs
+Will run 141 of 836 specs
+
+Apr 27 14:04:41.782: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:04:41.784: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
+Apr 27 14:04:41.800: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 27 14:04:41.896: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 27 14:04:41.896: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 27 14:04:41.901: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 27 14:04:41.901: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Apr 27 14:04:41.905: INFO: e2e test version: v1.10.0
+Apr 27 14:04:41.907: INFO: kube-apiserver version: v1.10.1
+SSSSSSSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:04:41.907: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+Apr 27 14:04:41.984: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-ee769bb7-4a23-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:04:41.999: INFO: Waiting up to 5m0s for pod "pod-secrets-ee771971-4a23-11e8-8194-02aee6f695c9" in namespace "e2e-tests-secrets-gnhth" to be "success or failure"
+Apr 27 14:04:42.002: INFO: Pod "pod-secrets-ee771971-4a23-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.626441ms
+Apr 27 14:04:44.005: INFO: Pod "pod-secrets-ee771971-4a23-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006155838s
+Apr 27 14:04:46.013: INFO: Pod "pod-secrets-ee771971-4a23-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013677239s
+STEP: Saw pod success
+Apr 27 14:04:46.013: INFO: Pod "pod-secrets-ee771971-4a23-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:04:46.015: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-secrets-ee771971-4a23-11e8-8194-02aee6f695c9 container secret-env-test: <nil>
+STEP: delete the pod
+Apr 27 14:04:46.092: INFO: Waiting for pod pod-secrets-ee771971-4a23-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:04:46.095: INFO: Pod pod-secrets-ee771971-4a23-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:04:46.095: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-gnhth" for this suite.
+Apr 27 14:04:52.107: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:04:52.171: INFO: namespace: e2e-tests-secrets-gnhth, resource: bindings, ignored listing per whitelist
+Apr 27 14:04:52.223: INFO: namespace e2e-tests-secrets-gnhth deletion completed in 6.125278743s
+
+• [SLOW TEST:10.316 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:04:52.223: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-f49bdb77-4a23-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:04:52.304: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-f49c4895-4a23-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-pcxbn" to be "success or failure"
+Apr 27 14:04:52.306: INFO: Pod "pod-projected-secrets-f49c4895-4a23-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.151961ms
+Apr 27 14:04:54.309: INFO: Pod "pod-projected-secrets-f49c4895-4a23-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00558893s
+STEP: Saw pod success
+Apr 27 14:04:54.310: INFO: Pod "pod-projected-secrets-f49c4895-4a23-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:04:54.312: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-projected-secrets-f49c4895-4a23-11e8-8194-02aee6f695c9 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:04:54.387: INFO: Waiting for pod pod-projected-secrets-f49c4895-4a23-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:04:54.390: INFO: Pod pod-projected-secrets-f49c4895-4a23-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:04:54.390: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-pcxbn" for this suite.
+Apr 27 14:05:00.403: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:05:00.440: INFO: namespace: e2e-tests-projected-pcxbn, resource: bindings, ignored listing per whitelist
+Apr 27 14:05:00.527: INFO: namespace e2e-tests-projected-pcxbn deletion completed in 6.134111598s
+
+• [SLOW TEST:8.304 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:05:00.528: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-projected-all-test-volume-f98f710c-4a23-11e8-8194-02aee6f695c9
+STEP: Creating secret with name secret-projected-all-test-volume-f98f70dc-4a23-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Apr 27 14:05:00.615: INFO: Waiting up to 5m0s for pod "projected-volume-f98f70a8-4a23-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-rpf99" to be "success or failure"
+Apr 27 14:05:00.619: INFO: Pod "projected-volume-f98f70a8-4a23-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 3.418761ms
+Apr 27 14:05:02.622: INFO: Pod "projected-volume-f98f70a8-4a23-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007333851s
+Apr 27 14:05:04.626: INFO: Pod "projected-volume-f98f70a8-4a23-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010539572s
+STEP: Saw pod success
+Apr 27 14:05:04.626: INFO: Pod "projected-volume-f98f70a8-4a23-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:05:04.628: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod projected-volume-f98f70a8-4a23-11e8-8194-02aee6f695c9 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:05:04.649: INFO: Waiting for pod projected-volume-f98f70a8-4a23-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:05:04.654: INFO: Pod projected-volume-f98f70a8-4a23-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:05:04.654: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rpf99" for this suite.
+Apr 27 14:05:10.666: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:05:10.776: INFO: namespace: e2e-tests-projected-rpf99, resource: bindings, ignored listing per whitelist
+Apr 27 14:05:10.783: INFO: namespace e2e-tests-projected-rpf99 deletion completed in 6.126279684s
+
+• [SLOW TEST:10.256 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:05:10.783: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:05:10.861: INFO: Waiting up to 5m0s for pod "downward-api-ffabd495-4a23-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-t6qg8" to be "success or failure"
+Apr 27 14:05:10.864: INFO: Pod "downward-api-ffabd495-4a23-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.380512ms
+Apr 27 14:05:12.868: INFO: Pod "downward-api-ffabd495-4a23-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006211617s
+Apr 27 14:05:14.871: INFO: Pod "downward-api-ffabd495-4a23-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 4.009959411s
+Apr 27 14:05:16.878: INFO: Pod "downward-api-ffabd495-4a23-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.01646976s
+STEP: Saw pod success
+Apr 27 14:05:16.878: INFO: Pod "downward-api-ffabd495-4a23-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:05:16.881: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downward-api-ffabd495-4a23-11e8-8194-02aee6f695c9 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:05:16.899: INFO: Waiting for pod downward-api-ffabd495-4a23-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:05:16.902: INFO: Pod downward-api-ffabd495-4a23-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:05:16.902: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-t6qg8" for this suite.
+Apr 27 14:05:22.918: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:05:22.984: INFO: namespace: e2e-tests-downward-api-t6qg8, resource: bindings, ignored listing per whitelist
+Apr 27 14:05:23.033: INFO: namespace e2e-tests-downward-api-t6qg8 deletion completed in 6.125211306s
+
+• [SLOW TEST:12.250 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:05:23.034: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Apr 27 14:05:23.125: INFO: Waiting up to 5m0s for pod "pod-06fa2b5a-4a24-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-rnfbj" to be "success or failure"
+Apr 27 14:05:23.127: INFO: Pod "pod-06fa2b5a-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.329749ms
+Apr 27 14:05:25.131: INFO: Pod "pod-06fa2b5a-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006350676s
+Apr 27 14:05:27.138: INFO: Pod "pod-06fa2b5a-4a24-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013605654s
+STEP: Saw pod success
+Apr 27 14:05:27.138: INFO: Pod "pod-06fa2b5a-4a24-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:05:27.141: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-06fa2b5a-4a24-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:05:27.160: INFO: Waiting for pod pod-06fa2b5a-4a24-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:05:27.163: INFO: Pod pod-06fa2b5a-4a24-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:05:27.163: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-rnfbj" for this suite.
+Apr 27 14:05:33.175: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:05:33.254: INFO: namespace: e2e-tests-emptydir-rnfbj, resource: bindings, ignored listing per whitelist
+Apr 27 14:05:33.285: INFO: namespace e2e-tests-emptydir-rnfbj deletion completed in 6.118870086s
+
+• [SLOW TEST:10.251 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:05:33.285: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-0d15fc0c-4a24-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:05:33.370: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-0d167989-4a24-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-cch26" to be "success or failure"
+Apr 27 14:05:33.372: INFO: Pod "pod-projected-configmaps-0d167989-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 1.903243ms
+Apr 27 14:05:35.375: INFO: Pod "pod-projected-configmaps-0d167989-4a24-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005150345s
+STEP: Saw pod success
+Apr 27 14:05:35.375: INFO: Pod "pod-projected-configmaps-0d167989-4a24-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:05:35.377: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-projected-configmaps-0d167989-4a24-11e8-8194-02aee6f695c9 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:05:35.394: INFO: Waiting for pod pod-projected-configmaps-0d167989-4a24-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:05:35.396: INFO: Pod pod-projected-configmaps-0d167989-4a24-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:05:35.397: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-cch26" for this suite.
+Apr 27 14:05:41.409: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:05:41.485: INFO: namespace: e2e-tests-projected-cch26, resource: bindings, ignored listing per whitelist
+Apr 27 14:05:41.530: INFO: namespace e2e-tests-projected-cch26 deletion completed in 6.130701384s
+
+• [SLOW TEST:8.245 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:05:41.531: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:05:41.616: INFO: pod1.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod3", UID:"11fd9671-4a24-11e8-9870-221312dc233c", Controller:(*bool)(0xc421784066), BlockOwnerDeletion:(*bool)(0xc421784067)}}
+Apr 27 14:05:41.619: INFO: pod2.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod1", UID:"11fcb607-4a24-11e8-9870-221312dc233c", Controller:(*bool)(0xc4218402c6), BlockOwnerDeletion:(*bool)(0xc4218402c7)}}
+Apr 27 14:05:41.622: INFO: pod3.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod2", UID:"11fd2a2c-4a24-11e8-9870-221312dc233c", Controller:(*bool)(0xc420e354a6), BlockOwnerDeletion:(*bool)(0xc420e354a7)}}
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:05:46.629: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-jkt2p" for this suite.
+Apr 27 14:05:52.641: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:05:52.715: INFO: namespace: e2e-tests-gc-jkt2p, resource: bindings, ignored listing per whitelist
+Apr 27 14:05:52.769: INFO: namespace e2e-tests-gc-jkt2p deletion completed in 6.137312704s
+
+• [SLOW TEST:11.239 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:05:52.770: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override all
+Apr 27 14:05:52.855: INFO: Waiting up to 5m0s for pod "client-containers-18b39cb2-4a24-11e8-8194-02aee6f695c9" in namespace "e2e-tests-containers-z9c4g" to be "success or failure"
+Apr 27 14:05:52.858: INFO: Pod "client-containers-18b39cb2-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.466082ms
+Apr 27 14:05:54.861: INFO: Pod "client-containers-18b39cb2-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006145908s
+Apr 27 14:05:56.865: INFO: Pod "client-containers-18b39cb2-4a24-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009875349s
+STEP: Saw pod success
+Apr 27 14:05:56.865: INFO: Pod "client-containers-18b39cb2-4a24-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:05:56.868: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod client-containers-18b39cb2-4a24-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:05:56.884: INFO: Waiting for pod client-containers-18b39cb2-4a24-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:05:56.887: INFO: Pod client-containers-18b39cb2-4a24-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:05:56.887: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-z9c4g" for this suite.
+Apr 27 14:06:02.902: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:06:02.971: INFO: namespace: e2e-tests-containers-z9c4g, resource: bindings, ignored listing per whitelist
+Apr 27 14:06:03.016: INFO: namespace e2e-tests-containers-z9c4g deletion completed in 6.126125579s
+
+• [SLOW TEST:10.247 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:06:03.016: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:06:03.101: INFO: Creating simple daemon set daemon-set
+STEP: Check that daemon pods launch on every node of the cluster.
+Apr 27 14:06:03.111: INFO: Number of nodes with available pods: 0
+Apr 27 14:06:03.111: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:06:04.119: INFO: Number of nodes with available pods: 0
+Apr 27 14:06:04.119: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:06:05.119: INFO: Number of nodes with available pods: 0
+Apr 27 14:06:05.119: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:06:06.119: INFO: Number of nodes with available pods: 2
+Apr 27 14:06:06.119: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Update daemon pods image.
+STEP: Check that daemon pods images are updated.
+Apr 27 14:06:06.141: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:06.141: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:07.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:07.148: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:08.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:08.148: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:08.148: INFO: Pod daemon-set-pn72x is not available
+Apr 27 14:06:09.152: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:09.152: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:09.152: INFO: Pod daemon-set-pn72x is not available
+Apr 27 14:06:10.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:10.148: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:10.148: INFO: Pod daemon-set-pn72x is not available
+Apr 27 14:06:11.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:11.148: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:11.148: INFO: Pod daemon-set-pn72x is not available
+Apr 27 14:06:12.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:12.148: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:12.148: INFO: Pod daemon-set-pn72x is not available
+Apr 27 14:06:13.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:13.148: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:13.148: INFO: Pod daemon-set-pn72x is not available
+Apr 27 14:06:14.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:14.148: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:14.148: INFO: Pod daemon-set-pn72x is not available
+Apr 27 14:06:15.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:15.148: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:15.148: INFO: Pod daemon-set-pn72x is not available
+Apr 27 14:06:16.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:16.148: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:16.148: INFO: Pod daemon-set-pn72x is not available
+Apr 27 14:06:17.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:17.148: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:17.148: INFO: Pod daemon-set-pn72x is not available
+Apr 27 14:06:18.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:18.148: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:18.148: INFO: Pod daemon-set-pn72x is not available
+Apr 27 14:06:19.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:19.148: INFO: Wrong image for pod: daemon-set-pn72x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:19.148: INFO: Pod daemon-set-pn72x is not available
+Apr 27 14:06:20.152: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:20.153: INFO: Pod daemon-set-bgrb2 is not available
+Apr 27 14:06:21.147: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:21.147: INFO: Pod daemon-set-bgrb2 is not available
+Apr 27 14:06:22.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:22.148: INFO: Pod daemon-set-bgrb2 is not available
+Apr 27 14:06:23.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:24.148: INFO: Wrong image for pod: daemon-set-8bdzq. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:06:24.148: INFO: Pod daemon-set-8bdzq is not available
+Apr 27 14:06:25.149: INFO: Pod daemon-set-lq2nd is not available
+STEP: Check that daemon pods are still running on every node of the cluster.
+Apr 27 14:06:25.157: INFO: Number of nodes with available pods: 1
+Apr 27 14:06:25.157: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:06:26.166: INFO: Number of nodes with available pods: 1
+Apr 27 14:06:26.166: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:06:27.165: INFO: Number of nodes with available pods: 2
+Apr 27 14:06:27.165: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 27 14:06:40.200: INFO: Number of nodes with available pods: 0
+Apr 27 14:06:40.200: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 27 14:06:40.202: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-pm7px/daemonsets","resourceVersion":"2026"},"items":null}
+
+Apr 27 14:06:40.205: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-pm7px/pods","resourceVersion":"2028"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:06:40.213: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-pm7px" for this suite.
+Apr 27 14:06:46.227: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:06:46.317: INFO: namespace: e2e-tests-daemonsets-pm7px, resource: bindings, ignored listing per whitelist
+Apr 27 14:06:46.342: INFO: namespace e2e-tests-daemonsets-pm7px deletion completed in 6.125844758s
+
+• [SLOW TEST:43.325 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:06:46.342: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Apr 27 14:06:46.424: INFO: Waiting up to 5m0s for pod "pod-38a1ac54-4a24-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-9p7dt" to be "success or failure"
+Apr 27 14:06:46.426: INFO: Pod "pod-38a1ac54-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.107405ms
+Apr 27 14:06:48.429: INFO: Pod "pod-38a1ac54-4a24-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005184533s
+STEP: Saw pod success
+Apr 27 14:06:48.429: INFO: Pod "pod-38a1ac54-4a24-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:06:48.432: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-38a1ac54-4a24-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:06:48.456: INFO: Waiting for pod pod-38a1ac54-4a24-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:06:48.459: INFO: Pod pod-38a1ac54-4a24-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:06:48.459: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-9p7dt" for this suite.
+Apr 27 14:06:54.470: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:06:54.551: INFO: namespace: e2e-tests-emptydir-9p7dt, resource: bindings, ignored listing per whitelist
+Apr 27 14:06:54.581: INFO: namespace e2e-tests-emptydir-9p7dt deletion completed in 6.11869251s
+
+• [SLOW TEST:8.239 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:06:54.581: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:06:54.656: INFO: Waiting up to 5m0s for pod "downwardapi-volume-3d89bea1-4a24-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-2ncql" to be "success or failure"
+Apr 27 14:06:54.658: INFO: Pod "downwardapi-volume-3d89bea1-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005941ms
+Apr 27 14:06:56.661: INFO: Pod "downwardapi-volume-3d89bea1-4a24-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005706467s
+STEP: Saw pod success
+Apr 27 14:06:56.662: INFO: Pod "downwardapi-volume-3d89bea1-4a24-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:06:56.664: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod downwardapi-volume-3d89bea1-4a24-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:06:56.682: INFO: Waiting for pod downwardapi-volume-3d89bea1-4a24-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:06:56.686: INFO: Pod downwardapi-volume-3d89bea1-4a24-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:06:56.686: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2ncql" for this suite.
+Apr 27 14:07:02.700: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:07:02.814: INFO: namespace: e2e-tests-projected-2ncql, resource: bindings, ignored listing per whitelist
+Apr 27 14:07:02.823: INFO: namespace e2e-tests-projected-2ncql deletion completed in 6.131294296s
+
+• [SLOW TEST:8.242 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:07:02.823: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:07:02.903: INFO: Waiting up to 5m0s for pod "downwardapi-volume-42740b28-4a24-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-m7r6h" to be "success or failure"
+Apr 27 14:07:02.905: INFO: Pod "downwardapi-volume-42740b28-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.487148ms
+Apr 27 14:07:04.909: INFO: Pod "downwardapi-volume-42740b28-4a24-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006575289s
+STEP: Saw pod success
+Apr 27 14:07:04.909: INFO: Pod "downwardapi-volume-42740b28-4a24-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:07:04.912: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downwardapi-volume-42740b28-4a24-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:07:04.934: INFO: Waiting for pod downwardapi-volume-42740b28-4a24-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:07:04.937: INFO: Pod downwardapi-volume-42740b28-4a24-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:07:04.937: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-m7r6h" for this suite.
+Apr 27 14:07:10.950: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:07:10.981: INFO: namespace: e2e-tests-downward-api-m7r6h, resource: bindings, ignored listing per whitelist
+Apr 27 14:07:11.053: INFO: namespace e2e-tests-downward-api-m7r6h deletion completed in 6.114257039s
+
+• [SLOW TEST:8.231 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:07:11.054: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:07:11.126: INFO: Waiting up to 5m0s for pod "downward-api-475adef8-4a24-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-46ngq" to be "success or failure"
+Apr 27 14:07:11.128: INFO: Pod "downward-api-475adef8-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.03295ms
+Apr 27 14:07:13.131: INFO: Pod "downward-api-475adef8-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005686716s
+Apr 27 14:07:15.135: INFO: Pod "downward-api-475adef8-4a24-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009646506s
+STEP: Saw pod success
+Apr 27 14:07:15.135: INFO: Pod "downward-api-475adef8-4a24-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:07:15.138: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod downward-api-475adef8-4a24-11e8-8194-02aee6f695c9 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:07:15.155: INFO: Waiting for pod downward-api-475adef8-4a24-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:07:15.157: INFO: Pod downward-api-475adef8-4a24-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:07:15.157: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-46ngq" for this suite.
+Apr 27 14:07:21.173: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:07:21.283: INFO: namespace: e2e-tests-downward-api-46ngq, resource: bindings, ignored listing per whitelist
+Apr 27 14:07:21.287: INFO: namespace e2e-tests-downward-api-46ngq deletion completed in 6.127452698s
+
+• [SLOW TEST:10.234 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:07:21.288: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0427 14:07:27.386847      17 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:07:27.386: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:07:27.386: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-5pgnr" for this suite.
+Apr 27 14:07:33.400: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:07:33.451: INFO: namespace: e2e-tests-gc-5pgnr, resource: bindings, ignored listing per whitelist
+Apr 27 14:07:33.514: INFO: namespace e2e-tests-gc-5pgnr deletion completed in 6.124503456s
+
+• [SLOW TEST:12.226 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:07:33.514: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override arguments
+Apr 27 14:07:33.595: INFO: Waiting up to 5m0s for pod "client-containers-54bf517f-4a24-11e8-8194-02aee6f695c9" in namespace "e2e-tests-containers-vqb6q" to be "success or failure"
+Apr 27 14:07:33.598: INFO: Pod "client-containers-54bf517f-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 3.075564ms
+Apr 27 14:07:35.601: INFO: Pod "client-containers-54bf517f-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006063401s
+Apr 27 14:07:37.604: INFO: Pod "client-containers-54bf517f-4a24-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009391736s
+STEP: Saw pod success
+Apr 27 14:07:37.604: INFO: Pod "client-containers-54bf517f-4a24-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:07:37.607: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod client-containers-54bf517f-4a24-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:07:37.625: INFO: Waiting for pod client-containers-54bf517f-4a24-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:07:37.628: INFO: Pod client-containers-54bf517f-4a24-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:07:37.628: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-vqb6q" for this suite.
+Apr 27 14:07:43.639: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:07:43.753: INFO: namespace: e2e-tests-containers-vqb6q, resource: bindings, ignored listing per whitelist
+Apr 27 14:07:43.757: INFO: namespace e2e-tests-containers-vqb6q deletion completed in 6.127354378s
+
+• [SLOW TEST:10.244 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:07:43.758: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name cm-test-opt-del-5adb02f9-4a24-11e8-8194-02aee6f695c9
+STEP: Creating configMap with name cm-test-opt-upd-5adb0361-4a24-11e8-8194-02aee6f695c9
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-5adb02f9-4a24-11e8-8194-02aee6f695c9
+STEP: Updating configmap cm-test-opt-upd-5adb0361-4a24-11e8-8194-02aee6f695c9
+STEP: Creating configMap with name cm-test-opt-create-5adb03ad-4a24-11e8-8194-02aee6f695c9
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:08:58.551: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-cfjrd" for this suite.
+Apr 27 14:09:20.564: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:09:20.608: INFO: namespace: e2e-tests-projected-cfjrd, resource: bindings, ignored listing per whitelist
+Apr 27 14:09:20.679: INFO: namespace e2e-tests-projected-cfjrd deletion completed in 22.123838602s
+
+• [SLOW TEST:96.921 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:09:20.679: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:09:20.755: INFO: Waiting up to 5m0s for pod "downwardapi-volume-949ead41-4a24-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-j5ln5" to be "success or failure"
+Apr 27 14:09:20.757: INFO: Pod "downwardapi-volume-949ead41-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.077532ms
+Apr 27 14:09:22.760: INFO: Pod "downwardapi-volume-949ead41-4a24-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005681017s
+STEP: Saw pod success
+Apr 27 14:09:22.761: INFO: Pod "downwardapi-volume-949ead41-4a24-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:09:22.763: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downwardapi-volume-949ead41-4a24-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:09:22.784: INFO: Waiting for pod downwardapi-volume-949ead41-4a24-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:09:22.788: INFO: Pod downwardapi-volume-949ead41-4a24-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:09:22.788: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-j5ln5" for this suite.
+Apr 27 14:09:28.800: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:09:28.884: INFO: namespace: e2e-tests-downward-api-j5ln5, resource: bindings, ignored listing per whitelist
+Apr 27 14:09:28.916: INFO: namespace e2e-tests-downward-api-j5ln5 deletion completed in 6.125138059s
+
+• [SLOW TEST:8.237 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:09:28.916: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-lm866
+I0427 14:09:28.990593      17 runners.go:175] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-lm866, replica count: 1
+I0427 14:09:29.991104      17 runners.go:175] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0427 14:09:30.991363      17 runners.go:175] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Apr 27 14:09:31.100: INFO: Created: latency-svc-f99cn
+Apr 27 14:09:31.106: INFO: Got endpoints: latency-svc-f99cn [14.84568ms]
+Apr 27 14:09:31.116: INFO: Created: latency-svc-469fq
+Apr 27 14:09:31.119: INFO: Got endpoints: latency-svc-469fq [12.447115ms]
+Apr 27 14:09:31.120: INFO: Created: latency-svc-gsrvv
+Apr 27 14:09:31.122: INFO: Got endpoints: latency-svc-gsrvv [15.099435ms]
+Apr 27 14:09:31.124: INFO: Created: latency-svc-qrnmx
+Apr 27 14:09:31.129: INFO: Got endpoints: latency-svc-qrnmx [19.942687ms]
+Apr 27 14:09:31.129: INFO: Created: latency-svc-6nwwb
+Apr 27 14:09:31.143: INFO: Got endpoints: latency-svc-6nwwb [35.351506ms]
+Apr 27 14:09:31.144: INFO: Created: latency-svc-h5vht
+Apr 27 14:09:31.149: INFO: Created: latency-svc-vfnkr
+Apr 27 14:09:31.149: INFO: Got endpoints: latency-svc-h5vht [41.719257ms]
+Apr 27 14:09:31.154: INFO: Got endpoints: latency-svc-vfnkr [46.943967ms]
+Apr 27 14:09:31.155: INFO: Created: latency-svc-ch566
+Apr 27 14:09:31.158: INFO: Got endpoints: latency-svc-ch566 [49.802573ms]
+Apr 27 14:09:31.161: INFO: Created: latency-svc-6gg7n
+Apr 27 14:09:31.163: INFO: Got endpoints: latency-svc-6gg7n [55.421626ms]
+Apr 27 14:09:31.167: INFO: Created: latency-svc-8fhzv
+Apr 27 14:09:31.169: INFO: Got endpoints: latency-svc-8fhzv [61.175509ms]
+Apr 27 14:09:31.173: INFO: Created: latency-svc-kbm7p
+Apr 27 14:09:31.175: INFO: Got endpoints: latency-svc-kbm7p [67.147844ms]
+Apr 27 14:09:31.180: INFO: Created: latency-svc-5trjg
+Apr 27 14:09:31.185: INFO: Created: latency-svc-zllgz
+Apr 27 14:09:31.186: INFO: Got endpoints: latency-svc-5trjg [77.968647ms]
+Apr 27 14:09:31.187: INFO: Got endpoints: latency-svc-zllgz [79.040711ms]
+Apr 27 14:09:31.191: INFO: Created: latency-svc-5w8cs
+Apr 27 14:09:31.199: INFO: Got endpoints: latency-svc-5w8cs [92.491412ms]
+Apr 27 14:09:31.202: INFO: Created: latency-svc-wg7kg
+Apr 27 14:09:31.204: INFO: Got endpoints: latency-svc-wg7kg [17.420289ms]
+Apr 27 14:09:31.208: INFO: Created: latency-svc-lk6b9
+Apr 27 14:09:31.216: INFO: Got endpoints: latency-svc-lk6b9 [107.661007ms]
+Apr 27 14:09:31.218: INFO: Created: latency-svc-wlpkj
+Apr 27 14:09:31.220: INFO: Got endpoints: latency-svc-wlpkj [112.531899ms]
+Apr 27 14:09:31.227: INFO: Created: latency-svc-b5hnw
+Apr 27 14:09:31.229: INFO: Got endpoints: latency-svc-b5hnw [110.46321ms]
+Apr 27 14:09:31.232: INFO: Created: latency-svc-5jbpd
+Apr 27 14:09:31.240: INFO: Got endpoints: latency-svc-5jbpd [117.759039ms]
+Apr 27 14:09:31.245: INFO: Created: latency-svc-gx52p
+Apr 27 14:09:31.256: INFO: Got endpoints: latency-svc-gx52p [127.604495ms]
+Apr 27 14:09:31.259: INFO: Created: latency-svc-kk6tw
+Apr 27 14:09:31.263: INFO: Created: latency-svc-bc572
+Apr 27 14:09:31.263: INFO: Got endpoints: latency-svc-kk6tw [119.737737ms]
+Apr 27 14:09:31.266: INFO: Got endpoints: latency-svc-bc572 [116.492991ms]
+Apr 27 14:09:31.270: INFO: Created: latency-svc-vlcqf
+Apr 27 14:09:31.279: INFO: Got endpoints: latency-svc-vlcqf [124.418965ms]
+Apr 27 14:09:31.289: INFO: Created: latency-svc-hqv24
+Apr 27 14:09:31.297: INFO: Got endpoints: latency-svc-hqv24 [139.325082ms]
+Apr 27 14:09:31.299: INFO: Created: latency-svc-228c4
+Apr 27 14:09:31.302: INFO: Got endpoints: latency-svc-228c4 [138.455444ms]
+Apr 27 14:09:31.308: INFO: Created: latency-svc-5mgcp
+Apr 27 14:09:31.314: INFO: Got endpoints: latency-svc-5mgcp [144.238649ms]
+Apr 27 14:09:31.314: INFO: Created: latency-svc-lfgcl
+Apr 27 14:09:31.322: INFO: Got endpoints: latency-svc-lfgcl [146.416728ms]
+Apr 27 14:09:31.325: INFO: Created: latency-svc-sckgr
+Apr 27 14:09:31.330: INFO: Got endpoints: latency-svc-sckgr [142.732739ms]
+Apr 27 14:09:31.331: INFO: Created: latency-svc-6kv7x
+Apr 27 14:09:31.338: INFO: Got endpoints: latency-svc-6kv7x [138.672995ms]
+Apr 27 14:09:31.340: INFO: Created: latency-svc-g7wcq
+Apr 27 14:09:31.342: INFO: Got endpoints: latency-svc-g7wcq [138.305531ms]
+Apr 27 14:09:31.353: INFO: Created: latency-svc-7dbks
+Apr 27 14:09:31.372: INFO: Got endpoints: latency-svc-7dbks [155.853423ms]
+Apr 27 14:09:31.374: INFO: Created: latency-svc-hwslk
+Apr 27 14:09:31.377: INFO: Got endpoints: latency-svc-hwslk [156.583745ms]
+Apr 27 14:09:31.382: INFO: Created: latency-svc-c67vk
+Apr 27 14:09:31.387: INFO: Got endpoints: latency-svc-c67vk [157.852882ms]
+Apr 27 14:09:31.388: INFO: Created: latency-svc-d98z4
+Apr 27 14:09:31.398: INFO: Got endpoints: latency-svc-d98z4 [158.548522ms]
+Apr 27 14:09:31.409: INFO: Created: latency-svc-x2n82
+Apr 27 14:09:31.411: INFO: Got endpoints: latency-svc-x2n82 [154.592799ms]
+Apr 27 14:09:31.414: INFO: Created: latency-svc-rflnh
+Apr 27 14:09:31.423: INFO: Got endpoints: latency-svc-rflnh [159.693941ms]
+Apr 27 14:09:31.426: INFO: Created: latency-svc-jzdtn
+Apr 27 14:09:31.433: INFO: Created: latency-svc-z2qd6
+Apr 27 14:09:31.442: INFO: Created: latency-svc-k2qkn
+Apr 27 14:09:31.450: INFO: Created: latency-svc-68jtr
+Apr 27 14:09:31.456: INFO: Got endpoints: latency-svc-jzdtn [190.720786ms]
+Apr 27 14:09:31.458: INFO: Created: latency-svc-5pvvj
+Apr 27 14:09:31.466: INFO: Created: latency-svc-zfcbv
+Apr 27 14:09:31.489: INFO: Created: latency-svc-4sqkn
+Apr 27 14:09:31.497: INFO: Created: latency-svc-b6t4n
+Apr 27 14:09:31.507: INFO: Created: latency-svc-xbxpl
+Apr 27 14:09:31.508: INFO: Got endpoints: latency-svc-z2qd6 [228.321441ms]
+Apr 27 14:09:31.519: INFO: Created: latency-svc-sxw8k
+Apr 27 14:09:31.524: INFO: Created: latency-svc-4gg6n
+Apr 27 14:09:31.535: INFO: Created: latency-svc-ddhv9
+Apr 27 14:09:31.540: INFO: Created: latency-svc-klgsv
+Apr 27 14:09:31.551: INFO: Created: latency-svc-l2kwh
+Apr 27 14:09:31.553: INFO: Got endpoints: latency-svc-k2qkn [256.058772ms]
+Apr 27 14:09:31.557: INFO: Created: latency-svc-gsz68
+Apr 27 14:09:31.569: INFO: Created: latency-svc-j49h9
+Apr 27 14:09:31.581: INFO: Created: latency-svc-m8sgn
+Apr 27 14:09:31.594: INFO: Created: latency-svc-4hgn6
+Apr 27 14:09:31.603: INFO: Got endpoints: latency-svc-68jtr [301.042186ms]
+Apr 27 14:09:31.612: INFO: Created: latency-svc-9b4cm
+Apr 27 14:09:31.654: INFO: Got endpoints: latency-svc-5pvvj [340.087344ms]
+Apr 27 14:09:31.672: INFO: Created: latency-svc-8n44g
+Apr 27 14:09:31.704: INFO: Got endpoints: latency-svc-zfcbv [381.613195ms]
+Apr 27 14:09:31.712: INFO: Created: latency-svc-kjn7m
+Apr 27 14:09:31.754: INFO: Got endpoints: latency-svc-4sqkn [423.675081ms]
+Apr 27 14:09:31.765: INFO: Created: latency-svc-7lql2
+Apr 27 14:09:31.803: INFO: Got endpoints: latency-svc-b6t4n [465.530226ms]
+Apr 27 14:09:31.813: INFO: Created: latency-svc-bbnz7
+Apr 27 14:09:31.853: INFO: Got endpoints: latency-svc-xbxpl [510.845559ms]
+Apr 27 14:09:31.863: INFO: Created: latency-svc-gxzpq
+Apr 27 14:09:31.907: INFO: Got endpoints: latency-svc-sxw8k [535.019761ms]
+Apr 27 14:09:31.916: INFO: Created: latency-svc-nzk9r
+Apr 27 14:09:31.953: INFO: Got endpoints: latency-svc-4gg6n [576.418367ms]
+Apr 27 14:09:31.962: INFO: Created: latency-svc-88gpp
+Apr 27 14:09:32.005: INFO: Got endpoints: latency-svc-ddhv9 [618.292035ms]
+Apr 27 14:09:32.020: INFO: Created: latency-svc-nrrmq
+Apr 27 14:09:32.053: INFO: Got endpoints: latency-svc-klgsv [654.773571ms]
+Apr 27 14:09:32.062: INFO: Created: latency-svc-zqdcv
+Apr 27 14:09:32.103: INFO: Got endpoints: latency-svc-l2kwh [692.211734ms]
+Apr 27 14:09:32.117: INFO: Created: latency-svc-sk59d
+Apr 27 14:09:32.154: INFO: Got endpoints: latency-svc-gsz68 [730.346356ms]
+Apr 27 14:09:32.163: INFO: Created: latency-svc-dgdqr
+Apr 27 14:09:32.204: INFO: Got endpoints: latency-svc-j49h9 [747.200204ms]
+Apr 27 14:09:32.213: INFO: Created: latency-svc-swqnz
+Apr 27 14:09:32.253: INFO: Got endpoints: latency-svc-m8sgn [745.631055ms]
+Apr 27 14:09:32.262: INFO: Created: latency-svc-9hq4v
+Apr 27 14:09:32.304: INFO: Got endpoints: latency-svc-4hgn6 [750.777124ms]
+Apr 27 14:09:32.313: INFO: Created: latency-svc-jrlsv
+Apr 27 14:09:32.353: INFO: Got endpoints: latency-svc-9b4cm [750.077505ms]
+Apr 27 14:09:32.362: INFO: Created: latency-svc-lmjdh
+Apr 27 14:09:32.406: INFO: Got endpoints: latency-svc-8n44g [752.294644ms]
+Apr 27 14:09:32.416: INFO: Created: latency-svc-87cvt
+Apr 27 14:09:32.453: INFO: Got endpoints: latency-svc-kjn7m [749.522801ms]
+Apr 27 14:09:32.462: INFO: Created: latency-svc-6nrj6
+Apr 27 14:09:32.504: INFO: Got endpoints: latency-svc-7lql2 [749.790358ms]
+Apr 27 14:09:32.513: INFO: Created: latency-svc-ddrqg
+Apr 27 14:09:32.554: INFO: Got endpoints: latency-svc-bbnz7 [750.725019ms]
+Apr 27 14:09:32.564: INFO: Created: latency-svc-9kr29
+Apr 27 14:09:32.603: INFO: Got endpoints: latency-svc-gxzpq [749.363286ms]
+Apr 27 14:09:32.615: INFO: Created: latency-svc-lz4nz
+Apr 27 14:09:32.653: INFO: Got endpoints: latency-svc-nzk9r [746.468415ms]
+Apr 27 14:09:32.664: INFO: Created: latency-svc-n5c8n
+Apr 27 14:09:32.704: INFO: Got endpoints: latency-svc-88gpp [750.282399ms]
+Apr 27 14:09:32.713: INFO: Created: latency-svc-ghnss
+Apr 27 14:09:32.754: INFO: Got endpoints: latency-svc-nrrmq [748.173553ms]
+Apr 27 14:09:32.763: INFO: Created: latency-svc-8r6kj
+Apr 27 14:09:32.804: INFO: Got endpoints: latency-svc-zqdcv [750.668551ms]
+Apr 27 14:09:32.817: INFO: Created: latency-svc-z269r
+Apr 27 14:09:32.853: INFO: Got endpoints: latency-svc-sk59d [748.651745ms]
+Apr 27 14:09:32.863: INFO: Created: latency-svc-jltqt
+Apr 27 14:09:32.903: INFO: Got endpoints: latency-svc-dgdqr [749.859481ms]
+Apr 27 14:09:32.912: INFO: Created: latency-svc-s9xxz
+Apr 27 14:09:32.954: INFO: Got endpoints: latency-svc-swqnz [750.429829ms]
+Apr 27 14:09:32.963: INFO: Created: latency-svc-hxf62
+Apr 27 14:09:33.003: INFO: Got endpoints: latency-svc-9hq4v [750.113216ms]
+Apr 27 14:09:33.013: INFO: Created: latency-svc-dhpj9
+Apr 27 14:09:33.053: INFO: Got endpoints: latency-svc-jrlsv [749.57258ms]
+Apr 27 14:09:33.064: INFO: Created: latency-svc-zlq5b
+Apr 27 14:09:33.103: INFO: Got endpoints: latency-svc-lmjdh [750.28556ms]
+Apr 27 14:09:33.113: INFO: Created: latency-svc-nc2fc
+Apr 27 14:09:33.154: INFO: Got endpoints: latency-svc-87cvt [747.470737ms]
+Apr 27 14:09:33.164: INFO: Created: latency-svc-7gpx2
+Apr 27 14:09:33.204: INFO: Got endpoints: latency-svc-6nrj6 [750.443962ms]
+Apr 27 14:09:33.213: INFO: Created: latency-svc-w89f8
+Apr 27 14:09:33.253: INFO: Got endpoints: latency-svc-ddrqg [749.555875ms]
+Apr 27 14:09:33.269: INFO: Created: latency-svc-8rhsl
+Apr 27 14:09:33.304: INFO: Got endpoints: latency-svc-9kr29 [749.663304ms]
+Apr 27 14:09:33.312: INFO: Created: latency-svc-gsd2f
+Apr 27 14:09:33.354: INFO: Got endpoints: latency-svc-lz4nz [749.033796ms]
+Apr 27 14:09:33.363: INFO: Created: latency-svc-x6ddt
+Apr 27 14:09:33.403: INFO: Got endpoints: latency-svc-n5c8n [749.924413ms]
+Apr 27 14:09:33.413: INFO: Created: latency-svc-vqgm6
+Apr 27 14:09:33.453: INFO: Got endpoints: latency-svc-ghnss [749.492472ms]
+Apr 27 14:09:33.462: INFO: Created: latency-svc-zx7q6
+Apr 27 14:09:33.503: INFO: Got endpoints: latency-svc-8r6kj [749.799059ms]
+Apr 27 14:09:33.513: INFO: Created: latency-svc-54h2x
+Apr 27 14:09:33.553: INFO: Got endpoints: latency-svc-z269r [749.378029ms]
+Apr 27 14:09:33.564: INFO: Created: latency-svc-27rjr
+Apr 27 14:09:33.604: INFO: Got endpoints: latency-svc-jltqt [750.277605ms]
+Apr 27 14:09:33.627: INFO: Created: latency-svc-kwdq5
+Apr 27 14:09:33.655: INFO: Got endpoints: latency-svc-s9xxz [751.494271ms]
+Apr 27 14:09:33.669: INFO: Created: latency-svc-95t24
+Apr 27 14:09:33.704: INFO: Got endpoints: latency-svc-hxf62 [749.520029ms]
+Apr 27 14:09:33.712: INFO: Created: latency-svc-k5w6z
+Apr 27 14:09:33.754: INFO: Got endpoints: latency-svc-dhpj9 [750.306964ms]
+Apr 27 14:09:33.763: INFO: Created: latency-svc-dk9df
+Apr 27 14:09:33.804: INFO: Got endpoints: latency-svc-zlq5b [750.251556ms]
+Apr 27 14:09:33.812: INFO: Created: latency-svc-t4p8l
+Apr 27 14:09:33.854: INFO: Got endpoints: latency-svc-nc2fc [750.031325ms]
+Apr 27 14:09:33.862: INFO: Created: latency-svc-p28hm
+Apr 27 14:09:33.904: INFO: Got endpoints: latency-svc-7gpx2 [749.998121ms]
+Apr 27 14:09:33.912: INFO: Created: latency-svc-h2hqn
+Apr 27 14:09:33.954: INFO: Got endpoints: latency-svc-w89f8 [750.075303ms]
+Apr 27 14:09:33.962: INFO: Created: latency-svc-kcdb9
+Apr 27 14:09:34.004: INFO: Got endpoints: latency-svc-8rhsl [750.24992ms]
+Apr 27 14:09:34.012: INFO: Created: latency-svc-67shs
+Apr 27 14:09:34.054: INFO: Got endpoints: latency-svc-gsd2f [749.985441ms]
+Apr 27 14:09:34.062: INFO: Created: latency-svc-4pcqg
+Apr 27 14:09:34.108: INFO: Got endpoints: latency-svc-x6ddt [753.881973ms]
+Apr 27 14:09:34.117: INFO: Created: latency-svc-8x4bx
+Apr 27 14:09:34.154: INFO: Got endpoints: latency-svc-vqgm6 [750.285353ms]
+Apr 27 14:09:34.162: INFO: Created: latency-svc-sm742
+Apr 27 14:09:34.205: INFO: Got endpoints: latency-svc-zx7q6 [751.25175ms]
+Apr 27 14:09:34.217: INFO: Created: latency-svc-4wszb
+Apr 27 14:09:34.254: INFO: Got endpoints: latency-svc-54h2x [750.012744ms]
+Apr 27 14:09:34.262: INFO: Created: latency-svc-r6npg
+Apr 27 14:09:34.304: INFO: Got endpoints: latency-svc-27rjr [750.776562ms]
+Apr 27 14:09:34.316: INFO: Created: latency-svc-q8tpk
+Apr 27 14:09:34.354: INFO: Got endpoints: latency-svc-kwdq5 [749.896047ms]
+Apr 27 14:09:34.362: INFO: Created: latency-svc-t9wwc
+Apr 27 14:09:34.404: INFO: Got endpoints: latency-svc-95t24 [749.148933ms]
+Apr 27 14:09:34.413: INFO: Created: latency-svc-wg276
+Apr 27 14:09:34.454: INFO: Got endpoints: latency-svc-k5w6z [750.1792ms]
+Apr 27 14:09:34.462: INFO: Created: latency-svc-mc4lt
+Apr 27 14:09:34.504: INFO: Got endpoints: latency-svc-dk9df [750.027483ms]
+Apr 27 14:09:34.513: INFO: Created: latency-svc-gm77m
+Apr 27 14:09:34.554: INFO: Got endpoints: latency-svc-t4p8l [750.221429ms]
+Apr 27 14:09:34.564: INFO: Created: latency-svc-zzp74
+Apr 27 14:09:34.604: INFO: Got endpoints: latency-svc-p28hm [750.37432ms]
+Apr 27 14:09:34.617: INFO: Created: latency-svc-n7qbd
+Apr 27 14:09:34.654: INFO: Got endpoints: latency-svc-h2hqn [750.244354ms]
+Apr 27 14:09:34.663: INFO: Created: latency-svc-s9sfr
+Apr 27 14:09:34.704: INFO: Got endpoints: latency-svc-kcdb9 [750.033018ms]
+Apr 27 14:09:34.712: INFO: Created: latency-svc-fjvc5
+Apr 27 14:09:34.755: INFO: Got endpoints: latency-svc-67shs [750.865479ms]
+Apr 27 14:09:34.763: INFO: Created: latency-svc-zl7pm
+Apr 27 14:09:34.804: INFO: Got endpoints: latency-svc-4pcqg [750.114817ms]
+Apr 27 14:09:34.816: INFO: Created: latency-svc-rjcn6
+Apr 27 14:09:34.854: INFO: Got endpoints: latency-svc-8x4bx [745.944174ms]
+Apr 27 14:09:34.863: INFO: Created: latency-svc-vpgcz
+Apr 27 14:09:34.904: INFO: Got endpoints: latency-svc-sm742 [750.39976ms]
+Apr 27 14:09:34.913: INFO: Created: latency-svc-ghm8b
+Apr 27 14:09:34.955: INFO: Got endpoints: latency-svc-4wszb [749.818361ms]
+Apr 27 14:09:34.963: INFO: Created: latency-svc-lz679
+Apr 27 14:09:35.004: INFO: Got endpoints: latency-svc-r6npg [750.536161ms]
+Apr 27 14:09:35.012: INFO: Created: latency-svc-zz76b
+Apr 27 14:09:35.054: INFO: Got endpoints: latency-svc-q8tpk [749.874121ms]
+Apr 27 14:09:35.062: INFO: Created: latency-svc-svrgj
+Apr 27 14:09:35.104: INFO: Got endpoints: latency-svc-t9wwc [750.156687ms]
+Apr 27 14:09:35.113: INFO: Created: latency-svc-zt7v2
+Apr 27 14:09:35.154: INFO: Got endpoints: latency-svc-wg276 [749.699242ms]
+Apr 27 14:09:35.162: INFO: Created: latency-svc-c5gzp
+Apr 27 14:09:35.204: INFO: Got endpoints: latency-svc-mc4lt [749.982376ms]
+Apr 27 14:09:35.212: INFO: Created: latency-svc-wrjzp
+Apr 27 14:09:35.256: INFO: Got endpoints: latency-svc-gm77m [751.987325ms]
+Apr 27 14:09:35.264: INFO: Created: latency-svc-6fmxm
+Apr 27 14:09:35.304: INFO: Got endpoints: latency-svc-zzp74 [749.939439ms]
+Apr 27 14:09:35.312: INFO: Created: latency-svc-sqwbz
+Apr 27 14:09:35.354: INFO: Got endpoints: latency-svc-n7qbd [750.10035ms]
+Apr 27 14:09:35.365: INFO: Created: latency-svc-8chcn
+Apr 27 14:09:35.404: INFO: Got endpoints: latency-svc-s9sfr [749.84301ms]
+Apr 27 14:09:35.412: INFO: Created: latency-svc-jgfd8
+Apr 27 14:09:35.454: INFO: Got endpoints: latency-svc-fjvc5 [749.095444ms]
+Apr 27 14:09:35.466: INFO: Created: latency-svc-nlj77
+Apr 27 14:09:35.504: INFO: Got endpoints: latency-svc-zl7pm [749.479624ms]
+Apr 27 14:09:35.513: INFO: Created: latency-svc-9s8dj
+Apr 27 14:09:35.554: INFO: Got endpoints: latency-svc-rjcn6 [749.717689ms]
+Apr 27 14:09:35.562: INFO: Created: latency-svc-x48jm
+Apr 27 14:09:35.604: INFO: Got endpoints: latency-svc-vpgcz [750.725673ms]
+Apr 27 14:09:35.613: INFO: Created: latency-svc-j8z6z
+Apr 27 14:09:35.655: INFO: Got endpoints: latency-svc-ghm8b [750.714637ms]
+Apr 27 14:09:35.663: INFO: Created: latency-svc-8tm2h
+Apr 27 14:09:35.704: INFO: Got endpoints: latency-svc-lz679 [749.396792ms]
+Apr 27 14:09:35.712: INFO: Created: latency-svc-zlgdx
+Apr 27 14:09:35.754: INFO: Got endpoints: latency-svc-zz76b [749.963121ms]
+Apr 27 14:09:35.763: INFO: Created: latency-svc-kn7sr
+Apr 27 14:09:35.805: INFO: Got endpoints: latency-svc-svrgj [750.541871ms]
+Apr 27 14:09:35.814: INFO: Created: latency-svc-8wbzd
+Apr 27 14:09:35.854: INFO: Got endpoints: latency-svc-zt7v2 [750.003248ms]
+Apr 27 14:09:35.862: INFO: Created: latency-svc-mtx2q
+Apr 27 14:09:35.904: INFO: Got endpoints: latency-svc-c5gzp [749.583141ms]
+Apr 27 14:09:35.913: INFO: Created: latency-svc-f6glz
+Apr 27 14:09:35.954: INFO: Got endpoints: latency-svc-wrjzp [750.172057ms]
+Apr 27 14:09:35.963: INFO: Created: latency-svc-rqh9r
+Apr 27 14:09:36.004: INFO: Got endpoints: latency-svc-6fmxm [747.917518ms]
+Apr 27 14:09:36.015: INFO: Created: latency-svc-qcqsq
+Apr 27 14:09:36.057: INFO: Got endpoints: latency-svc-sqwbz [752.355786ms]
+Apr 27 14:09:36.065: INFO: Created: latency-svc-g6p7x
+Apr 27 14:09:36.104: INFO: Got endpoints: latency-svc-8chcn [749.892819ms]
+Apr 27 14:09:36.113: INFO: Created: latency-svc-qgmtf
+Apr 27 14:09:36.154: INFO: Got endpoints: latency-svc-jgfd8 [750.227906ms]
+Apr 27 14:09:36.163: INFO: Created: latency-svc-6v6t7
+Apr 27 14:09:36.205: INFO: Got endpoints: latency-svc-nlj77 [750.783188ms]
+Apr 27 14:09:36.213: INFO: Created: latency-svc-lg6w2
+Apr 27 14:09:36.254: INFO: Got endpoints: latency-svc-9s8dj [750.138345ms]
+Apr 27 14:09:36.264: INFO: Created: latency-svc-ppmgb
+Apr 27 14:09:36.304: INFO: Got endpoints: latency-svc-x48jm [750.111896ms]
+Apr 27 14:09:36.316: INFO: Created: latency-svc-j4w7w
+Apr 27 14:09:36.354: INFO: Got endpoints: latency-svc-j8z6z [749.778442ms]
+Apr 27 14:09:36.363: INFO: Created: latency-svc-c82ph
+Apr 27 14:09:36.407: INFO: Got endpoints: latency-svc-8tm2h [751.613847ms]
+Apr 27 14:09:36.415: INFO: Created: latency-svc-pz8qc
+Apr 27 14:09:36.454: INFO: Got endpoints: latency-svc-zlgdx [749.792125ms]
+Apr 27 14:09:36.461: INFO: Created: latency-svc-rt556
+Apr 27 14:09:36.504: INFO: Got endpoints: latency-svc-kn7sr [749.876905ms]
+Apr 27 14:09:36.516: INFO: Created: latency-svc-csv2n
+Apr 27 14:09:36.555: INFO: Got endpoints: latency-svc-8wbzd [749.931876ms]
+Apr 27 14:09:36.563: INFO: Created: latency-svc-ddbp5
+Apr 27 14:09:36.604: INFO: Got endpoints: latency-svc-mtx2q [750.257854ms]
+Apr 27 14:09:36.617: INFO: Created: latency-svc-bgm64
+Apr 27 14:09:36.654: INFO: Got endpoints: latency-svc-f6glz [750.287069ms]
+Apr 27 14:09:36.663: INFO: Created: latency-svc-5vbxs
+Apr 27 14:09:36.704: INFO: Got endpoints: latency-svc-rqh9r [750.200591ms]
+Apr 27 14:09:36.713: INFO: Created: latency-svc-kf55w
+Apr 27 14:09:36.755: INFO: Got endpoints: latency-svc-qcqsq [750.255772ms]
+Apr 27 14:09:36.764: INFO: Created: latency-svc-bb4cs
+Apr 27 14:09:36.804: INFO: Got endpoints: latency-svc-g6p7x [747.037569ms]
+Apr 27 14:09:36.812: INFO: Created: latency-svc-q7mjd
+Apr 27 14:09:36.854: INFO: Got endpoints: latency-svc-qgmtf [749.878595ms]
+Apr 27 14:09:36.863: INFO: Created: latency-svc-5jvjt
+Apr 27 14:09:36.904: INFO: Got endpoints: latency-svc-6v6t7 [750.027745ms]
+Apr 27 14:09:36.913: INFO: Created: latency-svc-w7wdf
+Apr 27 14:09:36.954: INFO: Got endpoints: latency-svc-lg6w2 [749.732505ms]
+Apr 27 14:09:36.963: INFO: Created: latency-svc-rcw77
+Apr 27 14:09:37.004: INFO: Got endpoints: latency-svc-ppmgb [749.967207ms]
+Apr 27 14:09:37.013: INFO: Created: latency-svc-b9l89
+Apr 27 14:09:37.054: INFO: Got endpoints: latency-svc-j4w7w [749.706831ms]
+Apr 27 14:09:37.062: INFO: Created: latency-svc-qxnkh
+Apr 27 14:09:37.105: INFO: Got endpoints: latency-svc-c82ph [750.492769ms]
+Apr 27 14:09:37.113: INFO: Created: latency-svc-jt7vw
+Apr 27 14:09:37.155: INFO: Got endpoints: latency-svc-pz8qc [747.891556ms]
+Apr 27 14:09:37.162: INFO: Created: latency-svc-zjq9x
+Apr 27 14:09:37.205: INFO: Got endpoints: latency-svc-rt556 [750.659113ms]
+Apr 27 14:09:37.214: INFO: Created: latency-svc-5g5mk
+Apr 27 14:09:37.254: INFO: Got endpoints: latency-svc-csv2n [749.535221ms]
+Apr 27 14:09:37.263: INFO: Created: latency-svc-4mnjg
+Apr 27 14:09:37.304: INFO: Got endpoints: latency-svc-ddbp5 [749.728005ms]
+Apr 27 14:09:37.313: INFO: Created: latency-svc-fhcdk
+Apr 27 14:09:37.355: INFO: Got endpoints: latency-svc-bgm64 [748.74318ms]
+Apr 27 14:09:37.363: INFO: Created: latency-svc-swhf7
+Apr 27 14:09:37.405: INFO: Got endpoints: latency-svc-5vbxs [750.687052ms]
+Apr 27 14:09:37.413: INFO: Created: latency-svc-4jdbj
+Apr 27 14:09:37.454: INFO: Got endpoints: latency-svc-kf55w [749.873199ms]
+Apr 27 14:09:37.462: INFO: Created: latency-svc-gdzkl
+Apr 27 14:09:37.505: INFO: Got endpoints: latency-svc-bb4cs [750.382044ms]
+Apr 27 14:09:37.514: INFO: Created: latency-svc-f8mdr
+Apr 27 14:09:37.558: INFO: Got endpoints: latency-svc-q7mjd [753.766066ms]
+Apr 27 14:09:37.568: INFO: Created: latency-svc-ptcc7
+Apr 27 14:09:37.605: INFO: Got endpoints: latency-svc-5jvjt [750.496277ms]
+Apr 27 14:09:37.613: INFO: Created: latency-svc-wgb5w
+Apr 27 14:09:37.654: INFO: Got endpoints: latency-svc-w7wdf [750.033149ms]
+Apr 27 14:09:37.663: INFO: Created: latency-svc-ft974
+Apr 27 14:09:37.704: INFO: Got endpoints: latency-svc-rcw77 [749.46679ms]
+Apr 27 14:09:37.712: INFO: Created: latency-svc-2xrxm
+Apr 27 14:09:37.755: INFO: Got endpoints: latency-svc-b9l89 [750.095401ms]
+Apr 27 14:09:37.766: INFO: Created: latency-svc-6w6rj
+Apr 27 14:09:37.805: INFO: Got endpoints: latency-svc-qxnkh [750.30697ms]
+Apr 27 14:09:37.814: INFO: Created: latency-svc-jgndh
+Apr 27 14:09:37.854: INFO: Got endpoints: latency-svc-jt7vw [749.46949ms]
+Apr 27 14:09:37.862: INFO: Created: latency-svc-2948s
+Apr 27 14:09:37.905: INFO: Got endpoints: latency-svc-zjq9x [750.211206ms]
+Apr 27 14:09:37.913: INFO: Created: latency-svc-88d26
+Apr 27 14:09:37.955: INFO: Got endpoints: latency-svc-5g5mk [750.00403ms]
+Apr 27 14:09:37.963: INFO: Created: latency-svc-vms9b
+Apr 27 14:09:38.005: INFO: Got endpoints: latency-svc-4mnjg [750.47442ms]
+Apr 27 14:09:38.013: INFO: Created: latency-svc-czt4w
+Apr 27 14:09:38.055: INFO: Got endpoints: latency-svc-fhcdk [750.077856ms]
+Apr 27 14:09:38.063: INFO: Created: latency-svc-tb6kk
+Apr 27 14:09:38.105: INFO: Got endpoints: latency-svc-swhf7 [750.265479ms]
+Apr 27 14:09:38.114: INFO: Created: latency-svc-5ns7s
+Apr 27 14:09:38.155: INFO: Got endpoints: latency-svc-4jdbj [749.805197ms]
+Apr 27 14:09:38.166: INFO: Created: latency-svc-hqgtl
+Apr 27 14:09:38.205: INFO: Got endpoints: latency-svc-gdzkl [750.528963ms]
+Apr 27 14:09:38.213: INFO: Created: latency-svc-sssbx
+Apr 27 14:09:38.255: INFO: Got endpoints: latency-svc-f8mdr [749.347338ms]
+Apr 27 14:09:38.263: INFO: Created: latency-svc-pm7tz
+Apr 27 14:09:38.305: INFO: Got endpoints: latency-svc-ptcc7 [747.435188ms]
+Apr 27 14:09:38.314: INFO: Created: latency-svc-nczg7
+Apr 27 14:09:38.354: INFO: Got endpoints: latency-svc-wgb5w [749.747035ms]
+Apr 27 14:09:38.363: INFO: Created: latency-svc-zjd9t
+Apr 27 14:09:38.405: INFO: Got endpoints: latency-svc-ft974 [750.273761ms]
+Apr 27 14:09:38.414: INFO: Created: latency-svc-xctdr
+Apr 27 14:09:38.455: INFO: Got endpoints: latency-svc-2xrxm [750.715145ms]
+Apr 27 14:09:38.464: INFO: Created: latency-svc-v9qr7
+Apr 27 14:09:38.505: INFO: Got endpoints: latency-svc-6w6rj [750.01987ms]
+Apr 27 14:09:38.513: INFO: Created: latency-svc-l2fqx
+Apr 27 14:09:38.555: INFO: Got endpoints: latency-svc-jgndh [750.344406ms]
+Apr 27 14:09:38.563: INFO: Created: latency-svc-jltbr
+Apr 27 14:09:38.605: INFO: Got endpoints: latency-svc-2948s [750.136198ms]
+Apr 27 14:09:38.614: INFO: Created: latency-svc-l4k25
+Apr 27 14:09:38.655: INFO: Got endpoints: latency-svc-88d26 [749.646036ms]
+Apr 27 14:09:38.666: INFO: Created: latency-svc-whr45
+Apr 27 14:09:38.706: INFO: Got endpoints: latency-svc-vms9b [751.0367ms]
+Apr 27 14:09:38.715: INFO: Created: latency-svc-mw4g8
+Apr 27 14:09:38.755: INFO: Got endpoints: latency-svc-czt4w [750.229184ms]
+Apr 27 14:09:38.764: INFO: Created: latency-svc-kqtnt
+Apr 27 14:09:38.805: INFO: Got endpoints: latency-svc-tb6kk [750.244625ms]
+Apr 27 14:09:38.816: INFO: Created: latency-svc-97kfs
+Apr 27 14:09:38.855: INFO: Got endpoints: latency-svc-5ns7s [749.922852ms]
+Apr 27 14:09:38.864: INFO: Created: latency-svc-467pf
+Apr 27 14:09:38.905: INFO: Got endpoints: latency-svc-hqgtl [749.82085ms]
+Apr 27 14:09:38.915: INFO: Created: latency-svc-wg8q7
+Apr 27 14:09:38.955: INFO: Got endpoints: latency-svc-sssbx [750.410189ms]
+Apr 27 14:09:39.005: INFO: Got endpoints: latency-svc-pm7tz [750.334791ms]
+Apr 27 14:09:39.055: INFO: Got endpoints: latency-svc-nczg7 [749.76802ms]
+Apr 27 14:09:39.105: INFO: Got endpoints: latency-svc-zjd9t [750.87895ms]
+Apr 27 14:09:39.155: INFO: Got endpoints: latency-svc-xctdr [750.218866ms]
+Apr 27 14:09:39.205: INFO: Got endpoints: latency-svc-v9qr7 [750.44187ms]
+Apr 27 14:09:39.255: INFO: Got endpoints: latency-svc-l2fqx [749.84096ms]
+Apr 27 14:09:39.305: INFO: Got endpoints: latency-svc-jltbr [750.098832ms]
+Apr 27 14:09:39.355: INFO: Got endpoints: latency-svc-l4k25 [750.163203ms]
+Apr 27 14:09:39.406: INFO: Got endpoints: latency-svc-whr45 [750.91565ms]
+Apr 27 14:09:39.455: INFO: Got endpoints: latency-svc-mw4g8 [748.87341ms]
+Apr 27 14:09:39.505: INFO: Got endpoints: latency-svc-kqtnt [750.010421ms]
+Apr 27 14:09:39.555: INFO: Got endpoints: latency-svc-97kfs [750.045291ms]
+Apr 27 14:09:39.605: INFO: Got endpoints: latency-svc-467pf [750.142715ms]
+Apr 27 14:09:39.656: INFO: Got endpoints: latency-svc-wg8q7 [750.918039ms]
+Apr 27 14:09:39.656: INFO: Latencies: [12.447115ms 15.099435ms 17.420289ms 19.942687ms 35.351506ms 41.719257ms 46.943967ms 49.802573ms 55.421626ms 61.175509ms 67.147844ms 77.968647ms 79.040711ms 92.491412ms 107.661007ms 110.46321ms 112.531899ms 116.492991ms 117.759039ms 119.737737ms 124.418965ms 127.604495ms 138.305531ms 138.455444ms 138.672995ms 139.325082ms 142.732739ms 144.238649ms 146.416728ms 154.592799ms 155.853423ms 156.583745ms 157.852882ms 158.548522ms 159.693941ms 190.720786ms 228.321441ms 256.058772ms 301.042186ms 340.087344ms 381.613195ms 423.675081ms 465.530226ms 510.845559ms 535.019761ms 576.418367ms 618.292035ms 654.773571ms 692.211734ms 730.346356ms 745.631055ms 745.944174ms 746.468415ms 747.037569ms 747.200204ms 747.435188ms 747.470737ms 747.891556ms 747.917518ms 748.173553ms 748.651745ms 748.74318ms 748.87341ms 749.033796ms 749.095444ms 749.148933ms 749.347338ms 749.363286ms 749.378029ms 749.396792ms 749.46679ms 749.46949ms 749.479624ms 749.492472ms 749.520029ms 749.522801ms 749.535221ms 749.555875ms 749.57258ms 749.583141ms 749.646036ms 749.663304ms 749.699242ms 749.706831ms 749.717689ms 749.728005ms 749.732505ms 749.747035ms 749.76802ms 749.778442ms 749.790358ms 749.792125ms 749.799059ms 749.805197ms 749.818361ms 749.82085ms 749.84096ms 749.84301ms 749.859481ms 749.873199ms 749.874121ms 749.876905ms 749.878595ms 749.892819ms 749.896047ms 749.922852ms 749.924413ms 749.931876ms 749.939439ms 749.963121ms 749.967207ms 749.982376ms 749.985441ms 749.998121ms 750.003248ms 750.00403ms 750.010421ms 750.012744ms 750.01987ms 750.027483ms 750.027745ms 750.031325ms 750.033018ms 750.033149ms 750.045291ms 750.075303ms 750.077505ms 750.077856ms 750.095401ms 750.098832ms 750.10035ms 750.111896ms 750.113216ms 750.114817ms 750.136198ms 750.138345ms 750.142715ms 750.156687ms 750.163203ms 750.172057ms 750.1792ms 750.200591ms 750.211206ms 750.218866ms 750.221429ms 750.227906ms 750.229184ms 750.244354ms 750.244625ms 750.24992ms 750.251556ms 750.255772ms 750.257854ms 750.265479ms 750.273761ms 750.277605ms 750.282399ms 750.285353ms 750.28556ms 750.287069ms 750.306964ms 750.30697ms 750.334791ms 750.344406ms 750.37432ms 750.382044ms 750.39976ms 750.410189ms 750.429829ms 750.44187ms 750.443962ms 750.47442ms 750.492769ms 750.496277ms 750.528963ms 750.536161ms 750.541871ms 750.659113ms 750.668551ms 750.687052ms 750.714637ms 750.715145ms 750.725019ms 750.725673ms 750.776562ms 750.777124ms 750.783188ms 750.865479ms 750.87895ms 750.91565ms 750.918039ms 751.0367ms 751.25175ms 751.494271ms 751.613847ms 751.987325ms 752.294644ms 752.355786ms 753.766066ms 753.881973ms]
+Apr 27 14:09:39.656: INFO: 50 %ile: 749.874121ms
+Apr 27 14:09:39.656: INFO: 90 %ile: 750.714637ms
+Apr 27 14:09:39.656: INFO: 99 %ile: 753.766066ms
+Apr 27 14:09:39.656: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:09:39.656: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-lm866" for this suite.
+Apr 27 14:09:51.672: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:09:51.782: INFO: namespace: e2e-tests-svc-latency-lm866, resource: bindings, ignored listing per whitelist
+Apr 27 14:09:51.808: INFO: namespace e2e-tests-svc-latency-lm866 deletion completed in 12.148808179s
+
+• [SLOW TEST:22.892 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:09:51.808: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:09:51.881: INFO: Creating ReplicaSet my-hostname-basic-a72cf027-4a24-11e8-8194-02aee6f695c9
+Apr 27 14:09:51.887: INFO: Pod name my-hostname-basic-a72cf027-4a24-11e8-8194-02aee6f695c9: Found 0 pods out of 1
+Apr 27 14:09:56.891: INFO: Pod name my-hostname-basic-a72cf027-4a24-11e8-8194-02aee6f695c9: Found 1 pods out of 1
+Apr 27 14:09:56.891: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-a72cf027-4a24-11e8-8194-02aee6f695c9" is running
+Apr 27 14:09:56.893: INFO: Pod "my-hostname-basic-a72cf027-4a24-11e8-8194-02aee6f695c9-kzq5m" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:09:51 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:09:52 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:09:51 +0000 UTC Reason: Message:}])
+Apr 27 14:09:56.893: INFO: Trying to dial the pod
+Apr 27 14:10:01.931: INFO: Controller my-hostname-basic-a72cf027-4a24-11e8-8194-02aee6f695c9: Got expected result from replica 1 [my-hostname-basic-a72cf027-4a24-11e8-8194-02aee6f695c9-kzq5m]: "my-hostname-basic-a72cf027-4a24-11e8-8194-02aee6f695c9-kzq5m", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:10:01.931: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-l9ktl" for this suite.
+Apr 27 14:10:07.943: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:10:08.048: INFO: namespace: e2e-tests-replicaset-l9ktl, resource: bindings, ignored listing per whitelist
+Apr 27 14:10:08.052: INFO: namespace e2e-tests-replicaset-l9ktl deletion completed in 6.117468322s
+
+• [SLOW TEST:16.244 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:10:08.053: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-b0dcab1d-4a24-11e8-8194-02aee6f695c9
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-b0dcab1d-4a24-11e8-8194-02aee6f695c9
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:10:12.219: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-7w59n" for this suite.
+Apr 27 14:10:34.230: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:10:34.344: INFO: namespace: e2e-tests-projected-7w59n, resource: bindings, ignored listing per whitelist
+Apr 27 14:10:34.352: INFO: namespace e2e-tests-projected-7w59n deletion completed in 22.130580634s
+
+• [SLOW TEST:26.300 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:10:34.353: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-k56xl
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-k56xl to expose endpoints map[]
+Apr 27 14:10:34.439: INFO: Get endpoints failed (1.927339ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Apr 27 14:10:35.443: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-k56xl exposes endpoints map[] (1.005438799s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-k56xl
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-k56xl to expose endpoints map[pod1:[80]]
+Apr 27 14:10:37.464: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-k56xl exposes endpoints map[pod1:[80]] (2.015336443s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-k56xl
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-k56xl to expose endpoints map[pod1:[80] pod2:[80]]
+Apr 27 14:10:39.491: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-k56xl exposes endpoints map[pod1:[80] pod2:[80]] (2.0218275s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-k56xl
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-k56xl to expose endpoints map[pod2:[80]]
+Apr 27 14:10:40.505: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-k56xl exposes endpoints map[pod2:[80]] (1.010579118s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-k56xl
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-k56xl to expose endpoints map[]
+Apr 27 14:10:40.512: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-k56xl exposes endpoints map[] (1.975883ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:10:40.519: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-k56xl" for this suite.
+Apr 27 14:11:02.531: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:11:02.570: INFO: namespace: e2e-tests-services-k56xl, resource: bindings, ignored listing per whitelist
+Apr 27 14:11:02.648: INFO: namespace e2e-tests-services-k56xl deletion completed in 22.125409783s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:28.295 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:11:02.648: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Apr 27 14:11:05.241: INFO: Successfully updated pod "pod-update-activedeadlineseconds-d165e224-4a24-11e8-8194-02aee6f695c9"
+Apr 27 14:11:05.241: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-d165e224-4a24-11e8-8194-02aee6f695c9" in namespace "e2e-tests-pods-8v2cd" to be "terminated due to deadline exceeded"
+Apr 27 14:11:05.244: INFO: Pod "pod-update-activedeadlineseconds-d165e224-4a24-11e8-8194-02aee6f695c9": Phase="Running", Reason="", readiness=true. Elapsed: 2.296263ms
+Apr 27 14:11:07.248: INFO: Pod "pod-update-activedeadlineseconds-d165e224-4a24-11e8-8194-02aee6f695c9": Phase="Running", Reason="", readiness=true. Elapsed: 2.006141828s
+Apr 27 14:11:09.251: INFO: Pod "pod-update-activedeadlineseconds-d165e224-4a24-11e8-8194-02aee6f695c9": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 4.009485105s
+Apr 27 14:11:09.251: INFO: Pod "pod-update-activedeadlineseconds-d165e224-4a24-11e8-8194-02aee6f695c9" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:11:09.251: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-8v2cd" for this suite.
+Apr 27 14:11:15.263: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:11:15.332: INFO: namespace: e2e-tests-pods-8v2cd, resource: bindings, ignored listing per whitelist
+Apr 27 14:11:15.380: INFO: namespace e2e-tests-pods-8v2cd deletion completed in 6.125237053s
+
+• [SLOW TEST:12.732 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:11:15.380: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-map-d8fd5202-4a24-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:11:15.464: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-d8fdc893-4a24-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-5wdjw" to be "success or failure"
+Apr 27 14:11:15.466: INFO: Pod "pod-projected-secrets-d8fdc893-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.162987ms
+Apr 27 14:11:17.469: INFO: Pod "pod-projected-secrets-d8fdc893-4a24-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005426882s
+STEP: Saw pod success
+Apr 27 14:11:17.469: INFO: Pod "pod-projected-secrets-d8fdc893-4a24-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:11:17.471: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-projected-secrets-d8fdc893-4a24-11e8-8194-02aee6f695c9 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:11:17.488: INFO: Waiting for pod pod-projected-secrets-d8fdc893-4a24-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:11:17.490: INFO: Pod pod-projected-secrets-d8fdc893-4a24-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:11:17.491: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5wdjw" for this suite.
+Apr 27 14:11:23.503: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:11:23.579: INFO: namespace: e2e-tests-projected-5wdjw, resource: bindings, ignored listing per whitelist
+Apr 27 14:11:23.615: INFO: namespace e2e-tests-projected-5wdjw deletion completed in 6.121452797s
+
+• [SLOW TEST:8.235 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:11:23.615: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test env composition
+Apr 27 14:11:23.689: INFO: Waiting up to 5m0s for pod "var-expansion-dde4da52-4a24-11e8-8194-02aee6f695c9" in namespace "e2e-tests-var-expansion-nt49x" to be "success or failure"
+Apr 27 14:11:23.691: INFO: Pod "var-expansion-dde4da52-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.104721ms
+Apr 27 14:11:25.694: INFO: Pod "var-expansion-dde4da52-4a24-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005747s
+Apr 27 14:11:27.697: INFO: Pod "var-expansion-dde4da52-4a24-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008818277s
+STEP: Saw pod success
+Apr 27 14:11:27.697: INFO: Pod "var-expansion-dde4da52-4a24-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:11:27.700: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod var-expansion-dde4da52-4a24-11e8-8194-02aee6f695c9 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:11:27.718: INFO: Waiting for pod var-expansion-dde4da52-4a24-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:11:27.720: INFO: Pod var-expansion-dde4da52-4a24-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:11:27.721: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-nt49x" for this suite.
+Apr 27 14:11:33.734: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:11:33.798: INFO: namespace: e2e-tests-var-expansion-nt49x, resource: bindings, ignored listing per whitelist
+Apr 27 14:11:33.849: INFO: namespace e2e-tests-var-expansion-nt49x deletion completed in 6.125226506s
+
+• [SLOW TEST:10.234 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:11:33.849: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 27 14:11:36.464: INFO: Successfully updated pod "labelsupdatee3ff89c0-4a24-11e8-8194-02aee6f695c9"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:11:38.488: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jmz7n" for this suite.
+Apr 27 14:12:00.500: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:12:00.573: INFO: namespace: e2e-tests-projected-jmz7n, resource: bindings, ignored listing per whitelist
+Apr 27 14:12:00.619: INFO: namespace e2e-tests-projected-jmz7n deletion completed in 22.128091202s
+
+• [SLOW TEST:26.770 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:12:00.620: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-kt65c
+Apr 27 14:12:02.712: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-kt65c
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:12:02.715: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:14:02.957: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-kt65c" for this suite.
+Apr 27 14:14:08.972: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:14:09.071: INFO: namespace: e2e-tests-container-probe-kt65c, resource: bindings, ignored listing per whitelist
+Apr 27 14:14:09.085: INFO: namespace e2e-tests-container-probe-kt65c deletion completed in 6.122610573s
+
+• [SLOW TEST:128.466 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:14:09.085: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: getting the auto-created API token
+Apr 27 14:14:09.678: INFO: created pod pod-service-account-defaultsa
+Apr 27 14:14:09.678: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Apr 27 14:14:09.685: INFO: created pod pod-service-account-mountsa
+Apr 27 14:14:09.685: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Apr 27 14:14:09.688: INFO: created pod pod-service-account-nomountsa
+Apr 27 14:14:09.688: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Apr 27 14:14:09.691: INFO: created pod pod-service-account-defaultsa-mountspec
+Apr 27 14:14:09.691: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Apr 27 14:14:09.695: INFO: created pod pod-service-account-mountsa-mountspec
+Apr 27 14:14:09.695: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Apr 27 14:14:09.702: INFO: created pod pod-service-account-nomountsa-mountspec
+Apr 27 14:14:09.702: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Apr 27 14:14:09.705: INFO: created pod pod-service-account-defaultsa-nomountspec
+Apr 27 14:14:09.705: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Apr 27 14:14:09.708: INFO: created pod pod-service-account-mountsa-nomountspec
+Apr 27 14:14:09.708: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Apr 27 14:14:09.712: INFO: created pod pod-service-account-nomountsa-nomountspec
+Apr 27 14:14:09.712: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:14:09.712: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-spx68" for this suite.
+Apr 27 14:14:15.729: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:14:15.794: INFO: namespace: e2e-tests-svcaccounts-spx68, resource: bindings, ignored listing per whitelist
+Apr 27 14:14:15.837: INFO: namespace e2e-tests-svcaccounts-spx68 deletion completed in 6.121916506s
+
+• [SLOW TEST:6.752 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:14:15.838: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Apr 27 14:14:17.928: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-448c1b09-4a25-11e8-8194-02aee6f695c9", GenerateName:"", Namespace:"e2e-tests-pods-wthq5", SelfLink:"/api/v1/namespaces/e2e-tests-pods-wthq5/pods/pod-submit-remove-448c1b09-4a25-11e8-8194-02aee6f695c9", UID:"4480e505-4a25-11e8-9870-221312dc233c", ResourceVersion:"4343", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63660435255, loc:(*time.Location)(0x65972e0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"907820945"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"100.96.0.33/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-fg2s5", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc421250540), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"k8s.gcr.io/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-fg2s5", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc42128f468), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42", HostNetwork:false, HostPID:false, HostIPC:false, ShareProcessNamespace:(*bool)(nil), SecurityContext:(*v1.PodSecurityContext)(0xc4212505c0), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc42128f4a0)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc42128f4d0)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63660435255, loc:(*time.Location)(0x65972e0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63660435256, loc:(*time.Location)(0x65972e0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63660435255, loc:(*time.Location)(0x65972e0)}}, Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"10.250.0.3", PodIP:"100.96.0.33", StartTime:(*v1.Time)(0xc420cd31e0), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc420cd3200), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"k8s.gcr.io/nginx-slim-amd64:0.20", ImageID:"docker-pullable://k8s.gcr.io/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://a4c4840fbf71a6719bfbeb34b4f47a7c088fcd27791e16dda551e5ea87e0b2ef"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:14:29.508: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-wthq5" for this suite.
+Apr 27 14:14:35.520: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:14:35.568: INFO: namespace: e2e-tests-pods-wthq5, resource: bindings, ignored listing per whitelist
+Apr 27 14:14:35.637: INFO: namespace e2e-tests-pods-wthq5 deletion completed in 6.126789818s
+
+• [SLOW TEST:19.800 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:14:35.637: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:14:35.721: INFO: Waiting up to 5m0s for pod "downwardapi-volume-505ab7ef-4a25-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-dvgsm" to be "success or failure"
+Apr 27 14:14:35.724: INFO: Pod "downwardapi-volume-505ab7ef-4a25-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.214594ms
+Apr 27 14:14:37.727: INFO: Pod "downwardapi-volume-505ab7ef-4a25-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005571667s
+STEP: Saw pod success
+Apr 27 14:14:37.727: INFO: Pod "downwardapi-volume-505ab7ef-4a25-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:14:37.729: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod downwardapi-volume-505ab7ef-4a25-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:14:37.747: INFO: Waiting for pod downwardapi-volume-505ab7ef-4a25-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:14:37.750: INFO: Pod downwardapi-volume-505ab7ef-4a25-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:14:37.750: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-dvgsm" for this suite.
+Apr 27 14:14:43.765: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:14:43.814: INFO: namespace: e2e-tests-projected-dvgsm, resource: bindings, ignored listing per whitelist
+Apr 27 14:14:43.886: INFO: namespace e2e-tests-projected-dvgsm deletion completed in 6.13171181s
+
+• [SLOW TEST:8.248 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:14:43.886: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Apr 27 14:14:43.964: INFO: Waiting up to 5m0s for pod "pod-55445cc1-4a25-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-5rbh2" to be "success or failure"
+Apr 27 14:14:43.968: INFO: Pod "pod-55445cc1-4a25-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 4.317518ms
+Apr 27 14:14:45.972: INFO: Pod "pod-55445cc1-4a25-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007911365s
+STEP: Saw pod success
+Apr 27 14:14:45.972: INFO: Pod "pod-55445cc1-4a25-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:14:45.974: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-55445cc1-4a25-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:14:45.992: INFO: Waiting for pod pod-55445cc1-4a25-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:14:45.995: INFO: Pod pod-55445cc1-4a25-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:14:45.995: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-5rbh2" for this suite.
+Apr 27 14:14:52.007: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:14:52.087: INFO: namespace: e2e-tests-emptydir-5rbh2, resource: bindings, ignored listing per whitelist
+Apr 27 14:14:52.125: INFO: namespace e2e-tests-emptydir-5rbh2 deletion completed in 6.127567234s
+
+• [SLOW TEST:8.240 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:14:52.126: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-5a2e8c20-4a25-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:14:52.214: INFO: Waiting up to 5m0s for pod "pod-configmaps-5a2f05e3-4a25-11e8-8194-02aee6f695c9" in namespace "e2e-tests-configmap-z6gx4" to be "success or failure"
+Apr 27 14:14:52.220: INFO: Pod "pod-configmaps-5a2f05e3-4a25-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 5.834863ms
+Apr 27 14:14:54.224: INFO: Pod "pod-configmaps-5a2f05e3-4a25-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009691185s
+Apr 27 14:14:56.228: INFO: Pod "pod-configmaps-5a2f05e3-4a25-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013724161s
+STEP: Saw pod success
+Apr 27 14:14:56.228: INFO: Pod "pod-configmaps-5a2f05e3-4a25-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:14:56.231: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-configmaps-5a2f05e3-4a25-11e8-8194-02aee6f695c9 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:14:56.247: INFO: Waiting for pod pod-configmaps-5a2f05e3-4a25-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:14:56.253: INFO: Pod pod-configmaps-5a2f05e3-4a25-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:14:56.253: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-z6gx4" for this suite.
+Apr 27 14:15:02.273: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:15:02.313: INFO: namespace: e2e-tests-configmap-z6gx4, resource: bindings, ignored listing per whitelist
+Apr 27 14:15:02.392: INFO: namespace e2e-tests-configmap-z6gx4 deletion completed in 6.133454969s
+
+• [SLOW TEST:10.267 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:15:02.392: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-msrdk
+[It] should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a new StatefulSet
+Apr 27 14:15:02.482: INFO: Found 0 stateful pods, waiting for 3
+Apr 27 14:15:12.501: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:15:12.501: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:15:12.501: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:15:12.510: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-msrdk ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:15:12.826: INFO: stderr: ""
+Apr 27 14:15:12.826: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+STEP: Updating StatefulSet template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Apr 27 14:15:22.858: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Updating Pods in reverse ordinal order
+Apr 27 14:15:32.875: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-msrdk ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:15:33.203: INFO: stderr: ""
+Apr 27 14:15:33.203: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:15:43.223: INFO: Waiting for StatefulSet e2e-tests-statefulset-msrdk/ss2 to complete update
+Apr 27 14:15:43.223: INFO: Waiting for Pod e2e-tests-statefulset-msrdk/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 27 14:15:43.223: INFO: Waiting for Pod e2e-tests-statefulset-msrdk/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 27 14:15:53.231: INFO: Waiting for StatefulSet e2e-tests-statefulset-msrdk/ss2 to complete update
+Apr 27 14:15:53.231: INFO: Waiting for Pod e2e-tests-statefulset-msrdk/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Rolling back to a previous revision
+Apr 27 14:16:03.231: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-msrdk ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:16:03.501: INFO: stderr: ""
+Apr 27 14:16:03.501: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:16:13.531: INFO: Updating stateful set ss2
+STEP: Rolling back update in reverse ordinal order
+Apr 27 14:16:23.547: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-msrdk ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:16:23.873: INFO: stderr: ""
+Apr 27 14:16:23.874: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:16:43.891: INFO: Waiting for StatefulSet e2e-tests-statefulset-msrdk/ss2 to complete update
+Apr 27 14:16:43.891: INFO: Waiting for Pod e2e-tests-statefulset-msrdk/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:16:53.897: INFO: Deleting all statefulset in ns e2e-tests-statefulset-msrdk
+Apr 27 14:16:53.900: INFO: Scaling statefulset ss2 to 0
+Apr 27 14:17:13.917: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:17:13.920: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:17:13.930: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-msrdk" for this suite.
+Apr 27 14:17:19.942: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:17:20.048: INFO: namespace: e2e-tests-statefulset-msrdk, resource: bindings, ignored listing per whitelist
+Apr 27 14:17:20.056: INFO: namespace e2e-tests-statefulset-msrdk deletion completed in 6.122902372s
+
+• [SLOW TEST:137.663 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should perform rolling updates and roll backs of template modifications [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:17:20.056: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:17:20.144: INFO: Waiting up to 5m0s for pod "downwardapi-volume-b25b1724-4a25-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-pqjfj" to be "success or failure"
+Apr 27 14:17:20.148: INFO: Pod "downwardapi-volume-b25b1724-4a25-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 3.976341ms
+Apr 27 14:17:22.151: INFO: Pod "downwardapi-volume-b25b1724-4a25-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007699892s
+Apr 27 14:17:24.156: INFO: Pod "downwardapi-volume-b25b1724-4a25-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012044968s
+STEP: Saw pod success
+Apr 27 14:17:24.156: INFO: Pod "downwardapi-volume-b25b1724-4a25-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:17:24.159: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downwardapi-volume-b25b1724-4a25-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:17:24.178: INFO: Waiting for pod downwardapi-volume-b25b1724-4a25-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:17:24.181: INFO: Pod downwardapi-volume-b25b1724-4a25-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:17:24.181: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-pqjfj" for this suite.
+Apr 27 14:17:30.193: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:17:30.239: INFO: namespace: e2e-tests-downward-api-pqjfj, resource: bindings, ignored listing per whitelist
+Apr 27 14:17:30.314: INFO: namespace e2e-tests-downward-api-pqjfj deletion completed in 6.12987388s
+
+• [SLOW TEST:10.258 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:17:30.314: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:17:30.393: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-t2thc" for this suite.
+Apr 27 14:17:36.407: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:17:36.444: INFO: namespace: e2e-tests-services-t2thc, resource: bindings, ignored listing per whitelist
+Apr 27 14:17:36.520: INFO: namespace e2e-tests-services-t2thc deletion completed in 6.124195602s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:6.206 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:17:36.521: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-bc2a514b-4a25-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:17:36.606: INFO: Waiting up to 5m0s for pod "pod-configmaps-bc2ac9a5-4a25-11e8-8194-02aee6f695c9" in namespace "e2e-tests-configmap-6wd94" to be "success or failure"
+Apr 27 14:17:36.609: INFO: Pod "pod-configmaps-bc2ac9a5-4a25-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.583687ms
+Apr 27 14:17:38.613: INFO: Pod "pod-configmaps-bc2ac9a5-4a25-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006447536s
+STEP: Saw pod success
+Apr 27 14:17:38.613: INFO: Pod "pod-configmaps-bc2ac9a5-4a25-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:17:38.616: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-configmaps-bc2ac9a5-4a25-11e8-8194-02aee6f695c9 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:17:38.631: INFO: Waiting for pod pod-configmaps-bc2ac9a5-4a25-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:17:38.636: INFO: Pod pod-configmaps-bc2ac9a5-4a25-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:17:38.636: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-6wd94" for this suite.
+Apr 27 14:17:44.648: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:17:44.696: INFO: namespace: e2e-tests-configmap-6wd94, resource: bindings, ignored listing per whitelist
+Apr 27 14:17:44.762: INFO: namespace e2e-tests-configmap-6wd94 deletion completed in 6.122234933s
+
+• [SLOW TEST:8.241 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:17:44.762: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:17:44.846: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c114bb60-4a25-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-k2rvq" to be "success or failure"
+Apr 27 14:17:44.848: INFO: Pod "downwardapi-volume-c114bb60-4a25-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.221583ms
+Apr 27 14:17:46.851: INFO: Pod "downwardapi-volume-c114bb60-4a25-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005765066s
+STEP: Saw pod success
+Apr 27 14:17:46.851: INFO: Pod "downwardapi-volume-c114bb60-4a25-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:17:46.854: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downwardapi-volume-c114bb60-4a25-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:17:46.869: INFO: Waiting for pod downwardapi-volume-c114bb60-4a25-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:17:46.872: INFO: Pod downwardapi-volume-c114bb60-4a25-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:17:46.872: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-k2rvq" for this suite.
+Apr 27 14:17:52.883: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:17:52.961: INFO: namespace: e2e-tests-projected-k2rvq, resource: bindings, ignored listing per whitelist
+Apr 27 14:17:52.994: INFO: namespace e2e-tests-projected-k2rvq deletion completed in 6.118543826s
+
+• [SLOW TEST:8.232 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:17:52.994: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating server pod server in namespace e2e-tests-prestop-r5kld
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-r5kld
+STEP: Deleting pre-stop pod
+Apr 27 14:18:06.162: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:18:06.167: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-r5kld" for this suite.
+Apr 27 14:18:44.180: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:18:44.252: INFO: namespace: e2e-tests-prestop-r5kld, resource: bindings, ignored listing per whitelist
+Apr 27 14:18:44.296: INFO: namespace e2e-tests-prestop-r5kld deletion completed in 38.126282058s
+
+• [SLOW TEST:51.303 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:18:44.296: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-lb785
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 27 14:18:44.374: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 27 14:19:10.431: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.45:8080/dial?request=hostName&protocol=http&host=100.96.0.44&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-lb785 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:19:10.431: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:19:10.560: INFO: Waiting for endpoints: map[]
+Apr 27 14:19:10.563: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.45:8080/dial?request=hostName&protocol=http&host=100.96.1.35&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-lb785 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:19:10.563: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:19:12.489: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:19:12.490: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-lb785" for this suite.
+Apr 27 14:19:34.503: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:19:34.543: INFO: namespace: e2e-tests-pod-network-test-lb785, resource: bindings, ignored listing per whitelist
+Apr 27 14:19:34.611: INFO: namespace e2e-tests-pod-network-test-lb785 deletion completed in 22.11802226s
+
+• [SLOW TEST:50.315 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:19:34.611: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Apr 27 14:19:34.708: INFO: Number of nodes with available pods: 0
+Apr 27 14:19:34.708: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:19:35.715: INFO: Number of nodes with available pods: 0
+Apr 27 14:19:35.715: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:19:36.717: INFO: Number of nodes with available pods: 2
+Apr 27 14:19:36.717: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Stop a daemon pod, check that the daemon pod is revived.
+Apr 27 14:19:36.732: INFO: Number of nodes with available pods: 1
+Apr 27 14:19:36.732: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:19:37.740: INFO: Number of nodes with available pods: 1
+Apr 27 14:19:37.740: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:19:38.739: INFO: Number of nodes with available pods: 1
+Apr 27 14:19:38.739: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:19:39.740: INFO: Number of nodes with available pods: 1
+Apr 27 14:19:39.740: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:19:40.740: INFO: Number of nodes with available pods: 1
+Apr 27 14:19:40.740: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:19:41.740: INFO: Number of nodes with available pods: 1
+Apr 27 14:19:41.740: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:19:42.739: INFO: Number of nodes with available pods: 2
+Apr 27 14:19:42.739: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 27 14:19:49.758: INFO: Number of nodes with available pods: 0
+Apr 27 14:19:49.758: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 27 14:19:49.761: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-dz6t9/daemonsets","resourceVersion":"5212"},"items":null}
+
+Apr 27 14:19:49.764: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-dz6t9/pods","resourceVersion":"5212"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:19:49.772: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-dz6t9" for this suite.
+Apr 27 14:19:55.784: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:19:55.835: INFO: namespace: e2e-tests-daemonsets-dz6t9, resource: bindings, ignored listing per whitelist
+Apr 27 14:19:55.894: INFO: namespace e2e-tests-daemonsets-dz6t9 deletion completed in 6.119219195s
+
+• [SLOW TEST:21.283 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:19:55.894: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Apr 27 14:19:55.990: INFO: Waiting up to 1m0s for all nodes to be ready
+Apr 27 14:20:56.009: INFO: Waiting for terminating namespaces to be deleted...
+Apr 27 14:20:56.014: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 27 14:20:56.024: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 27 14:20:56.024: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 27 14:20:56.028: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 27 14:20:56.028: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h before test
+Apr 27 14:20:56.048: INFO: node-exporter-wk4vh from kube-system started at 2018-04-27 13:52:32 +0000 UTC (1 container statuses recorded)
+Apr 27 14:20:56.048: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: calico-node-6qnh2 from kube-system started at 2018-04-27 13:52:32 +0000 UTC (2 container statuses recorded)
+Apr 27 14:20:56.048: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-65z9k from kube-system started at 2018-04-27 13:53:33 +0000 UTC (1 container statuses recorded)
+Apr 27 14:20:56.048: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: addons-heapster-e3b0c-5c98c994fc-fcjnb from kube-system started at 2018-04-27 13:53:34 +0000 UTC (2 container statuses recorded)
+Apr 27 14:20:56.048: INFO: 	Container heapster ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: 	Container heapster-nanny ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: kube-dns-67b49bdfd8-kzgp5 from kube-system started at 2018-04-27 13:53:34 +0000 UTC (3 container statuses recorded)
+Apr 27 14:20:56.048: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: sonobuoy from sonobuoy started at 2018-04-27 14:04:09 +0000 UTC (1 container statuses recorded)
+Apr 27 14:20:56.048: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: sonobuoy-e2e-job-137eed9de25c425d from sonobuoy started at 2018-04-27 14:04:25 +0000 UTC (2 container statuses recorded)
+Apr 27 14:20:56.048: INFO: 	Container e2e ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: kube-proxy-9kttt from kube-system started at 2018-04-27 13:52:32 +0000 UTC (1 container statuses recorded)
+Apr 27 14:20:56.048: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:20:56.048: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 before test
+Apr 27 14:20:56.057: INFO: addons-nginx-ingress-controller-7c8749685-6m9kp from kube-system started at 2018-04-27 13:53:33 +0000 UTC (1 container statuses recorded)
+Apr 27 14:20:56.057: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Apr 27 14:20:56.057: INFO: addons-kubernetes-dashboard-8478f49fbf-snb4l from kube-system started at 2018-04-27 13:53:35 +0000 UTC (1 container statuses recorded)
+Apr 27 14:20:56.057: INFO: 	Container main ready: true, restart count 0
+Apr 27 14:20:56.057: INFO: kube-dns-67b49bdfd8-566ks from kube-system started at 2018-04-27 13:53:46 +0000 UTC (3 container statuses recorded)
+Apr 27 14:20:56.057: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:20:56.057: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:20:56.057: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:20:56.057: INFO: kube-proxy-5v9vj from kube-system started at 2018-04-27 13:52:32 +0000 UTC (1 container statuses recorded)
+Apr 27 14:20:56.057: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:20:56.057: INFO: node-exporter-6r4qq from kube-system started at 2018-04-27 13:52:32 +0000 UTC (1 container statuses recorded)
+Apr 27 14:20:56.057: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:20:56.057: INFO: calico-node-jphjj from kube-system started at 2018-04-27 13:52:32 +0000 UTC (2 container statuses recorded)
+Apr 27 14:20:56.057: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:20:56.057: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:20:56.057: INFO: vpn-shoot-665bbc666-c27z4 from kube-system started at 2018-04-27 13:53:33 +0000 UTC (1 container statuses recorded)
+Apr 27 14:20:56.057: INFO: 	Container vpn-shoot ready: true, restart count 1
+Apr 27 14:20:56.057: INFO: kube-dns-autoscaler-699b4b55c4-8qw7j from kube-system started at 2018-04-27 13:53:34 +0000 UTC (1 container statuses recorded)
+Apr 27 14:20:56.057: INFO: 	Container autoscaler ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.152950dc526855e1], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 node(s) didn't match node selector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:20:57.083: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-zmmx8" for this suite.
+Apr 27 14:21:19.095: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:21:19.130: INFO: namespace: e2e-tests-sched-pred-zmmx8, resource: bindings, ignored listing per whitelist
+Apr 27 14:21:19.214: INFO: namespace e2e-tests-sched-pred-zmmx8 deletion completed in 22.12876884s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.320 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:21:19.215: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:37
+[It] should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test hostPath mode
+Apr 27 14:21:19.301: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-tdvmd" to be "success or failure"
+Apr 27 14:21:19.303: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 2.485733ms
+Apr 27 14:21:21.307: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006183569s
+Apr 27 14:21:23.311: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010011341s
+STEP: Saw pod success
+Apr 27 14:21:23.311: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Apr 27 14:21:23.313: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Apr 27 14:21:23.330: INFO: Waiting for pod pod-host-path-test to disappear
+Apr 27 14:21:23.339: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:21:23.339: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-tdvmd" for this suite.
+Apr 27 14:21:29.352: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:21:29.430: INFO: namespace: e2e-tests-hostpath-tdvmd, resource: bindings, ignored listing per whitelist
+Apr 27 14:21:29.478: INFO: namespace e2e-tests-hostpath-tdvmd deletion completed in 6.13470296s
+
+• [SLOW TEST:10.263 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:34
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:21:29.478: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-4706e31d-4a26-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:21:29.572: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-4707533e-4a26-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-xcq4d" to be "success or failure"
+Apr 27 14:21:29.574: INFO: Pod "pod-projected-configmaps-4707533e-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.236281ms
+Apr 27 14:21:31.578: INFO: Pod "pod-projected-configmaps-4707533e-4a26-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006433654s
+STEP: Saw pod success
+Apr 27 14:21:31.578: INFO: Pod "pod-projected-configmaps-4707533e-4a26-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:21:31.581: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-projected-configmaps-4707533e-4a26-11e8-8194-02aee6f695c9 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:21:31.601: INFO: Waiting for pod pod-projected-configmaps-4707533e-4a26-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:21:31.603: INFO: Pod pod-projected-configmaps-4707533e-4a26-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:21:31.603: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xcq4d" for this suite.
+Apr 27 14:21:37.617: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:21:37.673: INFO: namespace: e2e-tests-projected-xcq4d, resource: bindings, ignored listing per whitelist
+Apr 27 14:21:37.747: INFO: namespace e2e-tests-projected-xcq4d deletion completed in 6.139421057s
+
+• [SLOW TEST:8.269 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:21:37.747: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-map-4bf2559a-4a26-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:21:37.827: INFO: Waiting up to 5m0s for pod "pod-secrets-4bf2d2b4-4a26-11e8-8194-02aee6f695c9" in namespace "e2e-tests-secrets-68zlt" to be "success or failure"
+Apr 27 14:21:37.829: INFO: Pod "pod-secrets-4bf2d2b4-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.233656ms
+Apr 27 14:21:39.832: INFO: Pod "pod-secrets-4bf2d2b4-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005682135s
+Apr 27 14:21:41.836: INFO: Pod "pod-secrets-4bf2d2b4-4a26-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.00943003s
+STEP: Saw pod success
+Apr 27 14:21:41.836: INFO: Pod "pod-secrets-4bf2d2b4-4a26-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:21:41.839: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-secrets-4bf2d2b4-4a26-11e8-8194-02aee6f695c9 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:21:41.867: INFO: Waiting for pod pod-secrets-4bf2d2b4-4a26-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:21:41.870: INFO: Pod pod-secrets-4bf2d2b4-4a26-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:21:41.870: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-68zlt" for this suite.
+Apr 27 14:21:47.894: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:21:47.958: INFO: namespace: e2e-tests-secrets-68zlt, resource: bindings, ignored listing per whitelist
+Apr 27 14:21:48.013: INFO: namespace e2e-tests-secrets-68zlt deletion completed in 6.135911253s
+
+• [SLOW TEST:10.265 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:21:48.013: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:21:48.091: INFO: Waiting up to 5m0s for pod "downwardapi-volume-5210fa3a-4a26-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-nl6vz" to be "success or failure"
+Apr 27 14:21:48.093: INFO: Pod "downwardapi-volume-5210fa3a-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.139448ms
+Apr 27 14:21:50.097: INFO: Pod "downwardapi-volume-5210fa3a-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006443018s
+Apr 27 14:21:52.101: INFO: Pod "downwardapi-volume-5210fa3a-4a26-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010093842s
+STEP: Saw pod success
+Apr 27 14:21:52.101: INFO: Pod "downwardapi-volume-5210fa3a-4a26-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:21:52.103: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downwardapi-volume-5210fa3a-4a26-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:21:52.120: INFO: Waiting for pod downwardapi-volume-5210fa3a-4a26-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:21:52.123: INFO: Pod downwardapi-volume-5210fa3a-4a26-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:21:52.123: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-nl6vz" for this suite.
+Apr 27 14:21:58.135: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:21:58.177: INFO: namespace: e2e-tests-projected-nl6vz, resource: bindings, ignored listing per whitelist
+Apr 27 14:21:58.248: INFO: namespace e2e-tests-projected-nl6vz deletion completed in 6.121795323s
+
+• [SLOW TEST:10.235 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:21:58.248: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:21:58.327: INFO: Waiting up to 5m0s for pod "downwardapi-volume-582b0b83-4a26-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-s9b5l" to be "success or failure"
+Apr 27 14:21:58.330: INFO: Pod "downwardapi-volume-582b0b83-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.493888ms
+Apr 27 14:22:00.333: INFO: Pod "downwardapi-volume-582b0b83-4a26-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006134772s
+STEP: Saw pod success
+Apr 27 14:22:00.333: INFO: Pod "downwardapi-volume-582b0b83-4a26-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:22:00.336: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downwardapi-volume-582b0b83-4a26-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:22:00.351: INFO: Waiting for pod downwardapi-volume-582b0b83-4a26-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:22:00.354: INFO: Pod downwardapi-volume-582b0b83-4a26-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:00.354: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-s9b5l" for this suite.
+Apr 27 14:22:06.365: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:22:06.451: INFO: namespace: e2e-tests-projected-s9b5l, resource: bindings, ignored listing per whitelist
+Apr 27 14:22:06.490: INFO: namespace e2e-tests-projected-s9b5l deletion completed in 6.133020549s
+
+• [SLOW TEST:8.242 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:22:06.490: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating secret e2e-tests-secrets-sn6w4/secret-test-5d155b47-4a26-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:22:06.578: INFO: Waiting up to 5m0s for pod "pod-configmaps-5d15db27-4a26-11e8-8194-02aee6f695c9" in namespace "e2e-tests-secrets-sn6w4" to be "success or failure"
+Apr 27 14:22:06.580: INFO: Pod "pod-configmaps-5d15db27-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.297365ms
+Apr 27 14:22:08.584: INFO: Pod "pod-configmaps-5d15db27-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006071006s
+Apr 27 14:22:10.588: INFO: Pod "pod-configmaps-5d15db27-4a26-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009816072s
+STEP: Saw pod success
+Apr 27 14:22:10.588: INFO: Pod "pod-configmaps-5d15db27-4a26-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:22:10.591: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-configmaps-5d15db27-4a26-11e8-8194-02aee6f695c9 container env-test: <nil>
+STEP: delete the pod
+Apr 27 14:22:10.609: INFO: Waiting for pod pod-configmaps-5d15db27-4a26-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:22:10.613: INFO: Pod pod-configmaps-5d15db27-4a26-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:10.613: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-sn6w4" for this suite.
+Apr 27 14:22:16.632: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:22:16.675: INFO: namespace: e2e-tests-secrets-sn6w4, resource: bindings, ignored listing per whitelist
+Apr 27 14:22:16.750: INFO: namespace e2e-tests-secrets-sn6w4 deletion completed in 6.130075672s
+
+• [SLOW TEST:10.260 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:22:16.750: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Apr 27 14:22:16.849: INFO: Waiting up to 5m0s for pod "pod-6333540b-4a26-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-7fjcz" to be "success or failure"
+Apr 27 14:22:16.852: INFO: Pod "pod-6333540b-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.707129ms
+Apr 27 14:22:18.856: INFO: Pod "pod-6333540b-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006499683s
+Apr 27 14:22:20.859: INFO: Pod "pod-6333540b-4a26-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010213095s
+STEP: Saw pod success
+Apr 27 14:22:20.859: INFO: Pod "pod-6333540b-4a26-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:22:20.862: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-6333540b-4a26-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:22:20.880: INFO: Waiting for pod pod-6333540b-4a26-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:22:20.882: INFO: Pod pod-6333540b-4a26-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:20.882: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-7fjcz" for this suite.
+Apr 27 14:22:26.896: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:22:26.970: INFO: namespace: e2e-tests-emptydir-7fjcz, resource: bindings, ignored listing per whitelist
+Apr 27 14:22:27.014: INFO: namespace e2e-tests-emptydir-7fjcz deletion completed in 6.12832784s
+
+• [SLOW TEST:10.263 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:22:27.014: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-6950cd79-4a26-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:22:27.099: INFO: Waiting up to 5m0s for pod "pod-secrets-69513c7d-4a26-11e8-8194-02aee6f695c9" in namespace "e2e-tests-secrets-wk76q" to be "success or failure"
+Apr 27 14:22:27.101: INFO: Pod "pod-secrets-69513c7d-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.032759ms
+Apr 27 14:22:29.105: INFO: Pod "pod-secrets-69513c7d-4a26-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005799095s
+STEP: Saw pod success
+Apr 27 14:22:29.105: INFO: Pod "pod-secrets-69513c7d-4a26-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:22:29.107: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-secrets-69513c7d-4a26-11e8-8194-02aee6f695c9 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:22:29.133: INFO: Waiting for pod pod-secrets-69513c7d-4a26-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:22:29.136: INFO: Pod pod-secrets-69513c7d-4a26-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:29.136: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-wk76q" for this suite.
+Apr 27 14:22:35.156: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:22:35.239: INFO: namespace: e2e-tests-secrets-wk76q, resource: bindings, ignored listing per whitelist
+Apr 27 14:22:35.275: INFO: namespace e2e-tests-secrets-wk76q deletion completed in 6.13280701s
+
+• [SLOW TEST:8.261 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:22:35.275: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-upd-6e3e247a-4a26-11e8-8194-02aee6f695c9
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-6e3e247a-4a26-11e8-8194-02aee6f695c9
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:39.452: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-dk2ls" for this suite.
+Apr 27 14:23:01.467: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:23:01.557: INFO: namespace: e2e-tests-configmap-dk2ls, resource: bindings, ignored listing per whitelist
+Apr 27 14:23:01.596: INFO: namespace e2e-tests-configmap-dk2ls deletion completed in 22.139665363s
+
+• [SLOW TEST:26.321 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:23:01.596: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name cm-test-opt-del-7dee99b9-4a26-11e8-8194-02aee6f695c9
+STEP: Creating configMap with name cm-test-opt-upd-7dee99fc-4a26-11e8-8194-02aee6f695c9
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-7dee99b9-4a26-11e8-8194-02aee6f695c9
+STEP: Updating configmap cm-test-opt-upd-7dee99fc-4a26-11e8-8194-02aee6f695c9
+STEP: Creating configMap with name cm-test-opt-create-7dee9a1b-4a26-11e8-8194-02aee6f695c9
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:24:07.679: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-hkc4k" for this suite.
+Apr 27 14:24:29.691: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:24:29.786: INFO: namespace: e2e-tests-configmap-hkc4k, resource: bindings, ignored listing per whitelist
+Apr 27 14:24:29.813: INFO: namespace e2e-tests-configmap-hkc4k deletion completed in 22.130922823s
+
+• [SLOW TEST:88.217 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:24:29.813: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-b2830169-4a26-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:24:29.903: INFO: Waiting up to 5m0s for pod "pod-configmaps-b28383d4-4a26-11e8-8194-02aee6f695c9" in namespace "e2e-tests-configmap-j2k4h" to be "success or failure"
+Apr 27 14:24:29.905: INFO: Pod "pod-configmaps-b28383d4-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.263857ms
+Apr 27 14:24:31.909: INFO: Pod "pod-configmaps-b28383d4-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006120086s
+Apr 27 14:24:33.912: INFO: Pod "pod-configmaps-b28383d4-4a26-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009816896s
+STEP: Saw pod success
+Apr 27 14:24:33.913: INFO: Pod "pod-configmaps-b28383d4-4a26-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:24:33.915: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-configmaps-b28383d4-4a26-11e8-8194-02aee6f695c9 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:24:33.973: INFO: Waiting for pod pod-configmaps-b28383d4-4a26-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:24:33.975: INFO: Pod pod-configmaps-b28383d4-4a26-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:24:33.975: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-j2k4h" for this suite.
+Apr 27 14:24:39.988: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:24:40.035: INFO: namespace: e2e-tests-configmap-j2k4h, resource: bindings, ignored listing per whitelist
+Apr 27 14:24:40.108: INFO: namespace e2e-tests-configmap-j2k4h deletion completed in 6.129932813s
+
+• [SLOW TEST:10.295 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:24:40.108: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:24:40.195: INFO: Creating daemon "daemon-set" with a node selector
+STEP: Initially, daemon pods should not be running on any nodes.
+Apr 27 14:24:40.201: INFO: Number of nodes with available pods: 0
+Apr 27 14:24:40.201: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Change node label to blue, check that daemon pod is launched.
+Apr 27 14:24:40.215: INFO: Number of nodes with available pods: 0
+Apr 27 14:24:40.215: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:24:41.219: INFO: Number of nodes with available pods: 0
+Apr 27 14:24:41.219: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:24:42.219: INFO: Number of nodes with available pods: 0
+Apr 27 14:24:42.220: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:24:43.219: INFO: Number of nodes with available pods: 1
+Apr 27 14:24:43.219: INFO: Number of running nodes: 1, number of available pods: 1
+STEP: Update the node label to green, and wait for daemons to be unscheduled
+Apr 27 14:24:43.231: INFO: Number of nodes with available pods: 1
+Apr 27 14:24:43.231: INFO: Number of running nodes: 0, number of available pods: 1
+Apr 27 14:24:44.236: INFO: Number of nodes with available pods: 0
+Apr 27 14:24:44.236: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Update DaemonSet node selector to green, and change its update strategy to RollingUpdate
+Apr 27 14:24:44.245: INFO: Number of nodes with available pods: 0
+Apr 27 14:24:44.245: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:24:45.249: INFO: Number of nodes with available pods: 0
+Apr 27 14:24:45.249: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:24:46.249: INFO: Number of nodes with available pods: 0
+Apr 27 14:24:46.249: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:24:47.248: INFO: Number of nodes with available pods: 0
+Apr 27 14:24:47.248: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:24:48.249: INFO: Number of nodes with available pods: 0
+Apr 27 14:24:48.249: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:24:49.249: INFO: Number of nodes with available pods: 1
+Apr 27 14:24:49.249: INFO: Number of running nodes: 1, number of available pods: 1
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 27 14:24:53.273: INFO: Number of nodes with available pods: 0
+Apr 27 14:24:53.273: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 27 14:24:53.276: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-67tp9/daemonsets","resourceVersion":"5881"},"items":null}
+
+Apr 27 14:24:53.278: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-67tp9/pods","resourceVersion":"5881"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:24:53.291: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-67tp9" for this suite.
+Apr 27 14:24:59.304: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:24:59.345: INFO: namespace: e2e-tests-daemonsets-67tp9, resource: bindings, ignored listing per whitelist
+Apr 27 14:24:59.432: INFO: namespace e2e-tests-daemonsets-67tp9 deletion completed in 6.137229731s
+
+• [SLOW TEST:19.323 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:24:59.432: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for 2 Minute to see if the garbage collector mistakenly deletes the rs
+STEP: expected 0 Deploymentss, got 1 Deployments
+STEP: Gathering metrics
+W0427 14:25:05.051631      17 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:25:05.051: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:25:05.051: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-cg5zm" for this suite.
+Apr 27 14:25:11.064: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:25:11.177: INFO: namespace: e2e-tests-gc-cg5zm, resource: bindings, ignored listing per whitelist
+Apr 27 14:25:11.185: INFO: namespace e2e-tests-gc-cg5zm deletion completed in 6.130701607s
+
+• [SLOW TEST:11.754 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:25:11.185: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-cb2b541f-4a26-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:25:11.270: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-cb2bc576-4a26-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-lhxmk" to be "success or failure"
+Apr 27 14:25:11.272: INFO: Pod "pod-projected-configmaps-cb2bc576-4a26-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.098423ms
+Apr 27 14:25:13.275: INFO: Pod "pod-projected-configmaps-cb2bc576-4a26-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005475488s
+STEP: Saw pod success
+Apr 27 14:25:13.275: INFO: Pod "pod-projected-configmaps-cb2bc576-4a26-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:25:13.278: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-projected-configmaps-cb2bc576-4a26-11e8-8194-02aee6f695c9 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:25:13.295: INFO: Waiting for pod pod-projected-configmaps-cb2bc576-4a26-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:25:13.304: INFO: Pod pod-projected-configmaps-cb2bc576-4a26-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:25:13.304: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lhxmk" for this suite.
+Apr 27 14:25:19.321: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:25:19.387: INFO: namespace: e2e-tests-projected-lhxmk, resource: bindings, ignored listing per whitelist
+Apr 27 14:25:19.440: INFO: namespace e2e-tests-projected-lhxmk deletion completed in 6.12872249s
+
+• [SLOW TEST:8.254 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:25:19.440: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-d9f49 A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-d9f49;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-d9f49 A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-d9f49;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-d9f49.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-d9f49.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-d9f49.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-d9f49.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-d9f49.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-d9f49.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-d9f49.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-d9f49.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-d9f49.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-d9f49.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-d9f49.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-d9f49.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-d9f49.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 66.183.65.100.in-addr.arpa. PTR)" && echo OK > /results/100.65.183.66_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 66.183.65.100.in-addr.arpa. PTR)" && echo OK > /results/100.65.183.66_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-d9f49 A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-d9f49;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-d9f49 A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-d9f49;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-d9f49.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-d9f49.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-d9f49.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-d9f49.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-d9f49.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-d9f49.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-d9f49.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-d9f49.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-d9f49.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-d9f49.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-d9f49.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-d9f49.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-d9f49.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 66.183.65.100.in-addr.arpa. PTR)" && echo OK > /results/100.65.183.66_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 66.183.65.100.in-addr.arpa. PTR)" && echo OK > /results/100.65.183.66_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Apr 27 14:25:42.828: INFO: DNS probes using dns-test-d01806bd-4a26-11e8-8194-02aee6f695c9 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:25:42.854: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-d9f49" for this suite.
+Apr 27 14:25:48.867: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:25:48.978: INFO: namespace: e2e-tests-dns-d9f49, resource: bindings, ignored listing per whitelist
+Apr 27 14:25:48.991: INFO: namespace e2e-tests-dns-d9f49 deletion completed in 6.133456377s
+
+• [SLOW TEST:29.551 seconds]
+[sig-network] DNS
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:25:48.991: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-cnztr
+Apr 27 14:25:53.080: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-cnztr
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:25:53.083: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:27:53.314: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-cnztr" for this suite.
+Apr 27 14:27:59.330: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:27:59.425: INFO: namespace: e2e-tests-container-probe-cnztr, resource: bindings, ignored listing per whitelist
+Apr 27 14:27:59.444: INFO: namespace e2e-tests-container-probe-cnztr deletion completed in 6.126795548s
+
+• [SLOW TEST:130.453 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Pods 
+  should be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:27:59.445: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Apr 27 14:28:04.042: INFO: Successfully updated pod "pod-update-2f7506b7-4a27-11e8-8194-02aee6f695c9"
+STEP: verifying the updated pod is in kubernetes
+Apr 27 14:28:04.048: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:28:04.048: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-kknzt" for this suite.
+Apr 27 14:28:26.061: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:28:26.114: INFO: namespace: e2e-tests-pods-kknzt, resource: bindings, ignored listing per whitelist
+Apr 27 14:28:26.180: INFO: namespace e2e-tests-pods-kknzt deletion completed in 22.128760575s
+
+• [SLOW TEST:26.736 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:28:26.181: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-3f650b03-4a27-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:28:26.263: INFO: Waiting up to 5m0s for pod "pod-configmaps-3f657a43-4a27-11e8-8194-02aee6f695c9" in namespace "e2e-tests-configmap-dpmzs" to be "success or failure"
+Apr 27 14:28:26.266: INFO: Pod "pod-configmaps-3f657a43-4a27-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.385181ms
+Apr 27 14:28:28.270: INFO: Pod "pod-configmaps-3f657a43-4a27-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006187007s
+STEP: Saw pod success
+Apr 27 14:28:28.270: INFO: Pod "pod-configmaps-3f657a43-4a27-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:28:28.272: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-configmaps-3f657a43-4a27-11e8-8194-02aee6f695c9 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:28:28.293: INFO: Waiting for pod pod-configmaps-3f657a43-4a27-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:28:28.296: INFO: Pod pod-configmaps-3f657a43-4a27-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:28:28.296: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-dpmzs" for this suite.
+Apr 27 14:28:34.309: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:28:34.394: INFO: namespace: e2e-tests-configmap-dpmzs, resource: bindings, ignored listing per whitelist
+Apr 27 14:28:34.426: INFO: namespace e2e-tests-configmap-dpmzs deletion completed in 6.126601306s
+
+• [SLOW TEST:8.246 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:28:34.426: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:29:34.505: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-tmn7f" for this suite.
+Apr 27 14:29:56.518: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:29:56.610: INFO: namespace: e2e-tests-container-probe-tmn7f, resource: bindings, ignored listing per whitelist
+Apr 27 14:29:56.639: INFO: namespace e2e-tests-container-probe-tmn7f deletion completed in 22.131303569s
+
+• [SLOW TEST:82.213 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:29:56.640: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-vpr7b
+Apr 27 14:30:00.735: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-vpr7b
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:30:00.739: INFO: Initial restart count of pod liveness-exec is 0
+Apr 27 14:30:52.835: INFO: Restart count of pod e2e-tests-container-probe-vpr7b/liveness-exec is now 1 (52.096161723s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:30:52.842: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-vpr7b" for this suite.
+Apr 27 14:30:58.855: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:30:58.895: INFO: namespace: e2e-tests-container-probe-vpr7b, resource: bindings, ignored listing per whitelist
+Apr 27 14:30:58.968: INFO: namespace e2e-tests-container-probe-vpr7b deletion completed in 6.122757849s
+
+• [SLOW TEST:62.329 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:30:58.968: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc1
+STEP: create the rc2
+STEP: set half of pods created by rc simpletest-rc-to-be-deleted to have rc simpletest-rc-to-stay as owner as well
+STEP: delete the rc simpletest-rc-to-be-deleted
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0427 14:31:09.101549      17 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:31:09.101: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:31:09.101: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-btz2f" for this suite.
+Apr 27 14:31:15.113: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:31:15.218: INFO: namespace: e2e-tests-gc-btz2f, resource: bindings, ignored listing per whitelist
+Apr 27 14:31:15.229: INFO: namespace e2e-tests-gc-btz2f deletion completed in 6.124442793s
+
+• [SLOW TEST:16.260 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:31:15.229: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:31:15.315: INFO: (0) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 8.574748ms)
+Apr 27 14:31:15.320: INFO: (1) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.936525ms)
+Apr 27 14:31:15.325: INFO: (2) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.833741ms)
+Apr 27 14:31:15.330: INFO: (3) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.955959ms)
+Apr 27 14:31:15.335: INFO: (4) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.938262ms)
+Apr 27 14:31:15.340: INFO: (5) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.635749ms)
+Apr 27 14:31:15.345: INFO: (6) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.548392ms)
+Apr 27 14:31:15.349: INFO: (7) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.789947ms)
+Apr 27 14:31:15.354: INFO: (8) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.428054ms)
+Apr 27 14:31:15.359: INFO: (9) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.897879ms)
+Apr 27 14:31:15.364: INFO: (10) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.837337ms)
+Apr 27 14:31:15.368: INFO: (11) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.595993ms)
+Apr 27 14:31:15.373: INFO: (12) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.524645ms)
+Apr 27 14:31:15.377: INFO: (13) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.347921ms)
+Apr 27 14:31:15.382: INFO: (14) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.144801ms)
+Apr 27 14:31:15.387: INFO: (15) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.868446ms)
+Apr 27 14:31:15.392: INFO: (16) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.847424ms)
+Apr 27 14:31:15.397: INFO: (17) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.705123ms)
+Apr 27 14:31:15.402: INFO: (18) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.989732ms)
+Apr 27 14:31:15.407: INFO: (19) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.693125ms)
+[AfterEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:31:15.407: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-d9tcw" for this suite.
+Apr 27 14:31:21.420: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:31:21.501: INFO: namespace: e2e-tests-proxy-d9tcw, resource: bindings, ignored listing per whitelist
+Apr 27 14:31:21.531: INFO: namespace e2e-tests-proxy-d9tcw deletion completed in 6.120804181s
+
+• [SLOW TEST:6.302 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:31:21.531: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the pods
+STEP: Gathering metrics
+W0427 14:32:01.631708      17 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:32:01.631: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:32:01.631: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-rwnnl" for this suite.
+Apr 27 14:32:07.644: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:32:07.702: INFO: namespace: e2e-tests-gc-rwnnl, resource: bindings, ignored listing per whitelist
+Apr 27 14:32:07.762: INFO: namespace e2e-tests-gc-rwnnl deletion completed in 6.128283248s
+
+• [SLOW TEST:46.232 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:32:07.763: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test substitution in container's args
+Apr 27 14:32:07.844: INFO: Waiting up to 5m0s for pod "var-expansion-c377e483-4a27-11e8-8194-02aee6f695c9" in namespace "e2e-tests-var-expansion-kxpvl" to be "success or failure"
+Apr 27 14:32:07.847: INFO: Pod "var-expansion-c377e483-4a27-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.464223ms
+Apr 27 14:32:09.850: INFO: Pod "var-expansion-c377e483-4a27-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005625136s
+Apr 27 14:32:11.853: INFO: Pod "var-expansion-c377e483-4a27-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008738317s
+STEP: Saw pod success
+Apr 27 14:32:11.853: INFO: Pod "var-expansion-c377e483-4a27-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:32:11.856: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod var-expansion-c377e483-4a27-11e8-8194-02aee6f695c9 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:32:11.874: INFO: Waiting for pod var-expansion-c377e483-4a27-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:32:11.877: INFO: Pod var-expansion-c377e483-4a27-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:32:11.877: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-kxpvl" for this suite.
+Apr 27 14:32:17.888: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:32:17.936: INFO: namespace: e2e-tests-var-expansion-kxpvl, resource: bindings, ignored listing per whitelist
+Apr 27 14:32:17.997: INFO: namespace e2e-tests-var-expansion-kxpvl deletion completed in 6.1168008s
+
+• [SLOW TEST:10.234 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:32:17.997: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap e2e-tests-configmap-7gjwp/configmap-test-c990fbe3-4a27-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:32:18.077: INFO: Waiting up to 5m0s for pod "pod-configmaps-c99165da-4a27-11e8-8194-02aee6f695c9" in namespace "e2e-tests-configmap-7gjwp" to be "success or failure"
+Apr 27 14:32:18.079: INFO: Pod "pod-configmaps-c99165da-4a27-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 1.99036ms
+Apr 27 14:32:20.082: INFO: Pod "pod-configmaps-c99165da-4a27-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005489012s
+Apr 27 14:32:22.086: INFO: Pod "pod-configmaps-c99165da-4a27-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009152464s
+STEP: Saw pod success
+Apr 27 14:32:22.086: INFO: Pod "pod-configmaps-c99165da-4a27-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:32:22.088: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-configmaps-c99165da-4a27-11e8-8194-02aee6f695c9 container env-test: <nil>
+STEP: delete the pod
+Apr 27 14:32:22.112: INFO: Waiting for pod pod-configmaps-c99165da-4a27-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:32:22.120: INFO: Pod pod-configmaps-c99165da-4a27-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:32:22.120: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-7gjwp" for this suite.
+Apr 27 14:32:28.133: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:32:28.168: INFO: namespace: e2e-tests-configmap-7gjwp, resource: bindings, ignored listing per whitelist
+Apr 27 14:32:28.239: INFO: namespace e2e-tests-configmap-7gjwp deletion completed in 6.114487841s
+
+• [SLOW TEST:10.242 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:32:28.239: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:32:28.317: INFO: (0) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.732924ms)
+Apr 27 14:32:28.321: INFO: (1) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.93664ms)
+Apr 27 14:32:28.325: INFO: (2) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.812105ms)
+Apr 27 14:32:28.331: INFO: (3) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.09198ms)
+Apr 27 14:32:28.335: INFO: (4) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.966072ms)
+Apr 27 14:32:28.339: INFO: (5) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.102438ms)
+Apr 27 14:32:28.344: INFO: (6) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.388643ms)
+Apr 27 14:32:28.348: INFO: (7) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.039865ms)
+Apr 27 14:32:28.352: INFO: (8) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.942551ms)
+Apr 27 14:32:28.355: INFO: (9) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.562841ms)
+Apr 27 14:32:28.359: INFO: (10) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.7737ms)
+Apr 27 14:32:28.363: INFO: (11) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.007562ms)
+Apr 27 14:32:28.367: INFO: (12) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.953509ms)
+Apr 27 14:32:28.372: INFO: (13) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.53787ms)
+Apr 27 14:32:28.377: INFO: (14) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.261891ms)
+Apr 27 14:32:28.383: INFO: (15) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.080964ms)
+Apr 27 14:32:28.387: INFO: (16) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.157078ms)
+Apr 27 14:32:28.391: INFO: (17) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.019333ms)
+Apr 27 14:32:28.395: INFO: (18) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.756025ms)
+Apr 27 14:32:28.399: INFO: (19) /api/v1/nodes/shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.843828ms)
+[AfterEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:32:28.399: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-z7k8v" for this suite.
+Apr 27 14:32:34.410: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:32:34.539: INFO: namespace: e2e-tests-proxy-z7k8v, resource: bindings, ignored listing per whitelist
+Apr 27 14:32:34.548: INFO: namespace e2e-tests-proxy-z7k8v deletion completed in 6.145520654s
+
+• [SLOW TEST:6.309 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:32:34.548: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name s-test-opt-del-d36ed3bd-4a27-11e8-8194-02aee6f695c9
+STEP: Creating secret with name s-test-opt-upd-d36ed414-4a27-11e8-8194-02aee6f695c9
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-d36ed3bd-4a27-11e8-8194-02aee6f695c9
+STEP: Updating secret s-test-opt-upd-d36ed414-4a27-11e8-8194-02aee6f695c9
+STEP: Creating secret with name s-test-opt-create-d36ed42d-4a27-11e8-8194-02aee6f695c9
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:33:45.321: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6qxn2" for this suite.
+Apr 27 14:34:07.335: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:34:07.454: INFO: namespace: e2e-tests-projected-6qxn2, resource: bindings, ignored listing per whitelist
+Apr 27 14:34:07.457: INFO: namespace e2e-tests-projected-6qxn2 deletion completed in 22.131271684s
+
+• [SLOW TEST:92.909 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:34:07.457: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:34:07.538: INFO: Waiting up to 5m0s for pod "downwardapi-volume-0acfc912-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-96r7j" to be "success or failure"
+Apr 27 14:34:07.540: INFO: Pod "downwardapi-volume-0acfc912-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 1.963488ms
+Apr 27 14:34:09.544: INFO: Pod "downwardapi-volume-0acfc912-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006209604s
+STEP: Saw pod success
+Apr 27 14:34:09.545: INFO: Pod "downwardapi-volume-0acfc912-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:34:09.547: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod downwardapi-volume-0acfc912-4a28-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:34:09.566: INFO: Waiting for pod downwardapi-volume-0acfc912-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:34:09.569: INFO: Pod downwardapi-volume-0acfc912-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:34:09.569: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-96r7j" for this suite.
+Apr 27 14:34:15.581: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:34:15.631: INFO: namespace: e2e-tests-projected-96r7j, resource: bindings, ignored listing per whitelist
+Apr 27 14:34:15.708: INFO: namespace e2e-tests-projected-96r7j deletion completed in 6.136688717s
+
+• [SLOW TEST:8.252 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:34:15.709: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating replication controller my-hostname-basic-0fb9f8d5-4a28-11e8-8194-02aee6f695c9
+Apr 27 14:34:15.785: INFO: Pod name my-hostname-basic-0fb9f8d5-4a28-11e8-8194-02aee6f695c9: Found 0 pods out of 1
+Apr 27 14:34:20.789: INFO: Pod name my-hostname-basic-0fb9f8d5-4a28-11e8-8194-02aee6f695c9: Found 1 pods out of 1
+Apr 27 14:34:20.789: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-0fb9f8d5-4a28-11e8-8194-02aee6f695c9" are running
+Apr 27 14:34:20.792: INFO: Pod "my-hostname-basic-0fb9f8d5-4a28-11e8-8194-02aee6f695c9-g22dt" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:34:15 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:34:17 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:34:15 +0000 UTC Reason: Message:}])
+Apr 27 14:34:20.792: INFO: Trying to dial the pod
+Apr 27 14:34:25.846: INFO: Controller my-hostname-basic-0fb9f8d5-4a28-11e8-8194-02aee6f695c9: Got expected result from replica 1 [my-hostname-basic-0fb9f8d5-4a28-11e8-8194-02aee6f695c9-g22dt]: "my-hostname-basic-0fb9f8d5-4a28-11e8-8194-02aee6f695c9-g22dt", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:34:25.846: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-wh9j4" for this suite.
+Apr 27 14:34:31.858: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:34:31.940: INFO: namespace: e2e-tests-replication-controller-wh9j4, resource: bindings, ignored listing per whitelist
+Apr 27 14:34:31.961: INFO: namespace e2e-tests-replication-controller-wh9j4 deletion completed in 6.111751298s
+
+• [SLOW TEST:16.253 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:34:31.962: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Apr 27 14:34:32.043: INFO: Waiting up to 5m0s for pod "pod-196b031a-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-fv8g6" to be "success or failure"
+Apr 27 14:34:32.045: INFO: Pod "pod-196b031a-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.002126ms
+Apr 27 14:34:34.049: INFO: Pod "pod-196b031a-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005677588s
+STEP: Saw pod success
+Apr 27 14:34:34.049: INFO: Pod "pod-196b031a-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:34:34.052: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-196b031a-4a28-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:34:34.067: INFO: Waiting for pod pod-196b031a-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:34:34.072: INFO: Pod pod-196b031a-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:34:34.072: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-fv8g6" for this suite.
+Apr 27 14:34:40.086: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:34:40.155: INFO: namespace: e2e-tests-emptydir-fv8g6, resource: bindings, ignored listing per whitelist
+Apr 27 14:34:40.194: INFO: namespace e2e-tests-emptydir-fv8g6 deletion completed in 6.11764667s
+
+• [SLOW TEST:8.233 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:34:40.195: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Apr 27 14:34:40.281: INFO: Number of nodes with available pods: 0
+Apr 27 14:34:40.281: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:34:41.288: INFO: Number of nodes with available pods: 0
+Apr 27 14:34:41.288: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:34:42.289: INFO: Number of nodes with available pods: 2
+Apr 27 14:34:42.289: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.
+Apr 27 14:34:42.305: INFO: Number of nodes with available pods: 1
+Apr 27 14:34:42.305: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:34:43.312: INFO: Number of nodes with available pods: 1
+Apr 27 14:34:43.312: INFO: Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h is running more than one daemon pod
+Apr 27 14:34:44.312: INFO: Number of nodes with available pods: 2
+Apr 27 14:34:44.312: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Wait for the failed daemon pod to be completely deleted.
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 27 14:34:48.332: INFO: Number of nodes with available pods: 0
+Apr 27 14:34:48.332: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 27 14:34:48.335: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-692sg/daemonsets","resourceVersion":"7263"},"items":null}
+
+Apr 27 14:34:48.337: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-692sg/pods","resourceVersion":"7265"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:34:48.344: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-692sg" for this suite.
+Apr 27 14:34:54.357: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:34:54.444: INFO: namespace: e2e-tests-daemonsets-692sg, resource: bindings, ignored listing per whitelist
+Apr 27 14:34:54.480: INFO: namespace e2e-tests-daemonsets-692sg deletion completed in 6.132530023s
+
+• [SLOW TEST:14.285 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:34:54.480: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-qx6cs
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 27 14:34:54.557: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 27 14:35:14.612: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.74:8080/dial?request=hostName&protocol=udp&host=100.96.0.73&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-qx6cs PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:35:14.612: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:35:14.761: INFO: Waiting for endpoints: map[]
+Apr 27 14:35:14.764: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.74:8080/dial?request=hostName&protocol=udp&host=100.96.1.63&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-qx6cs PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:35:14.764: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:35:14.907: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:35:14.907: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-qx6cs" for this suite.
+Apr 27 14:35:36.921: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:35:37.023: INFO: namespace: e2e-tests-pod-network-test-qx6cs, resource: bindings, ignored listing per whitelist
+Apr 27 14:35:37.036: INFO: namespace e2e-tests-pod-network-test-qx6cs deletion completed in 22.12498836s
+
+• [SLOW TEST:42.556 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:35:37.036: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name projected-secret-test-4034b6b1-4a28-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:35:37.122: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-403538af-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-swwtg" to be "success or failure"
+Apr 27 14:35:37.124: INFO: Pod "pod-projected-secrets-403538af-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.15156ms
+Apr 27 14:35:39.129: INFO: Pod "pod-projected-secrets-403538af-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006446424s
+STEP: Saw pod success
+Apr 27 14:35:39.129: INFO: Pod "pod-projected-secrets-403538af-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:35:39.132: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-projected-secrets-403538af-4a28-11e8-8194-02aee6f695c9 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:35:39.153: INFO: Waiting for pod pod-projected-secrets-403538af-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:35:39.155: INFO: Pod pod-projected-secrets-403538af-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:35:39.156: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-swwtg" for this suite.
+Apr 27 14:35:45.168: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:35:45.244: INFO: namespace: e2e-tests-projected-swwtg, resource: bindings, ignored listing per whitelist
+Apr 27 14:35:45.305: INFO: namespace e2e-tests-projected-swwtg deletion completed in 6.146023034s
+
+• [SLOW TEST:8.268 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:35:45.305: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-4521574a-4a28-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:35:45.385: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-4521fd7a-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-q2p5n" to be "success or failure"
+Apr 27 14:35:45.387: INFO: Pod "pod-projected-configmaps-4521fd7a-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.136185ms
+Apr 27 14:35:47.391: INFO: Pod "pod-projected-configmaps-4521fd7a-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006118206s
+STEP: Saw pod success
+Apr 27 14:35:47.391: INFO: Pod "pod-projected-configmaps-4521fd7a-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:35:47.394: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-projected-configmaps-4521fd7a-4a28-11e8-8194-02aee6f695c9 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:35:47.416: INFO: Waiting for pod pod-projected-configmaps-4521fd7a-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:35:47.419: INFO: Pod pod-projected-configmaps-4521fd7a-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:35:47.419: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-q2p5n" for this suite.
+Apr 27 14:35:53.432: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:35:53.550: INFO: namespace: e2e-tests-projected-q2p5n, resource: bindings, ignored listing per whitelist
+Apr 27 14:35:53.559: INFO: namespace e2e-tests-projected-q2p5n deletion completed in 6.137067673s
+
+• [SLOW TEST:8.254 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:35:53.559: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-4a0dc76e-4a28-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:35:53.645: INFO: Waiting up to 5m0s for pod "pod-secrets-4a0e4b45-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-secrets-gt45j" to be "success or failure"
+Apr 27 14:35:53.647: INFO: Pod "pod-secrets-4a0e4b45-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.331657ms
+Apr 27 14:35:55.650: INFO: Pod "pod-secrets-4a0e4b45-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005844298s
+STEP: Saw pod success
+Apr 27 14:35:55.650: INFO: Pod "pod-secrets-4a0e4b45-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:35:55.653: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-secrets-4a0e4b45-4a28-11e8-8194-02aee6f695c9 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:35:55.670: INFO: Waiting for pod pod-secrets-4a0e4b45-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:35:55.672: INFO: Pod pod-secrets-4a0e4b45-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:35:55.672: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-gt45j" for this suite.
+Apr 27 14:36:01.684: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:36:01.740: INFO: namespace: e2e-tests-secrets-gt45j, resource: bindings, ignored listing per whitelist
+Apr 27 14:36:01.811: INFO: namespace e2e-tests-secrets-gt45j deletion completed in 6.136231269s
+
+• [SLOW TEST:8.252 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:36:01.812: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-6669v
+[It] Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Looking for a node to schedule stateful set and pod
+STEP: Creating pod with conflicting port in namespace e2e-tests-statefulset-6669v
+STEP: Creating statefulset with conflicting port in namespace e2e-tests-statefulset-6669v
+STEP: Waiting until pod test-pod will start running in namespace e2e-tests-statefulset-6669v
+STEP: Waiting until stateful pod ss-0 will be recreated and deleted at least once in namespace e2e-tests-statefulset-6669v
+Apr 27 14:36:05.906: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-6669v, name: ss-0, uid: 50bef5c7-4a28-11e8-9870-221312dc233c, status phase: Pending. Waiting for statefulset controller to delete.
+Apr 27 14:36:06.105: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-6669v, name: ss-0, uid: 50bef5c7-4a28-11e8-9870-221312dc233c, status phase: Failed. Waiting for statefulset controller to delete.
+Apr 27 14:36:06.110: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-6669v, name: ss-0, uid: 50bef5c7-4a28-11e8-9870-221312dc233c, status phase: Failed. Waiting for statefulset controller to delete.
+Apr 27 14:36:06.111: INFO: Observed delete event for stateful pod ss-0 in namespace e2e-tests-statefulset-6669v
+STEP: Removing pod with conflicting port in namespace e2e-tests-statefulset-6669v
+STEP: Waiting when stateful pod ss-0 will be recreated in namespace e2e-tests-statefulset-6669v and will be in running state
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:36:10.128: INFO: Deleting all statefulset in ns e2e-tests-statefulset-6669v
+Apr 27 14:36:10.131: INFO: Scaling statefulset ss to 0
+Apr 27 14:36:20.146: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:36:20.148: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:36:20.158: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-6669v" for this suite.
+Apr 27 14:36:26.169: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:36:26.249: INFO: namespace: e2e-tests-statefulset-6669v, resource: bindings, ignored listing per whitelist
+Apr 27 14:36:26.285: INFO: namespace e2e-tests-statefulset-6669v deletion completed in 6.123875441s
+
+• [SLOW TEST:24.473 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Should recreate evicted statefulset [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:36:26.285: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Apr 27 14:36:26.365: INFO: Waiting up to 5m0s for pod "pod-5d8f3457-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-sv7cz" to be "success or failure"
+Apr 27 14:36:26.368: INFO: Pod "pod-5d8f3457-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.387602ms
+Apr 27 14:36:28.374: INFO: Pod "pod-5d8f3457-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008505644s
+STEP: Saw pod success
+Apr 27 14:36:28.374: INFO: Pod "pod-5d8f3457-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:36:28.377: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-5d8f3457-4a28-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:36:28.394: INFO: Waiting for pod pod-5d8f3457-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:36:28.397: INFO: Pod pod-5d8f3457-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:36:28.397: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-sv7cz" for this suite.
+Apr 27 14:36:34.409: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:36:34.446: INFO: namespace: e2e-tests-emptydir-sv7cz, resource: bindings, ignored listing per whitelist
+Apr 27 14:36:34.525: INFO: namespace e2e-tests-emptydir-sv7cz deletion completed in 6.125246285s
+
+• [SLOW TEST:8.240 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:36:34.525: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name s-test-opt-del-6278f67d-4a28-11e8-8194-02aee6f695c9
+STEP: Creating secret with name s-test-opt-upd-6278f6e0-4a28-11e8-8194-02aee6f695c9
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-6278f67d-4a28-11e8-8194-02aee6f695c9
+STEP: Updating secret s-test-opt-upd-6278f6e0-4a28-11e8-8194-02aee6f695c9
+STEP: Creating secret with name s-test-opt-create-6278f6f6-4a28-11e8-8194-02aee6f695c9
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:38:05.896: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-5nnds" for this suite.
+Apr 27 14:38:27.908: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:38:27.973: INFO: namespace: e2e-tests-secrets-5nnds, resource: bindings, ignored listing per whitelist
+Apr 27 14:38:28.018: INFO: namespace e2e-tests-secrets-5nnds deletion completed in 22.119157212s
+
+• [SLOW TEST:113.493 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:38:28.018: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-a61dbc7a-4a28-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:38:28.099: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-a61e36da-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-57n22" to be "success or failure"
+Apr 27 14:38:28.101: INFO: Pod "pod-projected-configmaps-a61e36da-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010888ms
+Apr 27 14:38:30.104: INFO: Pod "pod-projected-configmaps-a61e36da-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005501044s
+STEP: Saw pod success
+Apr 27 14:38:30.104: INFO: Pod "pod-projected-configmaps-a61e36da-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:38:30.107: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-projected-configmaps-a61e36da-4a28-11e8-8194-02aee6f695c9 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:38:30.125: INFO: Waiting for pod pod-projected-configmaps-a61e36da-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:38:30.130: INFO: Pod pod-projected-configmaps-a61e36da-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:38:30.130: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-57n22" for this suite.
+Apr 27 14:38:36.144: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:38:36.194: INFO: namespace: e2e-tests-projected-57n22, resource: bindings, ignored listing per whitelist
+Apr 27 14:38:36.255: INFO: namespace e2e-tests-projected-57n22 deletion completed in 6.119949565s
+
+• [SLOW TEST:8.237 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:38:36.255: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Apr 27 14:38:36.328: INFO: Waiting up to 5m0s for pod "pod-ab05ed91-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-6sp6v" to be "success or failure"
+Apr 27 14:38:36.331: INFO: Pod "pod-ab05ed91-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.186554ms
+Apr 27 14:38:38.334: INFO: Pod "pod-ab05ed91-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005718523s
+Apr 27 14:38:40.338: INFO: Pod "pod-ab05ed91-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009162984s
+STEP: Saw pod success
+Apr 27 14:38:40.338: INFO: Pod "pod-ab05ed91-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:38:40.340: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-ab05ed91-4a28-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:38:40.357: INFO: Waiting for pod pod-ab05ed91-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:38:40.359: INFO: Pod pod-ab05ed91-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:38:40.360: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-6sp6v" for this suite.
+Apr 27 14:38:46.371: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:38:46.414: INFO: namespace: e2e-tests-emptydir-6sp6v, resource: bindings, ignored listing per whitelist
+Apr 27 14:38:46.476: INFO: namespace e2e-tests-emptydir-6sp6v deletion completed in 6.113765408s
+
+• [SLOW TEST:10.222 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:38:46.477: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-map-b11e8106-4a28-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:38:46.559: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-b11ef6c2-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-n9fqz" to be "success or failure"
+Apr 27 14:38:46.561: INFO: Pod "pod-projected-secrets-b11ef6c2-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.512992ms
+Apr 27 14:38:48.565: INFO: Pod "pod-projected-secrets-b11ef6c2-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005938289s
+Apr 27 14:38:50.568: INFO: Pod "pod-projected-secrets-b11ef6c2-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009140901s
+STEP: Saw pod success
+Apr 27 14:38:50.568: INFO: Pod "pod-projected-secrets-b11ef6c2-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:38:50.571: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-projected-secrets-b11ef6c2-4a28-11e8-8194-02aee6f695c9 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:38:50.587: INFO: Waiting for pod pod-projected-secrets-b11ef6c2-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:38:50.594: INFO: Pod pod-projected-secrets-b11ef6c2-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:38:50.594: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-n9fqz" for this suite.
+Apr 27 14:38:56.607: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:38:56.668: INFO: namespace: e2e-tests-projected-n9fqz, resource: bindings, ignored listing per whitelist
+Apr 27 14:38:56.720: INFO: namespace e2e-tests-projected-n9fqz deletion completed in 6.12172211s
+
+• [SLOW TEST:10.243 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:38:56.720: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Apr 27 14:38:56.807: INFO: Waiting up to 5m0s for pod "pod-b73ab405-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-n4656" to be "success or failure"
+Apr 27 14:38:56.809: INFO: Pod "pod-b73ab405-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.223685ms
+Apr 27 14:38:58.812: INFO: Pod "pod-b73ab405-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00521707s
+STEP: Saw pod success
+Apr 27 14:38:58.812: INFO: Pod "pod-b73ab405-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:38:58.814: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-b73ab405-4a28-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:38:58.832: INFO: Waiting for pod pod-b73ab405-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:38:58.835: INFO: Pod pod-b73ab405-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:38:58.835: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-n4656" for this suite.
+Apr 27 14:39:04.846: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:39:04.943: INFO: namespace: e2e-tests-emptydir-n4656, resource: bindings, ignored listing per whitelist
+Apr 27 14:39:04.962: INFO: namespace e2e-tests-emptydir-n4656 deletion completed in 6.12404092s
+
+• [SLOW TEST:8.242 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:39:04.962: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Apr 27 14:39:05.547: INFO: Waiting up to 5m0s for pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-qh9gw" in namespace "e2e-tests-svcaccounts-jxf8d" to be "success or failure"
+Apr 27 14:39:05.549: INFO: Pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-qh9gw": Phase="Pending", Reason="", readiness=false. Elapsed: 2.296735ms
+Apr 27 14:39:07.553: INFO: Pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-qh9gw": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005863743s
+Apr 27 14:39:09.556: INFO: Pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-qh9gw": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009109081s
+STEP: Saw pod success
+Apr 27 14:39:09.556: INFO: Pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-qh9gw" satisfied condition "success or failure"
+Apr 27 14:39:09.558: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-qh9gw container token-test: <nil>
+STEP: delete the pod
+Apr 27 14:39:09.575: INFO: Waiting for pod pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-qh9gw to disappear
+Apr 27 14:39:09.577: INFO: Pod pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-qh9gw no longer exists
+STEP: Creating a pod to test consume service account root CA
+Apr 27 14:39:09.580: INFO: Waiting up to 5m0s for pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-n99ml" in namespace "e2e-tests-svcaccounts-jxf8d" to be "success or failure"
+Apr 27 14:39:09.582: INFO: Pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-n99ml": Phase="Pending", Reason="", readiness=false. Elapsed: 2.312267ms
+Apr 27 14:39:11.585: INFO: Pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-n99ml": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005457336s
+Apr 27 14:39:13.589: INFO: Pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-n99ml": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008619994s
+STEP: Saw pod success
+Apr 27 14:39:13.589: INFO: Pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-n99ml" satisfied condition "success or failure"
+Apr 27 14:39:13.591: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-n99ml container root-ca-test: <nil>
+STEP: delete the pod
+Apr 27 14:39:16.062: INFO: Waiting for pod pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-n99ml to disappear
+Apr 27 14:39:16.064: INFO: Pod pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-n99ml no longer exists
+STEP: Creating a pod to test consume service account namespace
+Apr 27 14:39:16.068: INFO: Waiting up to 5m0s for pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-kbfs4" in namespace "e2e-tests-svcaccounts-jxf8d" to be "success or failure"
+Apr 27 14:39:16.070: INFO: Pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-kbfs4": Phase="Pending", Reason="", readiness=false. Elapsed: 1.888813ms
+Apr 27 14:39:18.073: INFO: Pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-kbfs4": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005327052s
+Apr 27 14:39:20.076: INFO: Pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-kbfs4": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008293335s
+STEP: Saw pod success
+Apr 27 14:39:20.076: INFO: Pod "pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-kbfs4" satisfied condition "success or failure"
+Apr 27 14:39:20.078: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-kbfs4 container namespace-test: <nil>
+STEP: delete the pod
+Apr 27 14:39:20.094: INFO: Waiting for pod pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-kbfs4 to disappear
+Apr 27 14:39:20.097: INFO: Pod pod-service-account-bc704894-4a28-11e8-8194-02aee6f695c9-kbfs4 no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:39:20.097: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-jxf8d" for this suite.
+Apr 27 14:39:26.107: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:39:26.173: INFO: namespace: e2e-tests-svcaccounts-jxf8d, resource: bindings, ignored listing per whitelist
+Apr 27 14:39:26.211: INFO: namespace e2e-tests-svcaccounts-jxf8d deletion completed in 6.112224088s
+
+• [SLOW TEST:21.249 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:39:26.212: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap e2e-tests-configmap-4d6nm/configmap-test-c8ccef54-4a28-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:39:26.288: INFO: Waiting up to 5m0s for pod "pod-configmaps-c8cd536c-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-configmap-4d6nm" to be "success or failure"
+Apr 27 14:39:26.290: INFO: Pod "pod-configmaps-c8cd536c-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 1.828878ms
+Apr 27 14:39:28.294: INFO: Pod "pod-configmaps-c8cd536c-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005386239s
+Apr 27 14:39:30.297: INFO: Pod "pod-configmaps-c8cd536c-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008679307s
+STEP: Saw pod success
+Apr 27 14:39:30.297: INFO: Pod "pod-configmaps-c8cd536c-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:39:30.300: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-configmaps-c8cd536c-4a28-11e8-8194-02aee6f695c9 container env-test: <nil>
+STEP: delete the pod
+Apr 27 14:39:30.315: INFO: Waiting for pod pod-configmaps-c8cd536c-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:39:30.317: INFO: Pod pod-configmaps-c8cd536c-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:39:30.317: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-4d6nm" for this suite.
+Apr 27 14:39:36.330: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:39:36.419: INFO: namespace: e2e-tests-configmap-4d6nm, resource: bindings, ignored listing per whitelist
+Apr 27 14:39:36.436: INFO: namespace e2e-tests-configmap-4d6nm deletion completed in 6.116104694s
+
+• [SLOW TEST:10.224 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:39:36.436: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for all rs to be garbage collected
+STEP: expected 0 rs, got 1 rs
+STEP: expected 0 Pods, got 2 Pods
+STEP: Gathering metrics
+W0427 14:39:37.541249      17 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:39:37.541: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:39:37.541: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-994vw" for this suite.
+Apr 27 14:39:43.552: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:39:43.648: INFO: namespace: e2e-tests-gc-994vw, resource: bindings, ignored listing per whitelist
+Apr 27 14:39:43.661: INFO: namespace e2e-tests-gc-994vw deletion completed in 6.117799961s
+
+• [SLOW TEST:7.225 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:39:43.662: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Apr 27 14:39:49.754: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-j46nh PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:39:49.754: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:39:49.883: INFO: Exec stderr: ""
+Apr 27 14:39:49.883: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-j46nh PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:39:49.883: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:39:50.012: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Apr 27 14:39:50.012: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-j46nh PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:39:50.012: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:39:50.181: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Apr 27 14:39:50.181: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-j46nh PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:39:50.181: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:39:50.346: INFO: Exec stderr: ""
+Apr 27 14:39:50.346: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-j46nh PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:39:50.346: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:39:50.511: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:39:50.511: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-j46nh" for this suite.
+Apr 27 14:40:30.525: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:30.627: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-j46nh, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:30.634: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-j46nh deletion completed in 40.119288386s
+
+• [SLOW TEST:46.972 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:30.634: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-ef339b06-4a28-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:40:30.716: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-ef340b15-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-8xwcr" to be "success or failure"
+Apr 27 14:40:30.718: INFO: Pod "pod-projected-secrets-ef340b15-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.028196ms
+Apr 27 14:40:32.722: INFO: Pod "pod-projected-secrets-ef340b15-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005652286s
+Apr 27 14:40:34.726: INFO: Pod "pod-projected-secrets-ef340b15-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009750594s
+STEP: Saw pod success
+Apr 27 14:40:34.726: INFO: Pod "pod-projected-secrets-ef340b15-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:40:34.731: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-projected-secrets-ef340b15-4a28-11e8-8194-02aee6f695c9 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:40:34.750: INFO: Waiting for pod pod-projected-secrets-ef340b15-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:40:34.752: INFO: Pod pod-projected-secrets-ef340b15-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:34.752: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8xwcr" for this suite.
+Apr 27 14:40:40.776: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:40.882: INFO: namespace: e2e-tests-projected-8xwcr, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:40.892: INFO: namespace e2e-tests-projected-8xwcr deletion completed in 6.125050918s
+
+• [SLOW TEST:10.258 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:40.892: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:40:40.969: INFO: Waiting up to 5m0s for pod "downward-api-f55099e0-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-fsgsp" to be "success or failure"
+Apr 27 14:40:40.971: INFO: Pod "downward-api-f55099e0-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 1.993638ms
+Apr 27 14:40:42.975: INFO: Pod "downward-api-f55099e0-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005342223s
+Apr 27 14:40:44.978: INFO: Pod "downward-api-f55099e0-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008541876s
+STEP: Saw pod success
+Apr 27 14:40:44.978: INFO: Pod "downward-api-f55099e0-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:40:44.980: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downward-api-f55099e0-4a28-11e8-8194-02aee6f695c9 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:40:44.999: INFO: Waiting for pod downward-api-f55099e0-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:40:45.002: INFO: Pod downward-api-f55099e0-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:45.002: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-fsgsp" for this suite.
+Apr 27 14:40:51.015: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:51.104: INFO: namespace: e2e-tests-downward-api-fsgsp, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:51.119: INFO: namespace e2e-tests-downward-api-fsgsp deletion completed in 6.114250838s
+
+• [SLOW TEST:10.227 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:51.119: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:40:51.196: INFO: Waiting up to 5m0s for pod "downwardapi-volume-fb69211f-4a28-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-s2x92" to be "success or failure"
+Apr 27 14:40:51.198: INFO: Pod "downwardapi-volume-fb69211f-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.09171ms
+Apr 27 14:40:53.202: INFO: Pod "downwardapi-volume-fb69211f-4a28-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005943373s
+Apr 27 14:40:55.206: INFO: Pod "downwardapi-volume-fb69211f-4a28-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009678379s
+STEP: Saw pod success
+Apr 27 14:40:55.206: INFO: Pod "downwardapi-volume-fb69211f-4a28-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:40:55.208: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod downwardapi-volume-fb69211f-4a28-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:40:55.225: INFO: Waiting for pod downwardapi-volume-fb69211f-4a28-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:40:55.227: INFO: Pod downwardapi-volume-fb69211f-4a28-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:55.227: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-s2x92" for this suite.
+Apr 27 14:41:01.248: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:41:01.296: INFO: namespace: e2e-tests-downward-api-s2x92, resource: bindings, ignored listing per whitelist
+Apr 27 14:41:01.364: INFO: namespace e2e-tests-downward-api-s2x92 deletion completed in 6.127272718s
+
+• [SLOW TEST:10.245 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:41:01.364: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-tgrfv
+[It] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Initializing watcher for selector baz=blah,foo=bar
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-tgrfv
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-tgrfv
+Apr 27 14:41:01.449: INFO: Found 0 stateful pods, waiting for 1
+Apr 27 14:41:11.453: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will halt with unhealthy stateful pod
+Apr 27 14:41:11.457: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-tgrfv ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:41:11.755: INFO: stderr: ""
+Apr 27 14:41:11.755: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:41:11.759: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Apr 27 14:41:21.763: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:41:21.763: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:41:21.774: INFO: Verifying statefulset ss doesn't scale past 1 for another 9.99999964s
+Apr 27 14:41:22.777: INFO: Verifying statefulset ss doesn't scale past 1 for another 8.996965486s
+Apr 27 14:41:23.781: INFO: Verifying statefulset ss doesn't scale past 1 for another 7.99342513s
+Apr 27 14:41:24.785: INFO: Verifying statefulset ss doesn't scale past 1 for another 6.990045714s
+Apr 27 14:41:25.788: INFO: Verifying statefulset ss doesn't scale past 1 for another 5.986040776s
+Apr 27 14:41:26.792: INFO: Verifying statefulset ss doesn't scale past 1 for another 4.982466714s
+Apr 27 14:41:27.796: INFO: Verifying statefulset ss doesn't scale past 1 for another 3.978382356s
+Apr 27 14:41:28.800: INFO: Verifying statefulset ss doesn't scale past 1 for another 2.974568427s
+Apr 27 14:41:29.804: INFO: Verifying statefulset ss doesn't scale past 1 for another 1.970429074s
+Apr 27 14:41:30.809: INFO: Verifying statefulset ss doesn't scale past 1 for another 966.517923ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-tgrfv
+Apr 27 14:41:31.813: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-tgrfv ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:41:32.108: INFO: stderr: ""
+Apr 27 14:41:32.108: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:41:32.111: INFO: Found 1 stateful pods, waiting for 3
+Apr 27 14:41:42.116: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:41:42.116: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:41:42.116: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Verifying that stateful set ss was scaled up in order
+STEP: Scale down will halt with unhealthy stateful pod
+Apr 27 14:41:42.122: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-tgrfv ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:41:47.044: INFO: stderr: ""
+Apr 27 14:41:47.044: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:41:47.044: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-tgrfv ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:41:47.328: INFO: stderr: ""
+Apr 27 14:41:47.328: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:41:47.328: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-tgrfv ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:41:47.597: INFO: stderr: ""
+Apr 27 14:41:47.597: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:41:47.597: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:41:47.600: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 2
+Apr 27 14:41:57.610: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:41:57.610: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:41:57.610: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:41:57.618: INFO: Verifying statefulset ss doesn't scale past 3 for another 9.99999965s
+Apr 27 14:41:58.622: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.997145695s
+Apr 27 14:41:59.626: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.992769766s
+Apr 27 14:42:00.631: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.988791688s
+Apr 27 14:42:01.635: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.984327485s
+Apr 27 14:42:02.640: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.979828954s
+Apr 27 14:42:03.648: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.975474739s
+Apr 27 14:42:04.652: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.966882118s
+Apr 27 14:42:05.656: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.962953093s
+Apr 27 14:42:06.661: INFO: Verifying statefulset ss doesn't scale past 3 for another 958.841298ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-tgrfv
+Apr 27 14:42:07.665: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-tgrfv ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:42:07.935: INFO: stderr: ""
+Apr 27 14:42:07.935: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:42:07.935: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-tgrfv ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:42:08.222: INFO: stderr: ""
+Apr 27 14:42:08.222: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:42:08.222: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-tgrfv ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:42:08.531: INFO: stderr: ""
+Apr 27 14:42:08.531: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:42:08.531: INFO: Scaling statefulset ss to 0
+STEP: Verifying that stateful set ss was scaled down in reverse order
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:42:48.547: INFO: Deleting all statefulset in ns e2e-tests-statefulset-tgrfv
+Apr 27 14:42:48.550: INFO: Scaling statefulset ss to 0
+Apr 27 14:42:48.559: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:42:48.561: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:42:48.572: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-tgrfv" for this suite.
+Apr 27 14:42:54.584: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:42:54.687: INFO: namespace: e2e-tests-statefulset-tgrfv, resource: bindings, ignored listing per whitelist
+Apr 27 14:42:54.702: INFO: namespace e2e-tests-statefulset-tgrfv deletion completed in 6.12695436s
+
+• [SLOW TEST:113.338 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:42:54.702: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-vlkzk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-vlkzk to expose endpoints map[]
+Apr 27 14:42:54.785: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-vlkzk exposes endpoints map[] (2.402134ms elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-vlkzk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-vlkzk to expose endpoints map[pod1:[100]]
+Apr 27 14:42:56.807: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-vlkzk exposes endpoints map[pod1:[100]] (2.015868043s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-vlkzk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-vlkzk to expose endpoints map[pod2:[101] pod1:[100]]
+Apr 27 14:42:58.834: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-vlkzk exposes endpoints map[pod1:[100] pod2:[101]] (2.022630203s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-vlkzk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-vlkzk to expose endpoints map[pod2:[101]]
+Apr 27 14:42:59.847: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-vlkzk exposes endpoints map[pod2:[101]] (1.009320108s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-vlkzk
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-vlkzk to expose endpoints map[]
+Apr 27 14:43:00.857: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-vlkzk exposes endpoints map[] (1.005556775s elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:43:00.868: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-vlkzk" for this suite.
+Apr 27 14:43:22.880: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:43:22.969: INFO: namespace: e2e-tests-services-vlkzk, resource: bindings, ignored listing per whitelist
+Apr 27 14:43:22.989: INFO: namespace e2e-tests-services-vlkzk deletion completed in 22.118548134s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:28.287 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:43:22.989: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:43:23.074: INFO: Waiting up to 5m0s for pod "downwardapi-volume-55ef0c5f-4a29-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-48nzm" to be "success or failure"
+Apr 27 14:43:23.077: INFO: Pod "downwardapi-volume-55ef0c5f-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.409062ms
+Apr 27 14:43:25.080: INFO: Pod "downwardapi-volume-55ef0c5f-4a29-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005504202s
+STEP: Saw pod success
+Apr 27 14:43:25.080: INFO: Pod "downwardapi-volume-55ef0c5f-4a29-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:43:25.082: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod downwardapi-volume-55ef0c5f-4a29-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:43:25.099: INFO: Waiting for pod downwardapi-volume-55ef0c5f-4a29-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:43:25.101: INFO: Pod downwardapi-volume-55ef0c5f-4a29-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:43:25.102: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-48nzm" for this suite.
+Apr 27 14:43:31.112: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:43:31.210: INFO: namespace: e2e-tests-projected-48nzm, resource: bindings, ignored listing per whitelist
+Apr 27 14:43:31.223: INFO: namespace e2e-tests-projected-48nzm deletion completed in 6.119032025s
+
+• [SLOW TEST:8.234 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:43:31.224: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 27 14:43:33.834: INFO: Successfully updated pod "annotationupdate5ad7a872-4a29-11e8-8194-02aee6f695c9"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:43:35.857: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qfbdj" for this suite.
+Apr 27 14:43:57.869: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:43:57.907: INFO: namespace: e2e-tests-projected-qfbdj, resource: bindings, ignored listing per whitelist
+Apr 27 14:43:57.980: INFO: namespace e2e-tests-projected-qfbdj deletion completed in 22.120100559s
+
+• [SLOW TEST:26.757 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:43:57.981: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-44hsk
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 27 14:43:58.053: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 27 14:44:16.107: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.1.75 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-44hsk PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:44:16.107: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:44:17.244: INFO: Found all expected endpoints: [netserver-0]
+Apr 27 14:44:17.248: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.0.90 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-44hsk PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:44:17.248: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:44:18.399: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:44:18.399: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-44hsk" for this suite.
+Apr 27 14:44:40.412: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:44:40.480: INFO: namespace: e2e-tests-pod-network-test-44hsk, resource: bindings, ignored listing per whitelist
+Apr 27 14:44:40.524: INFO: namespace e2e-tests-pod-network-test-44hsk deletion completed in 22.120913738s
+
+• [SLOW TEST:42.543 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:44:40.524: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Apr 27 14:44:40.609: INFO: Waiting up to 5m0s for pod "pod-8426c5bb-4a29-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-5z8db" to be "success or failure"
+Apr 27 14:44:40.611: INFO: Pod "pod-8426c5bb-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.463806ms
+Apr 27 14:44:42.615: INFO: Pod "pod-8426c5bb-4a29-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00582868s
+STEP: Saw pod success
+Apr 27 14:44:42.615: INFO: Pod "pod-8426c5bb-4a29-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:44:42.617: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-8426c5bb-4a29-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:44:42.638: INFO: Waiting for pod pod-8426c5bb-4a29-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:44:42.640: INFO: Pod pod-8426c5bb-4a29-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:44:42.641: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-5z8db" for this suite.
+Apr 27 14:44:48.660: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:44:48.745: INFO: namespace: e2e-tests-emptydir-5z8db, resource: bindings, ignored listing per whitelist
+Apr 27 14:44:48.786: INFO: namespace e2e-tests-emptydir-5z8db deletion completed in 6.142334404s
+
+• [SLOW TEST:8.262 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:44:48.787: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:44:48.868: INFO: Waiting up to 5m0s for pod "downwardapi-volume-8912faf5-4a29-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-6wgds" to be "success or failure"
+Apr 27 14:44:48.871: INFO: Pod "downwardapi-volume-8912faf5-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.11521ms
+Apr 27 14:44:50.876: INFO: Pod "downwardapi-volume-8912faf5-4a29-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007328043s
+STEP: Saw pod success
+Apr 27 14:44:50.876: INFO: Pod "downwardapi-volume-8912faf5-4a29-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:44:50.879: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downwardapi-volume-8912faf5-4a29-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:44:50.899: INFO: Waiting for pod downwardapi-volume-8912faf5-4a29-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:44:50.902: INFO: Pod downwardapi-volume-8912faf5-4a29-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:44:50.902: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-6wgds" for this suite.
+Apr 27 14:44:56.914: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:44:56.975: INFO: namespace: e2e-tests-downward-api-6wgds, resource: bindings, ignored listing per whitelist
+Apr 27 14:44:57.029: INFO: namespace e2e-tests-downward-api-6wgds deletion completed in 6.124388373s
+
+• [SLOW TEST:8.243 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:44:57.030: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Apr 27 14:44:57.110: INFO: Waiting up to 5m0s for pod "pod-8dfc992f-4a29-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-mknlx" to be "success or failure"
+Apr 27 14:44:57.112: INFO: Pod "pod-8dfc992f-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.181472ms
+Apr 27 14:44:59.116: INFO: Pod "pod-8dfc992f-4a29-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006231817s
+STEP: Saw pod success
+Apr 27 14:44:59.116: INFO: Pod "pod-8dfc992f-4a29-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:44:59.118: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-8dfc992f-4a29-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:44:59.136: INFO: Waiting for pod pod-8dfc992f-4a29-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:44:59.138: INFO: Pod pod-8dfc992f-4a29-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:44:59.138: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-mknlx" for this suite.
+Apr 27 14:45:05.157: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:45:05.255: INFO: namespace: e2e-tests-emptydir-mknlx, resource: bindings, ignored listing per whitelist
+Apr 27 14:45:05.281: INFO: namespace e2e-tests-emptydir-mknlx deletion completed in 6.140140481s
+
+• [SLOW TEST:8.252 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:45:05.282: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-hl6qg.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-hl6qg.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-hl6qg.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-hl6qg.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-hl6qg.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-hl6qg.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Apr 27 14:45:24.625: INFO: DNS probes using dns-test-92e761f3-4a29-11e8-8194-02aee6f695c9 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:45:24.633: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-hl6qg" for this suite.
+Apr 27 14:45:30.645: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:45:30.709: INFO: namespace: e2e-tests-dns-hl6qg, resource: bindings, ignored listing per whitelist
+Apr 27 14:45:30.773: INFO: namespace e2e-tests-dns-hl6qg deletion completed in 6.136337062s
+
+• [SLOW TEST:25.491 seconds]
+[sig-network] DNS
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:45:30.773: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:45:30.856: INFO: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:45:30.857: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-6qvhj" for this suite.
+Apr 27 14:45:36.870: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:45:36.993: INFO: namespace: e2e-tests-container-probe-6qvhj, resource: bindings, ignored listing per whitelist
+Apr 27 14:45:36.996: INFO: namespace e2e-tests-container-probe-6qvhj deletion completed in 6.13528128s
+
+S [SKIPPING] [6.223 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a docker exec liveness probe with timeout  [Conformance] [It]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+
+  Apr 27 14:45:30.856: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:296
+------------------------------
+SSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:45:36.996: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-7shc4 in namespace e2e-tests-proxy-kcxc7
+I0427 14:45:37.108165      17 runners.go:175] Created replication controller with name: proxy-service-7shc4, namespace: e2e-tests-proxy-kcxc7, replica count: 1
+I0427 14:45:38.108657      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0427 14:45:39.108948      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0427 14:45:40.109232      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:45:41.109502      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:45:42.109832      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:45:43.110118      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:45:44.110397      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:45:45.110639      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:45:46.110879      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:45:47.111210      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:45:48.111494      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:45:49.111732      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:45:50.111962      17 runners.go:175] proxy-service-7shc4 Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Apr 27 14:45:50.115: INFO: setup took 13.045064939s, starting test cases
+STEP: running 16 cases, 20 attempts per case, 320 total attempts
+Apr 27 14:45:50.122: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 7.248464ms)
+Apr 27 14:45:50.123: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 8.109154ms)
+Apr 27 14:45:50.124: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 8.577984ms)
+Apr 27 14:45:50.124: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 8.903864ms)
+Apr 27 14:45:50.124: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 8.852902ms)
+Apr 27 14:45:50.124: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 9.022053ms)
+Apr 27 14:45:50.125: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 10.192599ms)
+Apr 27 14:45:50.128: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 13.307131ms)
+Apr 27 14:45:50.128: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 13.562939ms)
+Apr 27 14:45:50.129: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 13.566628ms)
+Apr 27 14:45:50.129: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 13.613772ms)
+Apr 27 14:45:50.133: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 18.42148ms)
+Apr 27 14:45:50.135: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 20.03454ms)
+Apr 27 14:45:50.138: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 22.658568ms)
+Apr 27 14:45:50.138: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 22.97035ms)
+Apr 27 14:45:50.139: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 23.82023ms)
+Apr 27 14:45:50.146: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 6.641647ms)
+Apr 27 14:45:50.147: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 8.361382ms)
+Apr 27 14:45:50.147: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 8.162812ms)
+Apr 27 14:45:50.147: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 8.27498ms)
+Apr 27 14:45:50.147: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 8.253063ms)
+Apr 27 14:45:50.147: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 8.193485ms)
+Apr 27 14:45:50.147: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 8.362196ms)
+Apr 27 14:45:50.147: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 8.30235ms)
+Apr 27 14:45:50.147: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 8.425619ms)
+Apr 27 14:45:50.148: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 8.381252ms)
+Apr 27 14:45:50.148: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 8.742265ms)
+Apr 27 14:45:50.148: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 8.745877ms)
+Apr 27 14:45:50.148: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 9.047804ms)
+Apr 27 14:45:50.149: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 9.680996ms)
+Apr 27 14:45:50.149: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 10.42733ms)
+Apr 27 14:45:50.150: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 10.690335ms)
+Apr 27 14:45:50.155: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 4.951173ms)
+Apr 27 14:45:50.155: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 4.957699ms)
+Apr 27 14:45:50.155: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 5.335629ms)
+Apr 27 14:45:50.155: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 5.322531ms)
+Apr 27 14:45:50.155: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 5.665525ms)
+Apr 27 14:45:50.155: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 5.786305ms)
+Apr 27 14:45:50.155: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 5.646765ms)
+Apr 27 14:45:50.155: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.711555ms)
+Apr 27 14:45:50.155: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 5.57996ms)
+Apr 27 14:45:50.157: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 6.891537ms)
+Apr 27 14:45:50.157: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 6.771458ms)
+Apr 27 14:45:50.157: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 6.887323ms)
+Apr 27 14:45:50.157: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 6.946823ms)
+Apr 27 14:45:50.157: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 7.065624ms)
+Apr 27 14:45:50.157: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 7.197659ms)
+Apr 27 14:45:50.157: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 7.293152ms)
+Apr 27 14:45:50.163: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 6.281966ms)
+Apr 27 14:45:50.163: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 6.245236ms)
+Apr 27 14:45:50.164: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 6.661976ms)
+Apr 27 14:45:50.164: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 6.513858ms)
+Apr 27 14:45:50.164: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 6.553024ms)
+Apr 27 14:45:50.164: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 6.635328ms)
+Apr 27 14:45:50.164: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 6.559261ms)
+Apr 27 14:45:50.164: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 6.67825ms)
+Apr 27 14:45:50.164: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 7.007754ms)
+Apr 27 14:45:50.167: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 9.279651ms)
+Apr 27 14:45:50.167: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 9.315845ms)
+Apr 27 14:45:50.167: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 9.364487ms)
+Apr 27 14:45:50.167: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 9.489463ms)
+Apr 27 14:45:50.167: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 9.576952ms)
+Apr 27 14:45:50.167: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 9.646629ms)
+Apr 27 14:45:50.167: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 9.622985ms)
+Apr 27 14:45:50.173: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 5.43631ms)
+Apr 27 14:45:50.173: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.485527ms)
+Apr 27 14:45:50.173: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.813679ms)
+Apr 27 14:45:50.173: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 5.623823ms)
+Apr 27 14:45:50.174: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 6.419288ms)
+Apr 27 14:45:50.174: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 6.368628ms)
+Apr 27 14:45:50.174: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 6.434919ms)
+Apr 27 14:45:50.178: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 9.790137ms)
+Apr 27 14:45:50.178: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 9.964473ms)
+Apr 27 14:45:50.178: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 9.822354ms)
+Apr 27 14:45:50.178: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 10.544056ms)
+Apr 27 14:45:50.178: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 10.275172ms)
+Apr 27 14:45:50.178: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 9.960917ms)
+Apr 27 14:45:50.178: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 9.913772ms)
+Apr 27 14:45:50.178: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 10.386395ms)
+Apr 27 14:45:50.179: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 12.049089ms)
+Apr 27 14:45:50.185: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.184302ms)
+Apr 27 14:45:50.185: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 4.943862ms)
+Apr 27 14:45:50.185: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 5.544547ms)
+Apr 27 14:45:50.185: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 5.641047ms)
+Apr 27 14:45:50.185: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 5.453641ms)
+Apr 27 14:45:50.186: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.839128ms)
+Apr 27 14:45:50.186: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 6.181443ms)
+Apr 27 14:45:50.186: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 6.211366ms)
+Apr 27 14:45:50.186: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 6.145982ms)
+Apr 27 14:45:50.186: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 6.041917ms)
+Apr 27 14:45:50.186: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 6.080552ms)
+Apr 27 14:45:50.187: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 7.020218ms)
+Apr 27 14:45:50.187: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 7.012981ms)
+Apr 27 14:45:50.187: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 7.11256ms)
+Apr 27 14:45:50.187: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 7.230529ms)
+Apr 27 14:45:50.187: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 7.538881ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 7.374915ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 7.342806ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 7.304059ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 7.255571ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 7.690819ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 7.632572ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 7.697629ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 7.479766ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 7.561516ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 7.458521ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 7.601503ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 7.673803ms)
+Apr 27 14:45:50.195: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 7.637231ms)
+Apr 27 14:45:50.196: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 8.594187ms)
+Apr 27 14:45:50.196: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 8.505584ms)
+Apr 27 14:45:50.196: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 8.543161ms)
+Apr 27 14:45:50.203: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 6.902498ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 7.152591ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 7.17776ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 7.303854ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 6.936049ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 7.458462ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 7.580692ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 7.450509ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 7.417588ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 7.474751ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 7.394174ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 7.439004ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 7.603527ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 7.863994ms)
+Apr 27 14:45:50.204: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 8.003612ms)
+Apr 27 14:45:50.205: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 8.866174ms)
+Apr 27 14:45:50.210: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 4.990341ms)
+Apr 27 14:45:50.215: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 8.47418ms)
+Apr 27 14:45:50.215: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 8.674124ms)
+Apr 27 14:45:50.215: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 8.781164ms)
+Apr 27 14:45:50.215: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 8.91435ms)
+Apr 27 14:45:50.215: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 8.975068ms)
+Apr 27 14:45:50.215: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 8.71812ms)
+Apr 27 14:45:50.215: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 9.425563ms)
+Apr 27 14:45:50.215: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 9.258089ms)
+Apr 27 14:45:50.215: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 9.560931ms)
+Apr 27 14:45:50.215: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 9.385324ms)
+Apr 27 14:45:50.215: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 9.289316ms)
+Apr 27 14:45:50.215: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 9.323346ms)
+Apr 27 14:45:50.216: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 9.839283ms)
+Apr 27 14:45:50.216: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 10.671811ms)
+Apr 27 14:45:50.216: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 10.073346ms)
+Apr 27 14:45:50.221: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 5.246906ms)
+Apr 27 14:45:50.221: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 5.197099ms)
+Apr 27 14:45:50.221: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.291996ms)
+Apr 27 14:45:50.222: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 5.634366ms)
+Apr 27 14:45:50.222: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 5.607954ms)
+Apr 27 14:45:50.222: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.697533ms)
+Apr 27 14:45:50.223: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 6.462153ms)
+Apr 27 14:45:50.223: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 6.440118ms)
+Apr 27 14:45:50.223: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 6.530691ms)
+Apr 27 14:45:50.223: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 6.601819ms)
+Apr 27 14:45:50.223: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 6.634813ms)
+Apr 27 14:45:50.223: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 6.807993ms)
+Apr 27 14:45:50.223: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 7.225354ms)
+Apr 27 14:45:50.224: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 7.647767ms)
+Apr 27 14:45:50.224: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 7.655827ms)
+Apr 27 14:45:50.225: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 8.615665ms)
+Apr 27 14:45:50.240: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 15.146459ms)
+Apr 27 14:45:50.243: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 17.519703ms)
+Apr 27 14:45:50.243: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 17.698933ms)
+Apr 27 14:45:50.244: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 18.742392ms)
+Apr 27 14:45:50.244: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 18.649695ms)
+Apr 27 14:45:50.244: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 18.992084ms)
+Apr 27 14:45:50.264: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 38.801912ms)
+Apr 27 14:45:50.265: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 40.254983ms)
+Apr 27 14:45:50.265: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 40.177263ms)
+Apr 27 14:45:50.265: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 40.011518ms)
+Apr 27 14:45:50.265: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 40.082713ms)
+Apr 27 14:45:50.265: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 40.140513ms)
+Apr 27 14:45:50.285: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 59.960326ms)
+Apr 27 14:45:50.285: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 60.056486ms)
+Apr 27 14:45:50.313: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 87.403417ms)
+Apr 27 14:45:50.313: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 87.454618ms)
+Apr 27 14:45:50.318: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.516555ms)
+Apr 27 14:45:50.318: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.587606ms)
+Apr 27 14:45:50.318: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.575602ms)
+Apr 27 14:45:50.318: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.569532ms)
+Apr 27 14:45:50.318: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 5.53098ms)
+Apr 27 14:45:50.319: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 6.256406ms)
+Apr 27 14:45:50.319: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 6.512667ms)
+Apr 27 14:45:50.319: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 6.367773ms)
+Apr 27 14:45:50.319: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 6.324142ms)
+Apr 27 14:45:50.319: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 6.432944ms)
+Apr 27 14:45:50.319: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 6.460184ms)
+Apr 27 14:45:50.319: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 6.399081ms)
+Apr 27 14:45:50.320: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 6.72185ms)
+Apr 27 14:45:50.321: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 7.782006ms)
+Apr 27 14:45:50.321: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 7.831434ms)
+Apr 27 14:45:50.321: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 7.922064ms)
+Apr 27 14:45:50.326: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 5.135974ms)
+Apr 27 14:45:50.326: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 4.975155ms)
+Apr 27 14:45:50.326: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 4.830142ms)
+Apr 27 14:45:50.326: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 4.806262ms)
+Apr 27 14:45:50.326: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 4.95344ms)
+Apr 27 14:45:50.326: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 5.511073ms)
+Apr 27 14:45:50.327: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 5.479665ms)
+Apr 27 14:45:50.327: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.611345ms)
+Apr 27 14:45:50.327: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 5.575961ms)
+Apr 27 14:45:50.327: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 5.574426ms)
+Apr 27 14:45:50.327: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 5.425168ms)
+Apr 27 14:45:50.327: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 6.221184ms)
+Apr 27 14:45:50.368: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 47.023346ms)
+Apr 27 14:45:50.368: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 46.464832ms)
+Apr 27 14:45:50.368: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 46.507533ms)
+Apr 27 14:45:50.369: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 47.139623ms)
+Apr 27 14:45:50.374: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 5.175988ms)
+Apr 27 14:45:50.374: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 5.482639ms)
+Apr 27 14:45:50.374: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 5.529272ms)
+Apr 27 14:45:50.374: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.286611ms)
+Apr 27 14:45:50.374: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 5.203795ms)
+Apr 27 14:45:50.374: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.16692ms)
+Apr 27 14:45:50.374: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 5.28817ms)
+Apr 27 14:45:50.374: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.443394ms)
+Apr 27 14:45:50.374: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.358682ms)
+Apr 27 14:45:50.374: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 5.421868ms)
+Apr 27 14:45:50.375: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 5.607123ms)
+Apr 27 14:45:50.375: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 5.572251ms)
+Apr 27 14:45:50.375: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 6.186821ms)
+Apr 27 14:45:50.375: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 5.936557ms)
+Apr 27 14:45:50.376: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 6.540606ms)
+Apr 27 14:45:50.376: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 6.747677ms)
+Apr 27 14:45:50.381: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.258107ms)
+Apr 27 14:45:50.382: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.999808ms)
+Apr 27 14:45:50.382: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 5.521582ms)
+Apr 27 14:45:50.382: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 5.324081ms)
+Apr 27 14:45:50.382: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.589315ms)
+Apr 27 14:45:50.384: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 7.782328ms)
+Apr 27 14:45:50.384: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 7.327555ms)
+Apr 27 14:45:50.384: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 7.710376ms)
+Apr 27 14:45:50.384: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 7.984952ms)
+Apr 27 14:45:50.384: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 8.014609ms)
+Apr 27 14:45:50.384: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 8.044697ms)
+Apr 27 14:45:50.384: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 8.103701ms)
+Apr 27 14:45:50.385: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 7.87864ms)
+Apr 27 14:45:50.385: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 8.09915ms)
+Apr 27 14:45:50.385: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 8.787184ms)
+Apr 27 14:45:50.385: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 8.449162ms)
+Apr 27 14:45:50.390: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 4.457779ms)
+Apr 27 14:45:50.390: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 4.422889ms)
+Apr 27 14:45:50.390: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 4.656908ms)
+Apr 27 14:45:50.390: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 4.669549ms)
+Apr 27 14:45:50.390: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 4.881129ms)
+Apr 27 14:45:50.390: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 4.94051ms)
+Apr 27 14:45:50.390: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 5.030982ms)
+Apr 27 14:45:50.390: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 4.855633ms)
+Apr 27 14:45:50.391: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 5.437405ms)
+Apr 27 14:45:50.391: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 5.418927ms)
+Apr 27 14:45:50.391: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 6.036598ms)
+Apr 27 14:45:50.391: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 6.056186ms)
+Apr 27 14:45:50.391: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 6.110189ms)
+Apr 27 14:45:50.392: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 6.691688ms)
+Apr 27 14:45:50.392: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 6.721961ms)
+Apr 27 14:45:50.392: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 6.648011ms)
+Apr 27 14:45:50.396: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 3.304163ms)
+Apr 27 14:45:50.396: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 3.617085ms)
+Apr 27 14:45:50.396: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 4.042115ms)
+Apr 27 14:45:50.397: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 4.649373ms)
+Apr 27 14:45:50.397: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 4.55617ms)
+Apr 27 14:45:50.397: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 4.297068ms)
+Apr 27 14:45:50.397: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 4.654246ms)
+Apr 27 14:45:50.397: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 4.754997ms)
+Apr 27 14:45:50.398: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 4.893657ms)
+Apr 27 14:45:50.398: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 5.483629ms)
+Apr 27 14:45:50.399: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 6.150249ms)
+Apr 27 14:45:50.399: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 6.280385ms)
+Apr 27 14:45:50.399: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 6.248973ms)
+Apr 27 14:45:50.399: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 6.478009ms)
+Apr 27 14:45:50.399: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 6.385427ms)
+Apr 27 14:45:50.399: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 6.375579ms)
+Apr 27 14:45:50.403: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 3.947346ms)
+Apr 27 14:45:50.404: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 4.671495ms)
+Apr 27 14:45:50.404: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.251005ms)
+Apr 27 14:45:50.404: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.309103ms)
+Apr 27 14:45:50.405: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 5.640256ms)
+Apr 27 14:45:50.405: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.463816ms)
+Apr 27 14:45:50.405: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 5.629127ms)
+Apr 27 14:45:50.405: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 5.612814ms)
+Apr 27 14:45:50.405: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 5.555726ms)
+Apr 27 14:45:50.406: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 6.759521ms)
+Apr 27 14:45:50.406: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 6.764534ms)
+Apr 27 14:45:50.407: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 7.530581ms)
+Apr 27 14:45:50.407: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 7.375353ms)
+Apr 27 14:45:50.407: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 8.042488ms)
+Apr 27 14:45:50.407: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 8.157417ms)
+Apr 27 14:45:50.407: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 8.040777ms)
+Apr 27 14:45:50.412: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 4.36078ms)
+Apr 27 14:45:50.412: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 4.922296ms)
+Apr 27 14:45:50.412: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 4.832402ms)
+Apr 27 14:45:50.413: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 4.601507ms)
+Apr 27 14:45:50.413: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 5.173862ms)
+Apr 27 14:45:50.413: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.069945ms)
+Apr 27 14:45:50.413: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.109934ms)
+Apr 27 14:45:50.414: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 6.185903ms)
+Apr 27 14:45:50.414: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 5.988671ms)
+Apr 27 14:45:50.430: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 21.824986ms)
+Apr 27 14:45:50.430: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 21.600792ms)
+Apr 27 14:45:50.430: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 22.356949ms)
+Apr 27 14:45:50.430: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 22.000324ms)
+Apr 27 14:45:50.430: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 22.289386ms)
+Apr 27 14:45:50.430: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 21.828666ms)
+Apr 27 14:45:50.430: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 21.72711ms)
+Apr 27 14:45:50.436: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:460/proxy/: tls baz (200; 5.882196ms)
+Apr 27 14:45:50.436: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 5.926241ms)
+Apr 27 14:45:50.436: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 5.936336ms)
+Apr 27 14:45:50.437: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v/proxy/rewriteme"... (200; 6.684281ms)
+Apr 27 14:45:50.437: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:162/proxy/: bar (200; 6.561994ms)
+Apr 27 14:45:50.437: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname1/proxy/: foo (200; 7.122988ms)
+Apr 27 14:45:50.437: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/http:proxy-service-7shc4-z7p5v:1080/proxy/... (200; 6.953607ms)
+Apr 27 14:45:50.437: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:462/proxy/: tls qux (200; 7.107762ms)
+Apr 27 14:45:50.437: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname2/proxy/: tls qux (200; 7.081383ms)
+Apr 27 14:45:50.437: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:1080/proxy/rewri... (200; 7.204981ms)
+Apr 27 14:45:50.438: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/https:proxy-service-7shc4-z7p5v:443/proxy/... (200; 7.588977ms)
+Apr 27 14:45:50.438: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/pods/proxy-service-7shc4-z7p5v:160/proxy/: foo (200; 7.443424ms)
+Apr 27 14:45:50.438: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/https:proxy-service-7shc4:tlsportname1/proxy/: tls baz (200; 7.703598ms)
+Apr 27 14:45:50.438: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/proxy-service-7shc4:portname2/proxy/: bar (200; 7.827835ms)
+Apr 27 14:45:50.438: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname1/proxy/: foo (200; 7.903745ms)
+Apr 27 14:45:50.439: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-kcxc7/services/http:proxy-service-7shc4:portname2/proxy/: bar (200; 8.461586ms)
+STEP: deleting { ReplicationController} proxy-service-7shc4 in namespace e2e-tests-proxy-kcxc7
+Apr 27 14:45:51.570: INFO: Deleting { ReplicationController} proxy-service-7shc4 took: 1.028883878s
+Apr 27 14:45:51.571: INFO: Terminating { ReplicationController} proxy-service-7shc4 pods took: 75.775µs
+Apr 27 14:45:52.271: INFO: Garbage collecting { ReplicationController} proxy-service-7shc4 pods took: 1.729180719s
+[AfterEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:45:52.271: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-kcxc7" for this suite.
+Apr 27 14:45:58.285: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:45:58.332: INFO: namespace: e2e-tests-proxy-kcxc7, resource: bindings, ignored listing per whitelist
+Apr 27 14:45:58.397: INFO: namespace e2e-tests-proxy-kcxc7 deletion completed in 6.122771637s
+
+• [SLOW TEST:21.401 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:45:58.397: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Apr 27 14:45:58.478: INFO: Waiting up to 5m0s for pod "pod-b2909a79-4a29-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-4kh64" to be "success or failure"
+Apr 27 14:45:58.480: INFO: Pod "pod-b2909a79-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.148028ms
+Apr 27 14:46:00.484: INFO: Pod "pod-b2909a79-4a29-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005654803s
+STEP: Saw pod success
+Apr 27 14:46:00.484: INFO: Pod "pod-b2909a79-4a29-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:46:00.486: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-b2909a79-4a29-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:46:00.504: INFO: Waiting for pod pod-b2909a79-4a29-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:46:00.507: INFO: Pod pod-b2909a79-4a29-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:46:00.507: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-4kh64" for this suite.
+Apr 27 14:46:06.519: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:46:06.603: INFO: namespace: e2e-tests-emptydir-4kh64, resource: bindings, ignored listing per whitelist
+Apr 27 14:46:06.637: INFO: namespace e2e-tests-emptydir-4kh64 deletion completed in 6.127171251s
+
+• [SLOW TEST:8.240 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:46:06.637: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for all pods to be garbage collected
+STEP: Gathering metrics
+W0427 14:46:16.738130      17 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:46:16.738: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:46:16.738: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-bmnw2" for this suite.
+Apr 27 14:46:22.750: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:46:22.837: INFO: namespace: e2e-tests-gc-bmnw2, resource: bindings, ignored listing per whitelist
+Apr 27 14:46:22.863: INFO: namespace e2e-tests-gc-bmnw2 deletion completed in 6.122309472s
+
+• [SLOW TEST:16.226 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:46:22.863: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-c1253df3-4a29-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:46:22.943: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-c125ab60-4a29-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-sqhpz" to be "success or failure"
+Apr 27 14:46:22.945: INFO: Pod "pod-projected-secrets-c125ab60-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.458575ms
+Apr 27 14:46:24.949: INFO: Pod "pod-projected-secrets-c125ab60-4a29-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00612065s
+STEP: Saw pod success
+Apr 27 14:46:24.949: INFO: Pod "pod-projected-secrets-c125ab60-4a29-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:46:24.952: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-projected-secrets-c125ab60-4a29-11e8-8194-02aee6f695c9 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:46:24.968: INFO: Waiting for pod pod-projected-secrets-c125ab60-4a29-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:46:24.971: INFO: Pod pod-projected-secrets-c125ab60-4a29-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:46:24.971: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-sqhpz" for this suite.
+Apr 27 14:46:30.986: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:46:31.075: INFO: namespace: e2e-tests-projected-sqhpz, resource: bindings, ignored listing per whitelist
+Apr 27 14:46:31.110: INFO: namespace e2e-tests-projected-sqhpz deletion completed in 6.133498803s
+
+• [SLOW TEST:8.247 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:46:31.111: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:46:31.207: INFO: Waiting up to 5m0s for pod "downward-api-c612a006-4a29-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-pchpc" to be "success or failure"
+Apr 27 14:46:31.210: INFO: Pod "downward-api-c612a006-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.425035ms
+Apr 27 14:46:33.214: INFO: Pod "downward-api-c612a006-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006317855s
+Apr 27 14:46:35.218: INFO: Pod "downward-api-c612a006-4a29-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010469903s
+STEP: Saw pod success
+Apr 27 14:46:35.218: INFO: Pod "downward-api-c612a006-4a29-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:46:35.222: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downward-api-c612a006-4a29-11e8-8194-02aee6f695c9 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:46:35.239: INFO: Waiting for pod downward-api-c612a006-4a29-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:46:35.242: INFO: Pod downward-api-c612a006-4a29-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:46:35.243: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-pchpc" for this suite.
+Apr 27 14:46:41.256: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:46:41.375: INFO: namespace: e2e-tests-downward-api-pchpc, resource: bindings, ignored listing per whitelist
+Apr 27 14:46:41.380: INFO: namespace e2e-tests-downward-api-pchpc deletion completed in 6.133672642s
+
+• [SLOW TEST:10.269 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:46:41.380: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test substitution in container's command
+Apr 27 14:46:41.460: INFO: Waiting up to 5m0s for pod "var-expansion-cc2f21ac-4a29-11e8-8194-02aee6f695c9" in namespace "e2e-tests-var-expansion-x9phl" to be "success or failure"
+Apr 27 14:46:41.464: INFO: Pod "var-expansion-cc2f21ac-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 3.75059ms
+Apr 27 14:46:43.468: INFO: Pod "var-expansion-cc2f21ac-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007571076s
+Apr 27 14:46:45.472: INFO: Pod "var-expansion-cc2f21ac-4a29-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011476722s
+STEP: Saw pod success
+Apr 27 14:46:45.472: INFO: Pod "var-expansion-cc2f21ac-4a29-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:46:45.474: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod var-expansion-cc2f21ac-4a29-11e8-8194-02aee6f695c9 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:46:45.493: INFO: Waiting for pod var-expansion-cc2f21ac-4a29-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:46:45.496: INFO: Pod var-expansion-cc2f21ac-4a29-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:46:45.496: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-x9phl" for this suite.
+Apr 27 14:46:51.510: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:46:51.600: INFO: namespace: e2e-tests-var-expansion-x9phl, resource: bindings, ignored listing per whitelist
+Apr 27 14:46:51.635: INFO: namespace e2e-tests-var-expansion-x9phl deletion completed in 6.135593593s
+
+• [SLOW TEST:10.255 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:46:51.635: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Apr 27 14:46:51.716: INFO: Waiting up to 5m0s for pod "pod-d24c1413-4a29-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-84w97" to be "success or failure"
+Apr 27 14:46:51.722: INFO: Pod "pod-d24c1413-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 6.531374ms
+Apr 27 14:46:53.726: INFO: Pod "pod-d24c1413-4a29-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010218887s
+STEP: Saw pod success
+Apr 27 14:46:53.726: INFO: Pod "pod-d24c1413-4a29-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:46:53.728: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-d24c1413-4a29-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:46:53.750: INFO: Waiting for pod pod-d24c1413-4a29-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:46:53.753: INFO: Pod pod-d24c1413-4a29-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:46:53.753: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-84w97" for this suite.
+Apr 27 14:46:59.765: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:46:59.810: INFO: namespace: e2e-tests-emptydir-84w97, resource: bindings, ignored listing per whitelist
+Apr 27 14:46:59.872: INFO: namespace e2e-tests-emptydir-84w97 deletion completed in 6.116269581s
+
+• [SLOW TEST:8.237 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:46:59.873: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-d73499e8-4a29-11e8-8194-02aee6f695c9,GenerateName:,Namespace:e2e-tests-events-6pbr4,SelfLink:/api/v1/namespaces/e2e-tests-events-6pbr4/pods/send-events-d73499e8-4a29-11e8-8194-02aee6f695c9,UID:d72de19b-4a29-11e8-9870-221312dc233c,ResourceVersion:9128,Generation:0,CreationTimestamp:2018-04-27 14:46:59 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 946345346,},Annotations:map[string]string{cni.projectcalico.org/podIP: 100.96.1.83/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-wjgtr {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-wjgtr,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-wjgtr true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc42163cbb0} {node.kubernetes.io/unreachable Exists  NoExecute 0xc42163cbd0}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:46:59 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:47:01 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:46:59 +0000 UTC  }],Message:,Reason:,HostIP:10.250.0.2,PodIP:100.96.1.83,StartTime:2018-04-27 14:46:59 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-04-27 14:47:00 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://b22d4b84e0d6b9ee4bae8436351534a363dd1dad43f97dacecc6c61774085944}],QOSClass:BestEffort,InitContainerStatuses:[],NominatedNodeName:,},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:05.975: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-6pbr4" for this suite.
+Apr 27 14:47:11.992: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:12.095: INFO: namespace: e2e-tests-events-6pbr4, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:12.112: INFO: namespace e2e-tests-events-6pbr4 deletion completed in 6.129525389s
+
+• [SLOW TEST:12.240 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:12.112: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir volume type on node default medium
+Apr 27 14:47:12.195: INFO: Waiting up to 5m0s for pod "pod-de80cf9a-4a29-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-lk4lx" to be "success or failure"
+Apr 27 14:47:12.197: INFO: Pod "pod-de80cf9a-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.099507ms
+Apr 27 14:47:14.201: INFO: Pod "pod-de80cf9a-4a29-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00604547s
+STEP: Saw pod success
+Apr 27 14:47:14.201: INFO: Pod "pod-de80cf9a-4a29-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:47:14.204: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-de80cf9a-4a29-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:47:14.222: INFO: Waiting for pod pod-de80cf9a-4a29-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:47:14.225: INFO: Pod pod-de80cf9a-4a29-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:14.225: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-lk4lx" for this suite.
+Apr 27 14:47:20.242: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:20.282: INFO: namespace: e2e-tests-emptydir-lk4lx, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:20.359: INFO: namespace e2e-tests-emptydir-lk4lx deletion completed in 6.126501869s
+
+• [SLOW TEST:8.246 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:20.359: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Apr 27 14:47:20.434: INFO: Waiting up to 5m0s for pod "pod-e36a1f0b-4a29-11e8-8194-02aee6f695c9" in namespace "e2e-tests-emptydir-tqgvx" to be "success or failure"
+Apr 27 14:47:20.437: INFO: Pod "pod-e36a1f0b-4a29-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.437386ms
+Apr 27 14:47:22.441: INFO: Pod "pod-e36a1f0b-4a29-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006714909s
+STEP: Saw pod success
+Apr 27 14:47:22.441: INFO: Pod "pod-e36a1f0b-4a29-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:47:22.444: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-e36a1f0b-4a29-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:47:22.464: INFO: Waiting for pod pod-e36a1f0b-4a29-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:47:22.468: INFO: Pod pod-e36a1f0b-4a29-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:22.468: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-tqgvx" for this suite.
+Apr 27 14:47:28.482: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:28.567: INFO: namespace: e2e-tests-emptydir-tqgvx, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:28.603: INFO: namespace e2e-tests-emptydir-tqgvx deletion completed in 6.130859718s
+
+• [SLOW TEST:8.244 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:28.603: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Apr 27 14:47:28.681: INFO: Waiting up to 1m0s for all nodes to be ready
+Apr 27 14:48:28.701: INFO: Waiting for terminating namespaces to be deleted...
+Apr 27 14:48:28.706: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 27 14:48:28.717: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 27 14:48:28.717: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 27 14:48:28.720: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 27 14:48:28.720: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h before test
+Apr 27 14:48:28.731: INFO: calico-node-6qnh2 from kube-system started at 2018-04-27 13:52:32 +0000 UTC (2 container statuses recorded)
+Apr 27 14:48:28.731: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-65z9k from kube-system started at 2018-04-27 13:53:33 +0000 UTC (1 container statuses recorded)
+Apr 27 14:48:28.731: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: addons-heapster-e3b0c-5c98c994fc-fcjnb from kube-system started at 2018-04-27 13:53:34 +0000 UTC (2 container statuses recorded)
+Apr 27 14:48:28.731: INFO: 	Container heapster ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: 	Container heapster-nanny ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: kube-dns-67b49bdfd8-kzgp5 from kube-system started at 2018-04-27 13:53:34 +0000 UTC (3 container statuses recorded)
+Apr 27 14:48:28.731: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: sonobuoy from sonobuoy started at 2018-04-27 14:04:09 +0000 UTC (1 container statuses recorded)
+Apr 27 14:48:28.731: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: sonobuoy-e2e-job-137eed9de25c425d from sonobuoy started at 2018-04-27 14:04:25 +0000 UTC (2 container statuses recorded)
+Apr 27 14:48:28.731: INFO: 	Container e2e ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: node-exporter-wk4vh from kube-system started at 2018-04-27 13:52:32 +0000 UTC (1 container statuses recorded)
+Apr 27 14:48:28.731: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: kube-proxy-9kttt from kube-system started at 2018-04-27 13:52:32 +0000 UTC (1 container statuses recorded)
+Apr 27 14:48:28.731: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:48:28.731: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 before test
+Apr 27 14:48:28.740: INFO: calico-node-jphjj from kube-system started at 2018-04-27 13:52:32 +0000 UTC (2 container statuses recorded)
+Apr 27 14:48:28.740: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:48:28.740: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:48:28.740: INFO: vpn-shoot-665bbc666-c27z4 from kube-system started at 2018-04-27 13:53:33 +0000 UTC (1 container statuses recorded)
+Apr 27 14:48:28.740: INFO: 	Container vpn-shoot ready: true, restart count 1
+Apr 27 14:48:28.740: INFO: addons-nginx-ingress-controller-7c8749685-6m9kp from kube-system started at 2018-04-27 13:53:33 +0000 UTC (1 container statuses recorded)
+Apr 27 14:48:28.740: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Apr 27 14:48:28.740: INFO: addons-kubernetes-dashboard-8478f49fbf-snb4l from kube-system started at 2018-04-27 13:53:35 +0000 UTC (1 container statuses recorded)
+Apr 27 14:48:28.740: INFO: 	Container main ready: true, restart count 0
+Apr 27 14:48:28.740: INFO: kube-dns-67b49bdfd8-566ks from kube-system started at 2018-04-27 13:53:46 +0000 UTC (3 container statuses recorded)
+Apr 27 14:48:28.740: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:48:28.740: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:48:28.740: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:48:28.740: INFO: kube-proxy-5v9vj from kube-system started at 2018-04-27 13:52:32 +0000 UTC (1 container statuses recorded)
+Apr 27 14:48:28.740: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:48:28.740: INFO: node-exporter-6r4qq from kube-system started at 2018-04-27 13:52:32 +0000 UTC (1 container statuses recorded)
+Apr 27 14:48:28.740: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:48:28.740: INFO: kube-dns-autoscaler-699b4b55c4-8qw7j from kube-system started at 2018-04-27 13:53:34 +0000 UTC (1 container statuses recorded)
+Apr 27 14:48:28.740: INFO: 	Container autoscaler ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-0e875ec3-4a2a-11e8-8194-02aee6f695c9 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-0e875ec3-4a2a-11e8-8194-02aee6f695c9 off the node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-0e875ec3-4a2a-11e8-8194-02aee6f695c9
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:48:36.790: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-gs5hh" for this suite.
+Apr 27 14:48:58.802: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:48:58.916: INFO: namespace: e2e-tests-sched-pred-gs5hh, resource: bindings, ignored listing per whitelist
+Apr 27 14:48:58.920: INFO: namespace e2e-tests-sched-pred-gs5hh deletion completed in 22.12714209s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:90.317 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:48:58.920: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override command
+Apr 27 14:48:59.005: INFO: Waiting up to 5m0s for pod "client-containers-1e2ae634-4a2a-11e8-8194-02aee6f695c9" in namespace "e2e-tests-containers-xztlm" to be "success or failure"
+Apr 27 14:48:59.008: INFO: Pod "client-containers-1e2ae634-4a2a-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.389798ms
+Apr 27 14:49:01.012: INFO: Pod "client-containers-1e2ae634-4a2a-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006209872s
+STEP: Saw pod success
+Apr 27 14:49:01.012: INFO: Pod "client-containers-1e2ae634-4a2a-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:49:01.014: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod client-containers-1e2ae634-4a2a-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:49:01.031: INFO: Waiting for pod client-containers-1e2ae634-4a2a-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:49:01.034: INFO: Pod client-containers-1e2ae634-4a2a-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:49:01.034: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-xztlm" for this suite.
+Apr 27 14:49:07.052: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:49:07.148: INFO: namespace: e2e-tests-containers-xztlm, resource: bindings, ignored listing per whitelist
+Apr 27 14:49:07.171: INFO: namespace e2e-tests-containers-xztlm deletion completed in 6.131363786s
+
+• [SLOW TEST:8.251 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:49:07.171: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:49:07.248: INFO: Waiting up to 5m0s for pod "downwardapi-volume-2314859a-4a2a-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-mx6wv" to be "success or failure"
+Apr 27 14:49:07.250: INFO: Pod "downwardapi-volume-2314859a-4a2a-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.052289ms
+Apr 27 14:49:09.253: INFO: Pod "downwardapi-volume-2314859a-4a2a-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005802302s
+Apr 27 14:49:11.257: INFO: Pod "downwardapi-volume-2314859a-4a2a-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.00966829s
+STEP: Saw pod success
+Apr 27 14:49:11.257: INFO: Pod "downwardapi-volume-2314859a-4a2a-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:49:11.260: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downwardapi-volume-2314859a-4a2a-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:49:11.286: INFO: Waiting for pod downwardapi-volume-2314859a-4a2a-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:49:11.289: INFO: Pod downwardapi-volume-2314859a-4a2a-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:49:11.289: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-mx6wv" for this suite.
+Apr 27 14:49:17.301: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:49:17.427: INFO: namespace: e2e-tests-downward-api-mx6wv, resource: bindings, ignored listing per whitelist
+Apr 27 14:49:17.430: INFO: namespace e2e-tests-downward-api-mx6wv deletion completed in 6.137864138s
+
+• [SLOW TEST:10.259 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:49:17.430: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:49:17.518: INFO: Requires at least 2 nodes (not -1)
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+Apr 27 14:49:17.527: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-kws49/daemonsets","resourceVersion":"9417"},"items":null}
+
+Apr 27 14:49:17.530: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-kws49/pods","resourceVersion":"9417"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:49:17.538: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-kws49" for this suite.
+Apr 27 14:49:23.550: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:49:23.600: INFO: namespace: e2e-tests-daemonsets-kws49, resource: bindings, ignored listing per whitelist
+Apr 27 14:49:23.661: INFO: namespace e2e-tests-daemonsets-kws49 deletion completed in 6.12020753s
+
+S [SKIPPING] [6.231 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should rollback without unnecessary restarts [Conformance] [It]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+
+  Apr 27 14:49:17.518: Requires at least 2 nodes (not -1)
+
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:296
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:49:23.661: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-2ce930c9-4a2a-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:49:23.743: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-2ce9a7ce-4a2a-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-4kqrj" to be "success or failure"
+Apr 27 14:49:23.745: INFO: Pod "pod-projected-configmaps-2ce9a7ce-4a2a-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011362ms
+Apr 27 14:49:25.749: INFO: Pod "pod-projected-configmaps-2ce9a7ce-4a2a-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006025835s
+STEP: Saw pod success
+Apr 27 14:49:25.749: INFO: Pod "pod-projected-configmaps-2ce9a7ce-4a2a-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:49:25.752: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-projected-configmaps-2ce9a7ce-4a2a-11e8-8194-02aee6f695c9 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:49:25.772: INFO: Waiting for pod pod-projected-configmaps-2ce9a7ce-4a2a-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:49:25.774: INFO: Pod pod-projected-configmaps-2ce9a7ce-4a2a-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:49:25.774: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4kqrj" for this suite.
+Apr 27 14:49:31.787: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:49:31.863: INFO: namespace: e2e-tests-projected-4kqrj, resource: bindings, ignored listing per whitelist
+Apr 27 14:49:31.907: INFO: namespace e2e-tests-projected-4kqrj deletion completed in 6.130026083s
+
+• [SLOW TEST:8.246 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:49:31.908: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-76ln2
+Apr 27 14:49:36.004: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-76ln2
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:49:36.006: INFO: Initial restart count of pod liveness-http is 0
+Apr 27 14:49:52.039: INFO: Restart count of pod e2e-tests-container-probe-76ln2/liveness-http is now 1 (16.033031046s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:49:52.047: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-76ln2" for this suite.
+Apr 27 14:49:58.059: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:49:58.138: INFO: namespace: e2e-tests-container-probe-76ln2, resource: bindings, ignored listing per whitelist
+Apr 27 14:49:58.185: INFO: namespace e2e-tests-container-probe-76ln2 deletion completed in 6.135767115s
+
+• [SLOW TEST:26.278 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:49:58.186: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-sc7s7
+Apr 27 14:50:00.274: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-sc7s7
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:50:00.277: INFO: Initial restart count of pod liveness-http is 0
+Apr 27 14:50:18.313: INFO: Restart count of pod e2e-tests-container-probe-sc7s7/liveness-http is now 1 (18.036095731s elapsed)
+Apr 27 14:50:38.348: INFO: Restart count of pod e2e-tests-container-probe-sc7s7/liveness-http is now 2 (38.071483665s elapsed)
+Apr 27 14:50:58.382: INFO: Restart count of pod e2e-tests-container-probe-sc7s7/liveness-http is now 3 (58.10518646s elapsed)
+Apr 27 14:51:18.419: INFO: Restart count of pod e2e-tests-container-probe-sc7s7/liveness-http is now 4 (1m18.142399399s elapsed)
+Apr 27 14:52:20.534: INFO: Restart count of pod e2e-tests-container-probe-sc7s7/liveness-http is now 5 (2m20.257029745s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:52:20.541: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-sc7s7" for this suite.
+Apr 27 14:52:26.559: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:52:26.671: INFO: namespace: e2e-tests-container-probe-sc7s7, resource: bindings, ignored listing per whitelist
+Apr 27 14:52:26.680: INFO: namespace e2e-tests-container-probe-sc7s7 deletion completed in 6.136005562s
+
+• [SLOW TEST:148.495 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:52:26.681: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:52:26.768: INFO: Waiting up to 5m0s for pod "downwardapi-volume-9a00e735-4a2a-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-x554l" to be "success or failure"
+Apr 27 14:52:26.770: INFO: Pod "downwardapi-volume-9a00e735-4a2a-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.020534ms
+Apr 27 14:52:28.774: INFO: Pod "downwardapi-volume-9a00e735-4a2a-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005549035s
+Apr 27 14:52:30.777: INFO: Pod "downwardapi-volume-9a00e735-4a2a-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009079492s
+STEP: Saw pod success
+Apr 27 14:52:30.777: INFO: Pod "downwardapi-volume-9a00e735-4a2a-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:52:30.780: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downwardapi-volume-9a00e735-4a2a-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:52:30.799: INFO: Waiting for pod downwardapi-volume-9a00e735-4a2a-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:52:30.803: INFO: Pod downwardapi-volume-9a00e735-4a2a-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:52:30.803: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-x554l" for this suite.
+Apr 27 14:52:36.815: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:52:36.911: INFO: namespace: e2e-tests-projected-x554l, resource: bindings, ignored listing per whitelist
+Apr 27 14:52:36.925: INFO: namespace e2e-tests-projected-x554l deletion completed in 6.118657125s
+
+• [SLOW TEST:10.245 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:52:36.925: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:52:37.006: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-5z9lc" for this suite.
+Apr 27 14:52:59.019: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:52:59.069: INFO: namespace: e2e-tests-pods-5z9lc, resource: bindings, ignored listing per whitelist
+Apr 27 14:52:59.135: INFO: namespace e2e-tests-pods-5z9lc deletion completed in 22.126469411s
+
+• [SLOW TEST:22.210 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:52:59.136: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test use defaults
+Apr 27 14:52:59.216: INFO: Waiting up to 5m0s for pod "client-containers-ad5822a5-4a2a-11e8-8194-02aee6f695c9" in namespace "e2e-tests-containers-jsfbp" to be "success or failure"
+Apr 27 14:52:59.218: INFO: Pod "client-containers-ad5822a5-4a2a-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006254ms
+Apr 27 14:53:01.221: INFO: Pod "client-containers-ad5822a5-4a2a-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005790458s
+Apr 27 14:53:03.225: INFO: Pod "client-containers-ad5822a5-4a2a-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009599465s
+STEP: Saw pod success
+Apr 27 14:53:03.225: INFO: Pod "client-containers-ad5822a5-4a2a-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:53:03.228: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod client-containers-ad5822a5-4a2a-11e8-8194-02aee6f695c9 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:53:03.249: INFO: Waiting for pod client-containers-ad5822a5-4a2a-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:53:03.251: INFO: Pod client-containers-ad5822a5-4a2a-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:53:03.252: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-jsfbp" for this suite.
+Apr 27 14:53:09.263: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:53:09.329: INFO: namespace: e2e-tests-containers-jsfbp, resource: bindings, ignored listing per whitelist
+Apr 27 14:53:09.381: INFO: namespace e2e-tests-containers-jsfbp deletion completed in 6.126308952s
+
+• [SLOW TEST:10.245 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:53:09.381: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-b373ac00-4a2a-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:53:09.466: INFO: Waiting up to 5m0s for pod "pod-configmaps-b374217f-4a2a-11e8-8194-02aee6f695c9" in namespace "e2e-tests-configmap-mw8x6" to be "success or failure"
+Apr 27 14:53:09.468: INFO: Pod "pod-configmaps-b374217f-4a2a-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.510965ms
+Apr 27 14:53:11.472: INFO: Pod "pod-configmaps-b374217f-4a2a-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006365458s
+STEP: Saw pod success
+Apr 27 14:53:11.472: INFO: Pod "pod-configmaps-b374217f-4a2a-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:53:11.475: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-configmaps-b374217f-4a2a-11e8-8194-02aee6f695c9 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:53:11.494: INFO: Waiting for pod pod-configmaps-b374217f-4a2a-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:53:11.497: INFO: Pod pod-configmaps-b374217f-4a2a-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:53:11.497: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-mw8x6" for this suite.
+Apr 27 14:53:17.510: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:53:17.601: INFO: namespace: e2e-tests-configmap-mw8x6, resource: bindings, ignored listing per whitelist
+Apr 27 14:53:17.619: INFO: namespace e2e-tests-configmap-mw8x6 deletion completed in 6.118864795s
+
+• [SLOW TEST:8.238 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:53:17.619: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating pod
+Apr 27 14:53:19.708: INFO: Pod pod-hostip-b85bdafb-4a2a-11e8-8194-02aee6f695c9 has hostIP: 10.250.0.3
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:53:19.708: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-jr27r" for this suite.
+Apr 27 14:53:41.720: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:53:41.791: INFO: namespace: e2e-tests-pods-jr27r, resource: bindings, ignored listing per whitelist
+Apr 27 14:53:41.838: INFO: namespace e2e-tests-pods-jr27r deletion completed in 22.12663482s
+
+• [SLOW TEST:24.219 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:53:41.838: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-c6cbee45-4a2a-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:53:41.921: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-c6cc6660-4a2a-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-4tp7b" to be "success or failure"
+Apr 27 14:53:41.923: INFO: Pod "pod-projected-configmaps-c6cc6660-4a2a-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.060169ms
+Apr 27 14:53:43.927: INFO: Pod "pod-projected-configmaps-c6cc6660-4a2a-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005885543s
+STEP: Saw pod success
+Apr 27 14:53:43.927: INFO: Pod "pod-projected-configmaps-c6cc6660-4a2a-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:53:43.929: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-projected-configmaps-c6cc6660-4a2a-11e8-8194-02aee6f695c9 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:53:43.948: INFO: Waiting for pod pod-projected-configmaps-c6cc6660-4a2a-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:53:43.952: INFO: Pod pod-projected-configmaps-c6cc6660-4a2a-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:53:43.952: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4tp7b" for this suite.
+Apr 27 14:53:49.965: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:53:50.021: INFO: namespace: e2e-tests-projected-4tp7b, resource: bindings, ignored listing per whitelist
+Apr 27 14:53:50.081: INFO: namespace e2e-tests-projected-4tp7b deletion completed in 6.125346814s
+
+• [SLOW TEST:8.243 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:53:50.081: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-zxgc2
+[It] Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-zxgc2
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-zxgc2
+Apr 27 14:53:50.167: INFO: Found 0 stateful pods, waiting for 1
+Apr 27 14:54:00.172: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will not halt with unhealthy stateful pod
+Apr 27 14:54:00.176: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-zxgc2 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:54:03.685: INFO: stderr: ""
+Apr 27 14:54:03.685: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:54:03.688: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Apr 27 14:54:13.693: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:54:13.693: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:54:13.705: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Apr 27 14:54:13.705: INFO: ss-0  shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:53:50 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:04 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:53:50 +0000 UTC  }]
+Apr 27 14:54:13.705: INFO: 
+Apr 27 14:54:13.705: INFO: StatefulSet ss has not reached scale 3, at 1
+Apr 27 14:54:14.709: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.99691561s
+Apr 27 14:54:15.713: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.993371831s
+Apr 27 14:54:16.716: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.989102333s
+Apr 27 14:54:17.720: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.985902481s
+Apr 27 14:54:18.724: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.981727334s
+Apr 27 14:54:19.728: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.977879401s
+Apr 27 14:54:20.733: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.973626476s
+Apr 27 14:54:21.736: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.969175766s
+Apr 27 14:54:22.741: INFO: Verifying statefulset ss doesn't scale past 3 for another 965.44519ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-zxgc2
+Apr 27 14:54:23.745: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-zxgc2 ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:54:24.026: INFO: stderr: ""
+Apr 27 14:54:24.026: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:54:24.026: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-zxgc2 ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:54:24.301: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Apr 27 14:54:24.301: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: 
+Apr 27 14:54:24.301: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-zxgc2 ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:54:24.565: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Apr 27 14:54:24.565: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Apr 27 14:54:24.568: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:54:24.568: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:54:24.568: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Scale down will not halt with unhealthy stateful pod
+Apr 27 14:54:24.571: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-zxgc2 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:54:24.843: INFO: stderr: ""
+Apr 27 14:54:24.843: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:54:24.843: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-zxgc2 ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:54:25.104: INFO: stderr: ""
+Apr 27 14:54:25.104: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:54:25.104: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-590915753 exec --namespace=e2e-tests-statefulset-zxgc2 ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:54:25.363: INFO: stderr: ""
+Apr 27 14:54:25.363: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:54:25.363: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:54:25.365: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 3
+Apr 27 14:54:35.372: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:54:35.373: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:54:35.373: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:54:35.381: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Apr 27 14:54:35.381: INFO: ss-0  shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:53:50 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:25 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:53:50 +0000 UTC  }]
+Apr 27 14:54:35.381: INFO: ss-1  shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:25 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  }]
+Apr 27 14:54:35.381: INFO: ss-2  shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:25 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  }]
+Apr 27 14:54:35.381: INFO: 
+Apr 27 14:54:35.381: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 27 14:54:36.386: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Apr 27 14:54:36.386: INFO: ss-0  shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:53:50 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:25 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:53:50 +0000 UTC  }]
+Apr 27 14:54:36.386: INFO: ss-1  shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:25 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  }]
+Apr 27 14:54:36.386: INFO: ss-2  shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:25 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  }]
+Apr 27 14:54:36.386: INFO: 
+Apr 27 14:54:36.386: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 27 14:54:37.390: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Apr 27 14:54:37.390: INFO: ss-0  shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:53:50 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:25 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:53:50 +0000 UTC  }]
+Apr 27 14:54:37.390: INFO: ss-1  shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:25 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  }]
+Apr 27 14:54:37.390: INFO: ss-2  shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:25 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  }]
+Apr 27 14:54:37.390: INFO: 
+Apr 27 14:54:37.390: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 27 14:54:38.395: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Apr 27 14:54:38.395: INFO: ss-1  shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:25 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  }]
+Apr 27 14:54:38.395: INFO: 
+Apr 27 14:54:38.395: INFO: StatefulSet ss has not reached scale 0, at 1
+Apr 27 14:54:39.399: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Apr 27 14:54:39.399: INFO: ss-1  shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:25 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:54:13 +0000 UTC  }]
+Apr 27 14:54:39.399: INFO: 
+Apr 27 14:54:39.399: INFO: StatefulSet ss has not reached scale 0, at 1
+Apr 27 14:54:40.402: INFO: Verifying statefulset ss doesn't scale past 0 for another 4.979391586s
+Apr 27 14:54:41.406: INFO: Verifying statefulset ss doesn't scale past 0 for another 3.975657753s
+Apr 27 14:54:42.410: INFO: Verifying statefulset ss doesn't scale past 0 for another 2.971926207s
+Apr 27 14:54:43.414: INFO: Verifying statefulset ss doesn't scale past 0 for another 1.968357437s
+Apr 27 14:54:44.417: INFO: Verifying statefulset ss doesn't scale past 0 for another 964.405131ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-zxgc2
+Apr 27 14:54:45.421: INFO: Scaling statefulset ss to 0
+Apr 27 14:54:45.429: INFO: Waiting for statefulset status.replicas updated to 0
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:54:45.431: INFO: Deleting all statefulset in ns e2e-tests-statefulset-zxgc2
+Apr 27 14:54:45.434: INFO: Scaling statefulset ss to 0
+Apr 27 14:54:45.441: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:54:45.443: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:54:45.452: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-zxgc2" for this suite.
+Apr 27 14:54:51.463: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:54:51.540: INFO: namespace: e2e-tests-statefulset-zxgc2, resource: bindings, ignored listing per whitelist
+Apr 27 14:54:51.574: INFO: namespace e2e-tests-statefulset-zxgc2 deletion completed in 6.118833779s
+
+• [SLOW TEST:61.493 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Burst scaling should run to completion even with unhealthy pods [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:54:51.574: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:54:51.653: INFO: Waiting up to 5m0s for pod "downward-api-f05c9cc5-4a2a-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-8tcjr" to be "success or failure"
+Apr 27 14:54:51.655: INFO: Pod "downward-api-f05c9cc5-4a2a-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.110789ms
+Apr 27 14:54:53.659: INFO: Pod "downward-api-f05c9cc5-4a2a-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005695057s
+Apr 27 14:54:55.662: INFO: Pod "downward-api-f05c9cc5-4a2a-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009413528s
+STEP: Saw pod success
+Apr 27 14:54:55.662: INFO: Pod "downward-api-f05c9cc5-4a2a-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:54:55.665: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downward-api-f05c9cc5-4a2a-11e8-8194-02aee6f695c9 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:54:55.682: INFO: Waiting for pod downward-api-f05c9cc5-4a2a-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:54:55.685: INFO: Pod downward-api-f05c9cc5-4a2a-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:54:55.685: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-8tcjr" for this suite.
+Apr 27 14:55:01.696: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:55:01.786: INFO: namespace: e2e-tests-downward-api-8tcjr, resource: bindings, ignored listing per whitelist
+Apr 27 14:55:01.818: INFO: namespace e2e-tests-downward-api-8tcjr deletion completed in 6.130788666s
+
+• [SLOW TEST:10.244 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:55:01.819: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-826cp
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 27 14:55:01.896: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 27 14:55:17.950: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.0.108:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-826cp PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:55:17.950: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:55:18.093: INFO: Found all expected endpoints: [netserver-0]
+Apr 27 14:55:18.096: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.1.92:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-826cp PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:55:18.096: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+Apr 27 14:55:18.285: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:55:18.285: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-826cp" for this suite.
+Apr 27 14:55:40.300: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:55:40.367: INFO: namespace: e2e-tests-pod-network-test-826cp, resource: bindings, ignored listing per whitelist
+Apr 27 14:55:40.417: INFO: namespace e2e-tests-pod-network-test-826cp deletion completed in 22.126567659s
+
+• [SLOW TEST:38.599 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:55:40.417: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-map-0d799d02-4a2b-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:55:40.500: INFO: Waiting up to 5m0s for pod "pod-secrets-0d7a0f43-4a2b-11e8-8194-02aee6f695c9" in namespace "e2e-tests-secrets-rsxkb" to be "success or failure"
+Apr 27 14:55:40.502: INFO: Pod "pod-secrets-0d7a0f43-4a2b-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.298014ms
+Apr 27 14:55:42.505: INFO: Pod "pod-secrets-0d7a0f43-4a2b-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005251058s
+STEP: Saw pod success
+Apr 27 14:55:42.505: INFO: Pod "pod-secrets-0d7a0f43-4a2b-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:55:42.507: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-secrets-0d7a0f43-4a2b-11e8-8194-02aee6f695c9 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:55:42.524: INFO: Waiting for pod pod-secrets-0d7a0f43-4a2b-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:55:42.527: INFO: Pod pod-secrets-0d7a0f43-4a2b-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:55:42.527: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-rsxkb" for this suite.
+Apr 27 14:55:48.540: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:55:48.657: INFO: namespace: e2e-tests-secrets-rsxkb, resource: bindings, ignored listing per whitelist
+Apr 27 14:55:48.663: INFO: namespace e2e-tests-secrets-rsxkb deletion completed in 6.132920233s
+
+• [SLOW TEST:8.246 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:55:48.664: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-l5f4m
+[It] should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a new StaefulSet
+Apr 27 14:55:48.745: INFO: Found 0 stateful pods, waiting for 3
+Apr 27 14:55:58.750: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:55:58.750: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:55:58.750: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Updating stateful set template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Apr 27 14:55:58.778: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Not applying an update when the partition is greater than the number of replicas
+STEP: Performing a canary update
+Apr 27 14:56:08.807: INFO: Updating stateful set ss2
+Apr 27 14:56:08.812: INFO: Waiting for Pod e2e-tests-statefulset-l5f4m/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 27 14:56:18.819: INFO: Waiting for Pod e2e-tests-statefulset-l5f4m/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Restoring Pods to the correct revision when they are deleted
+Apr 27 14:56:28.846: INFO: Found 2 stateful pods, waiting for 3
+Apr 27 14:56:38.851: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:56:38.851: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:56:38.851: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Performing a phased rolling update
+Apr 27 14:56:38.875: INFO: Updating stateful set ss2
+Apr 27 14:56:38.880: INFO: Waiting for Pod e2e-tests-statefulset-l5f4m/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 27 14:56:48.887: INFO: Waiting for Pod e2e-tests-statefulset-l5f4m/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 27 14:56:58.904: INFO: Updating stateful set ss2
+Apr 27 14:56:58.909: INFO: Waiting for StatefulSet e2e-tests-statefulset-l5f4m/ss2 to complete update
+Apr 27 14:56:58.909: INFO: Waiting for Pod e2e-tests-statefulset-l5f4m/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 27 14:57:08.916: INFO: Waiting for StatefulSet e2e-tests-statefulset-l5f4m/ss2 to complete update
+Apr 27 14:57:08.916: INFO: Waiting for Pod e2e-tests-statefulset-l5f4m/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:57:18.916: INFO: Deleting all statefulset in ns e2e-tests-statefulset-l5f4m
+Apr 27 14:57:18.919: INFO: Scaling statefulset ss2 to 0
+Apr 27 14:57:38.931: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:57:38.933: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:57:38.942: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-l5f4m" for this suite.
+Apr 27 14:57:44.954: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:57:45.001: INFO: namespace: e2e-tests-statefulset-l5f4m, resource: bindings, ignored listing per whitelist
+Apr 27 14:57:45.058: INFO: namespace e2e-tests-statefulset-l5f4m deletion completed in 6.11322051s
+
+• [SLOW TEST:116.395 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should perform canary updates and phased rolling updates of template modifications [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:57:45.058: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-57c3f28a-4a2b-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 14:57:45.137: INFO: Waiting up to 5m0s for pod "pod-secrets-57c455eb-4a2b-11e8-8194-02aee6f695c9" in namespace "e2e-tests-secrets-lzqmn" to be "success or failure"
+Apr 27 14:57:45.139: INFO: Pod "pod-secrets-57c455eb-4a2b-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.125644ms
+Apr 27 14:57:47.143: INFO: Pod "pod-secrets-57c455eb-4a2b-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00579971s
+STEP: Saw pod success
+Apr 27 14:57:47.143: INFO: Pod "pod-secrets-57c455eb-4a2b-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:57:47.145: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-secrets-57c455eb-4a2b-11e8-8194-02aee6f695c9 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:57:47.162: INFO: Waiting for pod pod-secrets-57c455eb-4a2b-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:57:47.164: INFO: Pod pod-secrets-57c455eb-4a2b-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:57:47.164: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-lzqmn" for this suite.
+Apr 27 14:57:53.178: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:57:53.225: INFO: namespace: e2e-tests-secrets-lzqmn, resource: bindings, ignored listing per whitelist
+Apr 27 14:57:53.292: INFO: namespace e2e-tests-secrets-lzqmn deletion completed in 6.124883664s
+
+• [SLOW TEST:8.234 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:57:53.292: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:57:53.366: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:57:53.912: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-h5v42" for this suite.
+Apr 27 14:57:59.925: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:57:59.975: INFO: namespace: e2e-tests-custom-resource-definition-h5v42, resource: bindings, ignored listing per whitelist
+Apr 27 14:58:00.030: INFO: namespace e2e-tests-custom-resource-definition-h5v42 deletion completed in 6.113997682s
+
+• [SLOW TEST:6.738 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:58:00.030: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:58:02.133: INFO: Waiting up to 5m0s for pod "client-envvars-61e5bbda-4a2b-11e8-8194-02aee6f695c9" in namespace "e2e-tests-pods-mbcdp" to be "success or failure"
+Apr 27 14:58:02.135: INFO: Pod "client-envvars-61e5bbda-4a2b-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 1.826657ms
+Apr 27 14:58:04.138: INFO: Pod "client-envvars-61e5bbda-4a2b-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005471496s
+Apr 27 14:58:06.141: INFO: Pod "client-envvars-61e5bbda-4a2b-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008594647s
+STEP: Saw pod success
+Apr 27 14:58:06.141: INFO: Pod "client-envvars-61e5bbda-4a2b-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:58:06.144: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod client-envvars-61e5bbda-4a2b-11e8-8194-02aee6f695c9 container env3cont: <nil>
+STEP: delete the pod
+Apr 27 14:58:06.161: INFO: Waiting for pod client-envvars-61e5bbda-4a2b-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:58:06.164: INFO: Pod client-envvars-61e5bbda-4a2b-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:58:06.166: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-mbcdp" for this suite.
+Apr 27 14:58:28.183: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:58:28.253: INFO: namespace: e2e-tests-pods-mbcdp, resource: bindings, ignored listing per whitelist
+Apr 27 14:58:28.296: INFO: namespace e2e-tests-pods-mbcdp deletion completed in 22.124840948s
+
+• [SLOW TEST:28.266 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:58:28.296: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:58:46.380: INFO: Container started at 2018-04-27 14:58:29 +0000 UTC, pod became ready at 2018-04-27 14:58:44 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:58:46.381: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-gfwdr" for this suite.
+Apr 27 14:59:08.392: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:59:08.481: INFO: namespace: e2e-tests-container-probe-gfwdr, resource: bindings, ignored listing per whitelist
+Apr 27 14:59:08.512: INFO: namespace e2e-tests-container-probe-gfwdr deletion completed in 22.128397826s
+
+• [SLOW TEST:40.216 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:59:08.512: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-89822eed-4a2b-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:59:08.594: INFO: Waiting up to 5m0s for pod "pod-configmaps-8982ba3b-4a2b-11e8-8194-02aee6f695c9" in namespace "e2e-tests-configmap-vnmxd" to be "success or failure"
+Apr 27 14:59:08.597: INFO: Pod "pod-configmaps-8982ba3b-4a2b-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 3.175851ms
+Apr 27 14:59:10.601: INFO: Pod "pod-configmaps-8982ba3b-4a2b-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00741614s
+STEP: Saw pod success
+Apr 27 14:59:10.601: INFO: Pod "pod-configmaps-8982ba3b-4a2b-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:59:10.604: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-configmaps-8982ba3b-4a2b-11e8-8194-02aee6f695c9 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:59:10.620: INFO: Waiting for pod pod-configmaps-8982ba3b-4a2b-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:59:10.625: INFO: Pod pod-configmaps-8982ba3b-4a2b-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:59:10.625: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-vnmxd" for this suite.
+Apr 27 14:59:16.639: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:59:16.750: INFO: namespace: e2e-tests-configmap-vnmxd, resource: bindings, ignored listing per whitelist
+Apr 27 14:59:16.764: INFO: namespace e2e-tests-configmap-vnmxd deletion completed in 6.136067993s
+
+• [SLOW TEST:8.252 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:59:16.764: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:59:16.848: INFO: Waiting up to 5m0s for pod "downwardapi-volume-8e6de152-4a2b-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-j5b9z" to be "success or failure"
+Apr 27 14:59:16.852: INFO: Pod "downwardapi-volume-8e6de152-4a2b-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 4.363166ms
+Apr 27 14:59:18.856: INFO: Pod "downwardapi-volume-8e6de152-4a2b-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008253222s
+STEP: Saw pod success
+Apr 27 14:59:18.856: INFO: Pod "downwardapi-volume-8e6de152-4a2b-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 14:59:18.858: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downwardapi-volume-8e6de152-4a2b-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:59:18.877: INFO: Waiting for pod downwardapi-volume-8e6de152-4a2b-11e8-8194-02aee6f695c9 to disappear
+Apr 27 14:59:18.879: INFO: Pod downwardapi-volume-8e6de152-4a2b-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:59:18.879: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-j5b9z" for this suite.
+Apr 27 14:59:24.891: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:59:24.928: INFO: namespace: e2e-tests-downward-api-j5b9z, resource: bindings, ignored listing per whitelist
+Apr 27 14:59:25.004: INFO: namespace e2e-tests-downward-api-j5b9z deletion completed in 6.121921473s
+
+• [SLOW TEST:8.240 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:59:25.004: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Apr 27 14:59:25.080: INFO: Waiting up to 1m0s for all nodes to be ready
+Apr 27 15:00:25.098: INFO: Waiting for terminating namespaces to be deleted...
+Apr 27 15:00:25.103: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 27 15:00:25.113: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 27 15:00:25.113: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 27 15:00:25.116: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 27 15:00:25.116: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h before test
+Apr 27 15:00:25.126: INFO: kube-proxy-9kttt from kube-system started at 2018-04-27 13:52:32 +0000 UTC (1 container statuses recorded)
+Apr 27 15:00:25.126: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: sonobuoy-e2e-job-137eed9de25c425d from sonobuoy started at 2018-04-27 14:04:25 +0000 UTC (2 container statuses recorded)
+Apr 27 15:00:25.126: INFO: 	Container e2e ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: node-exporter-wk4vh from kube-system started at 2018-04-27 13:52:32 +0000 UTC (1 container statuses recorded)
+Apr 27 15:00:25.126: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: calico-node-6qnh2 from kube-system started at 2018-04-27 13:52:32 +0000 UTC (2 container statuses recorded)
+Apr 27 15:00:25.126: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-65z9k from kube-system started at 2018-04-27 13:53:33 +0000 UTC (1 container statuses recorded)
+Apr 27 15:00:25.126: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: addons-heapster-e3b0c-5c98c994fc-fcjnb from kube-system started at 2018-04-27 13:53:34 +0000 UTC (2 container statuses recorded)
+Apr 27 15:00:25.126: INFO: 	Container heapster ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: 	Container heapster-nanny ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: kube-dns-67b49bdfd8-kzgp5 from kube-system started at 2018-04-27 13:53:34 +0000 UTC (3 container statuses recorded)
+Apr 27 15:00:25.126: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: sonobuoy from sonobuoy started at 2018-04-27 14:04:09 +0000 UTC (1 container statuses recorded)
+Apr 27 15:00:25.126: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Apr 27 15:00:25.126: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 before test
+Apr 27 15:00:25.134: INFO: vpn-shoot-665bbc666-c27z4 from kube-system started at 2018-04-27 13:53:33 +0000 UTC (1 container statuses recorded)
+Apr 27 15:00:25.134: INFO: 	Container vpn-shoot ready: true, restart count 1
+Apr 27 15:00:25.134: INFO: addons-nginx-ingress-controller-7c8749685-6m9kp from kube-system started at 2018-04-27 13:53:33 +0000 UTC (1 container statuses recorded)
+Apr 27 15:00:25.134: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Apr 27 15:00:25.134: INFO: addons-kubernetes-dashboard-8478f49fbf-snb4l from kube-system started at 2018-04-27 13:53:35 +0000 UTC (1 container statuses recorded)
+Apr 27 15:00:25.134: INFO: 	Container main ready: true, restart count 0
+Apr 27 15:00:25.134: INFO: kube-dns-67b49bdfd8-566ks from kube-system started at 2018-04-27 13:53:46 +0000 UTC (3 container statuses recorded)
+Apr 27 15:00:25.134: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 15:00:25.134: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 15:00:25.134: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 15:00:25.134: INFO: kube-proxy-5v9vj from kube-system started at 2018-04-27 13:52:32 +0000 UTC (1 container statuses recorded)
+Apr 27 15:00:25.134: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 15:00:25.134: INFO: node-exporter-6r4qq from kube-system started at 2018-04-27 13:52:32 +0000 UTC (1 container statuses recorded)
+Apr 27 15:00:25.134: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 15:00:25.134: INFO: calico-node-jphjj from kube-system started at 2018-04-27 13:52:32 +0000 UTC (2 container statuses recorded)
+Apr 27 15:00:25.134: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 15:00:25.134: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 15:00:25.134: INFO: kube-dns-autoscaler-699b4b55c4-8qw7j from kube-system started at 2018-04-27 13:53:34 +0000 UTC (1 container statuses recorded)
+Apr 27 15:00:25.134: INFO: 	Container autoscaler ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: verifying the node has the label node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h
+STEP: verifying the node has the label node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42
+Apr 27 15:00:25.157: INFO: Pod addons-heapster-e3b0c-5c98c994fc-fcjnb requesting resource cpu=50m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h
+Apr 27 15:00:25.157: INFO: Pod addons-kubernetes-dashboard-8478f49fbf-snb4l requesting resource cpu=100m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42
+Apr 27 15:00:25.157: INFO: Pod addons-nginx-ingress-controller-7c8749685-6m9kp requesting resource cpu=0m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42
+Apr 27 15:00:25.157: INFO: Pod addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-65z9k requesting resource cpu=0m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h
+Apr 27 15:00:25.157: INFO: Pod calico-node-6qnh2 requesting resource cpu=250m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h
+Apr 27 15:00:25.157: INFO: Pod calico-node-jphjj requesting resource cpu=250m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42
+Apr 27 15:00:25.157: INFO: Pod kube-dns-67b49bdfd8-566ks requesting resource cpu=260m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42
+Apr 27 15:00:25.157: INFO: Pod kube-dns-67b49bdfd8-kzgp5 requesting resource cpu=260m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h
+Apr 27 15:00:25.157: INFO: Pod kube-dns-autoscaler-699b4b55c4-8qw7j requesting resource cpu=20m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42
+Apr 27 15:00:25.157: INFO: Pod kube-proxy-5v9vj requesting resource cpu=100m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42
+Apr 27 15:00:25.157: INFO: Pod kube-proxy-9kttt requesting resource cpu=100m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h
+Apr 27 15:00:25.157: INFO: Pod node-exporter-6r4qq requesting resource cpu=100m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42
+Apr 27 15:00:25.157: INFO: Pod node-exporter-wk4vh requesting resource cpu=100m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h
+Apr 27 15:00:25.157: INFO: Pod vpn-shoot-665bbc666-c27z4 requesting resource cpu=100m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42
+Apr 27 15:00:25.157: INFO: Pod sonobuoy requesting resource cpu=0m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h
+Apr 27 15:00:25.157: INFO: Pod sonobuoy-e2e-job-137eed9de25c425d requesting resource cpu=0m on Node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-b7262339-4a2b-11e8-8194-02aee6f695c9.15295303ea65d45a], Reason = [Scheduled], Message = [Successfully assigned filler-pod-b7262339-4a2b-11e8-8194-02aee6f695c9 to shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-b7262339-4a2b-11e8-8194-02aee6f695c9.15295303fd74135c], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-cxt96" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-b7262339-4a2b-11e8-8194-02aee6f695c9.152953041d992e6a], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause-amd64:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-b7262339-4a2b-11e8-8194-02aee6f695c9.1529530420c565ee], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-b7262339-4a2b-11e8-8194-02aee6f695c9.152953042dfb042a], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-b7274980-4a2b-11e8-8194-02aee6f695c9.15295303eaaee2f2], Reason = [Scheduled], Message = [Successfully assigned filler-pod-b7274980-4a2b-11e8-8194-02aee6f695c9 to shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-b7274980-4a2b-11e8-8194-02aee6f695c9.15295303f2b3f2b9], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-cxt96" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-b7274980-4a2b-11e8-8194-02aee6f695c9.15295304158bc06f], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause-amd64:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-b7274980-4a2b-11e8-8194-02aee6f695c9.1529530418a8f57d], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-b7274980-4a2b-11e8-8194-02aee6f695c9.152953042161d92d], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.1529530462bdb982], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 Insufficient cpu.]
+STEP: removing the label node off the node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:00:28.208: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-brk4v" for this suite.
+Apr 27 15:00:50.220: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:00:50.332: INFO: namespace: e2e-tests-sched-pred-brk4v, resource: bindings, ignored listing per whitelist
+Apr 27 15:00:50.339: INFO: namespace e2e-tests-sched-pred-brk4v deletion completed in 22.128007919s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:85.335 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:00:50.339: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 27 15:00:52.958: INFO: Successfully updated pod "labelsupdatec635a352-4a2b-11e8-8194-02aee6f695c9"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:00:56.989: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-ls5pc" for this suite.
+Apr 27 15:01:19.001: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:01:19.117: INFO: namespace: e2e-tests-downward-api-ls5pc, resource: bindings, ignored listing per whitelist
+Apr 27 15:01:19.123: INFO: namespace e2e-tests-downward-api-ls5pc deletion completed in 22.130323641s
+
+• [SLOW TEST:28.784 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:01:19.123: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 15:01:19.204: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d75c2500-4a2b-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-rhm79" to be "success or failure"
+Apr 27 15:01:19.206: INFO: Pod "downwardapi-volume-d75c2500-4a2b-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.199167ms
+Apr 27 15:01:21.209: INFO: Pod "downwardapi-volume-d75c2500-4a2b-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005626448s
+STEP: Saw pod success
+Apr 27 15:01:21.209: INFO: Pod "downwardapi-volume-d75c2500-4a2b-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 15:01:21.212: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downwardapi-volume-d75c2500-4a2b-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 15:01:21.230: INFO: Waiting for pod downwardapi-volume-d75c2500-4a2b-11e8-8194-02aee6f695c9 to disappear
+Apr 27 15:01:21.232: INFO: Pod downwardapi-volume-d75c2500-4a2b-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:01:21.232: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-rhm79" for this suite.
+Apr 27 15:01:27.245: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:01:27.329: INFO: namespace: e2e-tests-downward-api-rhm79, resource: bindings, ignored listing per whitelist
+Apr 27 15:01:27.376: INFO: namespace e2e-tests-downward-api-rhm79 deletion completed in 6.141210932s
+
+• [SLOW TEST:8.253 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:01:27.376: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-dc471fb3-4a2b-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume secrets
+Apr 27 15:01:27.457: INFO: Waiting up to 5m0s for pod "pod-secrets-dc4787ac-4a2b-11e8-8194-02aee6f695c9" in namespace "e2e-tests-secrets-n89xh" to be "success or failure"
+Apr 27 15:01:27.459: INFO: Pod "pod-secrets-dc4787ac-4a2b-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.177292ms
+Apr 27 15:01:29.463: INFO: Pod "pod-secrets-dc4787ac-4a2b-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005810456s
+STEP: Saw pod success
+Apr 27 15:01:29.463: INFO: Pod "pod-secrets-dc4787ac-4a2b-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 15:01:29.465: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod pod-secrets-dc4787ac-4a2b-11e8-8194-02aee6f695c9 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 15:01:29.483: INFO: Waiting for pod pod-secrets-dc4787ac-4a2b-11e8-8194-02aee6f695c9 to disappear
+Apr 27 15:01:29.486: INFO: Pod pod-secrets-dc4787ac-4a2b-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:01:29.486: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-n89xh" for this suite.
+Apr 27 15:01:35.501: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:01:35.551: INFO: namespace: e2e-tests-secrets-n89xh, resource: bindings, ignored listing per whitelist
+Apr 27 15:01:35.607: INFO: namespace e2e-tests-secrets-n89xh deletion completed in 6.117888082s
+
+• [SLOW TEST:8.231 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:01:35.607: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-e12f7b9a-4a2b-11e8-8194-02aee6f695c9
+STEP: Creating a pod to test consume configMaps
+Apr 27 15:01:35.690: INFO: Waiting up to 5m0s for pod "pod-configmaps-e12fe228-4a2b-11e8-8194-02aee6f695c9" in namespace "e2e-tests-configmap-bnbsw" to be "success or failure"
+Apr 27 15:01:35.692: INFO: Pod "pod-configmaps-e12fe228-4a2b-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 1.881002ms
+Apr 27 15:01:37.695: INFO: Pod "pod-configmaps-e12fe228-4a2b-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005081027s
+STEP: Saw pod success
+Apr 27 15:01:37.695: INFO: Pod "pod-configmaps-e12fe228-4a2b-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 15:01:37.697: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod pod-configmaps-e12fe228-4a2b-11e8-8194-02aee6f695c9 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 15:01:37.712: INFO: Waiting for pod pod-configmaps-e12fe228-4a2b-11e8-8194-02aee6f695c9 to disappear
+Apr 27 15:01:37.714: INFO: Pod pod-configmaps-e12fe228-4a2b-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:01:37.714: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-bnbsw" for this suite.
+Apr 27 15:01:43.725: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:01:43.793: INFO: namespace: e2e-tests-configmap-bnbsw, resource: bindings, ignored listing per whitelist
+Apr 27 15:01:43.832: INFO: namespace e2e-tests-configmap-bnbsw deletion completed in 6.115960157s
+
+• [SLOW TEST:8.225 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:01:43.833: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 27 15:01:46.443: INFO: Successfully updated pod "annotationupdatee617013d-4a2b-11e8-8194-02aee6f695c9"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:01:50.477: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-cgfp9" for this suite.
+Apr 27 15:02:12.489: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:02:12.568: INFO: namespace: e2e-tests-downward-api-cgfp9, resource: bindings, ignored listing per whitelist
+Apr 27 15:02:12.596: INFO: namespace e2e-tests-downward-api-cgfp9 deletion completed in 22.115595807s
+
+• [SLOW TEST:28.763 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:02:12.596: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 15:02:12.672: INFO: Waiting up to 5m0s for pod "downwardapi-volume-f73ada3b-4a2b-11e8-8194-02aee6f695c9" in namespace "e2e-tests-projected-dpm7v" to be "success or failure"
+Apr 27 15:02:12.677: INFO: Pod "downwardapi-volume-f73ada3b-4a2b-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 4.466307ms
+Apr 27 15:02:14.680: INFO: Pod "downwardapi-volume-f73ada3b-4a2b-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007520137s
+STEP: Saw pod success
+Apr 27 15:02:14.680: INFO: Pod "downwardapi-volume-f73ada3b-4a2b-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 15:02:14.682: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-rhg42 pod downwardapi-volume-f73ada3b-4a2b-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 15:02:14.698: INFO: Waiting for pod downwardapi-volume-f73ada3b-4a2b-11e8-8194-02aee6f695c9 to disappear
+Apr 27 15:02:14.702: INFO: Pod downwardapi-volume-f73ada3b-4a2b-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:02:14.702: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-dpm7v" for this suite.
+Apr 27 15:02:20.716: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:02:20.802: INFO: namespace: e2e-tests-projected-dpm7v, resource: bindings, ignored listing per whitelist
+Apr 27 15:02:20.837: INFO: namespace e2e-tests-projected-dpm7v deletion completed in 6.130512363s
+
+• [SLOW TEST:8.241 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:02:20.837: INFO: >>> kubeConfig: /tmp/kubeconfig-590915753
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 15:02:20.916: INFO: Waiting up to 5m0s for pod "downwardapi-volume-fc24c817-4a2b-11e8-8194-02aee6f695c9" in namespace "e2e-tests-downward-api-xnzlz" to be "success or failure"
+Apr 27 15:02:20.919: INFO: Pod "downwardapi-volume-fc24c817-4a2b-11e8-8194-02aee6f695c9": Phase="Pending", Reason="", readiness=false. Elapsed: 2.966264ms
+Apr 27 15:02:22.922: INFO: Pod "downwardapi-volume-fc24c817-4a2b-11e8-8194-02aee6f695c9": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006145891s
+STEP: Saw pod success
+Apr 27 15:02:22.922: INFO: Pod "downwardapi-volume-fc24c817-4a2b-11e8-8194-02aee6f695c9" satisfied condition "success or failure"
+Apr 27 15:02:22.924: INFO: Trying to get logs from node shoot-core-cncf-gcp-worker-p5n4n-z1-7679dcf4bf-pwr8h pod downwardapi-volume-fc24c817-4a2b-11e8-8194-02aee6f695c9 container client-container: <nil>
+STEP: delete the pod
+Apr 27 15:02:22.940: INFO: Waiting for pod downwardapi-volume-fc24c817-4a2b-11e8-8194-02aee6f695c9 to disappear
+Apr 27 15:02:22.943: INFO: Pod downwardapi-volume-fc24c817-4a2b-11e8-8194-02aee6f695c9 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:02:22.943: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-xnzlz" for this suite.
+Apr 27 15:02:28.962: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:02:29.044: INFO: namespace: e2e-tests-downward-api-xnzlz, resource: bindings, ignored listing per whitelist
+Apr 27 15:02:29.076: INFO: namespace e2e-tests-downward-api-xnzlz deletion completed in 6.122613823s
+
+• [SLOW TEST:8.239 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+Apr 27 15:02:29.076: INFO: Running AfterSuite actions on all node
+Apr 27 15:02:29.076: INFO: Running AfterSuite actions on node 1
+Apr 27 15:02:29.076: INFO: Skipping dumping logs from cluster
+
+Ran 139 of 836 Specs in 3467.294 seconds
+SUCCESS! -- 139 Passed | 0 Failed | 0 Pending | 697 Skipped PASS
+
+Ginkgo ran 1 suite in 57m47.727853822s
+Test Suite Passed

--- a/v1.10/sap-cp-gcp/junit_01.xml
+++ b/v1.10/sap-cp-gcp/junit_01.xml
@@ -1,0 +1,2233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="139" failures="0" time="3467.293800312">
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.31597503"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]" classname="Kubernetes e2e suite" time="8.304482428"></testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection] [Conformance]" classname="Kubernetes e2e suite" time="10.255711768"></testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]" classname="Kubernetes e2e suite" time="12.249974199"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that PVC in active use by a pod is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with downward pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="10.251017882"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pvc count metrics for pvc controller after creating pvc only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [Conformance]" classname="Kubernetes e2e suite" time="8.245427993"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle [Conformance]" classname="Kubernetes e2e suite" time="11.238990229"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments  [Conformance]" classname="Kubernetes e2e suite" time="10.24663159"></testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]" classname="Kubernetes e2e suite" time="43.325474216"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.238936808"></testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.241565064"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support proportional scaling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit  [Conformance]" classname="Kubernetes e2e suite" time="8.230612014"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate crd" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable  [Conformance]" classname="Kubernetes e2e suite" time="10.233946677"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]" classname="Kubernetes e2e suite" time="12.22630198"></testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd)  [Conformance]" classname="Kubernetes e2e suite" time="10.243559385"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="96.921344694"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only  [Conformance]" classname="Kubernetes e2e suite" time="8.237041572"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pv count metrics for pvc controller after creating pv only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="22.891621226"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.24402213"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with projected pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.299664634"></testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="28.295146968"></testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated  [Conformance]" classname="Kubernetes e2e suite" time="12.732081133"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.234572137"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.23426623"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 Scalability GCE [Slow] [Serial] [Feature:IngressScale] Creating and updating ingresses should happen promptly with small/medium/large amount of ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [Conformance]" classname="Kubernetes e2e suite" time="26.769932202"></testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="128.465640749"></testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="6.752283809"></testcase>
+      <testcase name="[sig-storage] Regional PD [Feature:RegionalPD] RegionalPD should failover to a different zone when all nodes in one zone become unreachable [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="19.799663383"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [Conformance]" classname="Kubernetes e2e suite" time="8.248245878"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.239714182"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="10.266826154"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance]" classname="Kubernetes e2e suite" time="137.663222427"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit  [Conformance]" classname="Kubernetes e2e suite" time="10.257968882"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.206479169"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.241197065"></testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  StatefulSet with pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Mounted volume expand [Feature:ExpandPersistentVolumes] [Slow] Should verify mounted devices can be resized" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Stress with local volume provisioner [Serial] should use be able to process many pods and reuse local volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify &#34;immediate&#34; deletion of a PV that is not bound to a PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [Conformance]" classname="Kubernetes e2e suite" time="8.231642552"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner deletion should be idempotent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Upgrade [Feature:IngressUpgrade] ingress upgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="51.302529087"></testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="50.314615086"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]" classname="Kubernetes e2e suite" time="21.283022011"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.320001104"></testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [Conformance]" classname="Kubernetes e2e suite" time="10.262962893"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with backside re-encryption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.2690747"></testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set  [Conformance]" classname="Kubernetes e2e suite" time="10.265429364"></testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [Conformance]" classname="Kubernetes e2e suite" time="10.235262003"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [Conformance]" classname="Kubernetes e2e suite" time="8.241715965"></testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.26041841"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="10.263414913"></testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]" classname="Kubernetes e2e suite" time="8.260998709"></testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.320817695"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="88.216959348"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="10.295258944"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]" classname="Kubernetes e2e suite" time="19.323458458"></testcase>
+      <testcase name="[sig-storage] PVC Protection Verify &#34;immediate&#34; deletion of a PVC that is not in active use by a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]" classname="Kubernetes e2e suite" time="11.753524948999999"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.254354818"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="29.55102159"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should not be able to prevent deleting validating-webhook-configurations or mutating-webhook-configurations" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="130.453337536"></testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated  [Conformance]" classname="Kubernetes e2e suite" time="26.735875654"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.24573165"></testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart  [Conformance]" classname="Kubernetes e2e suite" time="82.213000472"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="62.328766153"></testcase>
+      <testcase name="[sig-storage] Volume expand [Feature:ExpandPersistentVolumes] [Slow] Verify if editing PVC allows resize" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create none metrics for pvc controller before creating any PV or PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted [Conformance]" classname="Kubernetes e2e suite" time="16.260482026"></testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.30178383"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so [Conformance]" classname="Kubernetes e2e suite" time="46.23156454"></testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args  [Conformance]" classname="Kubernetes e2e suite" time="10.234089964"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.242125042"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.308756272"></testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="92.908643366"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [Conformance]" classname="Kubernetes e2e suite" time="8.251731441"></testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.252674611"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.232922487"></testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap binary data should be reflected in volume " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods [Conformance]" classname="Kubernetes e2e suite" time="14.285381442"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="42.555965434"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive] node unregister" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes [Feature:CSI] Sanity CSI plugin test using hostPath CSI driver should provision storage with a hostPath CSI driver" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [Conformance]" classname="Kubernetes e2e suite" time="8.268414598"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.253989006"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.252486883"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existent secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset [Conformance]" classname="Kubernetes e2e suite" time="24.472939785"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.240427248"></testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="113.492858415"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.236533389"></testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="10.22167808"></testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [Conformance]" classname="Kubernetes e2e suite" time="10.243424722"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.241639662"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="21.249489126"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable  [Conformance]" classname="Kubernetes e2e suite" time="10.224409934"></testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="7.225122649"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that a pod with an invalid NodeAffinity is rejected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file  [Conformance]" classname="Kubernetes e2e suite" time="46.972462561"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with secret pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should not reconcile manually modified health check for ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="10.25799512"></testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.226545251"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="10.245170697"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]" classname="Kubernetes e2e suite" time="113.33821808"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="28.286952298"></testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.234051055"></testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [Conformance]" classname="Kubernetes e2e suite" time="26.756762471000002"></testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should support configurable pod resolv.conf" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="42.543353269"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify that PV bound to a PVC is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.262250878"></testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file  [Conformance]" classname="Kubernetes e2e suite" time="8.242800257"></testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [DisabledForLargeClusters] kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.251750191"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="25.491316291"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout  [Conformance]" classname="Kubernetes e2e suite" time="6.222864003">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha docker/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="21.401209935"></testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.239813546"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="16.225714921"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.247360093"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates lower priority pod preemption by critical pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var  [Conformance]" classname="Kubernetes e2e suite" time="10.269111476"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command  [Conformance]" classname="Kubernetes e2e suite" time="10.255196937000001"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.236961493"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="12.239666315"></testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.246366206"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.243961067"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="90.317378125"></testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command (docker entrypoint)  [Conformance]" classname="Kubernetes e2e suite" time="8.250639906"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="10.258625541"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.231187882">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.245958551"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="26.277955623"></testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count  [Slow] [Conformance]" classname="Kubernetes e2e suite" time="148.494924932"></testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [Conformance]" classname="Kubernetes e2e suite" time="10.244878659"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.210018275"></testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank  [Conformance]" classname="Kubernetes e2e suite" time="10.245022431"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.238300608"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP  [Conformance]" classname="Kubernetes e2e suite" time="24.218636625"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.242848608"></testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods [Conformance]" classname="Kubernetes e2e suite" time="61.492880464"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have accelerator metrics [Feature:StackdriverAcceleratorMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.244231102"></testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="38.598580767"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.246007973"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Downgrade [Feature:IngressDowngrade] ingress downgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications [Conformance]" classname="Kubernetes e2e suite" time="116.394630814"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod  [Conformance]" classname="Kubernetes e2e suite" time="8.23389245"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="6.737602507"></testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPU] run Nvidia GPU tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services  [Conformance]" classname="Kubernetes e2e suite" time="28.265903005"></testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart  [Conformance]" classname="Kubernetes e2e suite" time="40.215938016"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.251725061"></testcase>
+      <testcase name="[sig-storage] Regional PD [Feature:RegionalPD] RegionalPD should provision storage [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should update ingress while sync failures occur on other ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request  [Conformance]" classname="Kubernetes e2e suite" time="8.240435804"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="85.334508188"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification  [Conformance]" classname="Kubernetes e2e suite" time="28.783612176"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request  [Conformance]" classname="Kubernetes e2e suite" time="8.253353256"></testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.230872615"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod  [Conformance]" classname="Kubernetes e2e suite" time="8.225205407"></testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor using proxy subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification  [Conformance]" classname="Kubernetes e2e suite" time="28.763335737"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [Conformance]" classname="Kubernetes e2e suite" time="8.24076882"></testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files  [Conformance]" classname="Kubernetes e2e suite" time="8.238761362"></testcase>
+  </testsuite>

--- a/v1.10/sap-cp-gcp/version.txt
+++ b/v1.10/sap-cp-gcp/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.1", GitCommit:"d4ab47518836c750f9949b9e0d387f20fb92260b", GitTreeState:"clean", BuildDate:"2018-04-12T14:26:04Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.2", GitCommit:"81753b10df112992bf51bbc2c2f85208aad78335", GitTreeState:"clean", BuildDate:"2018-04-27T09:10:24Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}

--- a/v1.10/sap-cp-openstack/PRODUCT.yaml
+++ b/v1.10/sap-cp-openstack/PRODUCT.yaml
@@ -1,0 +1,6 @@
+vendor: SAP
+name: Cloud Platform - Gardener (https://github.com/gardener/gardener) shoot cluster deployed on Openstack
+version: 0.4.0
+website_url: https://cloudplatform.sap.com/index.html
+documentation_url: https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/
+product_logo_url: https://www.sap.com/dam/application/shared/logos/sap-logo-svg.svg

--- a/v1.10/sap-cp-openstack/README.md
+++ b/v1.10/sap-cp-openstack/README.md
@@ -1,0 +1,43 @@
+# To reproduce:
+
+## Create Kubernetes Cluster
+
+Login to SAP Gardener Dashboard to create a Kubernetes Clusters on Amazon Web Services, Microsoft Azure, Google Cloud Platform, or OpenStack cloud provider.
+
+After the creation completed, copy the cluster's kubeconfig, which is provided by the Gardener Dashboard in the cluster's detail view, to ~/.kube/config and launch the Kubernetes E2E conformance tests.
+
+## Launch E2E Conformance Tests
+1. Launch e2e pod and sonobuoy master under namespace `sonobuoy`   
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+    ```
+
+2. Check logs of `sonobuoy` pod to see when test can be finished   
+Run
+
+    ```shell
+    kubectl logs -f -n sonobuoy sonobuoy
+    ```
+    and wait for line `no-exit was specified, sonobuoy is now blocking`.
+
+3. Use `kubectl cp` to copy the results to the client   
+Get the name of the <result archive> from the log output in step 2.
+
+    ```shell
+    kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy/<result archive> /home/result
+    ```
+
+4. Delete the conformance test resources
+
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl delete -f -
+    ```
+
+5. Untar the tarball
+
+    ```shell
+    cd /home/result
+    tar -xzf *_sonobuoy_*.tar.gz
+    ```
+
+    The result files `e2e.log` and `junit_01.xml` are located in the in the directory `plugins/e2e/results/`.

--- a/v1.10/sap-cp-openstack/e2e.log
+++ b/v1.10/sap-cp-openstack/e2e.log
@@ -1,0 +1,7262 @@
+Apr 27 14:06:24.407: INFO: Overriding default scale value of zero to 1
+Apr 27 14:06:24.407: INFO: Overriding default milliseconds value of zero to 5000
+I0427 14:06:24.547270      15 test_context.go:358] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-187724608
+I0427 14:06:24.547397      15 e2e.go:333] Starting e2e run "2b76e4a9-4a24-11e8-87ef-0ee10445d8a2" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1524837984 - Will randomize all specs
+Will run 141 of 836 specs
+
+Apr 27 14:06:24.621: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 14:06:24.622: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
+Apr 27 14:06:24.637: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 27 14:06:24.719: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 27 14:06:24.719: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 27 14:06:24.724: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 27 14:06:24.724: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Apr 27 14:06:24.728: INFO: e2e test version: v1.10.0
+Apr 27 14:06:24.730: INFO: kube-apiserver version: v1.10.1
+[sig-storage] Projected 
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:06:24.730: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+Apr 27 14:06:24.812: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:06:24.821: INFO: Waiting up to 5m0s for pod "downwardapi-volume-2bc10165-4a24-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-7rk7c" to be "success or failure"
+Apr 27 14:06:24.824: INFO: Pod "downwardapi-volume-2bc10165-4a24-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.680057ms
+Apr 27 14:06:26.829: INFO: Pod "downwardapi-volume-2bc10165-4a24-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008454099s
+STEP: Saw pod success
+Apr 27 14:06:26.830: INFO: Pod "downwardapi-volume-2bc10165-4a24-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:06:26.832: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-2bc10165-4a24-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:06:26.849: INFO: Waiting for pod downwardapi-volume-2bc10165-4a24-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:06:26.852: INFO: Pod downwardapi-volume-2bc10165-4a24-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:06:26.852: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-7rk7c" for this suite.
+Apr 27 14:06:32.864: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:06:32.942: INFO: namespace: e2e-tests-projected-7rk7c, resource: bindings, ignored listing per whitelist
+Apr 27 14:06:32.985: INFO: namespace e2e-tests-projected-7rk7c deletion completed in 6.129631697s
+
+• [SLOW TEST:8.255 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:06:32.985: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Apr 27 14:06:33.074: INFO: Waiting up to 5m0s for pod "pod-30ac9723-4a24-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-vpw42" to be "success or failure"
+Apr 27 14:06:33.076: INFO: Pod "pod-30ac9723-4a24-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.590791ms
+Apr 27 14:06:35.081: INFO: Pod "pod-30ac9723-4a24-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007390445s
+STEP: Saw pod success
+Apr 27 14:06:35.081: INFO: Pod "pod-30ac9723-4a24-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:06:35.083: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-30ac9723-4a24-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:06:35.099: INFO: Waiting for pod pod-30ac9723-4a24-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:06:35.101: INFO: Pod pod-30ac9723-4a24-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:06:35.101: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-vpw42" for this suite.
+Apr 27 14:06:41.115: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:06:41.214: INFO: namespace: e2e-tests-emptydir-vpw42, resource: bindings, ignored listing per whitelist
+Apr 27 14:06:41.232: INFO: namespace e2e-tests-emptydir-vpw42 deletion completed in 6.126928s
+
+• [SLOW TEST:8.247 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:06:41.232: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:06:41.321: INFO: (0) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 7.335114ms)
+Apr 27 14:06:41.325: INFO: (1) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.120764ms)
+Apr 27 14:06:41.329: INFO: (2) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.096199ms)
+Apr 27 14:06:41.333: INFO: (3) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.811968ms)
+Apr 27 14:06:41.337: INFO: (4) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.641983ms)
+Apr 27 14:06:41.341: INFO: (5) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.489656ms)
+Apr 27 14:06:41.346: INFO: (6) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.128225ms)
+Apr 27 14:06:41.350: INFO: (7) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.064126ms)
+Apr 27 14:06:41.354: INFO: (8) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.980236ms)
+Apr 27 14:06:41.358: INFO: (9) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.880395ms)
+Apr 27 14:06:41.362: INFO: (10) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.923708ms)
+Apr 27 14:06:41.366: INFO: (11) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.010285ms)
+Apr 27 14:06:41.369: INFO: (12) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.654144ms)
+Apr 27 14:06:41.373: INFO: (13) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.505358ms)
+Apr 27 14:06:41.377: INFO: (14) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.672237ms)
+Apr 27 14:06:41.381: INFO: (15) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.425908ms)
+Apr 27 14:06:41.385: INFO: (16) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.777715ms)
+Apr 27 14:06:41.389: INFO: (17) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.948151ms)
+Apr 27 14:06:41.393: INFO: (18) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.74675ms)
+Apr 27 14:06:41.397: INFO: (19) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.91919ms)
+[AfterEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:06:41.397: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-4s6b9" for this suite.
+Apr 27 14:06:47.410: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:06:47.453: INFO: namespace: e2e-tests-proxy-4s6b9, resource: bindings, ignored listing per whitelist
+Apr 27 14:06:47.530: INFO: namespace e2e-tests-proxy-4s6b9 deletion completed in 6.128703574s
+
+• [SLOW TEST:6.298 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:06:47.530: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:37
+[It] should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test hostPath mode
+Apr 27 14:06:47.618: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-prmj2" to be "success or failure"
+Apr 27 14:06:47.622: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 3.298552ms
+Apr 27 14:06:49.625: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006661011s
+STEP: Saw pod success
+Apr 27 14:06:49.625: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Apr 27 14:06:49.627: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Apr 27 14:06:49.644: INFO: Waiting for pod pod-host-path-test to disappear
+Apr 27 14:06:49.646: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:06:49.646: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-prmj2" for this suite.
+Apr 27 14:06:55.661: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:06:55.724: INFO: namespace: e2e-tests-hostpath-prmj2, resource: bindings, ignored listing per whitelist
+Apr 27 14:06:55.795: INFO: namespace e2e-tests-hostpath-prmj2 deletion completed in 6.142906905s
+
+• [SLOW TEST:8.264 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:34
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:06:55.795: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-3e45c5a2-4a24-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:06:55.891: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-3e463af4-4a24-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-8jlxm" to be "success or failure"
+Apr 27 14:06:55.895: INFO: Pod "pod-projected-secrets-3e463af4-4a24-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.863946ms
+Apr 27 14:06:57.898: INFO: Pod "pod-projected-secrets-3e463af4-4a24-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007227691s
+STEP: Saw pod success
+Apr 27 14:06:57.898: INFO: Pod "pod-projected-secrets-3e463af4-4a24-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:06:57.901: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-secrets-3e463af4-4a24-11e8-87ef-0ee10445d8a2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:06:57.914: INFO: Waiting for pod pod-projected-secrets-3e463af4-4a24-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:06:57.917: INFO: Pod pod-projected-secrets-3e463af4-4a24-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:06:57.917: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8jlxm" for this suite.
+Apr 27 14:07:03.931: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:07:04.052: INFO: namespace: e2e-tests-projected-8jlxm, resource: bindings, ignored listing per whitelist
+Apr 27 14:07:04.059: INFO: namespace e2e-tests-projected-8jlxm deletion completed in 6.138636573s
+
+• [SLOW TEST:8.264 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:07:04.060: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap e2e-tests-configmap-tdcpd/configmap-test-4332a184-4a24-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:07:04.154: INFO: Waiting up to 5m0s for pod "pod-configmaps-43331c3a-4a24-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-configmap-tdcpd" to be "success or failure"
+Apr 27 14:07:04.161: INFO: Pod "pod-configmaps-43331c3a-4a24-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 6.52961ms
+Apr 27 14:07:06.164: INFO: Pod "pod-configmaps-43331c3a-4a24-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009903467s
+Apr 27 14:07:08.168: INFO: Pod "pod-configmaps-43331c3a-4a24-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013407712s
+STEP: Saw pod success
+Apr 27 14:07:08.168: INFO: Pod "pod-configmaps-43331c3a-4a24-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:07:08.171: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-configmaps-43331c3a-4a24-11e8-87ef-0ee10445d8a2 container env-test: <nil>
+STEP: delete the pod
+Apr 27 14:07:08.184: INFO: Waiting for pod pod-configmaps-43331c3a-4a24-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:07:08.186: INFO: Pod pod-configmaps-43331c3a-4a24-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:07:08.186: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-tdcpd" for this suite.
+Apr 27 14:07:14.198: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:07:14.278: INFO: namespace: e2e-tests-configmap-tdcpd, resource: bindings, ignored listing per whitelist
+Apr 27 14:07:14.335: INFO: namespace e2e-tests-configmap-tdcpd deletion completed in 6.146366899s
+
+• [SLOW TEST:10.276 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:07:14.336: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-4952365a-4a24-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:07:14.428: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-4952aa0a-4a24-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-7fspx" to be "success or failure"
+Apr 27 14:07:14.432: INFO: Pod "pod-projected-secrets-4952aa0a-4a24-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.747776ms
+Apr 27 14:07:16.440: INFO: Pod "pod-projected-secrets-4952aa0a-4a24-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012456011s
+STEP: Saw pod success
+Apr 27 14:07:16.440: INFO: Pod "pod-projected-secrets-4952aa0a-4a24-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:07:16.443: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-secrets-4952aa0a-4a24-11e8-87ef-0ee10445d8a2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:07:16.458: INFO: Waiting for pod pod-projected-secrets-4952aa0a-4a24-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:07:16.460: INFO: Pod pod-projected-secrets-4952aa0a-4a24-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:07:16.460: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-7fspx" for this suite.
+Apr 27 14:07:22.474: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:07:22.554: INFO: namespace: e2e-tests-projected-7fspx, resource: bindings, ignored listing per whitelist
+Apr 27 14:07:22.599: INFO: namespace e2e-tests-projected-7fspx deletion completed in 6.135211297s
+
+• [SLOW TEST:8.264 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:07:22.600: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating pod
+Apr 27 14:07:24.707: INFO: Pod pod-hostip-4e3f7467-4a24-11e8-87ef-0ee10445d8a2 has hostIP: 10.250.0.18
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:07:24.707: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-bvdrj" for this suite.
+Apr 27 14:07:46.721: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:07:46.839: INFO: namespace: e2e-tests-pods-bvdrj, resource: bindings, ignored listing per whitelist
+Apr 27 14:07:46.844: INFO: namespace e2e-tests-pods-bvdrj deletion completed in 22.132839629s
+
+• [SLOW TEST:24.245 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:07:46.846: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-5cb262b2-4a24-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:07:46.934: INFO: Waiting up to 5m0s for pod "pod-secrets-5cb2da78-4a24-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-secrets-8lt47" to be "success or failure"
+Apr 27 14:07:46.937: INFO: Pod "pod-secrets-5cb2da78-4a24-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.661803ms
+Apr 27 14:07:48.941: INFO: Pod "pod-secrets-5cb2da78-4a24-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00657729s
+STEP: Saw pod success
+Apr 27 14:07:48.941: INFO: Pod "pod-secrets-5cb2da78-4a24-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:07:48.943: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-secrets-5cb2da78-4a24-11e8-87ef-0ee10445d8a2 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:07:48.957: INFO: Waiting for pod pod-secrets-5cb2da78-4a24-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:07:48.960: INFO: Pod pod-secrets-5cb2da78-4a24-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:07:48.960: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-8lt47" for this suite.
+Apr 27 14:07:54.972: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:07:55.016: INFO: namespace: e2e-tests-secrets-8lt47, resource: bindings, ignored listing per whitelist
+Apr 27 14:07:55.105: INFO: namespace e2e-tests-secrets-8lt47 deletion completed in 6.141522997s
+
+• [SLOW TEST:8.259 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:07:55.106: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:07:55.190: INFO: Waiting up to 5m0s for pod "downwardapi-volume-619e98e9-4a24-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-gl68m" to be "success or failure"
+Apr 27 14:07:55.192: INFO: Pod "downwardapi-volume-619e98e9-4a24-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.070412ms
+Apr 27 14:07:57.196: INFO: Pod "downwardapi-volume-619e98e9-4a24-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00634551s
+STEP: Saw pod success
+Apr 27 14:07:57.196: INFO: Pod "downwardapi-volume-619e98e9-4a24-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:07:57.199: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-619e98e9-4a24-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:07:57.215: INFO: Waiting for pod downwardapi-volume-619e98e9-4a24-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:07:57.220: INFO: Pod downwardapi-volume-619e98e9-4a24-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:07:57.220: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-gl68m" for this suite.
+Apr 27 14:08:03.233: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:08:03.310: INFO: namespace: e2e-tests-projected-gl68m, resource: bindings, ignored listing per whitelist
+Apr 27 14:08:03.365: INFO: namespace e2e-tests-projected-gl68m deletion completed in 6.141037092s
+
+• [SLOW TEST:8.259 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:08:03.365: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:08:03.450: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-ctdxg" for this suite.
+Apr 27 14:08:25.463: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:08:25.519: INFO: namespace: e2e-tests-pods-ctdxg, resource: bindings, ignored listing per whitelist
+Apr 27 14:08:25.586: INFO: namespace e2e-tests-pods-ctdxg deletion completed in 22.131881496s
+
+• [SLOW TEST:22.221 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:08:25.586: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Apr 27 14:08:25.668: INFO: Waiting up to 5m0s for pod "pod-73c91c73-4a24-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-bpz65" to be "success or failure"
+Apr 27 14:08:25.670: INFO: Pod "pod-73c91c73-4a24-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.127858ms
+Apr 27 14:08:27.675: INFO: Pod "pod-73c91c73-4a24-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006547221s
+STEP: Saw pod success
+Apr 27 14:08:27.675: INFO: Pod "pod-73c91c73-4a24-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:08:27.678: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-73c91c73-4a24-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:08:27.694: INFO: Waiting for pod pod-73c91c73-4a24-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:08:27.697: INFO: Pod pod-73c91c73-4a24-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:08:27.697: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-bpz65" for this suite.
+Apr 27 14:08:33.711: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:08:33.807: INFO: namespace: e2e-tests-emptydir-bpz65, resource: bindings, ignored listing per whitelist
+Apr 27 14:08:33.838: INFO: namespace e2e-tests-emptydir-bpz65 deletion completed in 6.137093394s
+
+• [SLOW TEST:8.252 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:08:33.838: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Apr 27 14:08:36.437: INFO: Successfully updated pod "pod-update-activedeadlineseconds-78b419cf-4a24-11e8-87ef-0ee10445d8a2"
+Apr 27 14:08:36.437: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-78b419cf-4a24-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-pods-vwf6b" to be "terminated due to deadline exceeded"
+Apr 27 14:08:36.440: INFO: Pod "pod-update-activedeadlineseconds-78b419cf-4a24-11e8-87ef-0ee10445d8a2": Phase="Running", Reason="", readiness=true. Elapsed: 2.768257ms
+Apr 27 14:08:38.444: INFO: Pod "pod-update-activedeadlineseconds-78b419cf-4a24-11e8-87ef-0ee10445d8a2": Phase="Running", Reason="", readiness=true. Elapsed: 2.006210574s
+Apr 27 14:08:40.447: INFO: Pod "pod-update-activedeadlineseconds-78b419cf-4a24-11e8-87ef-0ee10445d8a2": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 4.009606754s
+Apr 27 14:08:40.447: INFO: Pod "pod-update-activedeadlineseconds-78b419cf-4a24-11e8-87ef-0ee10445d8a2" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:08:40.447: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-vwf6b" for this suite.
+Apr 27 14:08:46.459: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:08:46.517: INFO: namespace: e2e-tests-pods-vwf6b, resource: bindings, ignored listing per whitelist
+Apr 27 14:08:46.581: INFO: namespace e2e-tests-pods-vwf6b deletion completed in 6.130309499s
+
+• [SLOW TEST:12.743 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:08:46.581: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Apr 27 14:08:46.680: INFO: Number of nodes with available pods: 0
+Apr 27 14:08:46.680: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:47.687: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:47.687: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:48.688: INFO: Number of nodes with available pods: 2
+Apr 27 14:08:48.688: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Stop a daemon pod, check that the daemon pod is revived.
+Apr 27 14:08:48.705: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:48.705: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:49.714: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:49.714: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:50.712: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:50.712: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:51.713: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:51.713: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:52.713: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:52.713: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:53.713: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:53.713: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:54.714: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:54.714: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:55.714: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:55.714: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:56.714: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:56.714: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:57.713: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:57.713: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:58.713: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:58.713: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:08:59.713: INFO: Number of nodes with available pods: 1
+Apr 27 14:08:59.713: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:09:00.713: INFO: Number of nodes with available pods: 1
+Apr 27 14:09:00.713: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:09:01.714: INFO: Number of nodes with available pods: 1
+Apr 27 14:09:01.714: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:09:02.712: INFO: Number of nodes with available pods: 1
+Apr 27 14:09:02.713: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:09:03.713: INFO: Number of nodes with available pods: 1
+Apr 27 14:09:03.713: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:09:04.715: INFO: Number of nodes with available pods: 2
+Apr 27 14:09:04.715: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 27 14:09:11.737: INFO: Number of nodes with available pods: 0
+Apr 27 14:09:11.737: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 27 14:09:11.742: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-w6mwn/daemonsets","resourceVersion":"389836"},"items":null}
+
+Apr 27 14:09:11.744: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-w6mwn/pods","resourceVersion":"389836"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:09:11.752: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-w6mwn" for this suite.
+Apr 27 14:09:17.764: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:09:17.826: INFO: namespace: e2e-tests-daemonsets-w6mwn, resource: bindings, ignored listing per whitelist
+Apr 27 14:09:17.890: INFO: namespace e2e-tests-daemonsets-w6mwn deletion completed in 6.135590184s
+
+• [SLOW TEST:31.309 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:09:17.891: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 27 14:09:20.507: INFO: Successfully updated pod "labelsupdate92f79a37-4a24-11e8-87ef-0ee10445d8a2"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:09:24.536: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5mrd8" for this suite.
+Apr 27 14:09:44.549: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:09:44.657: INFO: namespace: e2e-tests-projected-5mrd8, resource: bindings, ignored listing per whitelist
+Apr 27 14:09:44.702: INFO: namespace e2e-tests-projected-5mrd8 deletion completed in 20.163250752s
+
+• [SLOW TEST:26.812 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:09:44.703: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Apr 27 14:09:48.814: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-svvwp PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:09:48.814: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 14:09:48.963: INFO: Exec stderr: ""
+Apr 27 14:09:48.964: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-svvwp PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:09:48.964: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 14:09:49.139: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Apr 27 14:09:49.139: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-svvwp PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:09:49.139: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 14:09:49.282: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Apr 27 14:09:49.283: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-svvwp PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:09:49.283: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 14:09:59.262: INFO: Exec stderr: ""
+Apr 27 14:09:59.262: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-svvwp PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:09:59.262: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 14:09:59.441: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:09:59.442: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-svvwp" for this suite.
+Apr 27 14:10:45.457: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:10:45.536: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-svvwp, resource: bindings, ignored listing per whitelist
+Apr 27 14:10:45.600: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-svvwp deletion completed in 46.152791987s
+
+• [SLOW TEST:60.898 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:10:45.601: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Apr 27 14:10:47.724: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-c741c500-4a24-11e8-87ef-0ee10445d8a2", GenerateName:"", Namespace:"e2e-tests-pods-sd22h", SelfLink:"/api/v1/namespaces/e2e-tests-pods-sd22h/pods/pod-submit-remove-c741c500-4a24-11e8-87ef-0ee10445d8a2", UID:"c741b8e4-4a24-11e8-95c2-6e9906a57104", ResourceVersion:"390029", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63660435045, loc:(*time.Location)(0x65972e0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"705451220"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"100.96.0.76/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-lrgw6", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc421639cc0), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"k8s.gcr.io/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-lrgw6", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc42103f7c8), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz", HostNetwork:false, HostPID:false, HostIPC:false, ShareProcessNamespace:(*bool)(nil), SecurityContext:(*v1.PodSecurityContext)(0xc421639d80), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc42103f800)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc42103f820)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63660435045, loc:(*time.Location)(0x65972e0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63660435047, loc:(*time.Location)(0x65972e0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63660435045, loc:(*time.Location)(0x65972e0)}}, Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"10.250.0.18", PodIP:"100.96.0.76", StartTime:(*v1.Time)(0xc421666560), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc421666580), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"k8s.gcr.io/nginx-slim-amd64:0.20", ImageID:"docker-pullable://k8s.gcr.io/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://1be2642c911ae87d2ad3b374bdca2ced7178dd3a4174d32248f5deebc5bb4f1d"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:11:01.680: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-sd22h" for this suite.
+Apr 27 14:11:07.692: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:11:07.768: INFO: namespace: e2e-tests-pods-sd22h, resource: bindings, ignored listing per whitelist
+Apr 27 14:11:07.819: INFO: namespace e2e-tests-pods-sd22h deletion completed in 6.135985661s
+
+• [SLOW TEST:22.219 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:11:07.821: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-4lwns
+Apr 27 14:11:13.915: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-4lwns
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:11:13.917: INFO: Initial restart count of pod liveness-exec is 0
+Apr 27 14:12:02.009: INFO: Restart count of pod e2e-tests-container-probe-4lwns/liveness-exec is now 1 (48.091907189s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:12:02.017: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-4lwns" for this suite.
+Apr 27 14:12:08.029: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:12:08.097: INFO: namespace: e2e-tests-container-probe-4lwns, resource: bindings, ignored listing per whitelist
+Apr 27 14:12:08.151: INFO: namespace e2e-tests-container-probe-4lwns deletion completed in 6.130251431s
+
+• [SLOW TEST:60.330 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:12:08.152: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-7rxg8
+[It] Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Looking for a node to schedule stateful set and pod
+STEP: Creating pod with conflicting port in namespace e2e-tests-statefulset-7rxg8
+STEP: Creating statefulset with conflicting port in namespace e2e-tests-statefulset-7rxg8
+STEP: Waiting until pod test-pod will start running in namespace e2e-tests-statefulset-7rxg8
+STEP: Waiting until stateful pod ss-0 will be recreated and deleted at least once in namespace e2e-tests-statefulset-7rxg8
+Apr 27 14:12:12.272: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-7rxg8, name: ss-0, uid: fad95ad0-4a24-11e8-95c2-6e9906a57104, status phase: Pending. Waiting for statefulset controller to delete.
+Apr 27 14:12:12.860: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-7rxg8, name: ss-0, uid: fad95ad0-4a24-11e8-95c2-6e9906a57104, status phase: Failed. Waiting for statefulset controller to delete.
+Apr 27 14:12:12.864: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-7rxg8, name: ss-0, uid: fad95ad0-4a24-11e8-95c2-6e9906a57104, status phase: Failed. Waiting for statefulset controller to delete.
+Apr 27 14:12:12.865: INFO: Observed delete event for stateful pod ss-0 in namespace e2e-tests-statefulset-7rxg8
+STEP: Removing pod with conflicting port in namespace e2e-tests-statefulset-7rxg8
+STEP: Waiting when stateful pod ss-0 will be recreated in namespace e2e-tests-statefulset-7rxg8 and will be in running state
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:12:16.893: INFO: Deleting all statefulset in ns e2e-tests-statefulset-7rxg8
+Apr 27 14:12:16.896: INFO: Scaling statefulset ss to 0
+Apr 27 14:12:26.916: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:12:26.918: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:12:26.927: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-7rxg8" for this suite.
+Apr 27 14:12:32.938: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:12:32.992: INFO: namespace: e2e-tests-statefulset-7rxg8, resource: bindings, ignored listing per whitelist
+Apr 27 14:12:33.056: INFO: namespace e2e-tests-statefulset-7rxg8 deletion completed in 6.126193559s
+
+• [SLOW TEST:24.904 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Should recreate evicted statefulset [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:12:33.056: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc1
+STEP: create the rc2
+STEP: set half of pods created by rc simpletest-rc-to-be-deleted to have rc simpletest-rc-to-stay as owner as well
+STEP: delete the rc simpletest-rc-to-be-deleted
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0427 14:12:43.197004      15 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:12:43.197: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:12:43.197: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-pg8jt" for this suite.
+Apr 27 14:12:49.210: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:12:49.282: INFO: namespace: e2e-tests-gc-pg8jt, resource: bindings, ignored listing per whitelist
+Apr 27 14:12:49.353: INFO: namespace e2e-tests-gc-pg8jt deletion completed in 6.152691411s
+
+• [SLOW TEST:16.296 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:12:49.355: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Apr 27 14:12:49.443: INFO: Waiting up to 5m0s for pod "pod-11020160-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-98gn2" to be "success or failure"
+Apr 27 14:12:49.446: INFO: Pod "pod-11020160-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.963752ms
+Apr 27 14:12:51.450: INFO: Pod "pod-11020160-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006735422s
+STEP: Saw pod success
+Apr 27 14:12:51.450: INFO: Pod "pod-11020160-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:12:51.453: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-11020160-4a25-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:12:51.473: INFO: Waiting for pod pod-11020160-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:12:51.475: INFO: Pod pod-11020160-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:12:51.475: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-98gn2" for this suite.
+Apr 27 14:12:57.488: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:12:57.593: INFO: namespace: e2e-tests-emptydir-98gn2, resource: bindings, ignored listing per whitelist
+Apr 27 14:12:57.625: INFO: namespace e2e-tests-emptydir-98gn2 deletion completed in 6.145011924s
+
+• [SLOW TEST:8.270 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:12:57.625: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test substitution in container's args
+Apr 27 14:12:57.709: INFO: Waiting up to 5m0s for pod "var-expansion-15ef5b5b-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-var-expansion-m7flx" to be "success or failure"
+Apr 27 14:12:57.711: INFO: Pod "var-expansion-15ef5b5b-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.17057ms
+Apr 27 14:12:59.716: INFO: Pod "var-expansion-15ef5b5b-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006344368s
+Apr 27 14:13:01.719: INFO: Pod "var-expansion-15ef5b5b-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01030776s
+STEP: Saw pod success
+Apr 27 14:13:01.720: INFO: Pod "var-expansion-15ef5b5b-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:13:01.722: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod var-expansion-15ef5b5b-4a25-11e8-87ef-0ee10445d8a2 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:13:01.744: INFO: Waiting for pod var-expansion-15ef5b5b-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:13:01.747: INFO: Pod var-expansion-15ef5b5b-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:13:01.747: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-m7flx" for this suite.
+Apr 27 14:13:07.760: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:13:07.820: INFO: namespace: e2e-tests-var-expansion-m7flx, resource: bindings, ignored listing per whitelist
+Apr 27 14:13:07.893: INFO: namespace e2e-tests-var-expansion-m7flx deletion completed in 6.142088493s
+
+• [SLOW TEST:10.267 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:13:07.894: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:13:07.983: INFO: Waiting up to 5m0s for pod "downward-api-1c0eff51-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-wlw26" to be "success or failure"
+Apr 27 14:13:07.985: INFO: Pod "downward-api-1c0eff51-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.416113ms
+Apr 27 14:13:09.989: INFO: Pod "downward-api-1c0eff51-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006547446s
+Apr 27 14:13:11.993: INFO: Pod "downward-api-1c0eff51-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010606654s
+STEP: Saw pod success
+Apr 27 14:13:11.994: INFO: Pod "downward-api-1c0eff51-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:13:11.996: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downward-api-1c0eff51-4a25-11e8-87ef-0ee10445d8a2 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:13:12.018: INFO: Waiting for pod downward-api-1c0eff51-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:13:12.020: INFO: Pod downward-api-1c0eff51-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:13:12.020: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-wlw26" for this suite.
+Apr 27 14:13:18.031: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:13:18.123: INFO: namespace: e2e-tests-downward-api-wlw26, resource: bindings, ignored listing per whitelist
+Apr 27 14:13:18.152: INFO: namespace e2e-tests-downward-api-wlw26 deletion completed in 6.12905159s
+
+• [SLOW TEST:10.259 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:13:18.153: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-l2nq9 A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-l2nq9;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-l2nq9 A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-l2nq9;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-l2nq9.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-l2nq9.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-l2nq9.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-l2nq9.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-l2nq9.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-l2nq9.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-l2nq9.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-l2nq9.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-l2nq9.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-l2nq9.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-l2nq9.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-l2nq9.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-l2nq9.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 105.3.69.100.in-addr.arpa. PTR)" && echo OK > /results/100.69.3.105_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 105.3.69.100.in-addr.arpa. PTR)" && echo OK > /results/100.69.3.105_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-l2nq9 A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-l2nq9;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-l2nq9 A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-l2nq9;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-l2nq9.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-l2nq9.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-l2nq9.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-l2nq9.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-l2nq9.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-l2nq9.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-l2nq9.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-l2nq9.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-l2nq9.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-l2nq9.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-l2nq9.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-l2nq9.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-l2nq9.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 105.3.69.100.in-addr.arpa. PTR)" && echo OK > /results/100.69.3.105_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 105.3.69.100.in-addr.arpa. PTR)" && echo OK > /results/100.69.3.105_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Apr 27 14:13:31.501: INFO: DNS probes using dns-test-222cee9d-4a25-11e8-87ef-0ee10445d8a2 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:13:31.540: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-l2nq9" for this suite.
+Apr 27 14:13:37.564: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:13:37.629: INFO: namespace: e2e-tests-dns-l2nq9, resource: bindings, ignored listing per whitelist
+Apr 27 14:13:37.698: INFO: namespace e2e-tests-dns-l2nq9 deletion completed in 6.154592488s
+
+• [SLOW TEST:19.545 seconds]
+[sig-network] DNS
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:13:37.698: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:13:37.790: INFO: Waiting up to 5m0s for pod "downwardapi-volume-2dd32b8b-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-m7pqn" to be "success or failure"
+Apr 27 14:13:37.792: INFO: Pod "downwardapi-volume-2dd32b8b-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.297305ms
+Apr 27 14:13:39.796: INFO: Pod "downwardapi-volume-2dd32b8b-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006441728s
+STEP: Saw pod success
+Apr 27 14:13:39.796: INFO: Pod "downwardapi-volume-2dd32b8b-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:13:39.799: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-2dd32b8b-4a25-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:13:39.814: INFO: Waiting for pod downwardapi-volume-2dd32b8b-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:13:39.816: INFO: Pod downwardapi-volume-2dd32b8b-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:13:39.817: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-m7pqn" for this suite.
+Apr 27 14:13:45.830: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:13:45.890: INFO: namespace: e2e-tests-downward-api-m7pqn, resource: bindings, ignored listing per whitelist
+Apr 27 14:13:45.950: INFO: namespace e2e-tests-downward-api-m7pqn deletion completed in 6.129978815s
+
+• [SLOW TEST:8.252 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:13:45.952: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:13:46.052: INFO: pod1.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod3", UID:"32bd8f08-4a25-11e8-95c2-6e9906a57104", Controller:(*bool)(0xc421cf655a), BlockOwnerDeletion:(*bool)(0xc421cf655b)}}
+Apr 27 14:13:46.057: INFO: pod2.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod1", UID:"32bc9ea6-4a25-11e8-95c2-6e9906a57104", Controller:(*bool)(0xc420e627ca), BlockOwnerDeletion:(*bool)(0xc420e627cb)}}
+Apr 27 14:13:46.060: INFO: pod3.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod2", UID:"32bd28d0-4a25-11e8-95c2-6e9906a57104", Controller:(*bool)(0xc421cf671a), BlockOwnerDeletion:(*bool)(0xc421cf671b)}}
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:13:51.071: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-pq9hs" for this suite.
+Apr 27 14:13:57.085: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:13:57.124: INFO: namespace: e2e-tests-gc-pq9hs, resource: bindings, ignored listing per whitelist
+Apr 27 14:13:57.204: INFO: namespace e2e-tests-gc-pq9hs deletion completed in 6.129106008s
+
+• [SLOW TEST:11.253 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:13:57.205: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-3972f7a9-4a25-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:13:57.296: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-39736e84-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-hlvgt" to be "success or failure"
+Apr 27 14:13:57.300: INFO: Pod "pod-projected-configmaps-39736e84-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.359469ms
+Apr 27 14:13:59.303: INFO: Pod "pod-projected-configmaps-39736e84-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006979586s
+STEP: Saw pod success
+Apr 27 14:13:59.303: INFO: Pod "pod-projected-configmaps-39736e84-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:13:59.306: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-configmaps-39736e84-4a25-11e8-87ef-0ee10445d8a2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:13:59.323: INFO: Waiting for pod pod-projected-configmaps-39736e84-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:13:59.325: INFO: Pod pod-projected-configmaps-39736e84-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:13:59.325: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hlvgt" for this suite.
+Apr 27 14:14:05.338: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:14:05.433: INFO: namespace: e2e-tests-projected-hlvgt, resource: bindings, ignored listing per whitelist
+Apr 27 14:14:05.460: INFO: namespace e2e-tests-projected-hlvgt deletion completed in 6.131001566s
+
+• [SLOW TEST:8.255 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:14:05.461: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:14:05.545: INFO: Waiting up to 5m0s for pod "downwardapi-volume-3e5e414c-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-nq2qg" to be "success or failure"
+Apr 27 14:14:05.548: INFO: Pod "downwardapi-volume-3e5e414c-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.582618ms
+Apr 27 14:14:07.552: INFO: Pod "downwardapi-volume-3e5e414c-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006216541s
+STEP: Saw pod success
+Apr 27 14:14:07.552: INFO: Pod "downwardapi-volume-3e5e414c-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:14:07.554: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-3e5e414c-4a25-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:14:07.567: INFO: Waiting for pod downwardapi-volume-3e5e414c-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:14:07.571: INFO: Pod downwardapi-volume-3e5e414c-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:14:07.571: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-nq2qg" for this suite.
+Apr 27 14:14:13.584: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:14:13.670: INFO: namespace: e2e-tests-projected-nq2qg, resource: bindings, ignored listing per whitelist
+Apr 27 14:14:13.709: INFO: namespace e2e-tests-projected-nq2qg deletion completed in 6.134154313s
+
+• [SLOW TEST:8.248 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:14:13.710: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Apr 27 14:14:13.811: INFO: Number of nodes with available pods: 0
+Apr 27 14:14:13.811: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:14:14.818: INFO: Number of nodes with available pods: 1
+Apr 27 14:14:14.818: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz is running more than one daemon pod
+Apr 27 14:14:15.819: INFO: Number of nodes with available pods: 2
+Apr 27 14:14:15.819: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.
+Apr 27 14:14:15.835: INFO: Number of nodes with available pods: 2
+Apr 27 14:14:15.835: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Wait for the failed daemon pod to be completely deleted.
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 27 14:15:51.857: INFO: Number of nodes with available pods: 0
+Apr 27 14:15:51.857: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 27 14:15:51.860: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-hlkwp/daemonsets","resourceVersion":"390854"},"items":null}
+
+Apr 27 14:15:51.864: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-hlkwp/pods","resourceVersion":"390855"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:15:51.873: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-hlkwp" for this suite.
+Apr 27 14:15:57.885: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:15:57.988: INFO: namespace: e2e-tests-daemonsets-hlkwp, resource: bindings, ignored listing per whitelist
+Apr 27 14:15:58.001: INFO: namespace e2e-tests-daemonsets-hlkwp deletion completed in 6.12584731s
+
+• [SLOW TEST:104.292 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:15:58.001: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating replication controller my-hostname-basic-81736eaf-4a25-11e8-87ef-0ee10445d8a2
+Apr 27 14:15:58.092: INFO: Pod name my-hostname-basic-81736eaf-4a25-11e8-87ef-0ee10445d8a2: Found 0 pods out of 1
+Apr 27 14:16:03.097: INFO: Pod name my-hostname-basic-81736eaf-4a25-11e8-87ef-0ee10445d8a2: Found 1 pods out of 1
+Apr 27 14:16:03.097: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-81736eaf-4a25-11e8-87ef-0ee10445d8a2" are running
+Apr 27 14:16:03.099: INFO: Pod "my-hostname-basic-81736eaf-4a25-11e8-87ef-0ee10445d8a2-7rkpt" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:15:58 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:15:59 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:15:58 +0000 UTC Reason: Message:}])
+Apr 27 14:16:03.099: INFO: Trying to dial the pod
+Apr 27 14:16:08.150: INFO: Controller my-hostname-basic-81736eaf-4a25-11e8-87ef-0ee10445d8a2: Got expected result from replica 1 [my-hostname-basic-81736eaf-4a25-11e8-87ef-0ee10445d8a2-7rkpt]: "my-hostname-basic-81736eaf-4a25-11e8-87ef-0ee10445d8a2-7rkpt", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:16:08.150: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-6q5rf" for this suite.
+Apr 27 14:16:14.163: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:16:14.211: INFO: namespace: e2e-tests-replication-controller-6q5rf, resource: bindings, ignored listing per whitelist
+Apr 27 14:16:14.284: INFO: namespace e2e-tests-replication-controller-6q5rf deletion completed in 6.129783809s
+
+• [SLOW TEST:16.283 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:16:14.286: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 27 14:16:16.902: INFO: Successfully updated pod "annotationupdate8b283da0-4a25-11e8-87ef-0ee10445d8a2"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:16:18.921: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-jmrpv" for this suite.
+Apr 27 14:16:40.933: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:16:40.981: INFO: namespace: e2e-tests-downward-api-jmrpv, resource: bindings, ignored listing per whitelist
+Apr 27 14:16:41.060: INFO: namespace e2e-tests-downward-api-jmrpv deletion completed in 22.135652174s
+
+• [SLOW TEST:26.775 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:16:41.060: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Apr 27 14:16:41.664: INFO: Waiting up to 5m0s for pod "pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-h95v8" in namespace "e2e-tests-svcaccounts-zlcrk" to be "success or failure"
+Apr 27 14:16:41.667: INFO: Pod "pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-h95v8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.588947ms
+Apr 27 14:16:43.671: INFO: Pod "pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-h95v8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006714553s
+STEP: Saw pod success
+Apr 27 14:16:43.671: INFO: Pod "pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-h95v8" satisfied condition "success or failure"
+Apr 27 14:16:43.673: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-h95v8 container token-test: <nil>
+STEP: delete the pod
+Apr 27 14:16:43.688: INFO: Waiting for pod pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-h95v8 to disappear
+Apr 27 14:16:43.691: INFO: Pod pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-h95v8 no longer exists
+STEP: Creating a pod to test consume service account root CA
+Apr 27 14:16:43.694: INFO: Waiting up to 5m0s for pod "pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-tbgld" in namespace "e2e-tests-svcaccounts-zlcrk" to be "success or failure"
+Apr 27 14:16:43.696: INFO: Pod "pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-tbgld": Phase="Pending", Reason="", readiness=false. Elapsed: 1.928608ms
+Apr 27 14:16:45.700: INFO: Pod "pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-tbgld": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005562304s
+STEP: Saw pod success
+Apr 27 14:16:45.700: INFO: Pod "pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-tbgld" satisfied condition "success or failure"
+Apr 27 14:16:45.704: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-tbgld container root-ca-test: <nil>
+STEP: delete the pod
+Apr 27 14:16:45.719: INFO: Waiting for pod pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-tbgld to disappear
+Apr 27 14:16:45.722: INFO: Pod pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-tbgld no longer exists
+STEP: Creating a pod to test consume service account namespace
+Apr 27 14:16:45.725: INFO: Waiting up to 5m0s for pod "pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-z6dr4" in namespace "e2e-tests-svcaccounts-zlcrk" to be "success or failure"
+Apr 27 14:16:45.728: INFO: Pod "pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-z6dr4": Phase="Pending", Reason="", readiness=false. Elapsed: 2.354161ms
+Apr 27 14:16:47.731: INFO: Pod "pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-z6dr4": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005746078s
+STEP: Saw pod success
+Apr 27 14:16:47.731: INFO: Pod "pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-z6dr4" satisfied condition "success or failure"
+Apr 27 14:16:47.734: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-z6dr4 container namespace-test: <nil>
+STEP: delete the pod
+Apr 27 14:16:47.749: INFO: Waiting for pod pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-z6dr4 to disappear
+Apr 27 14:16:47.752: INFO: Pod pod-service-account-9b6bf047-4a25-11e8-87ef-0ee10445d8a2-z6dr4 no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:16:47.752: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-zlcrk" for this suite.
+Apr 27 14:16:53.763: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:16:53.806: INFO: namespace: e2e-tests-svcaccounts-zlcrk, resource: bindings, ignored listing per whitelist
+Apr 27 14:16:53.883: INFO: namespace e2e-tests-svcaccounts-zlcrk deletion completed in 6.128235956s
+
+• [SLOW TEST:12.823 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:16:53.883: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name s-test-opt-del-a2c2a33c-4a25-11e8-87ef-0ee10445d8a2
+STEP: Creating secret with name s-test-opt-upd-a2c2a377-4a25-11e8-87ef-0ee10445d8a2
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-a2c2a33c-4a25-11e8-87ef-0ee10445d8a2
+STEP: Updating secret s-test-opt-upd-a2c2a377-4a25-11e8-87ef-0ee10445d8a2
+STEP: Creating secret with name s-test-opt-create-a2c2a38b-4a25-11e8-87ef-0ee10445d8a2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:16:58.237: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-gwgvm" for this suite.
+Apr 27 14:17:20.251: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:17:20.326: INFO: namespace: e2e-tests-projected-gwgvm, resource: bindings, ignored listing per whitelist
+Apr 27 14:17:20.375: INFO: namespace e2e-tests-projected-gwgvm deletion completed in 22.13456383s
+
+• [SLOW TEST:26.492 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:17:20.377: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test use defaults
+Apr 27 14:17:20.466: INFO: Waiting up to 5m0s for pod "client-containers-b28c8811-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-containers-gkgl5" to be "success or failure"
+Apr 27 14:17:20.470: INFO: Pod "client-containers-b28c8811-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.429662ms
+Apr 27 14:17:22.473: INFO: Pod "client-containers-b28c8811-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006892232s
+STEP: Saw pod success
+Apr 27 14:17:22.473: INFO: Pod "client-containers-b28c8811-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:17:22.475: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod client-containers-b28c8811-4a25-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:17:22.489: INFO: Waiting for pod client-containers-b28c8811-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:17:22.491: INFO: Pod client-containers-b28c8811-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:17:22.491: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-gkgl5" for this suite.
+Apr 27 14:17:28.503: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:17:28.612: INFO: namespace: e2e-tests-containers-gkgl5, resource: bindings, ignored listing per whitelist
+Apr 27 14:17:28.631: INFO: namespace e2e-tests-containers-gkgl5 deletion completed in 6.136745662s
+
+• [SLOW TEST:8.254 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:17:28.634: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:17:28.721: INFO: Waiting up to 5m0s for pod "downward-api-b7777ae0-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-hqh2j" to be "success or failure"
+Apr 27 14:17:28.723: INFO: Pod "downward-api-b7777ae0-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.068794ms
+Apr 27 14:17:30.727: INFO: Pod "downward-api-b7777ae0-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006111514s
+Apr 27 14:17:32.731: INFO: Pod "downward-api-b7777ae0-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010061555s
+STEP: Saw pod success
+Apr 27 14:17:32.731: INFO: Pod "downward-api-b7777ae0-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:17:32.733: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downward-api-b7777ae0-4a25-11e8-87ef-0ee10445d8a2 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:17:32.749: INFO: Waiting for pod downward-api-b7777ae0-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:17:32.753: INFO: Pod downward-api-b7777ae0-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:17:32.753: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-hqh2j" for this suite.
+Apr 27 14:17:38.767: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:17:38.857: INFO: namespace: e2e-tests-downward-api-hqh2j, resource: bindings, ignored listing per whitelist
+Apr 27 14:17:38.891: INFO: namespace e2e-tests-downward-api-hqh2j deletion completed in 6.134157134s
+
+• [SLOW TEST:10.257 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:17:38.891: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name cm-test-opt-del-bd964c05-4a25-11e8-87ef-0ee10445d8a2
+STEP: Creating configMap with name cm-test-opt-upd-bd964c37-4a25-11e8-87ef-0ee10445d8a2
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-bd964c05-4a25-11e8-87ef-0ee10445d8a2
+STEP: Updating configmap cm-test-opt-upd-bd964c37-4a25-11e8-87ef-0ee10445d8a2
+STEP: Creating configMap with name cm-test-opt-create-bd964c4a-4a25-11e8-87ef-0ee10445d8a2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:17:43.241: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-hql7v" for this suite.
+Apr 27 14:18:05.254: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:18:05.353: INFO: namespace: e2e-tests-configmap-hql7v, resource: bindings, ignored listing per whitelist
+Apr 27 14:18:05.383: INFO: namespace e2e-tests-configmap-hql7v deletion completed in 22.13719493s
+
+• [SLOW TEST:26.492 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:18:05.383: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Apr 27 14:18:05.472: INFO: Waiting up to 5m0s for pod "pod-cd6028a1-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-ck8pk" to be "success or failure"
+Apr 27 14:18:05.474: INFO: Pod "pod-cd6028a1-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.271703ms
+Apr 27 14:18:07.478: INFO: Pod "pod-cd6028a1-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00628656s
+STEP: Saw pod success
+Apr 27 14:18:07.478: INFO: Pod "pod-cd6028a1-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:18:07.481: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-cd6028a1-4a25-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:18:07.498: INFO: Waiting for pod pod-cd6028a1-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:18:07.501: INFO: Pod pod-cd6028a1-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:18:07.501: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-ck8pk" for this suite.
+Apr 27 14:18:13.515: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:18:13.567: INFO: namespace: e2e-tests-emptydir-ck8pk, resource: bindings, ignored listing per whitelist
+Apr 27 14:18:13.633: INFO: namespace e2e-tests-emptydir-ck8pk deletion completed in 6.128071549s
+
+• [SLOW TEST:8.250 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:18:13.635: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-d24bb536-4a25-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:18:13.730: INFO: Waiting up to 5m0s for pod "pod-configmaps-d24c3fa9-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-configmap-d6hv9" to be "success or failure"
+Apr 27 14:18:13.732: INFO: Pod "pod-configmaps-d24c3fa9-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.386891ms
+Apr 27 14:18:15.736: INFO: Pod "pod-configmaps-d24c3fa9-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006113393s
+STEP: Saw pod success
+Apr 27 14:18:15.736: INFO: Pod "pod-configmaps-d24c3fa9-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:18:15.738: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-configmaps-d24c3fa9-4a25-11e8-87ef-0ee10445d8a2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:18:15.755: INFO: Waiting for pod pod-configmaps-d24c3fa9-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:18:15.757: INFO: Pod pod-configmaps-d24c3fa9-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:18:15.757: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-d6hv9" for this suite.
+Apr 27 14:18:21.769: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:18:21.898: INFO: namespace: e2e-tests-configmap-d6hv9, resource: bindings, ignored listing per whitelist
+Apr 27 14:18:21.903: INFO: namespace e2e-tests-configmap-d6hv9 deletion completed in 6.142144818s
+
+• [SLOW TEST:8.268 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:18:21.903: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-d738bb24-4a25-11e8-87ef-0ee10445d8a2
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-d738bb24-4a25-11e8-87ef-0ee10445d8a2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:18:26.067: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2xhrw" for this suite.
+Apr 27 14:18:48.080: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:18:48.150: INFO: namespace: e2e-tests-projected-2xhrw, resource: bindings, ignored listing per whitelist
+Apr 27 14:18:48.211: INFO: namespace e2e-tests-projected-2xhrw deletion completed in 22.140997502s
+
+• [SLOW TEST:26.308 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:18:48.212: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override all
+Apr 27 14:18:48.301: INFO: Waiting up to 5m0s for pod "client-containers-e6e74f6e-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-containers-8prkt" to be "success or failure"
+Apr 27 14:18:48.304: INFO: Pod "client-containers-e6e74f6e-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.597393ms
+Apr 27 14:18:50.308: INFO: Pod "client-containers-e6e74f6e-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007677801s
+STEP: Saw pod success
+Apr 27 14:18:50.309: INFO: Pod "client-containers-e6e74f6e-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:18:50.311: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod client-containers-e6e74f6e-4a25-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:18:50.328: INFO: Waiting for pod client-containers-e6e74f6e-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:18:50.331: INFO: Pod client-containers-e6e74f6e-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:18:50.331: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-8prkt" for this suite.
+Apr 27 14:18:56.344: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:18:56.413: INFO: namespace: e2e-tests-containers-8prkt, resource: bindings, ignored listing per whitelist
+Apr 27 14:18:56.473: INFO: namespace e2e-tests-containers-8prkt deletion completed in 6.138798509s
+
+• [SLOW TEST:8.262 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:18:56.473: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-nrsgw in namespace e2e-tests-proxy-fhwj4
+I0427 14:18:56.568977      15 runners.go:175] Created replication controller with name: proxy-service-nrsgw, namespace: e2e-tests-proxy-fhwj4, replica count: 1
+I0427 14:18:57.570539      15 runners.go:175] proxy-service-nrsgw Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0427 14:18:58.570791      15 runners.go:175] proxy-service-nrsgw Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0427 14:18:59.571074      15 runners.go:175] proxy-service-nrsgw Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Apr 27 14:18:59.574: INFO: setup took 3.018350811s, starting test cases
+STEP: running 16 cases, 20 attempts per case, 320 total attempts
+Apr 27 14:18:59.590: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 15.643879ms)
+Apr 27 14:18:59.595: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 20.570527ms)
+Apr 27 14:18:59.602: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 27.567442ms)
+Apr 27 14:18:59.602: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 27.480269ms)
+Apr 27 14:18:59.602: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 27.949714ms)
+Apr 27 14:18:59.602: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 27.533903ms)
+Apr 27 14:18:59.602: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 27.721372ms)
+Apr 27 14:18:59.603: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 28.660699ms)
+Apr 27 14:18:59.603: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 28.603916ms)
+Apr 27 14:18:59.604: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 29.520206ms)
+Apr 27 14:18:59.604: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 29.869282ms)
+Apr 27 14:18:59.604: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 30.032927ms)
+Apr 27 14:18:59.607: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 32.414523ms)
+Apr 27 14:18:59.607: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 32.744174ms)
+Apr 27 14:18:59.607: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 32.695274ms)
+Apr 27 14:18:59.612: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 37.664812ms)
+Apr 27 14:18:59.617: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 5.127831ms)
+Apr 27 14:18:59.618: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 6.175241ms)
+Apr 27 14:18:59.618: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 6.040042ms)
+Apr 27 14:18:59.618: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 6.435779ms)
+Apr 27 14:18:59.618: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 6.03493ms)
+Apr 27 14:18:59.618: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 6.161158ms)
+Apr 27 14:18:59.619: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 6.55533ms)
+Apr 27 14:18:59.619: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 6.831407ms)
+Apr 27 14:18:59.619: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 6.675394ms)
+Apr 27 14:18:59.619: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 6.886597ms)
+Apr 27 14:18:59.619: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 7.040661ms)
+Apr 27 14:18:59.619: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 6.954909ms)
+Apr 27 14:18:59.619: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 7.022362ms)
+Apr 27 14:18:59.620: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 7.335019ms)
+Apr 27 14:18:59.620: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 7.486561ms)
+Apr 27 14:18:59.620: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 7.561683ms)
+Apr 27 14:18:59.623: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 3.264232ms)
+Apr 27 14:18:59.624: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 4.216476ms)
+Apr 27 14:18:59.624: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 4.278255ms)
+Apr 27 14:18:59.625: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 4.62476ms)
+Apr 27 14:18:59.625: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 4.311967ms)
+Apr 27 14:18:59.625: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 5.198291ms)
+Apr 27 14:18:59.626: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 5.014357ms)
+Apr 27 14:18:59.626: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 5.182566ms)
+Apr 27 14:18:59.626: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 5.455976ms)
+Apr 27 14:18:59.626: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 6.025754ms)
+Apr 27 14:18:59.629: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 8.075634ms)
+Apr 27 14:18:59.631: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 10.570654ms)
+Apr 27 14:18:59.631: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 10.569062ms)
+Apr 27 14:18:59.631: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 10.99451ms)
+Apr 27 14:18:59.633: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 12.373814ms)
+Apr 27 14:18:59.679: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 58.0907ms)
+Apr 27 14:18:59.690: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 10.903952ms)
+Apr 27 14:18:59.690: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 10.904561ms)
+Apr 27 14:18:59.691: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 11.183945ms)
+Apr 27 14:18:59.691: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 11.810254ms)
+Apr 27 14:18:59.691: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 11.505262ms)
+Apr 27 14:18:59.691: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 11.564209ms)
+Apr 27 14:18:59.691: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 12.076831ms)
+Apr 27 14:18:59.691: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 12.230561ms)
+Apr 27 14:18:59.691: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 12.43513ms)
+Apr 27 14:18:59.691: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 12.180856ms)
+Apr 27 14:18:59.692: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 12.42574ms)
+Apr 27 14:18:59.692: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 12.609566ms)
+Apr 27 14:18:59.733: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 53.989547ms)
+Apr 27 14:18:59.733: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 54.225793ms)
+Apr 27 14:18:59.734: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 54.316568ms)
+Apr 27 14:18:59.734: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 54.490173ms)
+Apr 27 14:18:59.738: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 4.336257ms)
+Apr 27 14:18:59.739: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 5.520708ms)
+Apr 27 14:18:59.739: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 5.321749ms)
+Apr 27 14:18:59.739: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 5.371927ms)
+Apr 27 14:18:59.739: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 5.142566ms)
+Apr 27 14:18:59.739: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 5.512116ms)
+Apr 27 14:18:59.740: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 5.833798ms)
+Apr 27 14:18:59.740: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 5.714814ms)
+Apr 27 14:18:59.740: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 6.364193ms)
+Apr 27 14:18:59.741: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 7.023505ms)
+Apr 27 14:18:59.741: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 7.056702ms)
+Apr 27 14:18:59.741: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 6.812612ms)
+Apr 27 14:18:59.741: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 6.746074ms)
+Apr 27 14:18:59.741: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 6.908191ms)
+Apr 27 14:18:59.741: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 6.956809ms)
+Apr 27 14:18:59.741: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 7.49215ms)
+Apr 27 14:18:59.746: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 4.306255ms)
+Apr 27 14:18:59.746: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 4.402993ms)
+Apr 27 14:18:59.746: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 4.536214ms)
+Apr 27 14:18:59.746: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 4.319654ms)
+Apr 27 14:18:59.746: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 4.523676ms)
+Apr 27 14:18:59.746: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 4.711434ms)
+Apr 27 14:18:59.746: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 4.943607ms)
+Apr 27 14:18:59.747: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 4.716569ms)
+Apr 27 14:18:59.747: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 4.942621ms)
+Apr 27 14:18:59.747: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 4.656153ms)
+Apr 27 14:18:59.747: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 5.500147ms)
+Apr 27 14:18:59.747: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 5.464129ms)
+Apr 27 14:18:59.747: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 5.270578ms)
+Apr 27 14:18:59.748: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 5.291103ms)
+Apr 27 14:18:59.748: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 5.935566ms)
+Apr 27 14:18:59.749: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 6.346221ms)
+Apr 27 14:18:59.754: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 4.936249ms)
+Apr 27 14:18:59.754: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 5.003434ms)
+Apr 27 14:18:59.754: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 4.757277ms)
+Apr 27 14:18:59.754: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 4.833488ms)
+Apr 27 14:18:59.755: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 5.951714ms)
+Apr 27 14:18:59.755: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 6.089825ms)
+Apr 27 14:18:59.756: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 7.399892ms)
+Apr 27 14:18:59.756: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 7.150049ms)
+Apr 27 14:18:59.756: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 6.783288ms)
+Apr 27 14:18:59.757: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 7.572668ms)
+Apr 27 14:18:59.757: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 7.400796ms)
+Apr 27 14:18:59.757: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 7.23628ms)
+Apr 27 14:18:59.757: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 7.318324ms)
+Apr 27 14:18:59.757: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 8.061694ms)
+Apr 27 14:18:59.757: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 7.884638ms)
+Apr 27 14:18:59.757: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 7.118094ms)
+Apr 27 14:18:59.761: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 4.081524ms)
+Apr 27 14:18:59.762: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 4.80798ms)
+Apr 27 14:18:59.762: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 4.461609ms)
+Apr 27 14:18:59.762: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 4.538051ms)
+Apr 27 14:18:59.762: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 4.797138ms)
+Apr 27 14:18:59.762: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 5.204545ms)
+Apr 27 14:18:59.762: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 5.106487ms)
+Apr 27 14:18:59.762: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 5.271803ms)
+Apr 27 14:18:59.762: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 5.120933ms)
+Apr 27 14:18:59.763: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 5.379563ms)
+Apr 27 14:18:59.763: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 5.001091ms)
+Apr 27 14:18:59.763: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 5.159139ms)
+Apr 27 14:18:59.763: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 5.358733ms)
+Apr 27 14:18:59.763: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 5.378645ms)
+Apr 27 14:18:59.763: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 6.237677ms)
+Apr 27 14:18:59.763: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 5.892228ms)
+Apr 27 14:18:59.768: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 4.801795ms)
+Apr 27 14:18:59.768: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 4.837593ms)
+Apr 27 14:18:59.769: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 4.78776ms)
+Apr 27 14:18:59.769: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 5.01928ms)
+Apr 27 14:18:59.769: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 5.273098ms)
+Apr 27 14:18:59.769: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 5.608836ms)
+Apr 27 14:18:59.769: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 5.836204ms)
+Apr 27 14:18:59.770: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 5.924186ms)
+Apr 27 14:18:59.770: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 5.84101ms)
+Apr 27 14:18:59.770: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 5.874726ms)
+Apr 27 14:18:59.770: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 6.040386ms)
+Apr 27 14:18:59.770: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 6.20598ms)
+Apr 27 14:18:59.770: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 6.660824ms)
+Apr 27 14:18:59.771: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 6.804004ms)
+Apr 27 14:18:59.771: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 7.095349ms)
+Apr 27 14:18:59.771: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 7.090638ms)
+Apr 27 14:18:59.776: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 5.026416ms)
+Apr 27 14:18:59.776: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 4.889525ms)
+Apr 27 14:18:59.776: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 4.946742ms)
+Apr 27 14:18:59.776: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 5.235164ms)
+Apr 27 14:18:59.777: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 5.832978ms)
+Apr 27 14:18:59.777: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 5.587652ms)
+Apr 27 14:18:59.777: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 6.037952ms)
+Apr 27 14:18:59.777: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 6.006795ms)
+Apr 27 14:18:59.777: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 5.949237ms)
+Apr 27 14:18:59.777: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 6.259136ms)
+Apr 27 14:18:59.777: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 6.481039ms)
+Apr 27 14:18:59.777: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 6.227548ms)
+Apr 27 14:18:59.778: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 6.270262ms)
+Apr 27 14:18:59.778: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 6.810905ms)
+Apr 27 14:18:59.778: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 6.77743ms)
+Apr 27 14:18:59.778: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 6.708313ms)
+Apr 27 14:18:59.781: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 2.622834ms)
+Apr 27 14:18:59.784: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 5.811873ms)
+Apr 27 14:18:59.784: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 5.679595ms)
+Apr 27 14:18:59.784: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 6.113224ms)
+Apr 27 14:18:59.785: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 6.325801ms)
+Apr 27 14:18:59.785: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 5.76705ms)
+Apr 27 14:18:59.785: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 5.744996ms)
+Apr 27 14:18:59.785: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 5.858652ms)
+Apr 27 14:18:59.785: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 6.217511ms)
+Apr 27 14:18:59.785: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 6.300095ms)
+Apr 27 14:18:59.785: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 6.215552ms)
+Apr 27 14:18:59.785: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 6.463046ms)
+Apr 27 14:18:59.786: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 6.6426ms)
+Apr 27 14:18:59.786: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 7.137515ms)
+Apr 27 14:18:59.786: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 6.946348ms)
+Apr 27 14:18:59.786: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 7.154715ms)
+Apr 27 14:18:59.791: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 4.577954ms)
+Apr 27 14:18:59.791: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 4.428969ms)
+Apr 27 14:18:59.791: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 4.707753ms)
+Apr 27 14:18:59.791: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 5.012916ms)
+Apr 27 14:18:59.791: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 5.149575ms)
+Apr 27 14:18:59.791: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 4.97998ms)
+Apr 27 14:18:59.792: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 5.318317ms)
+Apr 27 14:18:59.792: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 5.365987ms)
+Apr 27 14:18:59.792: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 5.247558ms)
+Apr 27 14:18:59.792: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 5.500237ms)
+Apr 27 14:18:59.792: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 5.848451ms)
+Apr 27 14:18:59.792: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 5.632191ms)
+Apr 27 14:18:59.792: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 5.778179ms)
+Apr 27 14:18:59.792: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 5.620251ms)
+Apr 27 14:18:59.792: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 6.168152ms)
+Apr 27 14:18:59.792: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 5.680025ms)
+Apr 27 14:18:59.796: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 4.109213ms)
+Apr 27 14:18:59.798: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 5.678872ms)
+Apr 27 14:18:59.798: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 5.617994ms)
+Apr 27 14:18:59.798: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 5.382183ms)
+Apr 27 14:18:59.798: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 5.736796ms)
+Apr 27 14:18:59.798: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 5.732579ms)
+Apr 27 14:18:59.798: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 5.819384ms)
+Apr 27 14:18:59.799: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 6.083366ms)
+Apr 27 14:18:59.799: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 6.007333ms)
+Apr 27 14:18:59.799: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 6.492357ms)
+Apr 27 14:18:59.799: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 6.537547ms)
+Apr 27 14:18:59.799: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 6.743301ms)
+Apr 27 14:18:59.800: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 7.068546ms)
+Apr 27 14:18:59.800: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 7.270721ms)
+Apr 27 14:18:59.800: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 7.233303ms)
+Apr 27 14:18:59.800: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 7.812306ms)
+Apr 27 14:18:59.804: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 3.664644ms)
+Apr 27 14:18:59.804: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 4.065553ms)
+Apr 27 14:18:59.805: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 4.772024ms)
+Apr 27 14:18:59.806: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 5.421002ms)
+Apr 27 14:18:59.806: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 5.27246ms)
+Apr 27 14:18:59.806: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 4.878237ms)
+Apr 27 14:18:59.806: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 5.318538ms)
+Apr 27 14:18:59.806: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 5.739257ms)
+Apr 27 14:18:59.807: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 5.730185ms)
+Apr 27 14:18:59.808: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 6.53016ms)
+Apr 27 14:18:59.808: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 6.846685ms)
+Apr 27 14:18:59.808: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 6.859152ms)
+Apr 27 14:18:59.808: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 7.016007ms)
+Apr 27 14:18:59.808: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 6.721781ms)
+Apr 27 14:18:59.809: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 7.573286ms)
+Apr 27 14:18:59.809: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 8.28277ms)
+Apr 27 14:18:59.815: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 5.718362ms)
+Apr 27 14:18:59.815: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 5.87064ms)
+Apr 27 14:18:59.815: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 6.247731ms)
+Apr 27 14:18:59.816: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 6.291408ms)
+Apr 27 14:18:59.816: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 6.281447ms)
+Apr 27 14:18:59.816: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 6.418526ms)
+Apr 27 14:18:59.816: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 6.679893ms)
+Apr 27 14:18:59.816: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 6.650342ms)
+Apr 27 14:18:59.816: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 6.757145ms)
+Apr 27 14:18:59.816: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 7.147177ms)
+Apr 27 14:18:59.816: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 7.108203ms)
+Apr 27 14:18:59.817: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 6.856369ms)
+Apr 27 14:18:59.817: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 6.938607ms)
+Apr 27 14:18:59.817: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 7.384976ms)
+Apr 27 14:18:59.817: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 7.409671ms)
+Apr 27 14:18:59.817: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 7.689496ms)
+Apr 27 14:18:59.821: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 4.014786ms)
+Apr 27 14:18:59.822: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 4.371963ms)
+Apr 27 14:18:59.822: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 4.518802ms)
+Apr 27 14:18:59.822: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 4.574692ms)
+Apr 27 14:18:59.823: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 5.270157ms)
+Apr 27 14:18:59.823: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 5.511181ms)
+Apr 27 14:18:59.823: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 5.766698ms)
+Apr 27 14:18:59.824: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 6.401061ms)
+Apr 27 14:18:59.824: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 6.433211ms)
+Apr 27 14:18:59.824: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 6.583269ms)
+Apr 27 14:18:59.824: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 6.710953ms)
+Apr 27 14:18:59.824: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 6.912622ms)
+Apr 27 14:18:59.824: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 6.963623ms)
+Apr 27 14:18:59.824: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 6.990955ms)
+Apr 27 14:18:59.825: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 7.582658ms)
+Apr 27 14:18:59.857: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 39.775554ms)
+Apr 27 14:18:59.862: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 4.426178ms)
+Apr 27 14:18:59.862: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 4.652342ms)
+Apr 27 14:18:59.863: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 5.007108ms)
+Apr 27 14:18:59.864: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 6.244155ms)
+Apr 27 14:18:59.864: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 6.709483ms)
+Apr 27 14:18:59.864: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 5.680552ms)
+Apr 27 14:18:59.864: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 6.583349ms)
+Apr 27 14:18:59.865: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 6.389599ms)
+Apr 27 14:18:59.866: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 7.620597ms)
+Apr 27 14:18:59.866: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 7.913235ms)
+Apr 27 14:18:59.866: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 7.858452ms)
+Apr 27 14:18:59.866: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 7.493639ms)
+Apr 27 14:18:59.866: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 7.512644ms)
+Apr 27 14:18:59.866: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 7.685295ms)
+Apr 27 14:18:59.866: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 8.992966ms)
+Apr 27 14:18:59.866: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 8.198031ms)
+Apr 27 14:18:59.871: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 4.270454ms)
+Apr 27 14:18:59.872: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 4.771547ms)
+Apr 27 14:18:59.872: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 5.035564ms)
+Apr 27 14:18:59.872: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 4.766692ms)
+Apr 27 14:18:59.872: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 5.102896ms)
+Apr 27 14:18:59.872: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 5.204651ms)
+Apr 27 14:18:59.873: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 5.735791ms)
+Apr 27 14:18:59.873: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 5.811076ms)
+Apr 27 14:18:59.873: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 5.838867ms)
+Apr 27 14:18:59.874: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 6.197511ms)
+Apr 27 14:18:59.874: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 6.394196ms)
+Apr 27 14:18:59.874: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 6.49481ms)
+Apr 27 14:18:59.874: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 6.663239ms)
+Apr 27 14:18:59.874: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 7.155697ms)
+Apr 27 14:18:59.874: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 6.775219ms)
+Apr 27 14:18:59.874: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 7.074742ms)
+Apr 27 14:18:59.878: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 3.566399ms)
+Apr 27 14:18:59.878: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 3.365335ms)
+Apr 27 14:18:59.879: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 4.127479ms)
+Apr 27 14:18:59.879: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 4.156309ms)
+Apr 27 14:18:59.879: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 4.551583ms)
+Apr 27 14:18:59.879: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 4.487039ms)
+Apr 27 14:18:59.879: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 4.127017ms)
+Apr 27 14:18:59.880: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 4.515464ms)
+Apr 27 14:18:59.881: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 4.980974ms)
+Apr 27 14:18:59.889: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 13.758627ms)
+Apr 27 14:18:59.889: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 13.269573ms)
+Apr 27 14:18:59.889: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 13.489597ms)
+Apr 27 14:18:59.889: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 14.420719ms)
+Apr 27 14:18:59.889: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 13.490532ms)
+Apr 27 14:18:59.889: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 13.738958ms)
+Apr 27 14:18:59.890: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 14.757313ms)
+Apr 27 14:18:59.896: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:1080/proxy/... (200; 6.195329ms)
+Apr 27 14:18:59.896: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 6.068188ms)
+Apr 27 14:18:59.896: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:462/proxy/: tls qux (200; 6.185555ms)
+Apr 27 14:18:59.897: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 6.303361ms)
+Apr 27 14:18:59.897: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:443/proxy/... (200; 6.706114ms)
+Apr 27 14:18:59.897: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25/proxy/rewriteme"... (200; 6.427914ms)
+Apr 27 14:18:59.897: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname2/proxy/: bar (200; 6.925047ms)
+Apr 27 14:18:59.897: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:1080/proxy/rewri... (200; 6.627785ms)
+Apr 27 14:18:59.897: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/http:proxy-service-nrsgw-ksh25:160/proxy/: foo (200; 7.201333ms)
+Apr 27 14:18:59.898: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/https:proxy-service-nrsgw-ksh25:460/proxy/: tls baz (200; 7.316978ms)
+Apr 27 14:18:59.898: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname1/proxy/: tls baz (200; 7.797605ms)
+Apr 27 14:18:59.898: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname2/proxy/: bar (200; 8.097066ms)
+Apr 27 14:18:59.898: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/https:proxy-service-nrsgw:tlsportname2/proxy/: tls qux (200; 7.982438ms)
+Apr 27 14:18:59.898: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/pods/proxy-service-nrsgw-ksh25:162/proxy/: bar (200; 7.784539ms)
+Apr 27 14:18:59.898: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/http:proxy-service-nrsgw:portname1/proxy/: foo (200; 7.967094ms)
+Apr 27 14:18:59.898: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fhwj4/services/proxy-service-nrsgw:portname1/proxy/: foo (200; 8.005848ms)
+STEP: deleting { ReplicationController} proxy-service-nrsgw in namespace e2e-tests-proxy-fhwj4
+Apr 27 14:19:01.033: INFO: Deleting { ReplicationController} proxy-service-nrsgw took: 1.031636096s
+Apr 27 14:19:01.033: INFO: Terminating { ReplicationController} proxy-service-nrsgw pods took: 49.084µs
+Apr 27 14:19:02.033: INFO: Garbage collecting { ReplicationController} proxy-service-nrsgw pods took: 2.031857217s
+[AfterEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:19:02.033: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-fhwj4" for this suite.
+Apr 27 14:19:08.046: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:19:08.118: INFO: namespace: e2e-tests-proxy-fhwj4, resource: bindings, ignored listing per whitelist
+Apr 27 14:19:08.176: INFO: namespace e2e-tests-proxy-fhwj4 deletion completed in 6.138194547s
+
+• [SLOW TEST:11.703 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:19:08.178: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Apr 27 14:19:08.265: INFO: Waiting up to 5m0s for pod "pod-f2cd6cd9-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-8qvvc" to be "success or failure"
+Apr 27 14:19:08.269: INFO: Pod "pod-f2cd6cd9-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.196838ms
+Apr 27 14:19:10.274: INFO: Pod "pod-f2cd6cd9-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008844898s
+STEP: Saw pod success
+Apr 27 14:19:10.274: INFO: Pod "pod-f2cd6cd9-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:19:10.277: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-f2cd6cd9-4a25-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:19:10.307: INFO: Waiting for pod pod-f2cd6cd9-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:19:10.310: INFO: Pod pod-f2cd6cd9-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:19:10.310: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-8qvvc" for this suite.
+Apr 27 14:19:16.324: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:19:16.364: INFO: namespace: e2e-tests-emptydir-8qvvc, resource: bindings, ignored listing per whitelist
+Apr 27 14:19:16.453: INFO: namespace e2e-tests-emptydir-8qvvc deletion completed in 6.13947462s
+
+• [SLOW TEST:8.276 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:19:16.454: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-map-f7bc2d94-4a25-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:19:16.547: INFO: Waiting up to 5m0s for pod "pod-secrets-f7bd5fb9-4a25-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-secrets-m96jb" to be "success or failure"
+Apr 27 14:19:16.550: INFO: Pod "pod-secrets-f7bd5fb9-4a25-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.756979ms
+Apr 27 14:19:18.554: INFO: Pod "pod-secrets-f7bd5fb9-4a25-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006535632s
+STEP: Saw pod success
+Apr 27 14:19:18.554: INFO: Pod "pod-secrets-f7bd5fb9-4a25-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:19:18.556: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-secrets-f7bd5fb9-4a25-11e8-87ef-0ee10445d8a2 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:19:18.572: INFO: Waiting for pod pod-secrets-f7bd5fb9-4a25-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:19:18.577: INFO: Pod pod-secrets-f7bd5fb9-4a25-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:19:18.578: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-m96jb" for this suite.
+Apr 27 14:19:24.601: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:19:24.707: INFO: namespace: e2e-tests-secrets-m96jb, resource: bindings, ignored listing per whitelist
+Apr 27 14:19:24.729: INFO: namespace e2e-tests-secrets-m96jb deletion completed in 6.146814206s
+
+• [SLOW TEST:8.275 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:19:24.729: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:19:24.829: INFO: Creating daemon "daemon-set" with a node selector
+STEP: Initially, daemon pods should not be running on any nodes.
+Apr 27 14:19:24.834: INFO: Number of nodes with available pods: 0
+Apr 27 14:19:24.834: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Change node label to blue, check that daemon pod is launched.
+Apr 27 14:19:24.849: INFO: Number of nodes with available pods: 0
+Apr 27 14:19:24.849: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:19:25.853: INFO: Number of nodes with available pods: 0
+Apr 27 14:19:25.853: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:19:26.853: INFO: Number of nodes with available pods: 1
+Apr 27 14:19:26.853: INFO: Number of running nodes: 1, number of available pods: 1
+STEP: Update the node label to green, and wait for daemons to be unscheduled
+Apr 27 14:19:26.869: INFO: Number of nodes with available pods: 1
+Apr 27 14:19:26.869: INFO: Number of running nodes: 0, number of available pods: 1
+Apr 27 14:19:27.873: INFO: Number of nodes with available pods: 0
+Apr 27 14:19:27.873: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Update DaemonSet node selector to green, and change its update strategy to RollingUpdate
+Apr 27 14:19:27.884: INFO: Number of nodes with available pods: 0
+Apr 27 14:19:27.884: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:19:28.889: INFO: Number of nodes with available pods: 0
+Apr 27 14:19:28.889: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:19:29.888: INFO: Number of nodes with available pods: 0
+Apr 27 14:19:29.888: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:19:30.889: INFO: Number of nodes with available pods: 1
+Apr 27 14:19:30.889: INFO: Number of running nodes: 1, number of available pods: 1
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 27 14:19:33.910: INFO: Number of nodes with available pods: 0
+Apr 27 14:19:33.910: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 27 14:19:33.921: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-5q9pv/daemonsets","resourceVersion":"391496"},"items":null}
+
+Apr 27 14:19:33.924: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-5q9pv/pods","resourceVersion":"391496"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:19:33.938: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-5q9pv" for this suite.
+Apr 27 14:19:39.955: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:19:39.995: INFO: namespace: e2e-tests-daemonsets-5q9pv, resource: bindings, ignored listing per whitelist
+Apr 27 14:19:40.077: INFO: namespace e2e-tests-daemonsets-5q9pv deletion completed in 6.134034636s
+
+• [SLOW TEST:15.348 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:19:40.078: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-05d07f28-4a26-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:19:40.165: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-05d0f826-4a26-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-qh8qv" to be "success or failure"
+Apr 27 14:19:40.167: INFO: Pod "pod-projected-configmaps-05d0f826-4a26-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.501072ms
+Apr 27 14:19:42.171: INFO: Pod "pod-projected-configmaps-05d0f826-4a26-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006488657s
+STEP: Saw pod success
+Apr 27 14:19:42.172: INFO: Pod "pod-projected-configmaps-05d0f826-4a26-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:19:42.174: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-configmaps-05d0f826-4a26-11e8-87ef-0ee10445d8a2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:19:42.190: INFO: Waiting for pod pod-projected-configmaps-05d0f826-4a26-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:19:42.193: INFO: Pod pod-projected-configmaps-05d0f826-4a26-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:19:42.193: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qh8qv" for this suite.
+Apr 27 14:19:48.206: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:19:48.303: INFO: namespace: e2e-tests-projected-qh8qv, resource: bindings, ignored listing per whitelist
+Apr 27 14:19:48.330: INFO: namespace e2e-tests-projected-qh8qv deletion completed in 6.133291774s
+
+• [SLOW TEST:8.252 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:19:48.330: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-map-0abc37fe-4a26-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:19:48.420: INFO: Waiting up to 5m0s for pod "pod-secrets-0abcbbb3-4a26-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-secrets-8k667" to be "success or failure"
+Apr 27 14:19:48.422: INFO: Pod "pod-secrets-0abcbbb3-4a26-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.234244ms
+Apr 27 14:19:50.427: INFO: Pod "pod-secrets-0abcbbb3-4a26-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006867096s
+Apr 27 14:19:52.430: INFO: Pod "pod-secrets-0abcbbb3-4a26-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010434966s
+STEP: Saw pod success
+Apr 27 14:19:52.430: INFO: Pod "pod-secrets-0abcbbb3-4a26-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:19:52.433: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-secrets-0abcbbb3-4a26-11e8-87ef-0ee10445d8a2 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:19:52.449: INFO: Waiting for pod pod-secrets-0abcbbb3-4a26-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:19:52.452: INFO: Pod pod-secrets-0abcbbb3-4a26-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:19:52.452: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-8k667" for this suite.
+Apr 27 14:19:58.465: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:19:58.555: INFO: namespace: e2e-tests-secrets-8k667, resource: bindings, ignored listing per whitelist
+Apr 27 14:19:58.598: INFO: namespace e2e-tests-secrets-8k667 deletion completed in 6.14217906s
+
+• [SLOW TEST:10.268 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:19:58.599: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-9wjvv
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-9wjvv to expose endpoints map[]
+Apr 27 14:19:58.693: INFO: Get endpoints failed (2.415931ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Apr 27 14:19:59.696: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-9wjvv exposes endpoints map[] (1.005846386s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-9wjvv
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-9wjvv to expose endpoints map[pod1:[80]]
+Apr 27 14:20:01.720: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-9wjvv exposes endpoints map[pod1:[80]] (2.017072204s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-9wjvv
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-9wjvv to expose endpoints map[pod2:[80] pod1:[80]]
+Apr 27 14:20:03.751: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-9wjvv exposes endpoints map[pod1:[80] pod2:[80]] (2.025418476s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-9wjvv
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-9wjvv to expose endpoints map[pod2:[80]]
+Apr 27 14:20:03.762: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-9wjvv exposes endpoints map[pod2:[80]] (7.481363ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-9wjvv
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-9wjvv to expose endpoints map[]
+Apr 27 14:20:03.777: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-9wjvv exposes endpoints map[] (11.449081ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:20:03.788: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-9wjvv" for this suite.
+Apr 27 14:20:25.808: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:20:25.903: INFO: namespace: e2e-tests-services-9wjvv, resource: bindings, ignored listing per whitelist
+Apr 27 14:20:25.935: INFO: namespace e2e-tests-services-9wjvv deletion completed in 22.140491677s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:27.336 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:20:25.935: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-mnj4q
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-mnj4q to expose endpoints map[]
+Apr 27 14:20:26.028: INFO: Get endpoints failed (2.760215ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Apr 27 14:20:27.033: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-mnj4q exposes endpoints map[] (1.007230517s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-mnj4q
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-mnj4q to expose endpoints map[pod1:[100]]
+Apr 27 14:20:28.053: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-mnj4q exposes endpoints map[pod1:[100]] (1.013199665s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-mnj4q
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-mnj4q to expose endpoints map[pod1:[100] pod2:[101]]
+Apr 27 14:20:30.086: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-mnj4q exposes endpoints map[pod1:[100] pod2:[101]] (2.027823742s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-mnj4q
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-mnj4q to expose endpoints map[pod2:[101]]
+Apr 27 14:20:31.104: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-mnj4q exposes endpoints map[pod2:[101]] (1.01463158s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-mnj4q
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-mnj4q to expose endpoints map[]
+Apr 27 14:20:31.113: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-mnj4q exposes endpoints map[] (4.57559ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:20:31.124: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-mnj4q" for this suite.
+Apr 27 14:20:53.140: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:20:53.222: INFO: namespace: e2e-tests-services-mnj4q, resource: bindings, ignored listing per whitelist
+Apr 27 14:20:53.263: INFO: namespace e2e-tests-services-mnj4q deletion completed in 22.134221917s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:27.328 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:20:53.263: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:21:15.366: INFO: Container started at 2018-04-27 14:20:54 +0000 UTC, pod became ready at 2018-04-27 14:21:13 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:21:15.366: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-fvvzc" for this suite.
+Apr 27 14:21:37.381: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:21:37.447: INFO: namespace: e2e-tests-container-probe-fvvzc, resource: bindings, ignored listing per whitelist
+Apr 27 14:21:37.515: INFO: namespace e2e-tests-container-probe-fvvzc deletion completed in 22.145125349s
+
+• [SLOW TEST:44.252 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:21:37.516: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:21:37.613: INFO: (0) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.926293ms)
+Apr 27 14:21:37.619: INFO: (1) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.520508ms)
+Apr 27 14:21:37.624: INFO: (2) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.118828ms)
+Apr 27 14:21:37.627: INFO: (3) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.825272ms)
+Apr 27 14:21:37.632: INFO: (4) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.445848ms)
+Apr 27 14:21:37.636: INFO: (5) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.506469ms)
+Apr 27 14:21:37.640: INFO: (6) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.974114ms)
+Apr 27 14:21:37.645: INFO: (7) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.306618ms)
+Apr 27 14:21:37.649: INFO: (8) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.636603ms)
+Apr 27 14:21:37.652: INFO: (9) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.846704ms)
+Apr 27 14:21:37.656: INFO: (10) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.875246ms)
+Apr 27 14:21:37.660: INFO: (11) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.867733ms)
+Apr 27 14:21:37.664: INFO: (12) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.893319ms)
+Apr 27 14:21:37.668: INFO: (13) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.640799ms)
+Apr 27 14:21:37.672: INFO: (14) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.864899ms)
+Apr 27 14:21:37.676: INFO: (15) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.525616ms)
+Apr 27 14:21:37.682: INFO: (16) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.315239ms)
+Apr 27 14:21:37.686: INFO: (17) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.135154ms)
+Apr 27 14:21:37.690: INFO: (18) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.319015ms)
+Apr 27 14:21:37.694: INFO: (19) /api/v1/nodes/shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.996718ms)
+[AfterEach] version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:21:37.694: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-77wvp" for this suite.
+Apr 27 14:21:43.706: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:21:43.792: INFO: namespace: e2e-tests-proxy-77wvp, resource: bindings, ignored listing per whitelist
+Apr 27 14:21:43.832: INFO: namespace e2e-tests-proxy-77wvp deletion completed in 6.134500246s
+
+• [SLOW TEST:6.317 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:57
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:21:43.833: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-4f93fd07-4a26-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:21:43.918: INFO: Waiting up to 5m0s for pod "pod-configmaps-4f946d73-4a26-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-configmap-r4msx" to be "success or failure"
+Apr 27 14:21:43.921: INFO: Pod "pod-configmaps-4f946d73-4a26-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.360864ms
+Apr 27 14:21:45.929: INFO: Pod "pod-configmaps-4f946d73-4a26-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010459622s
+STEP: Saw pod success
+Apr 27 14:21:45.929: INFO: Pod "pod-configmaps-4f946d73-4a26-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:21:45.932: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-configmaps-4f946d73-4a26-11e8-87ef-0ee10445d8a2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:21:45.949: INFO: Waiting for pod pod-configmaps-4f946d73-4a26-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:21:45.953: INFO: Pod pod-configmaps-4f946d73-4a26-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:21:45.953: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-r4msx" for this suite.
+Apr 27 14:21:51.965: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:21:52.076: INFO: namespace: e2e-tests-configmap-r4msx, resource: bindings, ignored listing per whitelist
+Apr 27 14:21:52.091: INFO: namespace e2e-tests-configmap-r4msx deletion completed in 6.134586722s
+
+• [SLOW TEST:8.258 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:21:52.091: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:21:52.172: INFO: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:21:52.173: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-dqvpp" for this suite.
+Apr 27 14:21:58.185: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:21:58.307: INFO: namespace: e2e-tests-container-probe-dqvpp, resource: bindings, ignored listing per whitelist
+Apr 27 14:21:58.314: INFO: namespace e2e-tests-container-probe-dqvpp deletion completed in 6.137415654s
+
+S [SKIPPING] [6.222 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a docker exec liveness probe with timeout  [Conformance] [It]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+
+  Apr 27 14:21:52.172: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:296
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:21:58.314: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override command
+Apr 27 14:21:58.396: INFO: Waiting up to 5m0s for pod "client-containers-58359a72-4a26-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-containers-d8hd8" to be "success or failure"
+Apr 27 14:21:58.398: INFO: Pod "client-containers-58359a72-4a26-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.002789ms
+Apr 27 14:22:00.407: INFO: Pod "client-containers-58359a72-4a26-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010368905s
+STEP: Saw pod success
+Apr 27 14:22:00.407: INFO: Pod "client-containers-58359a72-4a26-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:22:00.410: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod client-containers-58359a72-4a26-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:22:00.424: INFO: Waiting for pod client-containers-58359a72-4a26-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:22:00.426: INFO: Pod client-containers-58359a72-4a26-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:00.426: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-d8hd8" for this suite.
+Apr 27 14:22:06.439: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:22:06.536: INFO: namespace: e2e-tests-containers-d8hd8, resource: bindings, ignored listing per whitelist
+Apr 27 14:22:06.563: INFO: namespace e2e-tests-containers-d8hd8 deletion completed in 6.133417663s
+
+• [SLOW TEST:8.249 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:22:06.563: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-upd-5d20f284-4a26-11e8-87ef-0ee10445d8a2
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-5d20f284-4a26-11e8-87ef-0ee10445d8a2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:10.727: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-x6zh6" for this suite.
+Apr 27 14:22:32.741: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:22:32.860: INFO: namespace: e2e-tests-configmap-x6zh6, resource: bindings, ignored listing per whitelist
+Apr 27 14:22:32.868: INFO: namespace e2e-tests-configmap-x6zh6 deletion completed in 22.13636538s
+
+• [SLOW TEST:26.304 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:22:32.868: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:32.954: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-rw4d2" for this suite.
+Apr 27 14:22:38.966: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:22:39.086: INFO: namespace: e2e-tests-services-rw4d2, resource: bindings, ignored listing per whitelist
+Apr 27 14:22:39.091: INFO: namespace e2e-tests-services-rw4d2 deletion completed in 6.133484821s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:6.223 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:22:39.092: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:22:39.177: INFO: Requires at least 2 nodes (not -1)
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+Apr 27 14:22:39.183: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-ctsrf/daemonsets","resourceVersion":"391973"},"items":null}
+
+Apr 27 14:22:39.185: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-ctsrf/pods","resourceVersion":"391973"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:39.193: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-ctsrf" for this suite.
+Apr 27 14:22:45.205: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:22:45.268: INFO: namespace: e2e-tests-daemonsets-ctsrf, resource: bindings, ignored listing per whitelist
+Apr 27 14:22:45.331: INFO: namespace e2e-tests-daemonsets-ctsrf deletion completed in 6.135697744s
+
+S [SKIPPING] [6.240 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should rollback without unnecessary restarts [Conformance] [It]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+
+  Apr 27 14:22:39.177: Requires at least 2 nodes (not -1)
+
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:296
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:22:45.332: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:22:45.439: INFO: Waiting up to 5m0s for pod "downwardapi-volume-743fafd2-4a26-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-2hb77" to be "success or failure"
+Apr 27 14:22:45.442: INFO: Pod "downwardapi-volume-743fafd2-4a26-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.586777ms
+Apr 27 14:22:47.446: INFO: Pod "downwardapi-volume-743fafd2-4a26-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006168189s
+STEP: Saw pod success
+Apr 27 14:22:47.446: INFO: Pod "downwardapi-volume-743fafd2-4a26-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:22:47.448: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-743fafd2-4a26-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:22:47.466: INFO: Waiting for pod downwardapi-volume-743fafd2-4a26-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:22:47.469: INFO: Pod downwardapi-volume-743fafd2-4a26-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:47.469: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2hb77" for this suite.
+Apr 27 14:22:53.483: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:22:53.550: INFO: namespace: e2e-tests-projected-2hb77, resource: bindings, ignored listing per whitelist
+Apr 27 14:22:53.641: INFO: namespace e2e-tests-projected-2hb77 deletion completed in 6.1669945s
+
+• [SLOW TEST:8.309 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:22:53.643: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir volume type on node default medium
+Apr 27 14:22:53.731: INFO: Waiting up to 5m0s for pod "pod-7930cac6-4a26-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-zv47c" to be "success or failure"
+Apr 27 14:22:53.734: INFO: Pod "pod-7930cac6-4a26-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.949887ms
+Apr 27 14:22:55.738: INFO: Pod "pod-7930cac6-4a26-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006957421s
+STEP: Saw pod success
+Apr 27 14:22:55.738: INFO: Pod "pod-7930cac6-4a26-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:22:55.741: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-7930cac6-4a26-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:22:55.755: INFO: Waiting for pod pod-7930cac6-4a26-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:22:55.757: INFO: Pod pod-7930cac6-4a26-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:22:55.757: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-zv47c" for this suite.
+Apr 27 14:23:01.771: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:23:01.887: INFO: namespace: e2e-tests-emptydir-zv47c, resource: bindings, ignored listing per whitelist
+Apr 27 14:23:01.896: INFO: namespace e2e-tests-emptydir-zv47c deletion completed in 6.135185634s
+
+• [SLOW TEST:8.253 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:23:01.897: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap e2e-tests-configmap-mzshk/configmap-test-7e1c15b8-4a26-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:23:01.985: INFO: Waiting up to 5m0s for pod "pod-configmaps-7e1c81ec-4a26-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-configmap-mzshk" to be "success or failure"
+Apr 27 14:23:01.988: INFO: Pod "pod-configmaps-7e1c81ec-4a26-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.425724ms
+Apr 27 14:23:03.992: INFO: Pod "pod-configmaps-7e1c81ec-4a26-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00622087s
+Apr 27 14:23:05.995: INFO: Pod "pod-configmaps-7e1c81ec-4a26-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.00977332s
+STEP: Saw pod success
+Apr 27 14:23:05.995: INFO: Pod "pod-configmaps-7e1c81ec-4a26-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:23:05.998: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-configmaps-7e1c81ec-4a26-11e8-87ef-0ee10445d8a2 container env-test: <nil>
+STEP: delete the pod
+Apr 27 14:23:06.012: INFO: Waiting for pod pod-configmaps-7e1c81ec-4a26-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:23:06.015: INFO: Pod pod-configmaps-7e1c81ec-4a26-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:23:06.015: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-mzshk" for this suite.
+Apr 27 14:23:12.028: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:23:12.126: INFO: namespace: e2e-tests-configmap-mzshk, resource: bindings, ignored listing per whitelist
+Apr 27 14:23:12.151: INFO: namespace e2e-tests-configmap-mzshk deletion completed in 6.132959456s
+
+• [SLOW TEST:10.254 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:23:12.152: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name cm-test-opt-del-84392e5a-4a26-11e8-87ef-0ee10445d8a2
+STEP: Creating configMap with name cm-test-opt-upd-84392e93-4a26-11e8-87ef-0ee10445d8a2
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-84392e5a-4a26-11e8-87ef-0ee10445d8a2
+STEP: Updating configmap cm-test-opt-upd-84392e93-4a26-11e8-87ef-0ee10445d8a2
+STEP: Creating configMap with name cm-test-opt-create-84392ea8-4a26-11e8-87ef-0ee10445d8a2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:23:16.509: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-v8bbg" for this suite.
+Apr 27 14:23:38.522: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:23:38.580: INFO: namespace: e2e-tests-projected-v8bbg, resource: bindings, ignored listing per whitelist
+Apr 27 14:23:38.647: INFO: namespace e2e-tests-projected-v8bbg deletion completed in 22.134526775s
+
+• [SLOW TEST:26.496 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:23:38.648: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:23:38.741: INFO: Waiting up to 5m0s for pod "downwardapi-volume-94050f13-4a26-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-t5x24" to be "success or failure"
+Apr 27 14:23:38.743: INFO: Pod "downwardapi-volume-94050f13-4a26-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.26412ms
+Apr 27 14:23:40.748: INFO: Pod "downwardapi-volume-94050f13-4a26-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006507803s
+STEP: Saw pod success
+Apr 27 14:23:40.748: INFO: Pod "downwardapi-volume-94050f13-4a26-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:23:40.750: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-94050f13-4a26-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:23:40.800: INFO: Waiting for pod downwardapi-volume-94050f13-4a26-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:23:40.803: INFO: Pod downwardapi-volume-94050f13-4a26-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:23:40.803: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-t5x24" for this suite.
+Apr 27 14:23:46.815: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:23:46.909: INFO: namespace: e2e-tests-downward-api-t5x24, resource: bindings, ignored listing per whitelist
+Apr 27 14:23:46.932: INFO: namespace e2e-tests-downward-api-t5x24 deletion completed in 6.125980074s
+
+• [SLOW TEST:8.284 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:23:46.933: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Apr 27 14:23:47.011: INFO: Waiting up to 1m0s for all nodes to be ready
+Apr 27 14:24:47.052: INFO: Waiting for terminating namespaces to be deleted...
+Apr 27 14:24:47.058: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 27 14:24:47.080: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 27 14:24:47.080: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 27 14:24:47.084: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 27 14:24:47.084: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q before test
+Apr 27 14:24:47.096: INFO: kube-proxy-2cncd from kube-system started at 2018-04-24 07:26:16 +0000 UTC (1 container statuses recorded)
+Apr 27 14:24:47.096: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:24:47.096: INFO: sonobuoy-e2e-job-056f42649bc7442c from sonobuoy started at 2018-04-27 14:06:22 +0000 UTC (2 container statuses recorded)
+Apr 27 14:24:47.096: INFO: 	Container e2e ready: true, restart count 0
+Apr 27 14:24:47.096: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Apr 27 14:24:47.097: INFO: node-exporter-rl8xl from kube-system started at 2018-04-24 07:26:16 +0000 UTC (1 container statuses recorded)
+Apr 27 14:24:47.097: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:24:47.097: INFO: kube-dns-67b49bdfd8-s6hbn from kube-system started at 2018-04-24 07:27:16 +0000 UTC (3 container statuses recorded)
+Apr 27 14:24:47.097: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:24:47.097: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:24:47.097: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:24:47.097: INFO: calico-node-btd85 from kube-system started at 2018-04-24 07:26:16 +0000 UTC (2 container statuses recorded)
+Apr 27 14:24:47.097: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:24:47.097: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:24:47.097: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-lp7s2 from kube-system started at 2018-04-24 07:27:14 +0000 UTC (1 container statuses recorded)
+Apr 27 14:24:47.097: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Apr 27 14:24:47.097: INFO: addons-heapster-e3b0c-5c98c994fc-twn65 from kube-system started at 2018-04-24 07:27:15 +0000 UTC (2 container statuses recorded)
+Apr 27 14:24:47.097: INFO: 	Container heapster ready: true, restart count 0
+Apr 27 14:24:47.097: INFO: 	Container heapster-nanny ready: true, restart count 0
+Apr 27 14:24:47.097: INFO: sonobuoy from sonobuoy started at 2018-04-27 14:06:21 +0000 UTC (1 container statuses recorded)
+Apr 27 14:24:47.097: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Apr 27 14:24:47.097: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz before test
+Apr 27 14:24:47.104: INFO: kube-proxy-sgq59 from kube-system started at 2018-04-24 07:26:14 +0000 UTC (1 container statuses recorded)
+Apr 27 14:24:47.104: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:24:47.104: INFO: node-exporter-mvvzs from kube-system started at 2018-04-24 07:26:14 +0000 UTC (1 container statuses recorded)
+Apr 27 14:24:47.104: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:24:47.104: INFO: vpn-shoot-b6ddb5857-vjqnr from kube-system started at 2018-04-24 07:27:13 +0000 UTC (1 container statuses recorded)
+Apr 27 14:24:47.105: INFO: 	Container vpn-shoot ready: true, restart count 1
+Apr 27 14:24:47.105: INFO: addons-nginx-ingress-controller-7c8749685-4dfgp from kube-system started at 2018-04-24 07:27:15 +0000 UTC (1 container statuses recorded)
+Apr 27 14:24:47.105: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Apr 27 14:24:47.105: INFO: addons-kubernetes-dashboard-8478f49fbf-vgqts from kube-system started at 2018-04-24 07:27:16 +0000 UTC (1 container statuses recorded)
+Apr 27 14:24:47.105: INFO: 	Container main ready: true, restart count 0
+Apr 27 14:24:47.105: INFO: kube-dns-67b49bdfd8-hgkxt from kube-system started at 2018-04-24 07:27:24 +0000 UTC (3 container statuses recorded)
+Apr 27 14:24:47.105: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:24:47.105: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:24:47.105: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:24:47.105: INFO: calico-node-bcjtk from kube-system started at 2018-04-24 07:26:14 +0000 UTC (2 container statuses recorded)
+Apr 27 14:24:47.105: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:24:47.105: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:24:47.105: INFO: kube-dns-autoscaler-699b4b55c4-t7jll from kube-system started at 2018-04-24 07:27:16 +0000 UTC (1 container statuses recorded)
+Apr 27 14:24:47.105: INFO: 	Container autoscaler ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: verifying the node has the label node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q
+STEP: verifying the node has the label node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz
+Apr 27 14:24:47.134: INFO: Pod addons-heapster-e3b0c-5c98c994fc-twn65 requesting resource cpu=50m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q
+Apr 27 14:24:47.134: INFO: Pod addons-kubernetes-dashboard-8478f49fbf-vgqts requesting resource cpu=100m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz
+Apr 27 14:24:47.134: INFO: Pod addons-nginx-ingress-controller-7c8749685-4dfgp requesting resource cpu=0m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz
+Apr 27 14:24:47.134: INFO: Pod addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-lp7s2 requesting resource cpu=0m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q
+Apr 27 14:24:47.134: INFO: Pod calico-node-bcjtk requesting resource cpu=250m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz
+Apr 27 14:24:47.134: INFO: Pod calico-node-btd85 requesting resource cpu=250m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q
+Apr 27 14:24:47.134: INFO: Pod kube-dns-67b49bdfd8-hgkxt requesting resource cpu=260m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz
+Apr 27 14:24:47.134: INFO: Pod kube-dns-67b49bdfd8-s6hbn requesting resource cpu=260m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q
+Apr 27 14:24:47.134: INFO: Pod kube-dns-autoscaler-699b4b55c4-t7jll requesting resource cpu=20m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz
+Apr 27 14:24:47.134: INFO: Pod kube-proxy-2cncd requesting resource cpu=100m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q
+Apr 27 14:24:47.134: INFO: Pod kube-proxy-sgq59 requesting resource cpu=100m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz
+Apr 27 14:24:47.134: INFO: Pod node-exporter-mvvzs requesting resource cpu=100m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz
+Apr 27 14:24:47.134: INFO: Pod node-exporter-rl8xl requesting resource cpu=100m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q
+Apr 27 14:24:47.134: INFO: Pod vpn-shoot-b6ddb5857-vjqnr requesting resource cpu=100m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz
+Apr 27 14:24:47.134: INFO: Pod sonobuoy requesting resource cpu=0m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q
+Apr 27 14:24:47.134: INFO: Pod sonobuoy-e2e-job-056f42649bc7442c requesting resource cpu=0m on Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-bcc9a636-4a26-11e8-87ef-0ee10445d8a2.1529511220e527be], Reason = [Scheduled], Message = [Successfully assigned filler-pod-bcc9a636-4a26-11e8-87ef-0ee10445d8a2 to shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-bcc9a636-4a26-11e8-87ef-0ee10445d8a2.152951122a350714], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-5qwvs" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-bcc9a636-4a26-11e8-87ef-0ee10445d8a2.152951124bf0f966], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause-amd64:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-bcc9a636-4a26-11e8-87ef-0ee10445d8a2.152951124d5b1f1c], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-bcc9a636-4a26-11e8-87ef-0ee10445d8a2.1529511253de4482], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-bccb133b-4a26-11e8-87ef-0ee10445d8a2.152951122121a6f4], Reason = [Scheduled], Message = [Successfully assigned filler-pod-bccb133b-4a26-11e8-87ef-0ee10445d8a2 to shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-bccb133b-4a26-11e8-87ef-0ee10445d8a2.152951123349eb87], Reason = [SuccessfulMountVolume], Message = [MountVolume.SetUp succeeded for volume "default-token-5qwvs" ]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-bccb133b-4a26-11e8-87ef-0ee10445d8a2.152951124ec1b77b], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause-amd64:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-bccb133b-4a26-11e8-87ef-0ee10445d8a2.15295112511fa6c8], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-bccb133b-4a26-11e8-87ef-0ee10445d8a2.1529511259618d30], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.1529511299c98e96], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 Insufficient cpu.]
+STEP: removing the label node off the node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:24:50.202: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-hksjs" for this suite.
+Apr 27 14:25:12.221: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:25:12.300: INFO: namespace: e2e-tests-sched-pred-hksjs, resource: bindings, ignored listing per whitelist
+Apr 27 14:25:12.343: INFO: namespace e2e-tests-sched-pred-hksjs deletion completed in 22.138270564s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:85.411 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:25:12.344: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Apr 27 14:25:12.426: INFO: Waiting up to 1m0s for all nodes to be ready
+Apr 27 14:26:12.448: INFO: Waiting for terminating namespaces to be deleted...
+Apr 27 14:26:12.453: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 27 14:26:12.464: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 27 14:26:12.464: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 27 14:26:12.468: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 27 14:26:12.468: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q before test
+Apr 27 14:26:12.477: INFO: kube-proxy-2cncd from kube-system started at 2018-04-24 07:26:16 +0000 UTC (1 container statuses recorded)
+Apr 27 14:26:12.477: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: sonobuoy-e2e-job-056f42649bc7442c from sonobuoy started at 2018-04-27 14:06:22 +0000 UTC (2 container statuses recorded)
+Apr 27 14:26:12.477: INFO: 	Container e2e ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: node-exporter-rl8xl from kube-system started at 2018-04-24 07:26:16 +0000 UTC (1 container statuses recorded)
+Apr 27 14:26:12.477: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: kube-dns-67b49bdfd8-s6hbn from kube-system started at 2018-04-24 07:27:16 +0000 UTC (3 container statuses recorded)
+Apr 27 14:26:12.477: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: calico-node-btd85 from kube-system started at 2018-04-24 07:26:16 +0000 UTC (2 container statuses recorded)
+Apr 27 14:26:12.477: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-lp7s2 from kube-system started at 2018-04-24 07:27:14 +0000 UTC (1 container statuses recorded)
+Apr 27 14:26:12.477: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: addons-heapster-e3b0c-5c98c994fc-twn65 from kube-system started at 2018-04-24 07:27:15 +0000 UTC (2 container statuses recorded)
+Apr 27 14:26:12.477: INFO: 	Container heapster ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: 	Container heapster-nanny ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: sonobuoy from sonobuoy started at 2018-04-27 14:06:21 +0000 UTC (1 container statuses recorded)
+Apr 27 14:26:12.477: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Apr 27 14:26:12.477: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz before test
+Apr 27 14:26:12.484: INFO: kube-proxy-sgq59 from kube-system started at 2018-04-24 07:26:14 +0000 UTC (1 container statuses recorded)
+Apr 27 14:26:12.484: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:26:12.484: INFO: node-exporter-mvvzs from kube-system started at 2018-04-24 07:26:14 +0000 UTC (1 container statuses recorded)
+Apr 27 14:26:12.484: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:26:12.485: INFO: vpn-shoot-b6ddb5857-vjqnr from kube-system started at 2018-04-24 07:27:13 +0000 UTC (1 container statuses recorded)
+Apr 27 14:26:12.485: INFO: 	Container vpn-shoot ready: true, restart count 1
+Apr 27 14:26:12.485: INFO: addons-nginx-ingress-controller-7c8749685-4dfgp from kube-system started at 2018-04-24 07:27:15 +0000 UTC (1 container statuses recorded)
+Apr 27 14:26:12.485: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Apr 27 14:26:12.485: INFO: addons-kubernetes-dashboard-8478f49fbf-vgqts from kube-system started at 2018-04-24 07:27:16 +0000 UTC (1 container statuses recorded)
+Apr 27 14:26:12.485: INFO: 	Container main ready: true, restart count 0
+Apr 27 14:26:12.485: INFO: kube-dns-67b49bdfd8-hgkxt from kube-system started at 2018-04-24 07:27:24 +0000 UTC (3 container statuses recorded)
+Apr 27 14:26:12.485: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:26:12.485: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:26:12.485: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:26:12.485: INFO: calico-node-bcjtk from kube-system started at 2018-04-24 07:26:14 +0000 UTC (2 container statuses recorded)
+Apr 27 14:26:12.485: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:26:12.485: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:26:12.485: INFO: kube-dns-autoscaler-699b4b55c4-t7jll from kube-system started at 2018-04-24 07:27:16 +0000 UTC (1 container statuses recorded)
+Apr 27 14:26:12.485: INFO: 	Container autoscaler ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.1529512600965fe6], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 node(s) didn't match node selector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:26:13.507: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-qv7kk" for this suite.
+Apr 27 14:26:35.524: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:26:35.653: INFO: namespace: e2e-tests-sched-pred-qv7kk, resource: bindings, ignored listing per whitelist
+Apr 27 14:26:35.658: INFO: namespace e2e-tests-sched-pred-qv7kk deletion completed in 22.147385492s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.315 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:26:35.659: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-jsk9k
+Apr 27 14:26:37.756: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-jsk9k
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:26:37.758: INFO: Initial restart count of pod liveness-http is 0
+Apr 27 14:26:53.792: INFO: Restart count of pod e2e-tests-container-probe-jsk9k/liveness-http is now 1 (16.033143321s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:26:53.802: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-jsk9k" for this suite.
+Apr 27 14:26:59.814: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:26:59.904: INFO: namespace: e2e-tests-container-probe-jsk9k, resource: bindings, ignored listing per whitelist
+Apr 27 14:26:59.938: INFO: namespace e2e-tests-container-probe-jsk9k deletion completed in 6.132993367s
+
+• [SLOW TEST:24.279 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:26:59.938: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:27:00.026: INFO: Waiting up to 5m0s for pod "downward-api-0bfe4215-4a27-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-hfrkb" to be "success or failure"
+Apr 27 14:27:00.031: INFO: Pod "downward-api-0bfe4215-4a27-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 5.255184ms
+Apr 27 14:27:02.034: INFO: Pod "downward-api-0bfe4215-4a27-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00840147s
+Apr 27 14:27:04.038: INFO: Pod "downward-api-0bfe4215-4a27-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01192651s
+STEP: Saw pod success
+Apr 27 14:27:04.038: INFO: Pod "downward-api-0bfe4215-4a27-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:27:04.041: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downward-api-0bfe4215-4a27-11e8-87ef-0ee10445d8a2 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:27:04.056: INFO: Waiting for pod downward-api-0bfe4215-4a27-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:27:04.061: INFO: Pod downward-api-0bfe4215-4a27-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:27:04.061: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-hfrkb" for this suite.
+Apr 27 14:27:10.073: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:27:10.115: INFO: namespace: e2e-tests-downward-api-hfrkb, resource: bindings, ignored listing per whitelist
+Apr 27 14:27:10.197: INFO: namespace e2e-tests-downward-api-hfrkb deletion completed in 6.13282855s
+
+• [SLOW TEST:10.259 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:27:10.198: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-9k47k
+Apr 27 14:27:12.299: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-9k47k
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:27:12.301: INFO: Initial restart count of pod liveness-http is 0
+Apr 27 14:27:26.330: INFO: Restart count of pod e2e-tests-container-probe-9k47k/liveness-http is now 1 (14.028802056s elapsed)
+Apr 27 14:27:46.368: INFO: Restart count of pod e2e-tests-container-probe-9k47k/liveness-http is now 2 (34.066665822s elapsed)
+Apr 27 14:28:06.408: INFO: Restart count of pod e2e-tests-container-probe-9k47k/liveness-http is now 3 (54.106366999s elapsed)
+Apr 27 14:28:24.440: INFO: Restart count of pod e2e-tests-container-probe-9k47k/liveness-http is now 4 (1m12.139074236s elapsed)
+Apr 27 14:29:38.587: INFO: Restart count of pod e2e-tests-container-probe-9k47k/liveness-http is now 5 (2m26.285546442s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:29:38.594: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-9k47k" for this suite.
+Apr 27 14:29:44.607: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:29:44.678: INFO: namespace: e2e-tests-container-probe-9k47k, resource: bindings, ignored listing per whitelist
+Apr 27 14:29:44.736: INFO: namespace e2e-tests-container-probe-9k47k deletion completed in 6.138381872s
+
+• [SLOW TEST:154.538 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[k8s.io] Pods 
+  should be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:29:44.736: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Apr 27 14:29:47.347: INFO: Successfully updated pod "pod-update-6e38e7ea-4a27-11e8-87ef-0ee10445d8a2"
+STEP: verifying the updated pod is in kubernetes
+Apr 27 14:29:47.353: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:29:47.353: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-d4mwn" for this suite.
+Apr 27 14:30:09.367: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:30:09.443: INFO: namespace: e2e-tests-pods-d4mwn, resource: bindings, ignored listing per whitelist
+Apr 27 14:30:09.487: INFO: namespace e2e-tests-pods-d4mwn deletion completed in 22.131358389s
+
+• [SLOW TEST:24.751 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be updated  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:30:09.488: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-n9btn
+[It] Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-n9btn
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-n9btn
+Apr 27 14:30:09.576: INFO: Found 0 stateful pods, waiting for 1
+Apr 27 14:30:19.580: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will not halt with unhealthy stateful pod
+Apr 27 14:30:19.583: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:30:19.840: INFO: stderr: ""
+Apr 27 14:30:19.840: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:30:19.843: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Apr 27 14:30:29.847: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:30:29.847: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:30:29.857: INFO: POD   NODE                                                PHASE    GRACE  CONDITIONS
+Apr 27 14:30:29.857: INFO: ss-0  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:09 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:20 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:09 +0000 UTC  }]
+Apr 27 14:30:29.857: INFO: 
+Apr 27 14:30:29.857: INFO: StatefulSet ss has not reached scale 3, at 1
+Apr 27 14:30:30.861: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.997335377s
+Apr 27 14:30:31.865: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.993370265s
+Apr 27 14:30:32.870: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.989295075s
+Apr 27 14:30:33.874: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.984470362s
+Apr 27 14:30:34.878: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.980328018s
+Apr 27 14:30:35.882: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.976486658s
+Apr 27 14:30:36.886: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.972604968s
+Apr 27 14:30:37.890: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.968328496s
+Apr 27 14:30:38.895: INFO: Verifying statefulset ss doesn't scale past 3 for another 963.880146ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-n9btn
+Apr 27 14:30:39.899: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:30:40.147: INFO: stderr: ""
+Apr 27 14:30:40.147: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:30:40.147: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:30:40.459: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Apr 27 14:30:40.459: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: 
+Apr 27 14:30:40.459: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:30:40.732: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Apr 27 14:30:40.732: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Apr 27 14:30:40.736: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=false
+Apr 27 14:30:50.741: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:30:50.741: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:30:50.741: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Scale down will not halt with unhealthy stateful pod
+Apr 27 14:30:50.744: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:30:51.004: INFO: stderr: ""
+Apr 27 14:30:51.004: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:30:51.004: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:30:57.644: INFO: stderr: ""
+Apr 27 14:30:57.644: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:30:57.644: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:30:57.973: INFO: stderr: ""
+Apr 27 14:30:57.973: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:30:57.973: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:30:57.976: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 2
+Apr 27 14:31:07.984: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:31:07.984: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:31:07.984: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:31:07.992: INFO: POD   NODE                                                PHASE    GRACE  CONDITIONS
+Apr 27 14:31:07.992: INFO: ss-0  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:09 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:51 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:09 +0000 UTC  }]
+Apr 27 14:31:07.992: INFO: ss-1  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  }]
+Apr 27 14:31:07.992: INFO: ss-2  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  }]
+Apr 27 14:31:07.992: INFO: 
+Apr 27 14:31:07.992: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 27 14:31:08.997: INFO: POD   NODE                                                PHASE    GRACE  CONDITIONS
+Apr 27 14:31:08.997: INFO: ss-0  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:09 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:51 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:09 +0000 UTC  }]
+Apr 27 14:31:08.997: INFO: ss-1  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  }]
+Apr 27 14:31:08.997: INFO: ss-2  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  }]
+Apr 27 14:31:08.997: INFO: 
+Apr 27 14:31:08.997: INFO: StatefulSet ss has not reached scale 0, at 3
+Apr 27 14:31:10.001: INFO: POD   NODE                                                PHASE    GRACE  CONDITIONS
+Apr 27 14:31:10.001: INFO: ss-0  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:09 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:51 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:09 +0000 UTC  }]
+Apr 27 14:31:10.001: INFO: ss-2  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  }]
+Apr 27 14:31:10.001: INFO: 
+Apr 27 14:31:10.001: INFO: StatefulSet ss has not reached scale 0, at 2
+Apr 27 14:31:11.006: INFO: POD   NODE                                                PHASE    GRACE  CONDITIONS
+Apr 27 14:31:11.006: INFO: ss-2  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  }]
+Apr 27 14:31:11.006: INFO: 
+Apr 27 14:31:11.006: INFO: StatefulSet ss has not reached scale 0, at 1
+Apr 27 14:31:12.012: INFO: POD   NODE                                                PHASE    GRACE  CONDITIONS
+Apr 27 14:31:12.013: INFO: ss-2  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  }]
+Apr 27 14:31:12.013: INFO: 
+Apr 27 14:31:12.013: INFO: StatefulSet ss has not reached scale 0, at 1
+Apr 27 14:31:13.017: INFO: POD   NODE                                                PHASE    GRACE  CONDITIONS
+Apr 27 14:31:13.017: INFO: ss-2  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  }]
+Apr 27 14:31:13.017: INFO: 
+Apr 27 14:31:13.017: INFO: StatefulSet ss has not reached scale 0, at 1
+Apr 27 14:31:14.020: INFO: POD   NODE                                                PHASE    GRACE  CONDITIONS
+Apr 27 14:31:14.020: INFO: ss-2  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  }]
+Apr 27 14:31:14.020: INFO: 
+Apr 27 14:31:14.020: INFO: StatefulSet ss has not reached scale 0, at 1
+Apr 27 14:31:15.025: INFO: POD   NODE                                                PHASE    GRACE  CONDITIONS
+Apr 27 14:31:15.025: INFO: ss-2  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  }]
+Apr 27 14:31:15.025: INFO: 
+Apr 27 14:31:15.025: INFO: StatefulSet ss has not reached scale 0, at 1
+Apr 27 14:31:16.029: INFO: POD   NODE                                                PHASE    GRACE  CONDITIONS
+Apr 27 14:31:16.029: INFO: ss-2  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  }]
+Apr 27 14:31:16.029: INFO: 
+Apr 27 14:31:16.029: INFO: StatefulSet ss has not reached scale 0, at 1
+Apr 27 14:31:17.033: INFO: POD   NODE                                                PHASE    GRACE  CONDITIONS
+Apr 27 14:31:17.033: INFO: ss-2  shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:30:29 +0000 UTC  }]
+Apr 27 14:31:17.033: INFO: 
+Apr 27 14:31:17.033: INFO: StatefulSet ss has not reached scale 0, at 1
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-n9btn
+Apr 27 14:31:18.037: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:31:18.209: INFO: rc: 1
+Apr 27 14:31:18.209: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  error: unable to upgrade connection: container not found ("nginx")
+ [] <nil> 0xc420d50f30 exit status 1 <nil> <nil> true [0xc42069a2b8 0xc42069a320 0xc42069a420] [0xc42069a2b8 0xc42069a320 0xc42069a420] [0xc42069a308 0xc42069a3d8] [0x94d8e0 0x94d8e0] 0xc4217dc180 <nil>}:
+Command stdout:
+
+stderr:
+error: unable to upgrade connection: container not found ("nginx")
+
+error:
+exit status 1
+
+Apr 27 14:31:28.210: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:31:28.287: INFO: rc: 1
+Apr 27 14:31:28.287: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217acd50 exit status 1 <nil> <nil> true [0xc4218660a0 0xc4218660b8 0xc4218660d0] [0xc4218660a0 0xc4218660b8 0xc4218660d0] [0xc4218660b0 0xc4218660c8] [0x94d8e0 0x94d8e0] 0xc42172e240 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:31:38.287: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:31:38.369: INFO: rc: 1
+Apr 27 14:31:38.369: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217ad260 exit status 1 <nil> <nil> true [0xc4218660d8 0xc4218660f0 0xc421866108] [0xc4218660d8 0xc4218660f0 0xc421866108] [0xc4218660e8 0xc421866100] [0x94d8e0 0x94d8e0] 0xc42172e360 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:31:48.369: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:31:48.454: INFO: rc: 1
+Apr 27 14:31:48.454: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217ad650 exit status 1 <nil> <nil> true [0xc421866110 0xc421866128 0xc421866140] [0xc421866110 0xc421866128 0xc421866140] [0xc421866120 0xc421866138] [0x94d8e0 0x94d8e0] 0xc42172e480 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:31:58.454: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:31:58.538: INFO: rc: 1
+Apr 27 14:31:58.538: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217adad0 exit status 1 <nil> <nil> true [0xc421866148 0xc421866160 0xc421866178] [0xc421866148 0xc421866160 0xc421866178] [0xc421866158 0xc421866170] [0x94d8e0 0x94d8e0] 0xc42172e5a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:32:08.538: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:32:08.614: INFO: rc: 1
+Apr 27 14:32:08.614: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217adec0 exit status 1 <nil> <nil> true [0xc421866180 0xc421866198 0xc4218661b0] [0xc421866180 0xc421866198 0xc4218661b0] [0xc421866190 0xc4218661a8] [0x94d8e0 0x94d8e0] 0xc42172e6c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:32:18.615: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:32:18.693: INFO: rc: 1
+Apr 27 14:32:18.693: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219cc390 exit status 1 <nil> <nil> true [0xc4218661b8 0xc4218661d0 0xc4218661e8] [0xc4218661b8 0xc4218661d0 0xc4218661e8] [0xc4218661c8 0xc4218661e0] [0x94d8e0 0x94d8e0] 0xc42172e7e0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:32:28.693: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:32:28.776: INFO: rc: 1
+Apr 27 14:32:28.776: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219cc810 exit status 1 <nil> <nil> true [0xc4218661f0 0xc421866208 0xc421866220] [0xc4218661f0 0xc421866208 0xc421866220] [0xc421866200 0xc421866218] [0x94d8e0 0x94d8e0] 0xc42172e900 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:32:38.776: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:32:38.856: INFO: rc: 1
+Apr 27 14:32:38.856: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219ccc00 exit status 1 <nil> <nil> true [0xc421866228 0xc421866240 0xc421866258] [0xc421866228 0xc421866240 0xc421866258] [0xc421866238 0xc421866250] [0x94d8e0 0x94d8e0] 0xc42172ea80 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:32:48.856: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:32:48.936: INFO: rc: 1
+Apr 27 14:32:48.936: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219cd050 exit status 1 <nil> <nil> true [0xc421866260 0xc421866278 0xc421866290] [0xc421866260 0xc421866278 0xc421866290] [0xc421866270 0xc421866288] [0x94d8e0 0x94d8e0] 0xc42172eba0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:32:58.937: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:32:59.020: INFO: rc: 1
+Apr 27 14:32:59.020: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420d515f0 exit status 1 <nil> <nil> true [0xc42069a428 0xc42069a468 0xc42069a4f0] [0xc42069a428 0xc42069a468 0xc42069a4f0] [0xc42069a460 0xc42069a4b0] [0x94d8e0 0x94d8e0] 0xc4217dc2a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:33:09.021: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:33:09.097: INFO: rc: 1
+Apr 27 14:33:09.097: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219cd440 exit status 1 <nil> <nil> true [0xc421866298 0xc4218662b0 0xc4218662c8] [0xc421866298 0xc4218662b0 0xc4218662c8] [0xc4218662a8 0xc4218662c0] [0x94d8e0 0x94d8e0] 0xc42172ecc0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:33:19.097: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:33:19.178: INFO: rc: 1
+Apr 27 14:33:19.178: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217ac3f0 exit status 1 <nil> <nil> true [0xc42000e140 0xc42000e230 0xc42000e2c0] [0xc42000e140 0xc42000e230 0xc42000e2c0] [0xc42000e1a0 0xc42000e270] [0x94d8e0 0x94d8e0] 0xc420fb7b00 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:33:29.179: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:33:29.265: INFO: rc: 1
+Apr 27 14:33:29.265: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219cc420 exit status 1 <nil> <nil> true [0xc421866000 0xc421866018 0xc421866030] [0xc421866000 0xc421866018 0xc421866030] [0xc421866010 0xc421866028] [0x94d8e0 0x94d8e0] 0xc4217dc060 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:33:39.265: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:33:39.366: INFO: rc: 1
+Apr 27 14:33:39.366: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219cc870 exit status 1 <nil> <nil> true [0xc421866038 0xc421866050 0xc421866068] [0xc421866038 0xc421866050 0xc421866068] [0xc421866048 0xc421866060] [0x94d8e0 0x94d8e0] 0xc4217dc180 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:33:49.366: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:33:49.447: INFO: rc: 1
+Apr 27 14:33:49.447: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219ccc60 exit status 1 <nil> <nil> true [0xc421866070 0xc421866088 0xc4218660a0] [0xc421866070 0xc421866088 0xc4218660a0] [0xc421866080 0xc421866098] [0x94d8e0 0x94d8e0] 0xc4217dc2a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:33:59.448: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:33:59.540: INFO: rc: 1
+Apr 27 14:33:59.540: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217ac870 exit status 1 <nil> <nil> true [0xc42069a130 0xc42069a1f8 0xc42069a290] [0xc42069a130 0xc42069a1f8 0xc42069a290] [0xc42069a180 0xc42069a260] [0x94d8e0 0x94d8e0] 0xc42172e0c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:34:09.540: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:34:09.619: INFO: rc: 1
+Apr 27 14:34:09.619: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217acc60 exit status 1 <nil> <nil> true [0xc42069a2b8 0xc42069a320 0xc42069a420] [0xc42069a2b8 0xc42069a320 0xc42069a420] [0xc42069a308 0xc42069a3d8] [0x94d8e0 0x94d8e0] 0xc42172e1e0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:34:19.620: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:34:19.711: INFO: rc: 1
+Apr 27 14:34:19.711: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219cd080 exit status 1 <nil> <nil> true [0xc4218660a8 0xc4218660c0 0xc4218660d8] [0xc4218660a8 0xc4218660c0 0xc4218660d8] [0xc4218660b8 0xc4218660d0] [0x94d8e0 0x94d8e0] 0xc4217dc420 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:34:29.711: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:34:29.803: INFO: rc: 1
+Apr 27 14:34:29.803: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219cd470 exit status 1 <nil> <nil> true [0xc4218660e0 0xc4218660f8 0xc421866110] [0xc4218660e0 0xc4218660f8 0xc421866110] [0xc4218660f0 0xc421866108] [0x94d8e0 0x94d8e0] 0xc4217dc600 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:34:39.804: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:34:39.882: INFO: rc: 1
+Apr 27 14:34:39.882: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217ad0b0 exit status 1 <nil> <nil> true [0xc42069a428 0xc42069a468 0xc42069a4f0] [0xc42069a428 0xc42069a468 0xc42069a4f0] [0xc42069a460 0xc42069a4b0] [0x94d8e0 0x94d8e0] 0xc42172e300 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:34:49.883: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:34:49.970: INFO: rc: 1
+Apr 27 14:34:49.970: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217ad4a0 exit status 1 <nil> <nil> true [0xc42069a508 0xc42069a580 0xc42069a640] [0xc42069a508 0xc42069a580 0xc42069a640] [0xc42069a568 0xc42069a618] [0x94d8e0 0x94d8e0] 0xc42172e420 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:34:59.970: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:35:00.079: INFO: rc: 1
+Apr 27 14:35:00.079: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219cd890 exit status 1 <nil> <nil> true [0xc421866118 0xc421866130 0xc421866148] [0xc421866118 0xc421866130 0xc421866148] [0xc421866128 0xc421866140] [0x94d8e0 0x94d8e0] 0xc4217dc720 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:35:10.079: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:35:10.167: INFO: rc: 1
+Apr 27 14:35:10.167: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219cdef0 exit status 1 <nil> <nil> true [0xc421866150 0xc421866168 0xc421866180] [0xc421866150 0xc421866168 0xc421866180] [0xc421866160 0xc421866178] [0x94d8e0 0x94d8e0] 0xc4217dcf00 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:35:20.167: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:35:20.261: INFO: rc: 1
+Apr 27 14:35:20.261: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217ac420 exit status 1 <nil> <nil> true [0xc42000e140 0xc42000e230 0xc42000e2c0] [0xc42000e140 0xc42000e230 0xc42000e2c0] [0xc42000e1a0 0xc42000e270] [0x94d8e0 0x94d8e0] 0xc420fb7b00 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:35:30.261: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:35:30.349: INFO: rc: 1
+Apr 27 14:35:30.349: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219cc3f0 exit status 1 <nil> <nil> true [0xc42069a130 0xc42069a1f8 0xc42069a290] [0xc42069a130 0xc42069a1f8 0xc42069a290] [0xc42069a180 0xc42069a260] [0x94d8e0 0x94d8e0] 0xc4217dc060 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:35:40.349: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:35:40.432: INFO: rc: 1
+Apr 27 14:35:40.432: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217ac8d0 exit status 1 <nil> <nil> true [0xc421866000 0xc421866018 0xc421866030] [0xc421866000 0xc421866018 0xc421866030] [0xc421866010 0xc421866028] [0x94d8e0 0x94d8e0] 0xc42172e0c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:35:50.433: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:35:50.513: INFO: rc: 1
+Apr 27 14:35:50.513: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219cc840 exit status 1 <nil> <nil> true [0xc42069a2b8 0xc42069a320 0xc42069a420] [0xc42069a2b8 0xc42069a320 0xc42069a420] [0xc42069a308 0xc42069a3d8] [0x94d8e0 0x94d8e0] 0xc4217dc180 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:36:00.514: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:36:00.596: INFO: rc: 1
+Apr 27 14:36:00.596: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4217accf0 exit status 1 <nil> <nil> true [0xc421866038 0xc421866050 0xc421866068] [0xc421866038 0xc421866050 0xc421866068] [0xc421866048 0xc421866060] [0x94d8e0 0x94d8e0] 0xc42172e1e0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:36:10.596: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:36:10.678: INFO: rc: 1
+Apr 27 14:36:10.678: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4219ccc90 exit status 1 <nil> <nil> true [0xc42069a428 0xc42069a468 0xc42069a4f0] [0xc42069a428 0xc42069a468 0xc42069a4f0] [0xc42069a460 0xc42069a4b0] [0x94d8e0 0x94d8e0] 0xc4217dc2a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Apr 27 14:36:20.678: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-n9btn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:36:20.764: INFO: rc: 1
+Apr 27 14:36:20.764: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Apr 27 14:36:20.764: INFO: Scaling statefulset ss to 0
+Apr 27 14:36:20.781: INFO: Waiting for statefulset status.replicas updated to 0
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:36:20.783: INFO: Deleting all statefulset in ns e2e-tests-statefulset-n9btn
+Apr 27 14:36:20.786: INFO: Scaling statefulset ss to 0
+Apr 27 14:36:20.793: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:36:20.796: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:36:20.805: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-n9btn" for this suite.
+Apr 27 14:36:26.821: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:36:26.916: INFO: namespace: e2e-tests-statefulset-n9btn, resource: bindings, ignored listing per whitelist
+Apr 27 14:36:26.949: INFO: namespace e2e-tests-statefulset-n9btn deletion completed in 6.139810687s
+
+• [SLOW TEST:377.461 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Burst scaling should run to completion even with unhealthy pods [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:36:26.950: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-vmzvp
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 27 14:36:27.046: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 27 14:36:49.104: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.1.12 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-vmzvp PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:36:49.104: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 14:36:50.252: INFO: Found all expected endpoints: [netserver-0]
+Apr 27 14:36:50.255: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.0.129 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-vmzvp PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:36:50.255: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 14:36:51.433: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:36:51.433: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-vmzvp" for this suite.
+Apr 27 14:37:13.448: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:37:13.541: INFO: namespace: e2e-tests-pod-network-test-vmzvp, resource: bindings, ignored listing per whitelist
+Apr 27 14:37:13.579: INFO: namespace e2e-tests-pod-network-test-vmzvp deletion completed in 22.141266265s
+
+• [SLOW TEST:46.629 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:37:13.580: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for 2 Minute to see if the garbage collector mistakenly deletes the rs
+STEP: expected 0 Deploymentss, got 1 Deployments
+STEP: Gathering metrics
+W0427 14:37:19.215043      15 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:37:19.215: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:37:19.215: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-5vxcb" for this suite.
+Apr 27 14:37:25.228: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:37:25.314: INFO: namespace: e2e-tests-gc-5vxcb, resource: bindings, ignored listing per whitelist
+Apr 27 14:37:25.353: INFO: namespace e2e-tests-gc-5vxcb deletion completed in 6.135177307s
+
+• [SLOW TEST:11.773 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:37:25.353: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-ft6cd
+[It] should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a new StatefulSet
+Apr 27 14:37:25.446: INFO: Found 0 stateful pods, waiting for 3
+Apr 27 14:37:35.450: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:37:35.450: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:37:35.450: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:37:35.458: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-ft6cd ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:37:35.708: INFO: stderr: ""
+Apr 27 14:37:35.708: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+STEP: Updating StatefulSet template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Apr 27 14:37:45.738: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Updating Pods in reverse ordinal order
+Apr 27 14:37:55.754: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-ft6cd ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:37:55.997: INFO: stderr: ""
+Apr 27 14:37:55.997: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:38:16.017: INFO: Waiting for StatefulSet e2e-tests-statefulset-ft6cd/ss2 to complete update
+Apr 27 14:38:16.017: INFO: Waiting for Pod e2e-tests-statefulset-ft6cd/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Rolling back to a previous revision
+Apr 27 14:38:26.024: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-ft6cd ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:38:26.267: INFO: stderr: ""
+Apr 27 14:38:26.267: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:38:36.296: INFO: Updating stateful set ss2
+STEP: Rolling back update in reverse ordinal order
+Apr 27 14:38:46.311: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-ft6cd ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:38:46.574: INFO: stderr: ""
+Apr 27 14:38:46.574: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:39:06.594: INFO: Waiting for StatefulSet e2e-tests-statefulset-ft6cd/ss2 to complete update
+Apr 27 14:39:06.594: INFO: Waiting for Pod e2e-tests-statefulset-ft6cd/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:39:16.608: INFO: Deleting all statefulset in ns e2e-tests-statefulset-ft6cd
+Apr 27 14:39:16.611: INFO: Scaling statefulset ss2 to 0
+Apr 27 14:39:36.624: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:39:36.627: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:39:36.637: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-ft6cd" for this suite.
+Apr 27 14:39:42.650: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:39:42.718: INFO: namespace: e2e-tests-statefulset-ft6cd, resource: bindings, ignored listing per whitelist
+Apr 27 14:39:42.776: INFO: namespace e2e-tests-statefulset-ft6cd deletion completed in 6.135245376s
+
+• [SLOW TEST:137.423 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should perform rolling updates and roll backs of template modifications [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:39:42.777: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-tfs9q
+I0427 14:39:42.864709      15 runners.go:175] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-tfs9q, replica count: 1
+I0427 14:39:43.866218      15 runners.go:175] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0427 14:39:44.866478      15 runners.go:175] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Apr 27 14:39:44.976: INFO: Created: latency-svc-kjxh4
+Apr 27 14:39:44.979: INFO: Got endpoints: latency-svc-kjxh4 [11.500358ms]
+Apr 27 14:39:44.986: INFO: Created: latency-svc-bqpst
+Apr 27 14:39:44.989: INFO: Got endpoints: latency-svc-bqpst [10.401214ms]
+Apr 27 14:39:44.992: INFO: Created: latency-svc-x55g5
+Apr 27 14:39:44.995: INFO: Got endpoints: latency-svc-x55g5 [15.844424ms]
+Apr 27 14:39:44.995: INFO: Created: latency-svc-m9827
+Apr 27 14:39:44.998: INFO: Got endpoints: latency-svc-m9827 [18.499276ms]
+Apr 27 14:39:45.002: INFO: Created: latency-svc-6cr9w
+Apr 27 14:39:45.006: INFO: Got endpoints: latency-svc-6cr9w [27.246995ms]
+Apr 27 14:39:45.010: INFO: Created: latency-svc-scgrl
+Apr 27 14:39:45.015: INFO: Created: latency-svc-c8d2f
+Apr 27 14:39:45.016: INFO: Got endpoints: latency-svc-scgrl [36.455034ms]
+Apr 27 14:39:45.018: INFO: Got endpoints: latency-svc-c8d2f [38.595059ms]
+Apr 27 14:39:45.021: INFO: Created: latency-svc-gj824
+Apr 27 14:39:45.025: INFO: Got endpoints: latency-svc-gj824 [45.044483ms]
+Apr 27 14:39:45.025: INFO: Created: latency-svc-gvrgm
+Apr 27 14:39:45.031: INFO: Got endpoints: latency-svc-gvrgm [51.689609ms]
+Apr 27 14:39:45.032: INFO: Created: latency-svc-9fjlf
+Apr 27 14:39:45.037: INFO: Got endpoints: latency-svc-9fjlf [55.503892ms]
+Apr 27 14:39:45.039: INFO: Created: latency-svc-dz2mb
+Apr 27 14:39:45.039: INFO: Got endpoints: latency-svc-dz2mb [57.960297ms]
+Apr 27 14:39:45.044: INFO: Created: latency-svc-zvv2t
+Apr 27 14:39:45.048: INFO: Got endpoints: latency-svc-zvv2t [66.358678ms]
+Apr 27 14:39:45.048: INFO: Created: latency-svc-pqcz7
+Apr 27 14:39:45.057: INFO: Got endpoints: latency-svc-pqcz7 [75.057597ms]
+Apr 27 14:39:45.057: INFO: Created: latency-svc-ttch9
+Apr 27 14:39:45.057: INFO: Got endpoints: latency-svc-ttch9 [75.863238ms]
+Apr 27 14:39:45.058: INFO: Created: latency-svc-ljvkw
+Apr 27 14:39:45.074: INFO: Got endpoints: latency-svc-ljvkw [92.141308ms]
+Apr 27 14:39:45.074: INFO: Created: latency-svc-m9d4k
+Apr 27 14:39:45.077: INFO: Created: latency-svc-m78zs
+Apr 27 14:39:45.077: INFO: Got endpoints: latency-svc-m78zs [87.885151ms]
+Apr 27 14:39:45.083: INFO: Got endpoints: latency-svc-m9d4k [101.582787ms]
+Apr 27 14:39:45.087: INFO: Created: latency-svc-wkx6t
+Apr 27 14:39:45.088: INFO: Created: latency-svc-xhzpq
+Apr 27 14:39:45.088: INFO: Got endpoints: latency-svc-xhzpq [93.465509ms]
+Apr 27 14:39:45.091: INFO: Got endpoints: latency-svc-wkx6t [93.235094ms]
+Apr 27 14:39:45.093: INFO: Created: latency-svc-npgw8
+Apr 27 14:39:45.094: INFO: Got endpoints: latency-svc-npgw8 [87.932527ms]
+Apr 27 14:39:45.096: INFO: Created: latency-svc-cgfsc
+Apr 27 14:39:45.115: INFO: Got endpoints: latency-svc-cgfsc [99.665373ms]
+Apr 27 14:39:45.116: INFO: Created: latency-svc-c7lgw
+Apr 27 14:39:45.117: INFO: Got endpoints: latency-svc-c7lgw [99.365275ms]
+Apr 27 14:39:45.122: INFO: Created: latency-svc-tnm4h
+Apr 27 14:39:45.124: INFO: Got endpoints: latency-svc-tnm4h [99.560685ms]
+Apr 27 14:39:45.127: INFO: Created: latency-svc-xhgfm
+Apr 27 14:39:45.130: INFO: Got endpoints: latency-svc-xhgfm [98.190524ms]
+Apr 27 14:39:45.133: INFO: Created: latency-svc-5dv7c
+Apr 27 14:39:45.138: INFO: Got endpoints: latency-svc-5dv7c [101.753861ms]
+Apr 27 14:39:45.140: INFO: Created: latency-svc-nrztj
+Apr 27 14:39:45.144: INFO: Got endpoints: latency-svc-nrztj [103.875601ms]
+Apr 27 14:39:45.145: INFO: Created: latency-svc-jqrxs
+Apr 27 14:39:45.147: INFO: Got endpoints: latency-svc-jqrxs [98.253328ms]
+Apr 27 14:39:45.148: INFO: Created: latency-svc-kz76b
+Apr 27 14:39:45.150: INFO: Got endpoints: latency-svc-kz76b [92.253907ms]
+Apr 27 14:39:45.153: INFO: Created: latency-svc-jcrgn
+Apr 27 14:39:45.155: INFO: Got endpoints: latency-svc-jcrgn [98.024721ms]
+Apr 27 14:39:45.157: INFO: Created: latency-svc-qwdms
+Apr 27 14:39:45.160: INFO: Got endpoints: latency-svc-qwdms [86.094827ms]
+Apr 27 14:39:45.163: INFO: Created: latency-svc-h97fv
+Apr 27 14:39:45.165: INFO: Got endpoints: latency-svc-h97fv [86.174885ms]
+Apr 27 14:39:45.168: INFO: Created: latency-svc-gqfvq
+Apr 27 14:39:45.175: INFO: Got endpoints: latency-svc-gqfvq [90.443837ms]
+Apr 27 14:39:45.177: INFO: Created: latency-svc-jtcc7
+Apr 27 14:39:45.181: INFO: Got endpoints: latency-svc-jtcc7 [91.393522ms]
+Apr 27 14:39:45.181: INFO: Created: latency-svc-2lxfp
+Apr 27 14:39:45.183: INFO: Got endpoints: latency-svc-2lxfp [91.071429ms]
+Apr 27 14:39:45.186: INFO: Created: latency-svc-42b5v
+Apr 27 14:39:45.191: INFO: Created: latency-svc-6sc8v
+Apr 27 14:39:45.195: INFO: Created: latency-svc-2smxn
+Apr 27 14:39:45.199: INFO: Created: latency-svc-fft8g
+Apr 27 14:39:45.205: INFO: Created: latency-svc-z8bl8
+Apr 27 14:39:45.210: INFO: Created: latency-svc-hqjvs
+Apr 27 14:39:45.215: INFO: Created: latency-svc-kb5bq
+Apr 27 14:39:45.225: INFO: Created: latency-svc-rrd7j
+Apr 27 14:39:45.231: INFO: Created: latency-svc-nl4zp
+Apr 27 14:39:45.231: INFO: Got endpoints: latency-svc-42b5v [135.128718ms]
+Apr 27 14:39:45.235: INFO: Created: latency-svc-h4qn5
+Apr 27 14:39:45.240: INFO: Created: latency-svc-96r8q
+Apr 27 14:39:45.244: INFO: Created: latency-svc-zljtj
+Apr 27 14:39:45.250: INFO: Created: latency-svc-cnndx
+Apr 27 14:39:45.254: INFO: Created: latency-svc-llf85
+Apr 27 14:39:45.260: INFO: Created: latency-svc-6v9jw
+Apr 27 14:39:45.264: INFO: Created: latency-svc-sq8cf
+Apr 27 14:39:45.281: INFO: Got endpoints: latency-svc-6sc8v [165.053128ms]
+Apr 27 14:39:45.289: INFO: Created: latency-svc-k4tzw
+Apr 27 14:39:45.332: INFO: Got endpoints: latency-svc-2smxn [214.025255ms]
+Apr 27 14:39:45.340: INFO: Created: latency-svc-rcc9k
+Apr 27 14:39:45.384: INFO: Got endpoints: latency-svc-fft8g [259.773479ms]
+Apr 27 14:39:45.398: INFO: Created: latency-svc-vmd7g
+Apr 27 14:39:45.431: INFO: Got endpoints: latency-svc-z8bl8 [300.90111ms]
+Apr 27 14:39:45.439: INFO: Created: latency-svc-dhj5g
+Apr 27 14:39:45.480: INFO: Got endpoints: latency-svc-hqjvs [341.173348ms]
+Apr 27 14:39:45.491: INFO: Created: latency-svc-r9c4x
+Apr 27 14:39:45.530: INFO: Got endpoints: latency-svc-kb5bq [385.389812ms]
+Apr 27 14:39:45.540: INFO: Created: latency-svc-m45gx
+Apr 27 14:39:45.580: INFO: Got endpoints: latency-svc-rrd7j [433.249435ms]
+Apr 27 14:39:45.591: INFO: Created: latency-svc-pcftw
+Apr 27 14:39:45.629: INFO: Got endpoints: latency-svc-nl4zp [479.518779ms]
+Apr 27 14:39:45.638: INFO: Created: latency-svc-mzvmc
+Apr 27 14:39:45.679: INFO: Got endpoints: latency-svc-h4qn5 [524.062983ms]
+Apr 27 14:39:45.693: INFO: Created: latency-svc-b5xmd
+Apr 27 14:39:45.730: INFO: Got endpoints: latency-svc-96r8q [569.926143ms]
+Apr 27 14:39:45.742: INFO: Created: latency-svc-dtz92
+Apr 27 14:39:45.780: INFO: Got endpoints: latency-svc-zljtj [615.343544ms]
+Apr 27 14:39:45.789: INFO: Created: latency-svc-q9bmj
+Apr 27 14:39:45.830: INFO: Got endpoints: latency-svc-cnndx [654.779729ms]
+Apr 27 14:39:45.841: INFO: Created: latency-svc-cwwfx
+Apr 27 14:39:45.878: INFO: Got endpoints: latency-svc-llf85 [697.512617ms]
+Apr 27 14:39:45.887: INFO: Created: latency-svc-dkqbp
+Apr 27 14:39:45.930: INFO: Got endpoints: latency-svc-6v9jw [746.676298ms]
+Apr 27 14:39:45.939: INFO: Created: latency-svc-c79xl
+Apr 27 14:39:45.981: INFO: Got endpoints: latency-svc-sq8cf [750.090302ms]
+Apr 27 14:39:45.993: INFO: Created: latency-svc-vrsnt
+Apr 27 14:39:46.035: INFO: Got endpoints: latency-svc-k4tzw [754.486242ms]
+Apr 27 14:39:46.053: INFO: Created: latency-svc-ws9cs
+Apr 27 14:39:46.081: INFO: Got endpoints: latency-svc-rcc9k [748.997995ms]
+Apr 27 14:39:46.093: INFO: Created: latency-svc-2cq7p
+Apr 27 14:39:46.130: INFO: Got endpoints: latency-svc-vmd7g [745.43449ms]
+Apr 27 14:39:46.139: INFO: Created: latency-svc-bmh4f
+Apr 27 14:39:46.180: INFO: Got endpoints: latency-svc-dhj5g [748.889475ms]
+Apr 27 14:39:46.189: INFO: Created: latency-svc-cfpmc
+Apr 27 14:39:46.232: INFO: Got endpoints: latency-svc-r9c4x [751.812919ms]
+Apr 27 14:39:46.245: INFO: Created: latency-svc-8mbk6
+Apr 27 14:39:46.279: INFO: Got endpoints: latency-svc-m45gx [749.072192ms]
+Apr 27 14:39:46.290: INFO: Created: latency-svc-9b4sr
+Apr 27 14:39:46.331: INFO: Got endpoints: latency-svc-pcftw [750.167975ms]
+Apr 27 14:39:46.342: INFO: Created: latency-svc-kb8k9
+Apr 27 14:39:46.379: INFO: Got endpoints: latency-svc-mzvmc [749.716284ms]
+Apr 27 14:39:46.390: INFO: Created: latency-svc-jkgvl
+Apr 27 14:39:46.431: INFO: Got endpoints: latency-svc-b5xmd [751.876695ms]
+Apr 27 14:39:46.440: INFO: Created: latency-svc-2sgjq
+Apr 27 14:39:46.480: INFO: Got endpoints: latency-svc-dtz92 [750.404608ms]
+Apr 27 14:39:46.489: INFO: Created: latency-svc-9ldxf
+Apr 27 14:39:46.534: INFO: Got endpoints: latency-svc-q9bmj [753.36905ms]
+Apr 27 14:39:46.547: INFO: Created: latency-svc-2mntf
+Apr 27 14:39:46.579: INFO: Got endpoints: latency-svc-cwwfx [749.838397ms]
+Apr 27 14:39:46.587: INFO: Created: latency-svc-vbbsr
+Apr 27 14:39:46.631: INFO: Got endpoints: latency-svc-dkqbp [752.368859ms]
+Apr 27 14:39:46.644: INFO: Created: latency-svc-g57vs
+Apr 27 14:39:46.680: INFO: Got endpoints: latency-svc-c79xl [750.225629ms]
+Apr 27 14:39:46.688: INFO: Created: latency-svc-wk7kl
+Apr 27 14:39:46.729: INFO: Got endpoints: latency-svc-vrsnt [743.799221ms]
+Apr 27 14:39:46.744: INFO: Created: latency-svc-dl4z9
+Apr 27 14:39:46.783: INFO: Got endpoints: latency-svc-ws9cs [747.91068ms]
+Apr 27 14:39:46.799: INFO: Created: latency-svc-ck4np
+Apr 27 14:39:46.830: INFO: Got endpoints: latency-svc-2cq7p [749.092278ms]
+Apr 27 14:39:46.840: INFO: Created: latency-svc-lbbnx
+Apr 27 14:39:46.879: INFO: Got endpoints: latency-svc-bmh4f [748.958251ms]
+Apr 27 14:39:46.887: INFO: Created: latency-svc-2fh8f
+Apr 27 14:39:46.930: INFO: Got endpoints: latency-svc-cfpmc [749.925258ms]
+Apr 27 14:39:46.938: INFO: Created: latency-svc-5f7b8
+Apr 27 14:39:46.984: INFO: Got endpoints: latency-svc-8mbk6 [752.161663ms]
+Apr 27 14:39:47.006: INFO: Created: latency-svc-mrdkh
+Apr 27 14:39:47.030: INFO: Got endpoints: latency-svc-9b4sr [750.772185ms]
+Apr 27 14:39:47.040: INFO: Created: latency-svc-cr99f
+Apr 27 14:39:47.080: INFO: Got endpoints: latency-svc-kb8k9 [748.996582ms]
+Apr 27 14:39:47.089: INFO: Created: latency-svc-xczh2
+Apr 27 14:39:47.129: INFO: Got endpoints: latency-svc-jkgvl [749.753346ms]
+Apr 27 14:39:47.139: INFO: Created: latency-svc-gkvp5
+Apr 27 14:39:47.180: INFO: Got endpoints: latency-svc-2sgjq [748.541554ms]
+Apr 27 14:39:47.189: INFO: Created: latency-svc-wlzp6
+Apr 27 14:39:47.230: INFO: Got endpoints: latency-svc-9ldxf [749.561889ms]
+Apr 27 14:39:47.269: INFO: Created: latency-svc-rxgbz
+Apr 27 14:39:47.279: INFO: Got endpoints: latency-svc-2mntf [745.645751ms]
+Apr 27 14:39:47.288: INFO: Created: latency-svc-896kk
+Apr 27 14:39:47.330: INFO: Got endpoints: latency-svc-vbbsr [750.140767ms]
+Apr 27 14:39:47.339: INFO: Created: latency-svc-zcsj6
+Apr 27 14:39:47.380: INFO: Got endpoints: latency-svc-g57vs [749.312113ms]
+Apr 27 14:39:47.388: INFO: Created: latency-svc-6jnsx
+Apr 27 14:39:47.431: INFO: Got endpoints: latency-svc-wk7kl [750.410942ms]
+Apr 27 14:39:47.442: INFO: Created: latency-svc-b75bf
+Apr 27 14:39:47.480: INFO: Got endpoints: latency-svc-dl4z9 [750.839993ms]
+Apr 27 14:39:47.488: INFO: Created: latency-svc-nmhqb
+Apr 27 14:39:47.530: INFO: Got endpoints: latency-svc-ck4np [746.97174ms]
+Apr 27 14:39:47.543: INFO: Created: latency-svc-k6bmb
+Apr 27 14:39:47.580: INFO: Got endpoints: latency-svc-lbbnx [749.489177ms]
+Apr 27 14:39:47.588: INFO: Created: latency-svc-69z4b
+Apr 27 14:39:47.630: INFO: Got endpoints: latency-svc-2fh8f [750.205465ms]
+Apr 27 14:39:47.694: INFO: Created: latency-svc-bcx8j
+Apr 27 14:39:47.694: INFO: Got endpoints: latency-svc-5f7b8 [764.394198ms]
+Apr 27 14:39:47.703: INFO: Created: latency-svc-s44tt
+Apr 27 14:39:47.729: INFO: Got endpoints: latency-svc-mrdkh [745.37383ms]
+Apr 27 14:39:47.740: INFO: Created: latency-svc-wtffh
+Apr 27 14:39:47.779: INFO: Got endpoints: latency-svc-cr99f [748.962462ms]
+Apr 27 14:39:47.787: INFO: Created: latency-svc-x6lwk
+Apr 27 14:39:47.834: INFO: Got endpoints: latency-svc-xczh2 [753.767358ms]
+Apr 27 14:39:47.844: INFO: Created: latency-svc-g2kgf
+Apr 27 14:39:47.879: INFO: Got endpoints: latency-svc-gkvp5 [750.001763ms]
+Apr 27 14:39:47.892: INFO: Created: latency-svc-m9wsq
+Apr 27 14:39:47.930: INFO: Got endpoints: latency-svc-wlzp6 [749.79825ms]
+Apr 27 14:39:47.941: INFO: Created: latency-svc-hbhzl
+Apr 27 14:39:47.980: INFO: Got endpoints: latency-svc-rxgbz [749.443664ms]
+Apr 27 14:39:47.988: INFO: Created: latency-svc-dp6mn
+Apr 27 14:39:48.030: INFO: Got endpoints: latency-svc-896kk [750.70061ms]
+Apr 27 14:39:48.042: INFO: Created: latency-svc-86hkq
+Apr 27 14:39:48.080: INFO: Got endpoints: latency-svc-zcsj6 [749.885995ms]
+Apr 27 14:39:48.088: INFO: Created: latency-svc-cjglz
+Apr 27 14:39:48.130: INFO: Got endpoints: latency-svc-6jnsx [749.772958ms]
+Apr 27 14:39:48.143: INFO: Created: latency-svc-c8k7r
+Apr 27 14:39:48.180: INFO: Got endpoints: latency-svc-b75bf [748.871481ms]
+Apr 27 14:39:48.187: INFO: Created: latency-svc-fwdf4
+Apr 27 14:39:48.230: INFO: Got endpoints: latency-svc-nmhqb [749.736697ms]
+Apr 27 14:39:48.257: INFO: Created: latency-svc-4vdp9
+Apr 27 14:39:48.279: INFO: Got endpoints: latency-svc-k6bmb [748.822066ms]
+Apr 27 14:39:48.288: INFO: Created: latency-svc-8rmtn
+Apr 27 14:39:48.330: INFO: Got endpoints: latency-svc-69z4b [749.582541ms]
+Apr 27 14:39:48.384: INFO: Got endpoints: latency-svc-bcx8j [753.883212ms]
+Apr 27 14:39:48.386: INFO: Created: latency-svc-829qh
+Apr 27 14:39:48.392: INFO: Created: latency-svc-sbl2v
+Apr 27 14:39:48.430: INFO: Got endpoints: latency-svc-s44tt [735.902754ms]
+Apr 27 14:39:48.481: INFO: Got endpoints: latency-svc-wtffh [751.255891ms]
+Apr 27 14:39:48.506: INFO: Created: latency-svc-l4s2f
+Apr 27 14:39:48.508: INFO: Created: latency-svc-lmwll
+Apr 27 14:39:48.530: INFO: Got endpoints: latency-svc-x6lwk [750.651223ms]
+Apr 27 14:39:48.541: INFO: Created: latency-svc-wj5gc
+Apr 27 14:39:48.637: INFO: Got endpoints: latency-svc-m9wsq [757.14792ms]
+Apr 27 14:39:48.640: INFO: Got endpoints: latency-svc-g2kgf [806.061071ms]
+Apr 27 14:39:48.653: INFO: Created: latency-svc-4ps9m
+Apr 27 14:39:48.654: INFO: Created: latency-svc-vrmcv
+Apr 27 14:39:48.679: INFO: Got endpoints: latency-svc-hbhzl [749.220596ms]
+Apr 27 14:39:48.730: INFO: Got endpoints: latency-svc-dp6mn [749.708464ms]
+Apr 27 14:39:48.730: INFO: Created: latency-svc-rctpb
+Apr 27 14:39:48.749: INFO: Created: latency-svc-6dfd7
+Apr 27 14:39:48.780: INFO: Got endpoints: latency-svc-86hkq [750.170545ms]
+Apr 27 14:39:48.805: INFO: Created: latency-svc-6bs2p
+Apr 27 14:39:48.840: INFO: Got endpoints: latency-svc-cjglz [760.231776ms]
+Apr 27 14:39:48.870: INFO: Created: latency-svc-b8ghr
+Apr 27 14:39:48.879: INFO: Got endpoints: latency-svc-c8k7r [749.014451ms]
+Apr 27 14:39:48.887: INFO: Created: latency-svc-f44sb
+Apr 27 14:39:48.930: INFO: Got endpoints: latency-svc-fwdf4 [750.395983ms]
+Apr 27 14:39:48.938: INFO: Created: latency-svc-ztb5z
+Apr 27 14:39:48.996: INFO: Got endpoints: latency-svc-4vdp9 [765.894952ms]
+Apr 27 14:39:49.004: INFO: Created: latency-svc-kn7nb
+Apr 27 14:39:49.031: INFO: Got endpoints: latency-svc-8rmtn [751.144712ms]
+Apr 27 14:39:49.039: INFO: Created: latency-svc-5hbww
+Apr 27 14:39:49.080: INFO: Got endpoints: latency-svc-829qh [749.966157ms]
+Apr 27 14:39:49.095: INFO: Created: latency-svc-zvhtn
+Apr 27 14:39:49.129: INFO: Got endpoints: latency-svc-sbl2v [745.321142ms]
+Apr 27 14:39:49.138: INFO: Created: latency-svc-w22pc
+Apr 27 14:39:49.179: INFO: Got endpoints: latency-svc-l4s2f [747.04907ms]
+Apr 27 14:39:49.187: INFO: Created: latency-svc-mrcnh
+Apr 27 14:39:49.234: INFO: Got endpoints: latency-svc-lmwll [753.099693ms]
+Apr 27 14:39:49.249: INFO: Created: latency-svc-9qfwf
+Apr 27 14:39:49.282: INFO: Got endpoints: latency-svc-wj5gc [752.034436ms]
+Apr 27 14:39:49.292: INFO: Created: latency-svc-zw2pc
+Apr 27 14:39:49.334: INFO: Got endpoints: latency-svc-4ps9m [697.122915ms]
+Apr 27 14:39:49.351: INFO: Created: latency-svc-cdtnr
+Apr 27 14:39:49.379: INFO: Got endpoints: latency-svc-vrmcv [739.024313ms]
+Apr 27 14:39:49.387: INFO: Created: latency-svc-zlz52
+Apr 27 14:39:49.430: INFO: Got endpoints: latency-svc-rctpb [709.962988ms]
+Apr 27 14:39:49.441: INFO: Created: latency-svc-6nrnl
+Apr 27 14:39:49.479: INFO: Got endpoints: latency-svc-6dfd7 [749.293213ms]
+Apr 27 14:39:49.529: INFO: Got endpoints: latency-svc-6bs2p [747.653618ms]
+Apr 27 14:39:49.537: INFO: Created: latency-svc-l6n2k
+Apr 27 14:39:49.543: INFO: Created: latency-svc-n9wgc
+Apr 27 14:39:49.584: INFO: Got endpoints: latency-svc-b8ghr [742.26833ms]
+Apr 27 14:39:49.606: INFO: Created: latency-svc-dts8w
+Apr 27 14:39:49.631: INFO: Got endpoints: latency-svc-f44sb [751.557281ms]
+Apr 27 14:39:49.639: INFO: Created: latency-svc-4h699
+Apr 27 14:39:49.682: INFO: Got endpoints: latency-svc-ztb5z [751.53949ms]
+Apr 27 14:39:49.730: INFO: Got endpoints: latency-svc-kn7nb [734.006782ms]
+Apr 27 14:39:49.742: INFO: Created: latency-svc-69jl8
+Apr 27 14:39:49.744: INFO: Created: latency-svc-f8d7p
+Apr 27 14:39:49.780: INFO: Got endpoints: latency-svc-5hbww [749.033395ms]
+Apr 27 14:39:49.789: INFO: Created: latency-svc-j8gdp
+Apr 27 14:39:49.830: INFO: Got endpoints: latency-svc-zvhtn [749.724842ms]
+Apr 27 14:39:49.838: INFO: Created: latency-svc-8xh2z
+Apr 27 14:39:49.879: INFO: Got endpoints: latency-svc-w22pc [749.663692ms]
+Apr 27 14:39:49.930: INFO: Got endpoints: latency-svc-mrcnh [750.713731ms]
+Apr 27 14:39:49.944: INFO: Created: latency-svc-kw7cw
+Apr 27 14:39:49.947: INFO: Created: latency-svc-wrrnf
+Apr 27 14:39:49.981: INFO: Got endpoints: latency-svc-9qfwf [744.835715ms]
+Apr 27 14:39:49.990: INFO: Created: latency-svc-nrnkc
+Apr 27 14:39:50.030: INFO: Got endpoints: latency-svc-zw2pc [747.330775ms]
+Apr 27 14:39:50.041: INFO: Created: latency-svc-wqf5n
+Apr 27 14:39:50.080: INFO: Got endpoints: latency-svc-cdtnr [743.997393ms]
+Apr 27 14:39:50.087: INFO: Created: latency-svc-mgkxl
+Apr 27 14:39:50.129: INFO: Got endpoints: latency-svc-zlz52 [750.191876ms]
+Apr 27 14:39:50.150: INFO: Created: latency-svc-r8dmv
+Apr 27 14:39:50.187: INFO: Got endpoints: latency-svc-6nrnl [757.360022ms]
+Apr 27 14:39:50.199: INFO: Created: latency-svc-gbx25
+Apr 27 14:39:50.230: INFO: Got endpoints: latency-svc-l6n2k [750.709828ms]
+Apr 27 14:39:50.239: INFO: Created: latency-svc-lfzhj
+Apr 27 14:39:50.280: INFO: Got endpoints: latency-svc-n9wgc [750.543651ms]
+Apr 27 14:39:50.289: INFO: Created: latency-svc-6djlx
+Apr 27 14:39:50.330: INFO: Got endpoints: latency-svc-dts8w [734.448477ms]
+Apr 27 14:39:50.341: INFO: Created: latency-svc-h92zf
+Apr 27 14:39:50.380: INFO: Got endpoints: latency-svc-4h699 [748.853529ms]
+Apr 27 14:39:50.391: INFO: Created: latency-svc-9qnrv
+Apr 27 14:39:50.430: INFO: Got endpoints: latency-svc-69jl8 [748.077413ms]
+Apr 27 14:39:50.440: INFO: Created: latency-svc-sgzjq
+Apr 27 14:39:50.480: INFO: Got endpoints: latency-svc-f8d7p [749.842437ms]
+Apr 27 14:39:50.489: INFO: Created: latency-svc-lhkqm
+Apr 27 14:39:50.529: INFO: Got endpoints: latency-svc-j8gdp [748.688377ms]
+Apr 27 14:39:50.538: INFO: Created: latency-svc-mnhv8
+Apr 27 14:39:50.580: INFO: Got endpoints: latency-svc-8xh2z [750.018205ms]
+Apr 27 14:39:50.589: INFO: Created: latency-svc-j6khz
+Apr 27 14:39:50.629: INFO: Got endpoints: latency-svc-kw7cw [749.787476ms]
+Apr 27 14:39:50.639: INFO: Created: latency-svc-v2kpw
+Apr 27 14:39:50.679: INFO: Got endpoints: latency-svc-wrrnf [749.198601ms]
+Apr 27 14:39:50.688: INFO: Created: latency-svc-s7fz9
+Apr 27 14:39:50.729: INFO: Got endpoints: latency-svc-nrnkc [747.844853ms]
+Apr 27 14:39:50.738: INFO: Created: latency-svc-hnt8z
+Apr 27 14:39:50.784: INFO: Got endpoints: latency-svc-wqf5n [753.586241ms]
+Apr 27 14:39:50.792: INFO: Created: latency-svc-89kfg
+Apr 27 14:39:50.834: INFO: Got endpoints: latency-svc-mgkxl [753.886489ms]
+Apr 27 14:39:50.850: INFO: Created: latency-svc-wcvnn
+Apr 27 14:39:50.882: INFO: Got endpoints: latency-svc-r8dmv [751.831236ms]
+Apr 27 14:39:50.890: INFO: Created: latency-svc-p8nx8
+Apr 27 14:39:50.930: INFO: Got endpoints: latency-svc-gbx25 [740.132347ms]
+Apr 27 14:39:50.940: INFO: Created: latency-svc-d2m7b
+Apr 27 14:39:50.980: INFO: Got endpoints: latency-svc-lfzhj [749.55376ms]
+Apr 27 14:39:50.988: INFO: Created: latency-svc-qbszm
+Apr 27 14:39:51.029: INFO: Got endpoints: latency-svc-6djlx [749.228544ms]
+Apr 27 14:39:51.040: INFO: Created: latency-svc-c4vnp
+Apr 27 14:39:51.080: INFO: Got endpoints: latency-svc-h92zf [749.498392ms]
+Apr 27 14:39:51.088: INFO: Created: latency-svc-9hpj9
+Apr 27 14:39:51.130: INFO: Got endpoints: latency-svc-9qnrv [750.214183ms]
+Apr 27 14:39:51.139: INFO: Created: latency-svc-qhkb8
+Apr 27 14:39:51.180: INFO: Got endpoints: latency-svc-sgzjq [749.325463ms]
+Apr 27 14:39:51.191: INFO: Created: latency-svc-w5w9q
+Apr 27 14:39:51.230: INFO: Got endpoints: latency-svc-lhkqm [749.602891ms]
+Apr 27 14:39:51.239: INFO: Created: latency-svc-qczjr
+Apr 27 14:39:51.280: INFO: Got endpoints: latency-svc-mnhv8 [750.614453ms]
+Apr 27 14:39:51.289: INFO: Created: latency-svc-knpmv
+Apr 27 14:39:51.334: INFO: Got endpoints: latency-svc-j6khz [753.853385ms]
+Apr 27 14:39:51.342: INFO: Created: latency-svc-xt49w
+Apr 27 14:39:51.380: INFO: Got endpoints: latency-svc-v2kpw [751.247974ms]
+Apr 27 14:39:51.395: INFO: Created: latency-svc-8djcf
+Apr 27 14:39:51.430: INFO: Got endpoints: latency-svc-s7fz9 [750.431402ms]
+Apr 27 14:39:51.441: INFO: Created: latency-svc-cjcgl
+Apr 27 14:39:51.480: INFO: Got endpoints: latency-svc-hnt8z [750.58106ms]
+Apr 27 14:39:51.488: INFO: Created: latency-svc-m849d
+Apr 27 14:39:51.531: INFO: Got endpoints: latency-svc-89kfg [746.312588ms]
+Apr 27 14:39:51.539: INFO: Created: latency-svc-2hrwp
+Apr 27 14:39:51.580: INFO: Got endpoints: latency-svc-wcvnn [746.449634ms]
+Apr 27 14:39:51.589: INFO: Created: latency-svc-qnmcj
+Apr 27 14:39:51.630: INFO: Got endpoints: latency-svc-p8nx8 [748.308547ms]
+Apr 27 14:39:51.639: INFO: Created: latency-svc-9c2bz
+Apr 27 14:39:51.680: INFO: Got endpoints: latency-svc-d2m7b [750.426486ms]
+Apr 27 14:39:51.689: INFO: Created: latency-svc-vx978
+Apr 27 14:39:51.734: INFO: Got endpoints: latency-svc-qbszm [753.7976ms]
+Apr 27 14:39:51.743: INFO: Created: latency-svc-nmfdz
+Apr 27 14:39:51.780: INFO: Got endpoints: latency-svc-c4vnp [750.360893ms]
+Apr 27 14:39:51.804: INFO: Created: latency-svc-bcsrj
+Apr 27 14:39:51.830: INFO: Got endpoints: latency-svc-9hpj9 [750.079528ms]
+Apr 27 14:39:51.844: INFO: Created: latency-svc-8wptt
+Apr 27 14:39:51.881: INFO: Got endpoints: latency-svc-qhkb8 [750.111979ms]
+Apr 27 14:39:51.889: INFO: Created: latency-svc-zkw9h
+Apr 27 14:39:51.930: INFO: Got endpoints: latency-svc-w5w9q [748.953021ms]
+Apr 27 14:39:51.940: INFO: Created: latency-svc-6pnkl
+Apr 27 14:39:51.980: INFO: Got endpoints: latency-svc-qczjr [749.664444ms]
+Apr 27 14:39:51.988: INFO: Created: latency-svc-hd2xl
+Apr 27 14:39:52.031: INFO: Got endpoints: latency-svc-knpmv [751.64616ms]
+Apr 27 14:39:52.040: INFO: Created: latency-svc-2l42d
+Apr 27 14:39:52.080: INFO: Got endpoints: latency-svc-xt49w [745.635543ms]
+Apr 27 14:39:52.088: INFO: Created: latency-svc-wj85f
+Apr 27 14:39:52.130: INFO: Got endpoints: latency-svc-8djcf [748.979348ms]
+Apr 27 14:39:52.138: INFO: Created: latency-svc-btbg8
+Apr 27 14:39:52.180: INFO: Got endpoints: latency-svc-cjcgl [749.864558ms]
+Apr 27 14:39:52.189: INFO: Created: latency-svc-5qnm5
+Apr 27 14:39:52.239: INFO: Got endpoints: latency-svc-m849d [758.827371ms]
+Apr 27 14:39:52.248: INFO: Created: latency-svc-ndbht
+Apr 27 14:39:52.279: INFO: Got endpoints: latency-svc-2hrwp [748.248569ms]
+Apr 27 14:39:52.293: INFO: Created: latency-svc-zf9wt
+Apr 27 14:39:52.331: INFO: Got endpoints: latency-svc-qnmcj [750.646475ms]
+Apr 27 14:39:52.346: INFO: Created: latency-svc-8qtnc
+Apr 27 14:39:52.379: INFO: Got endpoints: latency-svc-9c2bz [748.95772ms]
+Apr 27 14:39:52.387: INFO: Created: latency-svc-4dcf2
+Apr 27 14:39:52.430: INFO: Got endpoints: latency-svc-vx978 [749.332469ms]
+Apr 27 14:39:52.439: INFO: Created: latency-svc-k2tdt
+Apr 27 14:39:52.479: INFO: Got endpoints: latency-svc-nmfdz [745.025701ms]
+Apr 27 14:39:52.486: INFO: Created: latency-svc-d9njr
+Apr 27 14:39:52.529: INFO: Got endpoints: latency-svc-bcsrj [749.477163ms]
+Apr 27 14:39:52.539: INFO: Created: latency-svc-fvmth
+Apr 27 14:39:52.579: INFO: Got endpoints: latency-svc-8wptt [743.149332ms]
+Apr 27 14:39:52.588: INFO: Created: latency-svc-x96sc
+Apr 27 14:39:52.630: INFO: Got endpoints: latency-svc-zkw9h [749.004798ms]
+Apr 27 14:39:52.638: INFO: Created: latency-svc-tskvx
+Apr 27 14:39:52.684: INFO: Got endpoints: latency-svc-6pnkl [753.119325ms]
+Apr 27 14:39:52.706: INFO: Created: latency-svc-5jdl8
+Apr 27 14:39:52.732: INFO: Got endpoints: latency-svc-hd2xl [752.123589ms]
+Apr 27 14:39:52.745: INFO: Created: latency-svc-ljk55
+Apr 27 14:39:52.779: INFO: Got endpoints: latency-svc-2l42d [747.551737ms]
+Apr 27 14:39:52.787: INFO: Created: latency-svc-pd6dt
+Apr 27 14:39:52.829: INFO: Got endpoints: latency-svc-wj85f [749.30092ms]
+Apr 27 14:39:52.880: INFO: Got endpoints: latency-svc-btbg8 [750.081074ms]
+Apr 27 14:39:52.929: INFO: Got endpoints: latency-svc-5qnm5 [749.006243ms]
+Apr 27 14:39:52.980: INFO: Got endpoints: latency-svc-ndbht [741.31017ms]
+Apr 27 14:39:53.030: INFO: Got endpoints: latency-svc-zf9wt [750.400915ms]
+Apr 27 14:39:53.091: INFO: Got endpoints: latency-svc-8qtnc [755.69353ms]
+Apr 27 14:39:53.130: INFO: Got endpoints: latency-svc-4dcf2 [750.673119ms]
+Apr 27 14:39:53.180: INFO: Got endpoints: latency-svc-k2tdt [750.099583ms]
+Apr 27 14:39:53.230: INFO: Got endpoints: latency-svc-d9njr [750.573608ms]
+Apr 27 14:39:53.280: INFO: Got endpoints: latency-svc-fvmth [750.05481ms]
+Apr 27 14:39:53.334: INFO: Got endpoints: latency-svc-x96sc [754.049902ms]
+Apr 27 14:39:53.381: INFO: Got endpoints: latency-svc-tskvx [751.071714ms]
+Apr 27 14:39:53.431: INFO: Got endpoints: latency-svc-5jdl8 [746.979704ms]
+Apr 27 14:39:53.480: INFO: Got endpoints: latency-svc-ljk55 [746.315651ms]
+Apr 27 14:39:53.530: INFO: Got endpoints: latency-svc-pd6dt [751.096235ms]
+Apr 27 14:39:53.530: INFO: Latencies: [10.401214ms 15.844424ms 18.499276ms 27.246995ms 36.455034ms 38.595059ms 45.044483ms 51.689609ms 55.503892ms 57.960297ms 66.358678ms 75.057597ms 75.863238ms 86.094827ms 86.174885ms 87.885151ms 87.932527ms 90.443837ms 91.071429ms 91.393522ms 92.141308ms 92.253907ms 93.235094ms 93.465509ms 98.024721ms 98.190524ms 98.253328ms 99.365275ms 99.560685ms 99.665373ms 101.582787ms 101.753861ms 103.875601ms 135.128718ms 165.053128ms 214.025255ms 259.773479ms 300.90111ms 341.173348ms 385.389812ms 433.249435ms 479.518779ms 524.062983ms 569.926143ms 615.343544ms 654.779729ms 697.122915ms 697.512617ms 709.962988ms 734.006782ms 734.448477ms 735.902754ms 739.024313ms 740.132347ms 741.31017ms 742.26833ms 743.149332ms 743.799221ms 743.997393ms 744.835715ms 745.025701ms 745.321142ms 745.37383ms 745.43449ms 745.635543ms 745.645751ms 746.312588ms 746.315651ms 746.449634ms 746.676298ms 746.97174ms 746.979704ms 747.04907ms 747.330775ms 747.551737ms 747.653618ms 747.844853ms 747.91068ms 748.077413ms 748.248569ms 748.308547ms 748.541554ms 748.688377ms 748.822066ms 748.853529ms 748.871481ms 748.889475ms 748.953021ms 748.95772ms 748.958251ms 748.962462ms 748.979348ms 748.996582ms 748.997995ms 749.004798ms 749.006243ms 749.014451ms 749.033395ms 749.072192ms 749.092278ms 749.198601ms 749.220596ms 749.228544ms 749.293213ms 749.30092ms 749.312113ms 749.325463ms 749.332469ms 749.443664ms 749.477163ms 749.489177ms 749.498392ms 749.55376ms 749.561889ms 749.582541ms 749.602891ms 749.663692ms 749.664444ms 749.708464ms 749.716284ms 749.724842ms 749.736697ms 749.753346ms 749.772958ms 749.787476ms 749.79825ms 749.838397ms 749.842437ms 749.864558ms 749.885995ms 749.925258ms 749.966157ms 750.001763ms 750.018205ms 750.05481ms 750.079528ms 750.081074ms 750.090302ms 750.099583ms 750.111979ms 750.140767ms 750.167975ms 750.170545ms 750.191876ms 750.205465ms 750.214183ms 750.225629ms 750.360893ms 750.395983ms 750.400915ms 750.404608ms 750.410942ms 750.426486ms 750.431402ms 750.543651ms 750.573608ms 750.58106ms 750.614453ms 750.646475ms 750.651223ms 750.673119ms 750.70061ms 750.709828ms 750.713731ms 750.772185ms 750.839993ms 751.071714ms 751.096235ms 751.144712ms 751.247974ms 751.255891ms 751.53949ms 751.557281ms 751.64616ms 751.812919ms 751.831236ms 751.876695ms 752.034436ms 752.123589ms 752.161663ms 752.368859ms 753.099693ms 753.119325ms 753.36905ms 753.586241ms 753.767358ms 753.7976ms 753.853385ms 753.883212ms 753.886489ms 754.049902ms 754.486242ms 755.69353ms 757.14792ms 757.360022ms 758.827371ms 760.231776ms 764.394198ms 765.894952ms 806.061071ms]
+Apr 27 14:39:53.530: INFO: 50 %ile: 749.198601ms
+Apr 27 14:39:53.530: INFO: 90 %ile: 752.368859ms
+Apr 27 14:39:53.530: INFO: 99 %ile: 765.894952ms
+Apr 27 14:39:53.530: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:39:53.530: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-tfs9q" for this suite.
+Apr 27 14:40:13.543: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:13.595: INFO: namespace: e2e-tests-svc-latency-tfs9q, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:13.665: INFO: namespace e2e-tests-svc-latency-tfs9q deletion completed in 20.131099995s
+
+• [SLOW TEST:30.888 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:13.665: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-e517b094-4a28-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:40:13.755: INFO: Waiting up to 5m0s for pod "pod-configmaps-e5180e9d-4a28-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-configmap-hq8s4" to be "success or failure"
+Apr 27 14:40:13.757: INFO: Pod "pod-configmaps-e5180e9d-4a28-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 1.993605ms
+Apr 27 14:40:15.760: INFO: Pod "pod-configmaps-e5180e9d-4a28-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005077136s
+STEP: Saw pod success
+Apr 27 14:40:15.760: INFO: Pod "pod-configmaps-e5180e9d-4a28-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:40:15.762: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-configmaps-e5180e9d-4a28-11e8-87ef-0ee10445d8a2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:40:15.776: INFO: Waiting for pod pod-configmaps-e5180e9d-4a28-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:40:15.779: INFO: Pod pod-configmaps-e5180e9d-4a28-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:15.779: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-hq8s4" for this suite.
+Apr 27 14:40:21.792: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:21.881: INFO: namespace: e2e-tests-configmap-hq8s4, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:21.916: INFO: namespace e2e-tests-configmap-hq8s4 deletion completed in 6.133387573s
+
+• [SLOW TEST:8.250 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:21.916: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Apr 27 14:40:22.007: INFO: Waiting up to 5m0s for pod "pod-ea033f6b-4a28-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-krz2k" to be "success or failure"
+Apr 27 14:40:22.010: INFO: Pod "pod-ea033f6b-4a28-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.906803ms
+Apr 27 14:40:24.014: INFO: Pod "pod-ea033f6b-4a28-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006732811s
+STEP: Saw pod success
+Apr 27 14:40:24.014: INFO: Pod "pod-ea033f6b-4a28-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:40:24.017: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-ea033f6b-4a28-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:40:24.030: INFO: Waiting for pod pod-ea033f6b-4a28-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:40:24.034: INFO: Pod pod-ea033f6b-4a28-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:24.034: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-krz2k" for this suite.
+Apr 27 14:40:30.046: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:30.110: INFO: namespace: e2e-tests-emptydir-krz2k, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:30.173: INFO: namespace e2e-tests-emptydir-krz2k deletion completed in 6.136235776s
+
+• [SLOW TEST:8.258 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:30.174: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Apr 27 14:40:30.268: INFO: Waiting up to 5m0s for pod "pod-eeefc20a-4a28-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-6zzrc" to be "success or failure"
+Apr 27 14:40:30.272: INFO: Pod "pod-eeefc20a-4a28-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.595477ms
+Apr 27 14:40:32.276: INFO: Pod "pod-eeefc20a-4a28-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007607701s
+STEP: Saw pod success
+Apr 27 14:40:32.276: INFO: Pod "pod-eeefc20a-4a28-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:40:32.278: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-eeefc20a-4a28-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:40:32.292: INFO: Waiting for pod pod-eeefc20a-4a28-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:40:32.295: INFO: Pod pod-eeefc20a-4a28-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:32.295: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-6zzrc" for this suite.
+Apr 27 14:40:38.308: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:38.375: INFO: namespace: e2e-tests-emptydir-6zzrc, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:38.433: INFO: namespace e2e-tests-emptydir-6zzrc deletion completed in 6.134513006s
+
+• [SLOW TEST:8.259 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:38.433: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:40:38.519: INFO: Waiting up to 5m0s for pod "downwardapi-volume-f3dab2e6-4a28-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-qw7zs" to be "success or failure"
+Apr 27 14:40:38.521: INFO: Pod "downwardapi-volume-f3dab2e6-4a28-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.137282ms
+Apr 27 14:40:40.525: INFO: Pod "downwardapi-volume-f3dab2e6-4a28-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006121123s
+STEP: Saw pod success
+Apr 27 14:40:40.525: INFO: Pod "downwardapi-volume-f3dab2e6-4a28-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:40:40.528: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-f3dab2e6-4a28-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:40:40.543: INFO: Waiting for pod downwardapi-volume-f3dab2e6-4a28-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:40:40.545: INFO: Pod downwardapi-volume-f3dab2e6-4a28-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:40.546: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-qw7zs" for this suite.
+Apr 27 14:40:46.559: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:46.638: INFO: namespace: e2e-tests-downward-api-qw7zs, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:46.681: INFO: namespace e2e-tests-downward-api-qw7zs deletion completed in 6.1311787s
+
+• [SLOW TEST:8.248 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:46.682: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-f8c56df7-4a28-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:40:46.771: INFO: Waiting up to 5m0s for pod "pod-configmaps-f8c5e1c0-4a28-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-configmap-2txw2" to be "success or failure"
+Apr 27 14:40:46.773: INFO: Pod "pod-configmaps-f8c5e1c0-4a28-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.24254ms
+Apr 27 14:40:48.778: INFO: Pod "pod-configmaps-f8c5e1c0-4a28-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006770139s
+STEP: Saw pod success
+Apr 27 14:40:48.778: INFO: Pod "pod-configmaps-f8c5e1c0-4a28-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:40:48.780: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-configmaps-f8c5e1c0-4a28-11e8-87ef-0ee10445d8a2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:40:48.796: INFO: Waiting for pod pod-configmaps-f8c5e1c0-4a28-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:40:48.799: INFO: Pod pod-configmaps-f8c5e1c0-4a28-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:48.799: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-2txw2" for this suite.
+Apr 27 14:40:54.810: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:40:54.885: INFO: namespace: e2e-tests-configmap-2txw2, resource: bindings, ignored listing per whitelist
+Apr 27 14:40:54.934: INFO: namespace e2e-tests-configmap-2txw2 deletion completed in 6.131489206s
+
+• [SLOW TEST:8.252 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:40:54.934: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:40:55.018: INFO: Waiting up to 5m0s for pod "downwardapi-volume-fdb02cb4-4a28-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-fkhpb" to be "success or failure"
+Apr 27 14:40:55.021: INFO: Pod "downwardapi-volume-fdb02cb4-4a28-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.316751ms
+Apr 27 14:40:57.025: INFO: Pod "downwardapi-volume-fdb02cb4-4a28-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007538409s
+STEP: Saw pod success
+Apr 27 14:40:57.025: INFO: Pod "downwardapi-volume-fdb02cb4-4a28-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:40:57.028: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-fdb02cb4-4a28-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:40:57.046: INFO: Waiting for pod downwardapi-volume-fdb02cb4-4a28-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:40:57.049: INFO: Pod downwardapi-volume-fdb02cb4-4a28-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:40:57.049: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-fkhpb" for this suite.
+Apr 27 14:41:03.062: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:41:03.158: INFO: namespace: e2e-tests-downward-api-fkhpb, resource: bindings, ignored listing per whitelist
+Apr 27 14:41:03.185: INFO: namespace e2e-tests-downward-api-fkhpb deletion completed in 6.132326829s
+
+• [SLOW TEST:8.251 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:41:03.185: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 27 14:41:05.797: INFO: Successfully updated pod "labelsupdate029bced9-4a29-11e8-87ef-0ee10445d8a2"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:41:07.822: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-k97r4" for this suite.
+Apr 27 14:41:29.835: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:41:29.931: INFO: namespace: e2e-tests-downward-api-k97r4, resource: bindings, ignored listing per whitelist
+Apr 27 14:41:29.963: INFO: namespace e2e-tests-downward-api-k97r4 deletion completed in 22.137220655s
+
+• [SLOW TEST:26.778 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:41:29.965: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:41:30.055: INFO: Waiting up to 5m0s for pod "downwardapi-volume-12926aeb-4a29-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-c5scs" to be "success or failure"
+Apr 27 14:41:30.059: INFO: Pod "downwardapi-volume-12926aeb-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.791763ms
+Apr 27 14:41:32.063: INFO: Pod "downwardapi-volume-12926aeb-4a29-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007755884s
+STEP: Saw pod success
+Apr 27 14:41:32.063: INFO: Pod "downwardapi-volume-12926aeb-4a29-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:41:32.065: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-12926aeb-4a29-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:41:32.088: INFO: Waiting for pod downwardapi-volume-12926aeb-4a29-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:41:32.091: INFO: Pod downwardapi-volume-12926aeb-4a29-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:41:32.091: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-c5scs" for this suite.
+Apr 27 14:41:38.104: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:41:38.179: INFO: namespace: e2e-tests-projected-c5scs, resource: bindings, ignored listing per whitelist
+Apr 27 14:41:38.239: INFO: namespace e2e-tests-projected-c5scs deletion completed in 6.144235024s
+
+• [SLOW TEST:8.275 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:41:38.239: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:41:38.320: INFO: Waiting up to 5m0s for pod "downwardapi-volume-177fc0a1-4a29-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-ffklc" to be "success or failure"
+Apr 27 14:41:38.323: INFO: Pod "downwardapi-volume-177fc0a1-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.47078ms
+Apr 27 14:41:40.326: INFO: Pod "downwardapi-volume-177fc0a1-4a29-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005967668s
+STEP: Saw pod success
+Apr 27 14:41:40.326: INFO: Pod "downwardapi-volume-177fc0a1-4a29-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:41:40.329: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-177fc0a1-4a29-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:41:40.345: INFO: Waiting for pod downwardapi-volume-177fc0a1-4a29-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:41:40.348: INFO: Pod downwardapi-volume-177fc0a1-4a29-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:41:40.348: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-ffklc" for this suite.
+Apr 27 14:41:46.361: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:41:46.449: INFO: namespace: e2e-tests-projected-ffklc, resource: bindings, ignored listing per whitelist
+Apr 27 14:41:46.477: INFO: namespace e2e-tests-projected-ffklc deletion completed in 6.124841245s
+
+• [SLOW TEST:8.237 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:41:46.477: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-1c68f73f-4a29-11e8-87ef-0ee10445d8a2,GenerateName:,Namespace:e2e-tests-events-dmj7s,SelfLink:/api/v1/namespaces/e2e-tests-events-dmj7s/pods/send-events-1c68f73f-4a29-11e8-87ef-0ee10445d8a2,UID:1c687f84-4a29-11e8-95c2-6e9906a57104,ResourceVersion:395465,Generation:0,CreationTimestamp:2018-04-27 14:41:46 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 555653692,},Annotations:map[string]string{cni.projectcalico.org/podIP: 100.96.0.148/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-44cmt {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-44cmt,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-44cmt true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc421f17580} {node.kubernetes.io/unreachable Exists  NoExecute 0xc421f175a0}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:41:46 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:41:48 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-04-27 14:41:46 +0000 UTC  }],Message:,Reason:,HostIP:10.250.0.18,PodIP:100.96.0.148,StartTime:2018-04-27 14:41:46 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-04-27 14:41:47 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://08bc1d07a91cc3f34f85cd35cb90dbd2b47b53c5be272739068644c3ad58242f}],QOSClass:BestEffort,InitContainerStatuses:[],NominatedNodeName:,},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:41:52.585: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-dmj7s" for this suite.
+Apr 27 14:42:14.597: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:42:14.685: INFO: namespace: e2e-tests-events-dmj7s, resource: bindings, ignored listing per whitelist
+Apr 27 14:42:14.718: INFO: namespace e2e-tests-events-dmj7s deletion completed in 22.129632259s
+
+• [SLOW TEST:28.242 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:42:14.720: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:42:14.817: INFO: Waiting up to 5m0s for pod "downwardapi-volume-2d40beae-4a29-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-7xpmd" to be "success or failure"
+Apr 27 14:42:14.821: INFO: Pod "downwardapi-volume-2d40beae-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.738311ms
+Apr 27 14:42:16.826: INFO: Pod "downwardapi-volume-2d40beae-4a29-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008290241s
+STEP: Saw pod success
+Apr 27 14:42:16.826: INFO: Pod "downwardapi-volume-2d40beae-4a29-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:42:16.828: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-2d40beae-4a29-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:42:16.845: INFO: Waiting for pod downwardapi-volume-2d40beae-4a29-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:42:16.848: INFO: Pod downwardapi-volume-2d40beae-4a29-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:42:16.848: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-7xpmd" for this suite.
+Apr 27 14:42:22.866: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:42:22.971: INFO: namespace: e2e-tests-projected-7xpmd, resource: bindings, ignored listing per whitelist
+Apr 27 14:42:22.991: INFO: namespace e2e-tests-projected-7xpmd deletion completed in 6.138767512s
+
+• [SLOW TEST:8.270 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:42:22.991: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-322d3221-4a29-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:42:23.082: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-322dbca0-4a29-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-wxj5w" to be "success or failure"
+Apr 27 14:42:23.085: INFO: Pod "pod-projected-configmaps-322dbca0-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.154873ms
+Apr 27 14:42:25.089: INFO: Pod "pod-projected-configmaps-322dbca0-4a29-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007506443s
+STEP: Saw pod success
+Apr 27 14:42:25.090: INFO: Pod "pod-projected-configmaps-322dbca0-4a29-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:42:25.092: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-configmaps-322dbca0-4a29-11e8-87ef-0ee10445d8a2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:42:25.107: INFO: Waiting for pod pod-projected-configmaps-322dbca0-4a29-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:42:25.109: INFO: Pod pod-projected-configmaps-322dbca0-4a29-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:42:25.109: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wxj5w" for this suite.
+Apr 27 14:42:31.122: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:42:31.214: INFO: namespace: e2e-tests-projected-wxj5w, resource: bindings, ignored listing per whitelist
+Apr 27 14:42:31.247: INFO: namespace e2e-tests-projected-wxj5w deletion completed in 6.134586694s
+
+• [SLOW TEST:8.256 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:42:31.249: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-4lrr2
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 27 14:42:31.330: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 27 14:42:55.379: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.152:8080/dial?request=hostName&protocol=udp&host=100.96.0.151&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-4lrr2 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:42:55.379: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 14:42:55.563: INFO: Waiting for endpoints: map[]
+Apr 27 14:42:55.566: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.152:8080/dial?request=hostName&protocol=udp&host=100.96.1.17&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-4lrr2 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 14:42:55.566: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 14:42:55.685: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:42:55.685: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-4lrr2" for this suite.
+Apr 27 14:43:17.699: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:43:17.805: INFO: namespace: e2e-tests-pod-network-test-4lrr2, resource: bindings, ignored listing per whitelist
+Apr 27 14:43:17.818: INFO: namespace e2e-tests-pod-network-test-4lrr2 deletion completed in 22.128827654s
+
+• [SLOW TEST:46.569 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:43:17.820: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-pzhtt
+Apr 27 14:43:21.915: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-pzhtt
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:43:21.918: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:45:22.155: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-pzhtt" for this suite.
+Apr 27 14:45:28.168: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:45:28.280: INFO: namespace: e2e-tests-container-probe-pzhtt, resource: bindings, ignored listing per whitelist
+Apr 27 14:45:28.293: INFO: namespace e2e-tests-container-probe-pzhtt deletion completed in 6.133826502s
+
+• [SLOW TEST:130.473 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:45:28.293: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-projected-all-test-volume-a0a0b5c2-4a29-11e8-87ef-0ee10445d8a2
+STEP: Creating secret with name secret-projected-all-test-volume-a0a0b5b1-4a29-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Apr 27 14:45:28.390: INFO: Waiting up to 5m0s for pod "projected-volume-a0a0b57e-4a29-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-bl4mh" to be "success or failure"
+Apr 27 14:45:28.393: INFO: Pod "projected-volume-a0a0b57e-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.098368ms
+Apr 27 14:45:30.397: INFO: Pod "projected-volume-a0a0b57e-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006165382s
+Apr 27 14:45:32.401: INFO: Pod "projected-volume-a0a0b57e-4a29-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010387035s
+STEP: Saw pod success
+Apr 27 14:45:32.401: INFO: Pod "projected-volume-a0a0b57e-4a29-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:45:32.404: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod projected-volume-a0a0b57e-4a29-11e8-87ef-0ee10445d8a2 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:45:32.418: INFO: Waiting for pod projected-volume-a0a0b57e-4a29-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:45:32.420: INFO: Pod projected-volume-a0a0b57e-4a29-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:45:32.420: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-bl4mh" for this suite.
+Apr 27 14:45:38.434: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:45:38.497: INFO: namespace: e2e-tests-projected-bl4mh, resource: bindings, ignored listing per whitelist
+Apr 27 14:45:38.560: INFO: namespace e2e-tests-projected-bl4mh deletion completed in 6.136551102s
+
+• [SLOW TEST:10.267 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:45:38.561: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Apr 27 14:45:38.642: INFO: Waiting up to 1m0s for all nodes to be ready
+Apr 27 14:46:38.665: INFO: Waiting for terminating namespaces to be deleted...
+Apr 27 14:46:38.670: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Apr 27 14:46:38.681: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Apr 27 14:46:38.681: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Apr 27 14:46:38.685: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Apr 27 14:46:38.685: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q before test
+Apr 27 14:46:38.697: INFO: calico-node-btd85 from kube-system started at 2018-04-24 07:26:16 +0000 UTC (2 container statuses recorded)
+Apr 27 14:46:38.697: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:46:38.697: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:46:38.697: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-59bf6f4f4c-lp7s2 from kube-system started at 2018-04-24 07:27:14 +0000 UTC (1 container statuses recorded)
+Apr 27 14:46:38.697: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Apr 27 14:46:38.697: INFO: addons-heapster-e3b0c-5c98c994fc-twn65 from kube-system started at 2018-04-24 07:27:15 +0000 UTC (2 container statuses recorded)
+Apr 27 14:46:38.697: INFO: 	Container heapster ready: true, restart count 0
+Apr 27 14:46:38.697: INFO: 	Container heapster-nanny ready: true, restart count 0
+Apr 27 14:46:38.697: INFO: sonobuoy from sonobuoy started at 2018-04-27 14:06:21 +0000 UTC (1 container statuses recorded)
+Apr 27 14:46:38.698: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Apr 27 14:46:38.698: INFO: kube-proxy-2cncd from kube-system started at 2018-04-24 07:26:16 +0000 UTC (1 container statuses recorded)
+Apr 27 14:46:38.698: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:46:38.698: INFO: sonobuoy-e2e-job-056f42649bc7442c from sonobuoy started at 2018-04-27 14:06:22 +0000 UTC (2 container statuses recorded)
+Apr 27 14:46:38.698: INFO: 	Container e2e ready: true, restart count 0
+Apr 27 14:46:38.698: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Apr 27 14:46:38.698: INFO: node-exporter-rl8xl from kube-system started at 2018-04-24 07:26:16 +0000 UTC (1 container statuses recorded)
+Apr 27 14:46:38.698: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:46:38.698: INFO: kube-dns-67b49bdfd8-s6hbn from kube-system started at 2018-04-24 07:27:16 +0000 UTC (3 container statuses recorded)
+Apr 27 14:46:38.698: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:46:38.698: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:46:38.698: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:46:38.698: INFO: 
+Logging pods the kubelet thinks is on node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz before test
+Apr 27 14:46:38.707: INFO: addons-nginx-ingress-controller-7c8749685-4dfgp from kube-system started at 2018-04-24 07:27:15 +0000 UTC (1 container statuses recorded)
+Apr 27 14:46:38.707: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Apr 27 14:46:38.707: INFO: addons-kubernetes-dashboard-8478f49fbf-vgqts from kube-system started at 2018-04-24 07:27:16 +0000 UTC (1 container statuses recorded)
+Apr 27 14:46:38.707: INFO: 	Container main ready: true, restart count 0
+Apr 27 14:46:38.707: INFO: kube-dns-67b49bdfd8-hgkxt from kube-system started at 2018-04-24 07:27:24 +0000 UTC (3 container statuses recorded)
+Apr 27 14:46:38.707: INFO: 	Container dnsmasq ready: true, restart count 0
+Apr 27 14:46:38.707: INFO: 	Container kubedns ready: true, restart count 0
+Apr 27 14:46:38.707: INFO: 	Container sidecar ready: true, restart count 0
+Apr 27 14:46:38.707: INFO: calico-node-bcjtk from kube-system started at 2018-04-24 07:26:14 +0000 UTC (2 container statuses recorded)
+Apr 27 14:46:38.707: INFO: 	Container calico-node ready: true, restart count 0
+Apr 27 14:46:38.707: INFO: 	Container install-cni ready: true, restart count 0
+Apr 27 14:46:38.707: INFO: kube-dns-autoscaler-699b4b55c4-t7jll from kube-system started at 2018-04-24 07:27:16 +0000 UTC (1 container statuses recorded)
+Apr 27 14:46:38.707: INFO: 	Container autoscaler ready: true, restart count 0
+Apr 27 14:46:38.707: INFO: kube-proxy-sgq59 from kube-system started at 2018-04-24 07:26:14 +0000 UTC (1 container statuses recorded)
+Apr 27 14:46:38.707: INFO: 	Container kube-proxy ready: true, restart count 0
+Apr 27 14:46:38.707: INFO: node-exporter-mvvzs from kube-system started at 2018-04-24 07:26:14 +0000 UTC (1 container statuses recorded)
+Apr 27 14:46:38.707: INFO: 	Container node-exporter ready: true, restart count 0
+Apr 27 14:46:38.707: INFO: vpn-shoot-b6ddb5857-vjqnr from kube-system started at 2018-04-24 07:27:13 +0000 UTC (1 container statuses recorded)
+Apr 27 14:46:38.707: INFO: 	Container vpn-shoot ready: true, restart count 1
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-cbc0aa08-4a29-11e8-87ef-0ee10445d8a2 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-cbc0aa08-4a29-11e8-87ef-0ee10445d8a2 off the node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-cbc0aa08-4a29-11e8-87ef-0ee10445d8a2
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:46:42.767: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-p2tw9" for this suite.
+Apr 27 14:47:04.780: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:04.886: INFO: namespace: e2e-tests-sched-pred-p2tw9, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:04.920: INFO: namespace e2e-tests-sched-pred-p2tw9 deletion completed in 22.148871354s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:86.359 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:04.921: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-da39529a-4a29-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:47:05.029: INFO: Waiting up to 5m0s for pod "pod-secrets-da39ea9b-4a29-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-secrets-j7lvl" to be "success or failure"
+Apr 27 14:47:05.033: INFO: Pod "pod-secrets-da39ea9b-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.420242ms
+Apr 27 14:47:07.036: INFO: Pod "pod-secrets-da39ea9b-4a29-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006942535s
+STEP: Saw pod success
+Apr 27 14:47:07.037: INFO: Pod "pod-secrets-da39ea9b-4a29-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:47:07.039: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-secrets-da39ea9b-4a29-11e8-87ef-0ee10445d8a2 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:47:07.053: INFO: Waiting for pod pod-secrets-da39ea9b-4a29-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:47:07.056: INFO: Pod pod-secrets-da39ea9b-4a29-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:07.056: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-j7lvl" for this suite.
+Apr 27 14:47:13.068: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:13.144: INFO: namespace: e2e-tests-secrets-j7lvl, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:13.205: INFO: namespace e2e-tests-secrets-j7lvl deletion completed in 6.145990531s
+
+• [SLOW TEST:8.284 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:13.206: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-map-df28a989-4a29-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:47:13.303: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-df29d2e4-4a29-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-scbk9" to be "success or failure"
+Apr 27 14:47:13.306: INFO: Pod "pod-projected-secrets-df29d2e4-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.853894ms
+Apr 27 14:47:15.311: INFO: Pod "pod-projected-secrets-df29d2e4-4a29-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007849692s
+STEP: Saw pod success
+Apr 27 14:47:15.311: INFO: Pod "pod-projected-secrets-df29d2e4-4a29-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:47:15.313: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-secrets-df29d2e4-4a29-11e8-87ef-0ee10445d8a2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:47:15.332: INFO: Waiting for pod pod-projected-secrets-df29d2e4-4a29-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:47:15.335: INFO: Pod pod-projected-secrets-df29d2e4-4a29-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:15.335: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-scbk9" for this suite.
+Apr 27 14:47:21.348: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:21.409: INFO: namespace: e2e-tests-projected-scbk9, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:21.473: INFO: namespace e2e-tests-projected-scbk9 deletion completed in 6.133821352s
+
+• [SLOW TEST:8.266 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:21.473: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-e415ac90-4a29-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:47:21.562: INFO: Waiting up to 5m0s for pod "pod-secrets-e4162a63-4a29-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-secrets-rjc5b" to be "success or failure"
+Apr 27 14:47:21.564: INFO: Pod "pod-secrets-e4162a63-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.268348ms
+Apr 27 14:47:23.569: INFO: Pod "pod-secrets-e4162a63-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00696959s
+Apr 27 14:47:25.573: INFO: Pod "pod-secrets-e4162a63-4a29-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010508993s
+STEP: Saw pod success
+Apr 27 14:47:25.573: INFO: Pod "pod-secrets-e4162a63-4a29-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:47:25.575: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-secrets-e4162a63-4a29-11e8-87ef-0ee10445d8a2 container secret-env-test: <nil>
+STEP: delete the pod
+Apr 27 14:47:25.591: INFO: Waiting for pod pod-secrets-e4162a63-4a29-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:47:25.594: INFO: Pod pod-secrets-e4162a63-4a29-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:25.594: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-rjc5b" for this suite.
+Apr 27 14:47:31.607: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:31.707: INFO: namespace: e2e-tests-secrets-rjc5b, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:31.729: INFO: namespace e2e-tests-secrets-rjc5b deletion completed in 6.13119312s
+
+• [SLOW TEST:10.256 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:31.729: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-ea3296bf-4a29-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:47:31.817: INFO: Waiting up to 5m0s for pod "pod-configmaps-ea32f9b2-4a29-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-configmap-9qfwh" to be "success or failure"
+Apr 27 14:47:31.819: INFO: Pod "pod-configmaps-ea32f9b2-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.446866ms
+Apr 27 14:47:33.823: INFO: Pod "pod-configmaps-ea32f9b2-4a29-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00667857s
+STEP: Saw pod success
+Apr 27 14:47:33.823: INFO: Pod "pod-configmaps-ea32f9b2-4a29-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:47:33.826: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-configmaps-ea32f9b2-4a29-11e8-87ef-0ee10445d8a2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:47:33.841: INFO: Waiting for pod pod-configmaps-ea32f9b2-4a29-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:47:33.844: INFO: Pod pod-configmaps-ea32f9b2-4a29-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:33.844: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-9qfwh" for this suite.
+Apr 27 14:47:39.861: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:39.972: INFO: namespace: e2e-tests-configmap-9qfwh, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:39.984: INFO: namespace e2e-tests-configmap-9qfwh deletion completed in 6.136597899s
+
+• [SLOW TEST:8.255 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:39.985: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:47:40.069: INFO: Waiting up to 5m0s for pod "downwardapi-volume-ef1e1666-4a29-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-qll42" to be "success or failure"
+Apr 27 14:47:40.071: INFO: Pod "downwardapi-volume-ef1e1666-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.367777ms
+Apr 27 14:47:42.077: INFO: Pod "downwardapi-volume-ef1e1666-4a29-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007613181s
+STEP: Saw pod success
+Apr 27 14:47:42.077: INFO: Pod "downwardapi-volume-ef1e1666-4a29-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:47:42.079: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-ef1e1666-4a29-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:47:42.096: INFO: Waiting for pod downwardapi-volume-ef1e1666-4a29-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:47:42.098: INFO: Pod downwardapi-volume-ef1e1666-4a29-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:42.098: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-qll42" for this suite.
+Apr 27 14:47:48.112: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:48.204: INFO: namespace: e2e-tests-downward-api-qll42, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:48.237: INFO: namespace e2e-tests-downward-api-qll42 deletion completed in 6.135299727s
+
+• [SLOW TEST:8.253 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:48.238: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:47:48.328: INFO: Waiting up to 5m0s for pod "downwardapi-volume-f40a5640-4a29-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-jlrks" to be "success or failure"
+Apr 27 14:47:48.330: INFO: Pod "downwardapi-volume-f40a5640-4a29-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.216466ms
+Apr 27 14:47:50.335: INFO: Pod "downwardapi-volume-f40a5640-4a29-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006598349s
+STEP: Saw pod success
+Apr 27 14:47:50.335: INFO: Pod "downwardapi-volume-f40a5640-4a29-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:47:50.338: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-f40a5640-4a29-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:47:50.353: INFO: Waiting for pod downwardapi-volume-f40a5640-4a29-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:47:50.356: INFO: Pod downwardapi-volume-f40a5640-4a29-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:50.356: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-jlrks" for this suite.
+Apr 27 14:47:56.374: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:47:56.496: INFO: namespace: e2e-tests-downward-api-jlrks, resource: bindings, ignored listing per whitelist
+Apr 27 14:47:56.496: INFO: namespace e2e-tests-downward-api-jlrks deletion completed in 6.134437612s
+
+• [SLOW TEST:8.258 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:47:56.496: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: getting the auto-created API token
+Apr 27 14:47:57.097: INFO: created pod pod-service-account-defaultsa
+Apr 27 14:47:57.097: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Apr 27 14:47:57.102: INFO: created pod pod-service-account-mountsa
+Apr 27 14:47:57.102: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Apr 27 14:47:57.106: INFO: created pod pod-service-account-nomountsa
+Apr 27 14:47:57.106: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Apr 27 14:47:57.110: INFO: created pod pod-service-account-defaultsa-mountspec
+Apr 27 14:47:57.110: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Apr 27 14:47:57.125: INFO: created pod pod-service-account-mountsa-mountspec
+Apr 27 14:47:57.125: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Apr 27 14:47:57.129: INFO: created pod pod-service-account-nomountsa-mountspec
+Apr 27 14:47:57.129: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Apr 27 14:47:57.132: INFO: created pod pod-service-account-defaultsa-nomountspec
+Apr 27 14:47:57.132: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Apr 27 14:47:57.137: INFO: created pod pod-service-account-mountsa-nomountspec
+Apr 27 14:47:57.137: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Apr 27 14:47:57.149: INFO: created pod pod-service-account-nomountsa-nomountspec
+Apr 27 14:47:57.149: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:47:57.149: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-bwpjw" for this suite.
+Apr 27 14:48:03.165: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:48:03.206: INFO: namespace: e2e-tests-svcaccounts-bwpjw, resource: bindings, ignored listing per whitelist
+Apr 27 14:48:03.288: INFO: namespace e2e-tests-svcaccounts-bwpjw deletion completed in 6.133960514s
+
+• [SLOW TEST:6.792 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:48:03.289: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the pods
+STEP: Gathering metrics
+W0427 14:48:43.416508      15 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:48:43.416: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:48:43.416: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-pt2c4" for this suite.
+Apr 27 14:48:49.429: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:48:49.490: INFO: namespace: e2e-tests-gc-pt2c4, resource: bindings, ignored listing per whitelist
+Apr 27 14:48:49.553: INFO: namespace e2e-tests-gc-pt2c4 deletion completed in 6.133953602s
+
+• [SLOW TEST:46.265 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:48:49.554: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-xcpzh
+Apr 27 14:48:53.650: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-xcpzh
+STEP: checking the pod's current state and verifying that restartCount is present
+Apr 27 14:48:53.653: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:50:53.888: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-xcpzh" for this suite.
+Apr 27 14:50:59.901: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:50:59.971: INFO: namespace: e2e-tests-container-probe-xcpzh, resource: bindings, ignored listing per whitelist
+Apr 27 14:51:00.042: INFO: namespace e2e-tests-container-probe-xcpzh deletion completed in 6.149282797s
+
+• [SLOW TEST:130.488 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:51:00.043: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:52:00.142: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-6vx92" for this suite.
+Apr 27 14:52:22.154: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:52:22.208: INFO: namespace: e2e-tests-container-probe-6vx92, resource: bindings, ignored listing per whitelist
+Apr 27 14:52:22.275: INFO: namespace e2e-tests-container-probe-6vx92 deletion completed in 22.130188262s
+
+• [SLOW TEST:82.232 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:52:22.277: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:52:22.375: INFO: Creating simple daemon set daemon-set
+STEP: Check that daemon pods launch on every node of the cluster.
+Apr 27 14:52:22.383: INFO: Number of nodes with available pods: 0
+Apr 27 14:52:22.383: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:52:23.391: INFO: Number of nodes with available pods: 0
+Apr 27 14:52:23.391: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:52:24.390: INFO: Number of nodes with available pods: 2
+Apr 27 14:52:24.390: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Update daemon pods image.
+STEP: Check that daemon pods images are updated.
+Apr 27 14:52:24.409: INFO: Wrong image for pod: daemon-set-lss9c. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:24.409: INFO: Wrong image for pod: daemon-set-tnvv4. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:25.416: INFO: Wrong image for pod: daemon-set-lss9c. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:25.416: INFO: Wrong image for pod: daemon-set-tnvv4. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:26.416: INFO: Wrong image for pod: daemon-set-lss9c. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:26.416: INFO: Wrong image for pod: daemon-set-tnvv4. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:26.417: INFO: Pod daemon-set-tnvv4 is not available
+Apr 27 14:52:27.416: INFO: Wrong image for pod: daemon-set-lss9c. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:27.416: INFO: Wrong image for pod: daemon-set-tnvv4. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:27.416: INFO: Pod daemon-set-tnvv4 is not available
+Apr 27 14:52:28.416: INFO: Wrong image for pod: daemon-set-lss9c. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:28.416: INFO: Wrong image for pod: daemon-set-tnvv4. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:28.416: INFO: Pod daemon-set-tnvv4 is not available
+Apr 27 14:52:29.416: INFO: Wrong image for pod: daemon-set-lss9c. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:29.416: INFO: Wrong image for pod: daemon-set-tnvv4. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:29.416: INFO: Pod daemon-set-tnvv4 is not available
+Apr 27 14:52:30.417: INFO: Wrong image for pod: daemon-set-lss9c. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:30.417: INFO: Wrong image for pod: daemon-set-tnvv4. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:30.417: INFO: Pod daemon-set-tnvv4 is not available
+Apr 27 14:52:31.416: INFO: Wrong image for pod: daemon-set-lss9c. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:31.416: INFO: Wrong image for pod: daemon-set-tnvv4. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:31.416: INFO: Pod daemon-set-tnvv4 is not available
+Apr 27 14:52:32.416: INFO: Wrong image for pod: daemon-set-lss9c. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:32.416: INFO: Pod daemon-set-wc9vl is not available
+Apr 27 14:52:33.416: INFO: Wrong image for pod: daemon-set-lss9c. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:34.416: INFO: Wrong image for pod: daemon-set-lss9c. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:35.416: INFO: Wrong image for pod: daemon-set-lss9c. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Apr 27 14:52:35.416: INFO: Pod daemon-set-lss9c is not available
+Apr 27 14:52:36.419: INFO: Pod daemon-set-bx24f is not available
+STEP: Check that daemon pods are still running on every node of the cluster.
+Apr 27 14:52:36.431: INFO: Number of nodes with available pods: 1
+Apr 27 14:52:36.431: INFO: Node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-8q99q is running more than one daemon pod
+Apr 27 14:52:37.440: INFO: Number of nodes with available pods: 2
+Apr 27 14:52:37.440: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Apr 27 14:52:43.473: INFO: Number of nodes with available pods: 0
+Apr 27 14:52:43.473: INFO: Number of running nodes: 0, number of available pods: 0
+Apr 27 14:52:43.476: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-w8vbg/daemonsets","resourceVersion":"396872"},"items":null}
+
+Apr 27 14:52:43.479: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-w8vbg/pods","resourceVersion":"396872"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:52:43.488: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-w8vbg" for this suite.
+Apr 27 14:52:49.509: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:52:49.552: INFO: namespace: e2e-tests-daemonsets-w8vbg, resource: bindings, ignored listing per whitelist
+Apr 27 14:52:49.635: INFO: namespace e2e-tests-daemonsets-w8vbg deletion completed in 6.13961806s
+
+• [SLOW TEST:27.358 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:52:49.636: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Apr 27 14:52:49.724: INFO: Waiting up to 5m0s for pod "pod-a7afbf02-4a2a-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-dzh64" to be "success or failure"
+Apr 27 14:52:49.727: INFO: Pod "pod-a7afbf02-4a2a-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.831641ms
+Apr 27 14:52:51.730: INFO: Pod "pod-a7afbf02-4a2a-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00584895s
+STEP: Saw pod success
+Apr 27 14:52:51.730: INFO: Pod "pod-a7afbf02-4a2a-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:52:51.732: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-a7afbf02-4a2a-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:52:51.749: INFO: Waiting for pod pod-a7afbf02-4a2a-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:52:51.752: INFO: Pod pod-a7afbf02-4a2a-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:52:51.752: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-dzh64" for this suite.
+Apr 27 14:52:57.765: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:52:57.814: INFO: namespace: e2e-tests-emptydir-dzh64, resource: bindings, ignored listing per whitelist
+Apr 27 14:52:57.889: INFO: namespace e2e-tests-emptydir-dzh64 deletion completed in 6.13302108s
+
+• [SLOW TEST:8.253 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:52:57.889: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for all pods to be garbage collected
+STEP: Gathering metrics
+W0427 14:53:07.997670      15 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:53:07.997: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:53:07.997: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-k4gnj" for this suite.
+Apr 27 14:53:14.012: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:53:14.141: INFO: namespace: e2e-tests-gc-k4gnj, resource: bindings, ignored listing per whitelist
+Apr 27 14:53:14.142: INFO: namespace e2e-tests-gc-k4gnj deletion completed in 6.141218766s
+
+• [SLOW TEST:16.253 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:53:14.142: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for all rs to be garbage collected
+STEP: expected 0 rs, got 1 rs
+STEP: expected 0 Pods, got 2 Pods
+STEP: Gathering metrics
+W0427 14:53:15.258998      15 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 14:53:15.259: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:53:15.259: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-55rtc" for this suite.
+Apr 27 14:53:21.271: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:53:21.373: INFO: namespace: e2e-tests-gc-55rtc, resource: bindings, ignored listing per whitelist
+Apr 27 14:53:21.398: INFO: namespace e2e-tests-gc-55rtc deletion completed in 6.135706337s
+
+• [SLOW TEST:7.256 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:53:21.398: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-ba9c9d92-4a2a-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:53:21.478: INFO: Waiting up to 5m0s for pod "pod-secrets-ba9d10aa-4a2a-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-secrets-9nt8q" to be "success or failure"
+Apr 27 14:53:21.480: INFO: Pod "pod-secrets-ba9d10aa-4a2a-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 1.815283ms
+Apr 27 14:53:23.484: INFO: Pod "pod-secrets-ba9d10aa-4a2a-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005467722s
+STEP: Saw pod success
+Apr 27 14:53:23.484: INFO: Pod "pod-secrets-ba9d10aa-4a2a-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:53:23.486: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-secrets-ba9d10aa-4a2a-11e8-87ef-0ee10445d8a2 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:53:23.503: INFO: Waiting for pod pod-secrets-ba9d10aa-4a2a-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:53:23.506: INFO: Pod pod-secrets-ba9d10aa-4a2a-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:53:23.506: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-9nt8q" for this suite.
+Apr 27 14:53:29.525: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:53:29.576: INFO: namespace: e2e-tests-secrets-9nt8q, resource: bindings, ignored listing per whitelist
+Apr 27 14:53:29.650: INFO: namespace e2e-tests-secrets-9nt8q deletion completed in 6.140778253s
+
+• [SLOW TEST:8.252 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:53:29.651: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating server pod server in namespace e2e-tests-prestop-5jpnq
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-5jpnq
+STEP: Deleting pre-stop pod
+Apr 27 14:53:40.809: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:53:40.813: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-5jpnq" for this suite.
+Apr 27 14:54:18.825: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:54:18.922: INFO: namespace: e2e-tests-prestop-5jpnq, resource: bindings, ignored listing per whitelist
+Apr 27 14:54:18.950: INFO: namespace e2e-tests-prestop-5jpnq deletion completed in 38.133382637s
+
+• [SLOW TEST:49.299 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:54:18.950: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-dceb776a-4a2a-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:54:19.038: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-dcebee68-4a2a-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-lzbkn" to be "success or failure"
+Apr 27 14:54:19.040: INFO: Pod "pod-projected-configmaps-dcebee68-4a2a-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.749781ms
+Apr 27 14:54:21.044: INFO: Pod "pod-projected-configmaps-dcebee68-4a2a-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005994553s
+STEP: Saw pod success
+Apr 27 14:54:21.044: INFO: Pod "pod-projected-configmaps-dcebee68-4a2a-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:54:21.046: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-configmaps-dcebee68-4a2a-11e8-87ef-0ee10445d8a2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:54:21.061: INFO: Waiting for pod pod-projected-configmaps-dcebee68-4a2a-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:54:21.064: INFO: Pod pod-projected-configmaps-dcebee68-4a2a-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:54:21.064: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lzbkn" for this suite.
+Apr 27 14:54:27.079: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:54:27.199: INFO: namespace: e2e-tests-projected-lzbkn, resource: bindings, ignored listing per whitelist
+Apr 27 14:54:27.201: INFO: namespace e2e-tests-projected-lzbkn deletion completed in 6.133411067s
+
+• [SLOW TEST:8.251 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:54:27.202: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Apr 27 14:54:27.292: INFO: Waiting up to 5m0s for pod "pod-e1d746a6-4a2a-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-7x6ts" to be "success or failure"
+Apr 27 14:54:27.297: INFO: Pod "pod-e1d746a6-4a2a-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 5.489367ms
+Apr 27 14:54:29.301: INFO: Pod "pod-e1d746a6-4a2a-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00958316s
+STEP: Saw pod success
+Apr 27 14:54:29.301: INFO: Pod "pod-e1d746a6-4a2a-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:54:29.304: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-e1d746a6-4a2a-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:54:29.326: INFO: Waiting for pod pod-e1d746a6-4a2a-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:54:29.329: INFO: Pod pod-e1d746a6-4a2a-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:54:29.329: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-7x6ts" for this suite.
+Apr 27 14:54:35.343: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:54:35.420: INFO: namespace: e2e-tests-emptydir-7x6ts, resource: bindings, ignored listing per whitelist
+Apr 27 14:54:35.475: INFO: namespace e2e-tests-emptydir-7x6ts deletion completed in 6.14251762s
+
+• [SLOW TEST:8.273 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:54:35.475: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Apr 27 14:54:35.565: INFO: Waiting up to 5m0s for pod "pod-e6c5c43a-4a2a-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-62vth" to be "success or failure"
+Apr 27 14:54:35.568: INFO: Pod "pod-e6c5c43a-4a2a-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.391153ms
+Apr 27 14:54:37.571: INFO: Pod "pod-e6c5c43a-4a2a-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006090426s
+STEP: Saw pod success
+Apr 27 14:54:37.571: INFO: Pod "pod-e6c5c43a-4a2a-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:54:37.574: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-e6c5c43a-4a2a-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:54:37.589: INFO: Waiting for pod pod-e6c5c43a-4a2a-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:54:37.592: INFO: Pod pod-e6c5c43a-4a2a-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:54:37.592: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-62vth" for this suite.
+Apr 27 14:54:43.607: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:54:43.724: INFO: namespace: e2e-tests-emptydir-62vth, resource: bindings, ignored listing per whitelist
+Apr 27 14:54:43.729: INFO: namespace e2e-tests-emptydir-62vth deletion completed in 6.132437728s
+
+• [SLOW TEST:8.253 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:54:43.729: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:54:43.802: INFO: Creating ReplicaSet my-hostname-basic-ebaf6497-4a2a-11e8-87ef-0ee10445d8a2
+Apr 27 14:54:43.808: INFO: Pod name my-hostname-basic-ebaf6497-4a2a-11e8-87ef-0ee10445d8a2: Found 0 pods out of 1
+Apr 27 14:54:48.812: INFO: Pod name my-hostname-basic-ebaf6497-4a2a-11e8-87ef-0ee10445d8a2: Found 1 pods out of 1
+Apr 27 14:54:48.812: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-ebaf6497-4a2a-11e8-87ef-0ee10445d8a2" is running
+Apr 27 14:54:48.814: INFO: Pod "my-hostname-basic-ebaf6497-4a2a-11e8-87ef-0ee10445d8a2-ktkth" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:54:43 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:54:45 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-04-27 14:54:43 +0000 UTC Reason: Message:}])
+Apr 27 14:54:48.814: INFO: Trying to dial the pod
+Apr 27 14:54:53.865: INFO: Controller my-hostname-basic-ebaf6497-4a2a-11e8-87ef-0ee10445d8a2: Got expected result from replica 1 [my-hostname-basic-ebaf6497-4a2a-11e8-87ef-0ee10445d8a2-ktkth]: "my-hostname-basic-ebaf6497-4a2a-11e8-87ef-0ee10445d8a2-ktkth", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:54:53.866: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-fkfpz" for this suite.
+Apr 27 14:54:59.880: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:54:59.975: INFO: namespace: e2e-tests-replicaset-fkfpz, resource: bindings, ignored listing per whitelist
+Apr 27 14:55:00.005: INFO: namespace e2e-tests-replicaset-fkfpz deletion completed in 6.136181979s
+
+• [SLOW TEST:16.277 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:55:00.006: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-f5666ffa-4a2a-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:55:00.112: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-f567253a-4a2a-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-gtrtr" to be "success or failure"
+Apr 27 14:55:00.115: INFO: Pod "pod-projected-configmaps-f567253a-4a2a-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.388873ms
+Apr 27 14:55:02.119: INFO: Pod "pod-projected-configmaps-f567253a-4a2a-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006975668s
+STEP: Saw pod success
+Apr 27 14:55:02.119: INFO: Pod "pod-projected-configmaps-f567253a-4a2a-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:55:02.122: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-configmaps-f567253a-4a2a-11e8-87ef-0ee10445d8a2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:55:02.143: INFO: Waiting for pod pod-projected-configmaps-f567253a-4a2a-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:55:02.146: INFO: Pod pod-projected-configmaps-f567253a-4a2a-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:55:02.146: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-gtrtr" for this suite.
+Apr 27 14:55:08.161: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:55:08.281: INFO: namespace: e2e-tests-projected-gtrtr, resource: bindings, ignored listing per whitelist
+Apr 27 14:55:08.295: INFO: namespace e2e-tests-projected-gtrtr deletion completed in 6.143972558s
+
+• [SLOW TEST:8.289 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:55:08.295: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 14:55:08.381: INFO: Waiting up to 5m0s for pod "downward-api-fa552044-4a2a-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-cm8r5" to be "success or failure"
+Apr 27 14:55:08.385: INFO: Pod "downward-api-fa552044-4a2a-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.435188ms
+Apr 27 14:55:10.389: INFO: Pod "downward-api-fa552044-4a2a-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007282535s
+Apr 27 14:55:12.393: INFO: Pod "downward-api-fa552044-4a2a-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011132519s
+STEP: Saw pod success
+Apr 27 14:55:12.393: INFO: Pod "downward-api-fa552044-4a2a-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:55:12.395: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downward-api-fa552044-4a2a-11e8-87ef-0ee10445d8a2 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:55:12.420: INFO: Waiting for pod downward-api-fa552044-4a2a-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:55:12.423: INFO: Pod downward-api-fa552044-4a2a-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:55:12.423: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-cm8r5" for this suite.
+Apr 27 14:55:18.436: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:55:18.526: INFO: namespace: e2e-tests-downward-api-cm8r5, resource: bindings, ignored listing per whitelist
+Apr 27 14:55:18.564: INFO: namespace e2e-tests-downward-api-cm8r5 deletion completed in 6.137678101s
+
+• [SLOW TEST:10.269 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:55:18.565: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-5gfq6.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-5gfq6.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-5gfq6.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-5gfq6.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-5gfq6.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-5gfq6.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Apr 27 14:55:31.565: INFO: DNS probes using dns-test-00748b39-4a2b-11e8-87ef-0ee10445d8a2 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:55:31.573: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-5gfq6" for this suite.
+Apr 27 14:55:37.585: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:55:37.665: INFO: namespace: e2e-tests-dns-5gfq6, resource: bindings, ignored listing per whitelist
+Apr 27 14:55:37.711: INFO: namespace e2e-tests-dns-5gfq6 deletion completed in 6.134449588s
+
+• [SLOW TEST:19.146 seconds]
+[sig-network] DNS
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:55:37.711: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-0bdeeaf9-4a2b-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:55:37.809: INFO: Waiting up to 5m0s for pod "pod-secrets-0bdf6ce5-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-secrets-jrb22" to be "success or failure"
+Apr 27 14:55:37.814: INFO: Pod "pod-secrets-0bdf6ce5-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.778277ms
+Apr 27 14:55:39.818: INFO: Pod "pod-secrets-0bdf6ce5-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008259168s
+STEP: Saw pod success
+Apr 27 14:55:39.818: INFO: Pod "pod-secrets-0bdf6ce5-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:55:39.820: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-secrets-0bdf6ce5-4a2b-11e8-87ef-0ee10445d8a2 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:55:39.838: INFO: Waiting for pod pod-secrets-0bdf6ce5-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:55:39.840: INFO: Pod pod-secrets-0bdf6ce5-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:55:39.840: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-jrb22" for this suite.
+Apr 27 14:55:45.855: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:55:45.928: INFO: namespace: e2e-tests-secrets-jrb22, resource: bindings, ignored listing per whitelist
+Apr 27 14:55:45.977: INFO: namespace e2e-tests-secrets-jrb22 deletion completed in 6.133360578s
+
+• [SLOW TEST:8.266 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:55:45.978: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Apr 27 14:55:46.075: INFO: Waiting up to 5m0s for pod "pod-10cccc95-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-lnk9p" to be "success or failure"
+Apr 27 14:55:46.078: INFO: Pod "pod-10cccc95-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.74514ms
+Apr 27 14:55:48.082: INFO: Pod "pod-10cccc95-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006974258s
+STEP: Saw pod success
+Apr 27 14:55:48.082: INFO: Pod "pod-10cccc95-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:55:48.084: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-10cccc95-4a2b-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:55:48.099: INFO: Waiting for pod pod-10cccc95-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:55:48.102: INFO: Pod pod-10cccc95-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:55:48.102: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-lnk9p" for this suite.
+Apr 27 14:55:54.115: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:55:54.189: INFO: namespace: e2e-tests-emptydir-lnk9p, resource: bindings, ignored listing per whitelist
+Apr 27 14:55:54.247: INFO: namespace e2e-tests-emptydir-lnk9p deletion completed in 6.140471072s
+
+• [SLOW TEST:8.269 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:55:54.247: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-lr6wd
+[It] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Initializing watcher for selector baz=blah,foo=bar
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-lr6wd
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-lr6wd
+Apr 27 14:55:54.350: INFO: Found 0 stateful pods, waiting for 1
+Apr 27 14:56:04.357: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will halt with unhealthy stateful pod
+Apr 27 14:56:04.359: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-lr6wd ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:56:04.667: INFO: stderr: ""
+Apr 27 14:56:04.667: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:56:04.671: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Apr 27 14:56:14.675: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:56:14.675: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:56:14.686: INFO: Verifying statefulset ss doesn't scale past 1 for another 9.999999779s
+Apr 27 14:56:15.691: INFO: Verifying statefulset ss doesn't scale past 1 for another 8.997392639s
+Apr 27 14:56:16.695: INFO: Verifying statefulset ss doesn't scale past 1 for another 7.992367277s
+Apr 27 14:56:17.698: INFO: Verifying statefulset ss doesn't scale past 1 for another 6.98865583s
+Apr 27 14:56:18.703: INFO: Verifying statefulset ss doesn't scale past 1 for another 5.984925586s
+Apr 27 14:56:19.708: INFO: Verifying statefulset ss doesn't scale past 1 for another 4.980367163s
+Apr 27 14:56:20.712: INFO: Verifying statefulset ss doesn't scale past 1 for another 3.975523892s
+Apr 27 14:56:21.716: INFO: Verifying statefulset ss doesn't scale past 1 for another 2.971388733s
+Apr 27 14:56:22.720: INFO: Verifying statefulset ss doesn't scale past 1 for another 1.967039515s
+Apr 27 14:56:23.725: INFO: Verifying statefulset ss doesn't scale past 1 for another 962.824343ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-lr6wd
+Apr 27 14:56:24.730: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-lr6wd ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:56:28.172: INFO: stderr: ""
+Apr 27 14:56:28.172: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:56:28.176: INFO: Found 1 stateful pods, waiting for 3
+Apr 27 14:56:38.180: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:56:38.180: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 14:56:38.180: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Verifying that stateful set ss was scaled up in order
+STEP: Scale down will halt with unhealthy stateful pod
+Apr 27 14:56:38.185: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-lr6wd ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:56:38.491: INFO: stderr: ""
+Apr 27 14:56:38.491: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:56:38.491: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-lr6wd ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:56:38.895: INFO: stderr: ""
+Apr 27 14:56:38.895: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:56:38.895: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-lr6wd ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Apr 27 14:56:39.280: INFO: stderr: ""
+Apr 27 14:56:39.280: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Apr 27 14:56:39.280: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:56:39.283: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 2
+Apr 27 14:56:49.291: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:56:49.291: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:56:49.291: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Apr 27 14:56:49.299: INFO: Verifying statefulset ss doesn't scale past 3 for another 9.999999789s
+Apr 27 14:56:50.305: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.997125525s
+Apr 27 14:56:51.311: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.990844749s
+Apr 27 14:56:52.319: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.984932856s
+Apr 27 14:56:53.323: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.977723403s
+Apr 27 14:56:54.327: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.973600609s
+Apr 27 14:56:55.331: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.969302512s
+Apr 27 14:56:56.335: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.965285373s
+Apr 27 14:56:57.341: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.960898422s
+Apr 27 14:56:58.346: INFO: Verifying statefulset ss doesn't scale past 3 for another 955.417572ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-lr6wd
+Apr 27 14:56:59.350: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-lr6wd ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:56:59.601: INFO: stderr: ""
+Apr 27 14:56:59.601: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:56:59.601: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-lr6wd ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:56:59.872: INFO: stderr: ""
+Apr 27 14:56:59.872: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:56:59.872: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-187724608 exec --namespace=e2e-tests-statefulset-lr6wd ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Apr 27 14:57:00.184: INFO: stderr: ""
+Apr 27 14:57:00.184: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Apr 27 14:57:00.184: INFO: Scaling statefulset ss to 0
+STEP: Verifying that stateful set ss was scaled down in reverse order
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 14:57:20.198: INFO: Deleting all statefulset in ns e2e-tests-statefulset-lr6wd
+Apr 27 14:57:20.200: INFO: Scaling statefulset ss to 0
+Apr 27 14:57:20.208: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 14:57:20.210: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:57:20.219: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-lr6wd" for this suite.
+Apr 27 14:57:26.232: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:57:26.281: INFO: namespace: e2e-tests-statefulset-lr6wd, resource: bindings, ignored listing per whitelist
+Apr 27 14:57:26.364: INFO: namespace e2e-tests-statefulset-lr6wd deletion completed in 6.142395652s
+
+• [SLOW TEST:92.118 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:57:26.366: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-4ca298bd-4a2b-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:57:26.464: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-4ca30926-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-hzrxh" to be "success or failure"
+Apr 27 14:57:26.467: INFO: Pod "pod-projected-configmaps-4ca30926-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.744278ms
+Apr 27 14:57:28.471: INFO: Pod "pod-projected-configmaps-4ca30926-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006531037s
+STEP: Saw pod success
+Apr 27 14:57:28.471: INFO: Pod "pod-projected-configmaps-4ca30926-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:57:28.474: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-configmaps-4ca30926-4a2b-11e8-87ef-0ee10445d8a2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:57:28.491: INFO: Waiting for pod pod-projected-configmaps-4ca30926-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:57:28.494: INFO: Pod pod-projected-configmaps-4ca30926-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:57:28.494: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hzrxh" for this suite.
+Apr 27 14:57:34.507: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:57:34.574: INFO: namespace: e2e-tests-projected-hzrxh, resource: bindings, ignored listing per whitelist
+Apr 27 14:57:34.633: INFO: namespace e2e-tests-projected-hzrxh deletion completed in 6.135619302s
+
+• [SLOW TEST:8.267 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:57:34.633: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 14:57:34.715: INFO: Waiting up to 5m0s for pod "downwardapi-volume-518dcf6a-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-f42wg" to be "success or failure"
+Apr 27 14:57:34.717: INFO: Pod "downwardapi-volume-518dcf6a-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.77346ms
+Apr 27 14:57:36.721: INFO: Pod "downwardapi-volume-518dcf6a-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006669808s
+STEP: Saw pod success
+Apr 27 14:57:36.721: INFO: Pod "downwardapi-volume-518dcf6a-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:57:36.724: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-518dcf6a-4a2b-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 14:57:36.741: INFO: Waiting for pod downwardapi-volume-518dcf6a-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:57:36.743: INFO: Pod downwardapi-volume-518dcf6a-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:57:36.743: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-f42wg" for this suite.
+Apr 27 14:57:42.756: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:57:42.812: INFO: namespace: e2e-tests-projected-f42wg, resource: bindings, ignored listing per whitelist
+Apr 27 14:57:42.891: INFO: namespace e2e-tests-projected-f42wg deletion completed in 6.14451102s
+
+• [SLOW TEST:8.257 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:57:42.891: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 14:57:45.015: INFO: Waiting up to 5m0s for pod "client-envvars-57b038f1-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-pods-5hwj5" to be "success or failure"
+Apr 27 14:57:45.019: INFO: Pod "client-envvars-57b038f1-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.398044ms
+Apr 27 14:57:47.023: INFO: Pod "client-envvars-57b038f1-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00702035s
+Apr 27 14:57:49.027: INFO: Pod "client-envvars-57b038f1-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010804421s
+STEP: Saw pod success
+Apr 27 14:57:49.027: INFO: Pod "client-envvars-57b038f1-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:57:49.030: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod client-envvars-57b038f1-4a2b-11e8-87ef-0ee10445d8a2 container env3cont: <nil>
+STEP: delete the pod
+Apr 27 14:57:49.055: INFO: Waiting for pod client-envvars-57b038f1-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:57:49.058: INFO: Pod client-envvars-57b038f1-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:57:49.058: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-5hwj5" for this suite.
+Apr 27 14:58:11.072: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:58:11.126: INFO: namespace: e2e-tests-pods-5hwj5, resource: bindings, ignored listing per whitelist
+Apr 27 14:58:11.197: INFO: namespace e2e-tests-pods-5hwj5 deletion completed in 22.134062378s
+
+• [SLOW TEST:28.306 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:58:11.198: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-675a685f-4a2b-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 14:58:11.290: INFO: Waiting up to 5m0s for pod "pod-configmaps-675ad833-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-configmap-5wrq4" to be "success or failure"
+Apr 27 14:58:11.300: INFO: Pod "pod-configmaps-675ad833-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 10.013325ms
+Apr 27 14:58:13.304: INFO: Pod "pod-configmaps-675ad833-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.014472384s
+STEP: Saw pod success
+Apr 27 14:58:13.304: INFO: Pod "pod-configmaps-675ad833-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:58:13.309: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-configmaps-675ad833-4a2b-11e8-87ef-0ee10445d8a2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:58:13.885: INFO: Waiting for pod pod-configmaps-675ad833-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:58:13.887: INFO: Pod pod-configmaps-675ad833-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:58:13.887: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-5wrq4" for this suite.
+Apr 27 14:58:19.902: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:58:19.987: INFO: namespace: e2e-tests-configmap-5wrq4, resource: bindings, ignored listing per whitelist
+Apr 27 14:58:20.031: INFO: namespace e2e-tests-configmap-5wrq4 deletion completed in 6.139431537s
+
+• [SLOW TEST:8.833 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:58:20.031: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test substitution in container's command
+Apr 27 14:58:20.112: INFO: Waiting up to 5m0s for pod "var-expansion-6c9cf24c-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-var-expansion-s8mwd" to be "success or failure"
+Apr 27 14:58:20.115: INFO: Pod "var-expansion-6c9cf24c-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.690952ms
+Apr 27 14:58:22.119: INFO: Pod "var-expansion-6c9cf24c-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006731533s
+Apr 27 14:58:24.122: INFO: Pod "var-expansion-6c9cf24c-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010323813s
+STEP: Saw pod success
+Apr 27 14:58:24.122: INFO: Pod "var-expansion-6c9cf24c-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:58:24.125: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod var-expansion-6c9cf24c-4a2b-11e8-87ef-0ee10445d8a2 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:58:24.148: INFO: Waiting for pod var-expansion-6c9cf24c-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:58:24.150: INFO: Pod var-expansion-6c9cf24c-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:58:24.150: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-s8mwd" for this suite.
+Apr 27 14:58:30.165: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:58:30.256: INFO: namespace: e2e-tests-var-expansion-s8mwd, resource: bindings, ignored listing per whitelist
+Apr 27 14:58:30.295: INFO: namespace e2e-tests-var-expansion-s8mwd deletion completed in 6.140172203s
+
+• [SLOW TEST:10.264 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:58:30.296: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-72bd0507-4a2b-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:58:30.392: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-72bd8420-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-6jvkk" to be "success or failure"
+Apr 27 14:58:30.394: INFO: Pod "pod-projected-secrets-72bd8420-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.217878ms
+Apr 27 14:58:32.398: INFO: Pod "pod-projected-secrets-72bd8420-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006192189s
+STEP: Saw pod success
+Apr 27 14:58:32.398: INFO: Pod "pod-projected-secrets-72bd8420-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:58:32.401: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-secrets-72bd8420-4a2b-11e8-87ef-0ee10445d8a2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:58:32.415: INFO: Waiting for pod pod-projected-secrets-72bd8420-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:58:32.418: INFO: Pod pod-projected-secrets-72bd8420-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:58:32.418: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6jvkk" for this suite.
+Apr 27 14:58:38.430: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:58:38.526: INFO: namespace: e2e-tests-projected-6jvkk, resource: bindings, ignored listing per whitelist
+Apr 27 14:58:38.556: INFO: namespace e2e-tests-projected-6jvkk deletion completed in 6.134143494s
+
+• [SLOW TEST:8.260 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:58:38.556: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Apr 27 14:58:41.167: INFO: Successfully updated pod "annotationupdate77a850ab-4a2b-11e8-87ef-0ee10445d8a2"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:58:43.186: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-b9xj9" for this suite.
+Apr 27 14:59:05.200: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:59:05.318: INFO: namespace: e2e-tests-projected-b9xj9, resource: bindings, ignored listing per whitelist
+Apr 27 14:59:05.333: INFO: namespace e2e-tests-projected-b9xj9 deletion completed in 22.142941454s
+
+• [SLOW TEST:26.777 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:59:05.333: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-map-879fc00a-4a2b-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:59:05.434: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-87a05187-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-9hppg" to be "success or failure"
+Apr 27 14:59:05.438: INFO: Pod "pod-projected-secrets-87a05187-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.955235ms
+Apr 27 14:59:07.441: INFO: Pod "pod-projected-secrets-87a05187-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007172429s
+STEP: Saw pod success
+Apr 27 14:59:07.441: INFO: Pod "pod-projected-secrets-87a05187-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:59:07.444: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-secrets-87a05187-4a2b-11e8-87ef-0ee10445d8a2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:59:07.460: INFO: Waiting for pod pod-projected-secrets-87a05187-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:59:07.463: INFO: Pod pod-projected-secrets-87a05187-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:59:07.463: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-9hppg" for this suite.
+Apr 27 14:59:13.476: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:59:13.582: INFO: namespace: e2e-tests-projected-9hppg, resource: bindings, ignored listing per whitelist
+Apr 27 14:59:13.591: INFO: namespace e2e-tests-projected-9hppg deletion completed in 6.124731057s
+
+• [SLOW TEST:8.259 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:59:13.591: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test env composition
+Apr 27 14:59:13.670: INFO: Waiting up to 5m0s for pod "var-expansion-8c8949c2-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-var-expansion-9fjlz" to be "success or failure"
+Apr 27 14:59:13.672: INFO: Pod "var-expansion-8c8949c2-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.182345ms
+Apr 27 14:59:15.676: INFO: Pod "var-expansion-8c8949c2-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005633793s
+Apr 27 14:59:17.679: INFO: Pod "var-expansion-8c8949c2-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009240375s
+STEP: Saw pod success
+Apr 27 14:59:17.679: INFO: Pod "var-expansion-8c8949c2-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:59:17.681: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod var-expansion-8c8949c2-4a2b-11e8-87ef-0ee10445d8a2 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 14:59:17.701: INFO: Waiting for pod var-expansion-8c8949c2-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:59:17.703: INFO: Pod var-expansion-8c8949c2-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:59:17.703: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-9fjlz" for this suite.
+Apr 27 14:59:23.716: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:59:23.777: INFO: namespace: e2e-tests-var-expansion-9fjlz, resource: bindings, ignored listing per whitelist
+Apr 27 14:59:23.831: INFO: namespace e2e-tests-var-expansion-9fjlz deletion completed in 6.12363864s
+
+• [SLOW TEST:10.240 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:59:23.831: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name s-test-opt-del-92a4c9d3-4a2b-11e8-87ef-0ee10445d8a2
+STEP: Creating secret with name s-test-opt-upd-92a4ca17-4a2b-11e8-87ef-0ee10445d8a2
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-92a4c9d3-4a2b-11e8-87ef-0ee10445d8a2
+STEP: Updating secret s-test-opt-upd-92a4ca17-4a2b-11e8-87ef-0ee10445d8a2
+STEP: Creating secret with name s-test-opt-create-92a4ca2e-4a2b-11e8-87ef-0ee10445d8a2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:59:30.206: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-82964" for this suite.
+Apr 27 14:59:46.222: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:59:46.275: INFO: namespace: e2e-tests-secrets-82964, resource: bindings, ignored listing per whitelist
+Apr 27 14:59:46.355: INFO: namespace e2e-tests-secrets-82964 deletion completed in 16.144589718s
+
+• [SLOW TEST:22.524 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:59:46.356: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Apr 27 14:59:46.445: INFO: Waiting up to 5m0s for pod "pod-a01256bd-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-rznph" to be "success or failure"
+Apr 27 14:59:46.450: INFO: Pod "pod-a01256bd-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.697628ms
+Apr 27 14:59:48.454: INFO: Pod "pod-a01256bd-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008318824s
+STEP: Saw pod success
+Apr 27 14:59:48.454: INFO: Pod "pod-a01256bd-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:59:48.457: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-a01256bd-4a2b-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 14:59:48.474: INFO: Waiting for pod pod-a01256bd-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:59:48.476: INFO: Pod pod-a01256bd-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:59:48.476: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-rznph" for this suite.
+Apr 27 14:59:54.490: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 14:59:54.591: INFO: namespace: e2e-tests-emptydir-rznph, resource: bindings, ignored listing per whitelist
+Apr 27 14:59:54.616: INFO: namespace e2e-tests-emptydir-rznph deletion completed in 6.134583867s
+
+• [SLOW TEST:8.260 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 14:59:54.617: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name projected-secret-test-a4fe4207-4a2b-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 14:59:54.705: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-a4febbc6-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-gxk6h" to be "success or failure"
+Apr 27 14:59:54.708: INFO: Pod "pod-projected-secrets-a4febbc6-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.763282ms
+Apr 27 14:59:56.712: INFO: Pod "pod-projected-secrets-a4febbc6-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006491683s
+STEP: Saw pod success
+Apr 27 14:59:56.712: INFO: Pod "pod-projected-secrets-a4febbc6-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 14:59:56.714: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-secrets-a4febbc6-4a2b-11e8-87ef-0ee10445d8a2 container secret-volume-test: <nil>
+STEP: delete the pod
+Apr 27 14:59:56.730: INFO: Waiting for pod pod-projected-secrets-a4febbc6-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 14:59:56.732: INFO: Pod pod-projected-secrets-a4febbc6-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 14:59:56.732: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-gxk6h" for this suite.
+Apr 27 15:00:02.746: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:00:02.858: INFO: namespace: e2e-tests-projected-gxk6h, resource: bindings, ignored listing per whitelist
+Apr 27 15:00:02.869: INFO: namespace e2e-tests-projected-gxk6h deletion completed in 6.132454779s
+
+• [SLOW TEST:8.252 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:00:02.870: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0427 15:00:08.985489      15 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Apr 27 15:00:08.985: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:00:08.985: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-h5r9d" for this suite.
+Apr 27 15:00:14.999: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:00:15.100: INFO: namespace: e2e-tests-gc-h5r9d, resource: bindings, ignored listing per whitelist
+Apr 27 15:00:15.121: INFO: namespace e2e-tests-gc-h5r9d deletion completed in 6.132711995s
+
+• [SLOW TEST:12.251 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:00:15.121: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-p55fz
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 27 15:00:15.210: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 27 15:00:37.265: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.1.33:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-p55fz PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 15:00:37.265: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 15:00:43.753: INFO: Found all expected endpoints: [netserver-0]
+Apr 27 15:00:43.756: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.0.214:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-p55fz PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 15:00:43.757: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 15:00:43.864: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:00:43.864: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-p55fz" for this suite.
+Apr 27 15:01:05.877: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:01:05.962: INFO: namespace: e2e-tests-pod-network-test-p55fz, resource: bindings, ignored listing per whitelist
+Apr 27 15:01:05.999: INFO: namespace e2e-tests-pod-network-test-p55fz deletion completed in 22.130543746s
+
+• [SLOW TEST:50.878 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:01:06.000: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Apr 27 15:01:06.089: INFO: Waiting up to 5m0s for pod "pod-cf8b05f8-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-emptydir-95ltb" to be "success or failure"
+Apr 27 15:01:06.092: INFO: Pod "pod-cf8b05f8-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.804364ms
+Apr 27 15:01:08.097: INFO: Pod "pod-cf8b05f8-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007603524s
+STEP: Saw pod success
+Apr 27 15:01:08.097: INFO: Pod "pod-cf8b05f8-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 15:01:08.100: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-cf8b05f8-4a2b-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 15:01:08.114: INFO: Waiting for pod pod-cf8b05f8-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 15:01:08.116: INFO: Pod pod-cf8b05f8-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:01:08.116: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-95ltb" for this suite.
+Apr 27 15:01:14.131: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:01:14.192: INFO: namespace: e2e-tests-emptydir-95ltb, resource: bindings, ignored listing per whitelist
+Apr 27 15:01:14.254: INFO: namespace e2e-tests-emptydir-95ltb deletion completed in 6.133343254s
+
+• [SLOW TEST:8.254 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:01:14.254: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 15:01:14.336: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d47565dd-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-rz688" to be "success or failure"
+Apr 27 15:01:14.338: INFO: Pod "downwardapi-volume-d47565dd-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.52998ms
+Apr 27 15:01:16.342: INFO: Pod "downwardapi-volume-d47565dd-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006326914s
+STEP: Saw pod success
+Apr 27 15:01:16.342: INFO: Pod "downwardapi-volume-d47565dd-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 15:01:16.345: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-d47565dd-4a2b-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 15:01:16.360: INFO: Waiting for pod downwardapi-volume-d47565dd-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 15:01:16.362: INFO: Pod downwardapi-volume-d47565dd-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:01:16.362: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rz688" for this suite.
+Apr 27 15:01:22.374: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:01:22.452: INFO: namespace: e2e-tests-projected-rz688, resource: bindings, ignored listing per whitelist
+Apr 27 15:01:22.504: INFO: namespace e2e-tests-projected-rz688 deletion completed in 6.139107799s
+
+• [SLOW TEST:8.250 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:01:22.505: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override arguments
+Apr 27 15:01:22.596: INFO: Waiting up to 5m0s for pod "client-containers-d961e771-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-containers-5f9l6" to be "success or failure"
+Apr 27 15:01:22.604: INFO: Pod "client-containers-d961e771-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 7.236665ms
+Apr 27 15:01:24.607: INFO: Pod "client-containers-d961e771-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010922914s
+STEP: Saw pod success
+Apr 27 15:01:24.607: INFO: Pod "client-containers-d961e771-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 15:01:24.610: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod client-containers-d961e771-4a2b-11e8-87ef-0ee10445d8a2 container test-container: <nil>
+STEP: delete the pod
+Apr 27 15:01:24.624: INFO: Waiting for pod client-containers-d961e771-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 15:01:24.626: INFO: Pod client-containers-d961e771-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:01:24.626: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-5f9l6" for this suite.
+Apr 27 15:01:30.638: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:01:30.712: INFO: namespace: e2e-tests-containers-5f9l6, resource: bindings, ignored listing per whitelist
+Apr 27 15:01:30.761: INFO: namespace e2e-tests-containers-5f9l6 deletion completed in 6.131171398s
+
+• [SLOW TEST:8.256 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:01:30.762: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating secret e2e-tests-secrets-dzch9/secret-test-de4cb1a6-4a2b-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume secrets
+Apr 27 15:01:30.849: INFO: Waiting up to 5m0s for pod "pod-configmaps-de4d18d6-4a2b-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-secrets-dzch9" to be "success or failure"
+Apr 27 15:01:30.852: INFO: Pod "pod-configmaps-de4d18d6-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.993215ms
+Apr 27 15:01:32.856: INFO: Pod "pod-configmaps-de4d18d6-4a2b-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007134064s
+Apr 27 15:01:34.860: INFO: Pod "pod-configmaps-de4d18d6-4a2b-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011275906s
+STEP: Saw pod success
+Apr 27 15:01:34.860: INFO: Pod "pod-configmaps-de4d18d6-4a2b-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 15:01:34.863: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-configmaps-de4d18d6-4a2b-11e8-87ef-0ee10445d8a2 container env-test: <nil>
+STEP: delete the pod
+Apr 27 15:01:34.880: INFO: Waiting for pod pod-configmaps-de4d18d6-4a2b-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 15:01:34.882: INFO: Pod pod-configmaps-de4d18d6-4a2b-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:01:34.882: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-dzch9" for this suite.
+Apr 27 15:01:40.894: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:01:40.985: INFO: namespace: e2e-tests-secrets-dzch9, resource: bindings, ignored listing per whitelist
+Apr 27 15:01:41.016: INFO: namespace e2e-tests-secrets-dzch9 deletion completed in 6.130670395s
+
+• [SLOW TEST:10.254 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:01:41.016: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-54gbw
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Apr 27 15:01:41.098: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Apr 27 15:02:01.156: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.221:8080/dial?request=hostName&protocol=http&host=100.96.1.34&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-54gbw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 15:02:01.156: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 15:02:01.274: INFO: Waiting for endpoints: map[]
+Apr 27 15:02:01.277: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.0.221:8080/dial?request=hostName&protocol=http&host=100.96.0.220&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-54gbw PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Apr 27 15:02:01.277: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+Apr 27 15:02:01.431: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:02:01.431: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-54gbw" for this suite.
+Apr 27 15:02:23.452: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:02:23.561: INFO: namespace: e2e-tests-pod-network-test-54gbw, resource: bindings, ignored listing per whitelist
+Apr 27 15:02:23.573: INFO: namespace e2e-tests-pod-network-test-54gbw deletion completed in 22.131785447s
+
+• [SLOW TEST:42.557 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:02:23.574: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-87pw9
+[It] should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a new StaefulSet
+Apr 27 15:02:23.674: INFO: Found 0 stateful pods, waiting for 3
+Apr 27 15:02:33.678: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 15:02:33.678: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 15:02:33.678: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Updating stateful set template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Apr 27 15:02:33.703: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Not applying an update when the partition is greater than the number of replicas
+STEP: Performing a canary update
+Apr 27 15:02:43.733: INFO: Updating stateful set ss2
+Apr 27 15:02:43.738: INFO: Waiting for Pod e2e-tests-statefulset-87pw9/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Restoring Pods to the correct revision when they are deleted
+Apr 27 15:02:53.762: INFO: Found 1 stateful pods, waiting for 3
+Apr 27 15:03:03.766: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 15:03:03.766: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Apr 27 15:03:03.766: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Performing a phased rolling update
+Apr 27 15:03:03.786: INFO: Updating stateful set ss2
+Apr 27 15:03:03.791: INFO: Waiting for Pod e2e-tests-statefulset-87pw9/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Apr 27 15:03:13.815: INFO: Updating stateful set ss2
+Apr 27 15:03:13.821: INFO: Waiting for StatefulSet e2e-tests-statefulset-87pw9/ss2 to complete update
+Apr 27 15:03:13.821: INFO: Waiting for Pod e2e-tests-statefulset-87pw9/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Apr 27 15:03:23.828: INFO: Deleting all statefulset in ns e2e-tests-statefulset-87pw9
+Apr 27 15:03:23.830: INFO: Scaling statefulset ss2 to 0
+Apr 27 15:03:43.843: INFO: Waiting for statefulset status.replicas updated to 0
+Apr 27 15:03:43.846: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:03:43.856: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-87pw9" for this suite.
+Apr 27 15:03:49.869: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:03:49.953: INFO: namespace: e2e-tests-statefulset-87pw9, resource: bindings, ignored listing per whitelist
+Apr 27 15:03:50.000: INFO: namespace e2e-tests-statefulset-87pw9 deletion completed in 6.140587344s
+
+• [SLOW TEST:86.426 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should perform canary updates and phased rolling updates of template modifications [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:03:50.000: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Apr 27 15:03:50.083: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:03:50.623: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-lcb58" for this suite.
+Apr 27 15:03:56.638: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:03:56.713: INFO: namespace: e2e-tests-custom-resource-definition-lcb58, resource: bindings, ignored listing per whitelist
+Apr 27 15:03:56.764: INFO: namespace e2e-tests-custom-resource-definition-lcb58 deletion completed in 6.136584802s
+
+• [SLOW TEST:6.764 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:03:56.766: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-35531252-4a2c-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 15:03:56.853: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-35537bc6-4a2c-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-projected-6sfng" to be "success or failure"
+Apr 27 15:03:56.855: INFO: Pod "pod-projected-configmaps-35537bc6-4a2c-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.066475ms
+Apr 27 15:03:58.858: INFO: Pod "pod-projected-configmaps-35537bc6-4a2c-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005699769s
+STEP: Saw pod success
+Apr 27 15:03:58.858: INFO: Pod "pod-projected-configmaps-35537bc6-4a2c-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 15:03:58.861: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-projected-configmaps-35537bc6-4a2c-11e8-87ef-0ee10445d8a2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 15:03:58.879: INFO: Waiting for pod pod-projected-configmaps-35537bc6-4a2c-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 15:03:58.882: INFO: Pod pod-projected-configmaps-35537bc6-4a2c-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:03:58.882: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6sfng" for this suite.
+Apr 27 15:04:04.896: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:04:04.958: INFO: namespace: e2e-tests-projected-6sfng, resource: bindings, ignored listing per whitelist
+Apr 27 15:04:05.046: INFO: namespace e2e-tests-projected-6sfng deletion completed in 6.159774735s
+
+• [SLOW TEST:8.281 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:04:05.047: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-3a468a69-4a2c-11e8-87ef-0ee10445d8a2
+STEP: Creating a pod to test consume configMaps
+Apr 27 15:04:05.159: INFO: Waiting up to 5m0s for pod "pod-configmaps-3a46fbfa-4a2c-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-configmap-x9lvr" to be "success or failure"
+Apr 27 15:04:05.162: INFO: Pod "pod-configmaps-3a46fbfa-4a2c-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.881055ms
+Apr 27 15:04:07.166: INFO: Pod "pod-configmaps-3a46fbfa-4a2c-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007070466s
+STEP: Saw pod success
+Apr 27 15:04:07.166: INFO: Pod "pod-configmaps-3a46fbfa-4a2c-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 15:04:07.169: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod pod-configmaps-3a46fbfa-4a2c-11e8-87ef-0ee10445d8a2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Apr 27 15:04:07.183: INFO: Waiting for pod pod-configmaps-3a46fbfa-4a2c-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 15:04:07.186: INFO: Pod pod-configmaps-3a46fbfa-4a2c-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:04:07.186: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-x9lvr" for this suite.
+Apr 27 15:04:13.198: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:04:13.314: INFO: namespace: e2e-tests-configmap-x9lvr, resource: bindings, ignored listing per whitelist
+Apr 27 15:04:13.334: INFO: namespace e2e-tests-configmap-x9lvr deletion completed in 6.145048558s
+
+• [SLOW TEST:8.287 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:04:13.335: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 15:04:13.430: INFO: Waiting up to 5m0s for pod "downwardapi-volume-3f34cb6d-4a2c-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-h7rjm" to be "success or failure"
+Apr 27 15:04:13.433: INFO: Pod "downwardapi-volume-3f34cb6d-4a2c-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.095066ms
+Apr 27 15:04:15.437: INFO: Pod "downwardapi-volume-3f34cb6d-4a2c-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007144645s
+STEP: Saw pod success
+Apr 27 15:04:15.437: INFO: Pod "downwardapi-volume-3f34cb6d-4a2c-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 15:04:15.440: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-3f34cb6d-4a2c-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 15:04:15.453: INFO: Waiting for pod downwardapi-volume-3f34cb6d-4a2c-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 15:04:15.455: INFO: Pod downwardapi-volume-3f34cb6d-4a2c-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:04:15.455: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-h7rjm" for this suite.
+Apr 27 15:04:21.468: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:04:21.590: INFO: namespace: e2e-tests-downward-api-h7rjm, resource: bindings, ignored listing per whitelist
+Apr 27 15:04:21.593: INFO: namespace e2e-tests-downward-api-h7rjm deletion completed in 6.133669546s
+
+• [SLOW TEST:8.258 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:04:21.593: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 15:04:21.690: INFO: Waiting up to 5m0s for pod "downwardapi-volume-44214f91-4a2c-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-dk5n9" to be "success or failure"
+Apr 27 15:04:21.694: INFO: Pod "downwardapi-volume-44214f91-4a2c-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.854582ms
+Apr 27 15:04:23.697: INFO: Pod "downwardapi-volume-44214f91-4a2c-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007348906s
+STEP: Saw pod success
+Apr 27 15:04:23.698: INFO: Pod "downwardapi-volume-44214f91-4a2c-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 15:04:23.700: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-44214f91-4a2c-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 15:04:23.715: INFO: Waiting for pod downwardapi-volume-44214f91-4a2c-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 15:04:23.718: INFO: Pod downwardapi-volume-44214f91-4a2c-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:04:23.718: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-dk5n9" for this suite.
+Apr 27 15:04:29.730: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:04:29.796: INFO: namespace: e2e-tests-downward-api-dk5n9, resource: bindings, ignored listing per whitelist
+Apr 27 15:04:29.855: INFO: namespace e2e-tests-downward-api-dk5n9 deletion completed in 6.134719947s
+
+• [SLOW TEST:8.263 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:04:29.856: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Apr 27 15:04:29.940: INFO: Waiting up to 5m0s for pod "downwardapi-volume-490c4ac8-4a2c-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-bcr2d" to be "success or failure"
+Apr 27 15:04:29.943: INFO: Pod "downwardapi-volume-490c4ac8-4a2c-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.49567ms
+Apr 27 15:04:31.947: INFO: Pod "downwardapi-volume-490c4ac8-4a2c-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006252444s
+STEP: Saw pod success
+Apr 27 15:04:31.947: INFO: Pod "downwardapi-volume-490c4ac8-4a2c-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 15:04:31.949: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downwardapi-volume-490c4ac8-4a2c-11e8-87ef-0ee10445d8a2 container client-container: <nil>
+STEP: delete the pod
+Apr 27 15:04:31.964: INFO: Waiting for pod downwardapi-volume-490c4ac8-4a2c-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 15:04:31.967: INFO: Pod downwardapi-volume-490c4ac8-4a2c-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:04:31.967: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-bcr2d" for this suite.
+Apr 27 15:04:37.983: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:04:38.073: INFO: namespace: e2e-tests-downward-api-bcr2d, resource: bindings, ignored listing per whitelist
+Apr 27 15:04:38.109: INFO: namespace e2e-tests-downward-api-bcr2d deletion completed in 6.13824653s
+
+• [SLOW TEST:8.253 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Apr 27 15:04:38.110: INFO: >>> kubeConfig: /tmp/kubeconfig-187724608
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Apr 27 15:04:38.197: INFO: Waiting up to 5m0s for pod "downward-api-4df82b68-4a2c-11e8-87ef-0ee10445d8a2" in namespace "e2e-tests-downward-api-hz899" to be "success or failure"
+Apr 27 15:04:38.199: INFO: Pod "downward-api-4df82b68-4a2c-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.35454ms
+Apr 27 15:04:40.202: INFO: Pod "downward-api-4df82b68-4a2c-11e8-87ef-0ee10445d8a2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005795598s
+Apr 27 15:04:42.206: INFO: Pod "downward-api-4df82b68-4a2c-11e8-87ef-0ee10445d8a2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009396596s
+STEP: Saw pod success
+Apr 27 15:04:42.206: INFO: Pod "downward-api-4df82b68-4a2c-11e8-87ef-0ee10445d8a2" satisfied condition "success or failure"
+Apr 27 15:04:42.209: INFO: Trying to get logs from node shoot-core-cncf-os-worker-cwlhy-z1-66b67cbd7-xwwcz pod downward-api-4df82b68-4a2c-11e8-87ef-0ee10445d8a2 container dapi-container: <nil>
+STEP: delete the pod
+Apr 27 15:04:42.229: INFO: Waiting for pod downward-api-4df82b68-4a2c-11e8-87ef-0ee10445d8a2 to disappear
+Apr 27 15:04:42.231: INFO: Pod downward-api-4df82b68-4a2c-11e8-87ef-0ee10445d8a2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Apr 27 15:04:42.231: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-hz899" for this suite.
+Apr 27 15:04:48.248: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Apr 27 15:04:48.310: INFO: namespace: e2e-tests-downward-api-hz899, resource: bindings, ignored listing per whitelist
+Apr 27 15:04:48.377: INFO: namespace e2e-tests-downward-api-hz899 deletion completed in 6.142854546s
+
+• [SLOW TEST:10.267 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSApr 27 15:04:48.378: INFO: Running AfterSuite actions on all node
+Apr 27 15:04:48.378: INFO: Running AfterSuite actions on node 1
+Apr 27 15:04:48.378: INFO: Skipping dumping logs from cluster
+
+Ran 139 of 836 Specs in 3503.758 seconds
+SUCCESS! -- 139 Passed | 0 Failed | 0 Pending | 697 Skipped PASS
+
+Ginkgo ran 1 suite in 58m24.174044108s
+Test Suite Passed

--- a/v1.10/sap-cp-openstack/junit_01.xml
+++ b/v1.10/sap-cp-openstack/junit_01.xml
@@ -1,0 +1,2233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="139" failures="0" time="3503.757537418">
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [Conformance]" classname="Kubernetes e2e suite" time="8.254565654"></testcase>
+      <testcase name="[sig-storage] PVC Protection Verify &#34;immediate&#34; deletion of a PVC that is not in active use by a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.246858819"></testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.298101023"></testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Stress with local volume provisioner [Serial] should use be able to process many pods and reuse local volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.264457697"></testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]" classname="Kubernetes e2e suite" time="8.264403685"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.275678112"></testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.263613616"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP  [Conformance]" classname="Kubernetes e2e suite" time="24.244869533"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.259355758"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha docker/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [Conformance]" classname="Kubernetes e2e suite" time="8.259036504000001"></testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.220695829"></testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="8.252130187"></testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated  [Conformance]" classname="Kubernetes e2e suite" time="12.742875058"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support proportional scaling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]" classname="Kubernetes e2e suite" time="31.3092258"></testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Downgrade [Feature:IngressDowngrade] ingress downgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [Conformance]" classname="Kubernetes e2e suite" time="26.811726439"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should not reconcile manually modified health check for ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file  [Conformance]" classname="Kubernetes e2e suite" time="60.897894302"></testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.218725998"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="60.330364651"></testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset [Conformance]" classname="Kubernetes e2e suite" time="24.904255106"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume expand [Feature:ExpandPersistentVolumes] [Slow] Verify if editing PVC allows resize" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted [Conformance]" classname="Kubernetes e2e suite" time="16.296409722"></testcase>
+      <testcase name="[k8s.io] Sysctls should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.269861273"></testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args  [Conformance]" classname="Kubernetes e2e suite" time="10.267400047"></testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable  [Conformance]" classname="Kubernetes e2e suite" time="10.258913496"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="19.545251568"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file  [Conformance]" classname="Kubernetes e2e suite" time="8.252421083"></testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle [Conformance]" classname="Kubernetes e2e suite" time="11.25291883"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [Conformance]" classname="Kubernetes e2e suite" time="8.255082479"></testcase>
+      <testcase name="[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive] node unregister" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [Conformance]" classname="Kubernetes e2e suite" time="8.247643219"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods [Conformance]" classname="Kubernetes e2e suite" time="104.291554583"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.283206185"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification  [Conformance]" classname="Kubernetes e2e suite" time="26.774572935"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="12.823142433"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existent secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.492065715"></testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank  [Conformance]" classname="Kubernetes e2e suite" time="8.254479914"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.257304997"></testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.49184807"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.250482468"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod  [Conformance]" classname="Kubernetes e2e suite" time="8.268047968"></testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 Scalability GCE [Slow] [Serial] [Feature:IngressScale] Creating and updating ingresses should happen promptly with small/medium/large amount of ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.308042316"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD [Feature:RegionalPD] RegionalPD should failover to a different zone when all nodes in one zone become unreachable [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments  [Conformance]" classname="Kubernetes e2e suite" time="8.261615949"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="11.70254779"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.275917933"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.27471362"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]" classname="Kubernetes e2e suite" time="15.348350107"></testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.251745563"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set  [Conformance]" classname="Kubernetes e2e suite" time="10.267741221"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pv count metrics for pvc controller after creating pv only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="27.336413146"></testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="27.327615096"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart  [Conformance]" classname="Kubernetes e2e suite" time="44.251581573"></testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.316646135"></testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap binary data should be reflected in volume " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.258238804"></testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout  [Conformance]" classname="Kubernetes e2e suite" time="6.222395226">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should support configurable pod resolv.conf" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command (docker entrypoint)  [Conformance]" classname="Kubernetes e2e suite" time="8.249212334"></testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.304238365"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.223205634"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.239582113">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.30934249"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.25337176"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable  [Conformance]" classname="Kubernetes e2e suite" time="10.254044101"></testcase>
+      <testcase name="[k8s.io] Sysctls should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pvc count metrics for pvc controller after creating pvc only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.495893664"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request  [Conformance]" classname="Kubernetes e2e suite" time="8.28418084"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="85.411125482"></testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.314583415"></testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="24.279174356"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.258770662"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count  [Slow] [Conformance]" classname="Kubernetes e2e suite" time="154.538210849"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated  [Conformance]" classname="Kubernetes e2e suite" time="24.751131644"></testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates lower priority pod preemption by critical pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods [Conformance]" classname="Kubernetes e2e suite" time="377.461142863"></testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="46.628600544"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]" classname="Kubernetes e2e suite" time="11.773179973"></testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance]" classname="Kubernetes e2e suite" time="137.423355823"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="30.887875361"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that a pod with an invalid NodeAffinity is rejected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify that PV bound to a PVC is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.250188732"></testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.257583549"></testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.258833376"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit  [Conformance]" classname="Kubernetes e2e suite" time="8.247964657"></testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.251634451"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request  [Conformance]" classname="Kubernetes e2e suite" time="8.250795642"></testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification  [Conformance]" classname="Kubernetes e2e suite" time="26.778143869"></testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.274523198"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [Conformance]" classname="Kubernetes e2e suite" time="8.237465956"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="28.241522185"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that PVC in active use by a pod is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  StatefulSet with pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [Conformance]" classname="Kubernetes e2e suite" time="8.27032356"></testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with downward pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.256335003"></testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with projected pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="46.569342078"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes [Feature:CSI] Sanity CSI plugin test using hostPath CSI driver should provision storage with a hostPath CSI driver" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="130.473491899"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection] [Conformance]" classname="Kubernetes e2e suite" time="10.267308465"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor using proxy subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="86.359264569"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]" classname="Kubernetes e2e suite" time="8.284197311"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with backside re-encryption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [Conformance]" classname="Kubernetes e2e suite" time="8.266407851"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.256079401"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.255271596"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files  [Conformance]" classname="Kubernetes e2e suite" time="8.252641101"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have accelerator metrics [Feature:StackdriverAcceleratorMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.257559309"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="6.79183961"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so [Conformance]" classname="Kubernetes e2e suite" time="46.264762801"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="130.488401439"></testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart  [Conformance]" classname="Kubernetes e2e suite" time="82.23240909"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]" classname="Kubernetes e2e suite" time="27.358366728"></testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.252602417"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="16.252742261"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="7.255570758"></testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.252251916"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="49.298983094"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.251498451"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.273407494"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Mounted volume expand [Feature:ExpandPersistentVolumes] [Slow] Should verify mounted devices can be resized" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="8.25332791"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.2767312"></testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.289299799"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var  [Conformance]" classname="Kubernetes e2e suite" time="10.269030578"></testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="19.146086437"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod  [Conformance]" classname="Kubernetes e2e suite" time="8.26601375"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.269138636"></testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Upgrade [Feature:IngressUpgrade] ingress upgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create none metrics for pvc controller before creating any PV or PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]" classname="Kubernetes e2e suite" time="92.117555282"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD [Feature:RegionalPD] RegionalPD should provision storage [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.267039004"></testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate crd" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with secret pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [Conformance]" classname="Kubernetes e2e suite" time="8.257456983"></testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services  [Conformance]" classname="Kubernetes e2e suite" time="28.306289574"></testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.833057934"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command  [Conformance]" classname="Kubernetes e2e suite" time="10.263707509"></testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [DisabledForLargeClusters] kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.259774649"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [Conformance]" classname="Kubernetes e2e suite" time="26.77681674"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.258542799"></testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.239535252"></testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="22.52419156"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify &#34;immediate&#34; deletion of a PV that is not bound to a PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.260489194"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [Conformance]" classname="Kubernetes e2e suite" time="8.252299339"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]" classname="Kubernetes e2e suite" time="12.251481754"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should update ingress while sync failures occur on other ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="50.877859543"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.253609065"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [Conformance]" classname="Kubernetes e2e suite" time="8.250411365"></testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd)  [Conformance]" classname="Kubernetes e2e suite" time="8.255964025"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPU] run Nvidia GPU tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.254070524"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="42.556629846"></testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications [Conformance]" classname="Kubernetes e2e suite" time="86.425825116"></testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner deletion should be idempotent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="6.7642440310000005"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.280701614"></testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.287361464"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should not be able to prevent deleting validating-webhook-configurations or mutating-webhook-configurations" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only  [Conformance]" classname="Kubernetes e2e suite" time="8.257872694"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.262663952"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit  [Conformance]" classname="Kubernetes e2e suite" time="8.253020636"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.267236796"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.10/sap-cp-openstack/version.txt
+++ b/v1.10/sap-cp-openstack/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.1", GitCommit:"d4ab47518836c750f9949b9e0d387f20fb92260b", GitTreeState:"clean", BuildDate:"2018-04-12T14:26:04Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.1", GitCommit:"d4ab47518836c750f9949b9e0d387f20fb92260b", GitTreeState:"clean", BuildDate:"2018-04-12T14:14:26Z", GoVersion:"go1.9.3", Compiler:"gc", Platform:"linux/amd64"}


### PR DESCRIPTION
SAP conformance results for kubernetes clusters deployed using Gardener 0.4.0
Since Gardener was published as open source in the meanwhile the
version number was reset to 0.1.0.

Gardener is used internally at SAP but is not yet released as part of a product.

v1.10/sap-cp-aws : cluster deployed on Amazon Web Services
v1.10/sap-cp-azure : cluster deployed on Microsoft Azure
v1.10/sap-cp-gcp : cluster deployed on Google Cloud Platform
v1.10/sap-cp-openstack : cluster deployed on OpenStack