### PR TITLE
Conformance results for v1.11/typhoon

### DIFF
--- a/v1.11/typhoon/PRODUCT.yaml
+++ b/v1.11/typhoon/PRODUCT.yaml
@@ -1,0 +1,8 @@
+vendor: Poseidon
+name: Typhoon
+version: v1.11.0
+website_url: https://typhoon.psdn.io/
+documentation_url: https://typhoon.psdn.io/
+product_logo_url: https://storage.googleapis.com/poseidon/typhoon.png
+type: distro
+description: Minimal and free Kubernetes distribution via Terraform 

--- a/v1.11/typhoon/README.md
+++ b/v1.11/typhoon/README.md
@@ -1,0 +1,72 @@
+# Typhoon
+
+## Setup
+
+Install a Typhoon Kubernetes v1.11.0 cluster on [bare-metal](https://typhoon.psdn.io/cl/bare-metal/), [AWS](https://typhoon.psdn.io/cl/aws/), or [Google Cloud](https://typhoon.psdn.io/cl/google-cloud/). You may pick any OS + platform combination marked [stable](https://github.com/poseidon/typhoon#modules).
+
+Define a cluster at v1.11.0 and `terraform apply`. Example:
+
+```
+module "google-cloud-yavin" {
+  source = "git::https://github.com/poseidon/typhoon//google-cloud/container-linux/kubernetes?ref=v1.11.0"
+
+  providers = {
+    google   = "google.default"
+    local    = "local.default"
+    null     = "null.default"
+    template = "template.default"
+    tls      = "tls.default"
+  }
+
+  # Google Cloud
+  cluster_name  = "yavin"
+  region        = "us-central1"
+  dns_zone      = "example.com"
+  dns_zone_name = "example-zone"
+
+  # configuration
+  ssh_authorized_key = "ssh-rsa AAAAB3Nz..."
+  asset_dir          = "/home/user/.secrets/clusters/yavin"
+
+  # optional
+  worker_count = 2
+}
+```
+
+Use the generated `kubeconfig` from `ASSETS_DIR/auth/kubeconfig`.
+
+```
+$ export KUBECONFIG=/home/user/.secrets/clusters/yavin/auth/kubeconfig
+$ kubectl get nodes
+NAME                                          STATUS   AGE    VERSION
+yavin-controller-0.c.example-com.internal     Ready    6m     v1.11.0
+yavin-worker-jrbf.c.example-com.internal      Ready    5m     v1.11.0
+yavin-worker-mzdm.c.example-com.internal      Ready    5m     v1.11.0
+```
+
+## Reproduce Conformance Results
+
+### curl
+
+Run the sonobuoy conformance tests using curl piped to kubectl.
+
+```
+curl -L https://github.com/cncf/k8s-conformance/blob/master/sonobuoy-conformance.yaml
+```
+
+Follow the [instructions](https://github.com/cncf/k8s-conformance/blob/master/instructions.md#running) to `kubectl cp` results from `plugins/e2e/results{e2e.log,junit.xml}`.
+
+
+### sonobuoy tool
+
+Alternately, use the `sonobuoy` command line tool (requires Go).
+
+```
+go get -u -v github.com/heptio/sonobuoy
+sonobuoy run
+sonobuoy status
+sonobuoy retrieve .
+mkdir ./results; tar xzf *.tar.gz -C ./results
+```
+
+Inspect the results in `plugins/e2e/results/{e2e.log,junit.xml}`.

--- a/v1.11/typhoon/e2e.log
+++ b/v1.11/typhoon/e2e.log
@@ -1,0 +1,7597 @@
+Jul  4 19:59:52.440: INFO: Overriding default scale value of zero to 1
+Jul  4 19:59:52.440: INFO: Overriding default milliseconds value of zero to 5000
+I0704 19:59:52.870425      14 test_context.go:382] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-830667735
+I0704 19:59:52.870581      14 e2e.go:333] Starting e2e run "d071abaf-7fc4-11e8-a4f0-6eaac417783a" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1530734391 - Will randomize all specs
+Will run 144 of 998 specs
+
+Jul  4 19:59:53.150: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 19:59:53.159: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
+Jul  4 19:59:53.193: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  4 19:59:53.254: INFO: 16 / 16 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  4 19:59:53.254: INFO: expected 5 pod replicas in namespace 'kube-system', 5 are Running and Ready.
+Jul  4 19:59:53.260: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  4 19:59:53.260: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Jul  4 19:59:53.269: INFO: e2e test version: v1.11.0
+Jul  4 19:59:53.271: INFO: kube-apiserver version: v1.11.0
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 19:59:53.272: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+Jul  4 19:59:53.371: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-d121398e-7fc4-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 19:59:53.387: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-d121d69b-7fc4-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-ksw57" to be "success or failure"
+Jul  4 19:59:53.394: INFO: Pod "pod-projected-configmaps-d121d69b-7fc4-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.105533ms
+Jul  4 19:59:55.398: INFO: Pod "pod-projected-configmaps-d121d69b-7fc4-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010597415s
+Jul  4 19:59:57.401: INFO: Pod "pod-projected-configmaps-d121d69b-7fc4-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013986416s
+STEP: Saw pod success
+Jul  4 19:59:57.401: INFO: Pod "pod-projected-configmaps-d121d69b-7fc4-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 19:59:57.403: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-configmaps-d121d69b-7fc4-11e8-a4f0-6eaac417783a container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 19:59:57.459: INFO: Waiting for pod pod-projected-configmaps-d121d69b-7fc4-11e8-a4f0-6eaac417783a to disappear
+Jul  4 19:59:57.462: INFO: Pod pod-projected-configmaps-d121d69b-7fc4-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 19:59:57.463: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-ksw57" for this suite.
+Jul  4 20:00:03.478: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:00:03.501: INFO: namespace: e2e-tests-projected-ksw57, resource: bindings, ignored listing per whitelist
+Jul  4 20:00:03.589: INFO: namespace e2e-tests-projected-ksw57 deletion completed in 6.124198057s
+
+• [SLOW TEST:10.318 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:00:03.590: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-xfdqq.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-xfdqq.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-xfdqq.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-xfdqq.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-xfdqq.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-xfdqq.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Jul  4 20:00:27.817: INFO: DNS probes using dns-test-d74559c5-7fc4-11e8-a4f0-6eaac417783a succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:00:27.839: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-xfdqq" for this suite.
+Jul  4 20:00:33.857: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:00:33.896: INFO: namespace: e2e-tests-dns-xfdqq, resource: bindings, ignored listing per whitelist
+Jul  4 20:00:33.943: INFO: namespace e2e-tests-dns-xfdqq deletion completed in 6.100920716s
+
+• [SLOW TEST:30.353 seconds]
+[sig-network] DNS
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:00:33.946: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  4 20:00:34.052: INFO: pod1.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod3", UID:"e96563b1-7fc4-11e8-94db-42010a800002", Controller:(*bool)(0xc42201cf3e), BlockOwnerDeletion:(*bool)(0xc42201cf3f)}}
+Jul  4 20:00:34.064: INFO: pod2.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod1", UID:"e962d3ad-7fc4-11e8-94db-42010a800002", Controller:(*bool)(0xc42201d10a), BlockOwnerDeletion:(*bool)(0xc42201d10b)}}
+Jul  4 20:00:34.074: INFO: pod3.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod2", UID:"e9639190-7fc4-11e8-94db-42010a800002", Controller:(*bool)(0xc42201d3fa), BlockOwnerDeletion:(*bool)(0xc42201d3fb)}}
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:00:39.092: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-7zdgf" for this suite.
+Jul  4 20:00:45.131: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:00:45.273: INFO: namespace: e2e-tests-gc-7zdgf, resource: bindings, ignored listing per whitelist
+Jul  4 20:00:45.311: INFO: namespace e2e-tests-gc-7zdgf deletion completed in 6.215489286s
+
+• [SLOW TEST:11.365 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:00:45.312: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Jul  4 20:00:55.432: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-spzcw PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:00:55.432: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:00:55.546: INFO: Exec stderr: ""
+Jul  4 20:00:55.546: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-spzcw PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:00:55.546: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:00:55.626: INFO: Exec stderr: ""
+Jul  4 20:00:55.627: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-spzcw PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:00:55.627: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:00:55.726: INFO: Exec stderr: ""
+Jul  4 20:00:55.727: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-spzcw PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:00:55.727: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:00:55.807: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Jul  4 20:00:55.807: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-spzcw PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:00:55.807: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:00:55.892: INFO: Exec stderr: ""
+Jul  4 20:00:55.893: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-spzcw PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:00:55.893: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:00:56.008: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Jul  4 20:00:56.008: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-spzcw PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:00:56.008: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:00:56.105: INFO: Exec stderr: ""
+Jul  4 20:00:56.105: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-spzcw PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:00:56.106: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:00:56.193: INFO: Exec stderr: ""
+Jul  4 20:00:56.193: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-spzcw PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:00:56.193: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:00:56.277: INFO: Exec stderr: ""
+Jul  4 20:00:56.277: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-spzcw PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:00:56.277: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:00:56.371: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:00:56.372: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-spzcw" for this suite.
+Jul  4 20:01:46.392: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:01:46.403: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-spzcw, resource: bindings, ignored listing per whitelist
+Jul  4 20:01:46.464: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-spzcw deletion completed in 50.087420748s
+
+• [SLOW TEST:61.152 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:01:46.466: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  4 20:01:46.543: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:01:46.546: INFO: Number of nodes with available pods: 0
+Jul  4 20:01:46.546: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:01:47.550: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:01:47.552: INFO: Number of nodes with available pods: 0
+Jul  4 20:01:47.553: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:01:48.550: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:01:48.553: INFO: Number of nodes with available pods: 1
+Jul  4 20:01:48.553: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:01:49.550: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:01:49.553: INFO: Number of nodes with available pods: 2
+Jul  4 20:01:49.553: INFO: Node jakku-worker-f0tz.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:01:50.550: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:01:50.553: INFO: Number of nodes with available pods: 3
+Jul  4 20:01:50.553: INFO: Number of running nodes: 3, number of available pods: 3
+STEP: Stop a daemon pod, check that the daemon pod is revived.
+Jul  4 20:01:50.571: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:01:50.574: INFO: Number of nodes with available pods: 2
+Jul  4 20:01:50.574: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:01:51.579: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:01:51.581: INFO: Number of nodes with available pods: 2
+Jul  4 20:01:51.582: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:01:52.579: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:01:52.582: INFO: Number of nodes with available pods: 2
+Jul  4 20:01:52.582: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:01:53.579: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:01:53.582: INFO: Number of nodes with available pods: 2
+Jul  4 20:01:53.582: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:01:54.583: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:01:54.586: INFO: Number of nodes with available pods: 3
+Jul  4 20:01:54.586: INFO: Number of running nodes: 3, number of available pods: 3
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-4rdxf, will wait for the garbage collector to delete the pods
+Jul  4 20:01:54.648: INFO: Deleting {extensions DaemonSet} daemon-set took: 6.962754ms
+Jul  4 20:01:54.749: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.466241ms
+Jul  4 20:01:57.553: INFO: Number of nodes with available pods: 0
+Jul  4 20:01:57.553: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  4 20:01:57.557: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-4rdxf/daemonsets","resourceVersion":"1671"},"items":null}
+
+Jul  4 20:01:57.560: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-4rdxf/pods","resourceVersion":"1671"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:01:57.569: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-4rdxf" for this suite.
+Jul  4 20:02:03.586: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:02:03.655: INFO: namespace: e2e-tests-daemonsets-4rdxf, resource: bindings, ignored listing per whitelist
+Jul  4 20:02:03.657: INFO: namespace e2e-tests-daemonsets-4rdxf deletion completed in 6.084692366s
+
+• [SLOW TEST:17.191 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:02:03.658: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:02:03.723: INFO: Waiting up to 5m0s for pod "downwardapi-volume-1ed1e8d7-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-2kfqq" to be "success or failure"
+Jul  4 20:02:03.728: INFO: Pod "downwardapi-volume-1ed1e8d7-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 5.22998ms
+Jul  4 20:02:05.731: INFO: Pod "downwardapi-volume-1ed1e8d7-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00843509s
+Jul  4 20:02:07.735: INFO: Pod "downwardapi-volume-1ed1e8d7-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011637333s
+STEP: Saw pod success
+Jul  4 20:02:07.735: INFO: Pod "downwardapi-volume-1ed1e8d7-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:02:07.737: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-1ed1e8d7-7fc5-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:02:07.753: INFO: Waiting for pod downwardapi-volume-1ed1e8d7-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:02:07.756: INFO: Pod downwardapi-volume-1ed1e8d7-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:02:07.756: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2kfqq" for this suite.
+Jul  4 20:02:13.778: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:02:13.815: INFO: namespace: e2e-tests-projected-2kfqq, resource: bindings, ignored listing per whitelist
+Jul  4 20:02:13.844: INFO: namespace e2e-tests-projected-2kfqq deletion completed in 6.085068759s
+
+• [SLOW TEST:10.187 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Pods 
+  should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:02:13.845: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating pod
+Jul  4 20:02:15.940: INFO: Pod pod-hostip-24e3f6b7-7fc5-11e8-a4f0-6eaac417783a has hostIP: 10.128.0.4
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:02:15.940: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-fcdct" for this suite.
+Jul  4 20:02:37.955: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:02:38.023: INFO: namespace: e2e-tests-pods-fcdct, resource: bindings, ignored listing per whitelist
+Jul  4 20:02:38.038: INFO: namespace e2e-tests-pods-fcdct deletion completed in 22.094598533s
+
+• [SLOW TEST:24.193 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:02:38.039: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-projected-all-test-volume-3350f097-7fc5-11e8-a4f0-6eaac417783a
+STEP: Creating secret with name secret-projected-all-test-volume-3350f07e-7fc5-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Jul  4 20:02:38.117: INFO: Waiting up to 5m0s for pod "projected-volume-3350f037-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-hjkkp" to be "success or failure"
+Jul  4 20:02:38.125: INFO: Pod "projected-volume-3350f037-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.991392ms
+Jul  4 20:02:40.128: INFO: Pod "projected-volume-3350f037-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011816581s
+Jul  4 20:02:42.131: INFO: Pod "projected-volume-3350f037-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014491072s
+STEP: Saw pod success
+Jul  4 20:02:42.131: INFO: Pod "projected-volume-3350f037-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:02:42.133: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod projected-volume-3350f037-7fc5-11e8-a4f0-6eaac417783a container projected-all-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:02:42.156: INFO: Waiting for pod projected-volume-3350f037-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:02:42.158: INFO: Pod projected-volume-3350f037-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:02:42.158: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hjkkp" for this suite.
+Jul  4 20:02:48.176: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:02:48.215: INFO: namespace: e2e-tests-projected-hjkkp, resource: bindings, ignored listing per whitelist
+Jul  4 20:02:48.252: INFO: namespace e2e-tests-projected-hjkkp deletion completed in 6.089519387s
+
+• [SLOW TEST:10.213 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:02:48.254: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:02:48.325: INFO: Waiting up to 5m0s for pod "downwardapi-volume-3967762a-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-rptp4" to be "success or failure"
+Jul  4 20:02:48.330: INFO: Pod "downwardapi-volume-3967762a-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 5.336623ms
+Jul  4 20:02:50.334: INFO: Pod "downwardapi-volume-3967762a-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009396862s
+STEP: Saw pod success
+Jul  4 20:02:50.334: INFO: Pod "downwardapi-volume-3967762a-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:02:50.336: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-3967762a-7fc5-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:02:50.361: INFO: Waiting for pod downwardapi-volume-3967762a-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:02:50.363: INFO: Pod downwardapi-volume-3967762a-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:02:50.364: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-rptp4" for this suite.
+Jul  4 20:02:56.385: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:02:56.405: INFO: namespace: e2e-tests-downward-api-rptp4, resource: bindings, ignored listing per whitelist
+Jul  4 20:02:56.466: INFO: namespace e2e-tests-downward-api-rptp4 deletion completed in 6.093412489s
+
+• [SLOW TEST:8.213 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:02:56.468: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  4 20:03:16.540: INFO: Container started at 2018-07-04 20:02:57 +0000 UTC, pod became ready at 2018-07-04 20:03:15 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:03:16.541: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-nxdhl" for this suite.
+Jul  4 20:03:38.554: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:03:38.594: INFO: namespace: e2e-tests-container-probe-nxdhl, resource: bindings, ignored listing per whitelist
+Jul  4 20:03:38.622: INFO: namespace e2e-tests-container-probe-nxdhl deletion completed in 22.078802858s
+
+• [SLOW TEST:42.155 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:03:38.625: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Jul  4 20:03:38.682: INFO: Waiting up to 5m0s for pod "pod-576bb102-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-d7cs8" to be "success or failure"
+Jul  4 20:03:38.687: INFO: Pod "pod-576bb102-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 4.842497ms
+Jul  4 20:03:40.690: INFO: Pod "pod-576bb102-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007574807s
+Jul  4 20:03:42.693: INFO: Pod "pod-576bb102-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010303414s
+STEP: Saw pod success
+Jul  4 20:03:42.693: INFO: Pod "pod-576bb102-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:03:42.695: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-576bb102-7fc5-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:03:42.715: INFO: Waiting for pod pod-576bb102-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:03:42.719: INFO: Pod pod-576bb102-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:03:42.719: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-d7cs8" for this suite.
+Jul  4 20:03:48.732: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:03:48.765: INFO: namespace: e2e-tests-emptydir-d7cs8, resource: bindings, ignored listing per whitelist
+Jul  4 20:03:48.801: INFO: namespace e2e-tests-emptydir-d7cs8 deletion completed in 6.079129569s
+
+• [SLOW TEST:10.177 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:03:48.803: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:03:48.868: INFO: Waiting up to 5m0s for pod "downwardapi-volume-5d7daf00-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-9hz7d" to be "success or failure"
+Jul  4 20:03:48.879: INFO: Pod "downwardapi-volume-5d7daf00-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 10.977905ms
+Jul  4 20:03:50.883: INFO: Pod "downwardapi-volume-5d7daf00-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.015023789s
+STEP: Saw pod success
+Jul  4 20:03:50.883: INFO: Pod "downwardapi-volume-5d7daf00-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:03:50.885: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-5d7daf00-7fc5-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:03:50.905: INFO: Waiting for pod downwardapi-volume-5d7daf00-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:03:50.908: INFO: Pod downwardapi-volume-5d7daf00-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:03:50.908: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-9hz7d" for this suite.
+Jul  4 20:03:56.933: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:03:56.949: INFO: namespace: e2e-tests-projected-9hz7d, resource: bindings, ignored listing per whitelist
+Jul  4 20:03:57.041: INFO: namespace e2e-tests-projected-9hz7d deletion completed in 6.12940286s
+
+• [SLOW TEST:8.239 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Watchers 
+  should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:03:57.043: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps with a certain label
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: changing the label value of the configmap
+STEP: Expecting to observe a delete notification for the watched object
+Jul  4 20:03:57.105: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-l4c4w,SelfLink:/api/v1/namespaces/e2e-tests-watch-l4c4w/configmaps/e2e-watch-test-label-changed,UID:6270f245-7fc5-11e8-94db-42010a800002,ResourceVersion:2074,Generation:0,CreationTimestamp:2018-07-04 20:03:57 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  4 20:03:57.105: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-l4c4w,SelfLink:/api/v1/namespaces/e2e-tests-watch-l4c4w/configmaps/e2e-watch-test-label-changed,UID:6270f245-7fc5-11e8-94db-42010a800002,ResourceVersion:2075,Generation:0,CreationTimestamp:2018-07-04 20:03:57 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+Jul  4 20:03:57.105: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-l4c4w,SelfLink:/api/v1/namespaces/e2e-tests-watch-l4c4w/configmaps/e2e-watch-test-label-changed,UID:6270f245-7fc5-11e8-94db-42010a800002,ResourceVersion:2076,Generation:0,CreationTimestamp:2018-07-04 20:03:57 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying the configmap a second time
+STEP: Expecting not to observe a notification because the object no longer meets the selector's requirements
+STEP: changing the label value of the configmap back
+STEP: modifying the configmap a third time
+STEP: deleting the configmap
+STEP: Expecting to observe an add notification for the watched object when the label value was restored
+Jul  4 20:04:07.138: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-l4c4w,SelfLink:/api/v1/namespaces/e2e-tests-watch-l4c4w/configmaps/e2e-watch-test-label-changed,UID:6270f245-7fc5-11e8-94db-42010a800002,ResourceVersion:2093,Generation:0,CreationTimestamp:2018-07-04 20:03:57 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  4 20:04:07.138: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-l4c4w,SelfLink:/api/v1/namespaces/e2e-tests-watch-l4c4w/configmaps/e2e-watch-test-label-changed,UID:6270f245-7fc5-11e8-94db-42010a800002,ResourceVersion:2094,Generation:0,CreationTimestamp:2018-07-04 20:03:57 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 3,},BinaryData:map[string][]byte{},}
+Jul  4 20:04:07.138: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-l4c4w,SelfLink:/api/v1/namespaces/e2e-tests-watch-l4c4w/configmaps/e2e-watch-test-label-changed,UID:6270f245-7fc5-11e8-94db-42010a800002,ResourceVersion:2095,Generation:0,CreationTimestamp:2018-07-04 20:03:57 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 3,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:04:07.138: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-l4c4w" for this suite.
+Jul  4 20:04:13.153: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:04:13.188: INFO: namespace: e2e-tests-watch-l4c4w, resource: bindings, ignored listing per whitelist
+Jul  4 20:04:13.228: INFO: namespace e2e-tests-watch-l4c4w deletion completed in 6.086586822s
+
+• [SLOW TEST:16.186 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:04:13.228: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:04:13.295: INFO: Waiting up to 5m0s for pod "downwardapi-volume-6c0d041e-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-2xtjw" to be "success or failure"
+Jul  4 20:04:13.301: INFO: Pod "downwardapi-volume-6c0d041e-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 6.529089ms
+Jul  4 20:04:15.305: INFO: Pod "downwardapi-volume-6c0d041e-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009998493s
+STEP: Saw pod success
+Jul  4 20:04:15.305: INFO: Pod "downwardapi-volume-6c0d041e-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:04:15.307: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-6c0d041e-7fc5-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:04:15.328: INFO: Waiting for pod downwardapi-volume-6c0d041e-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:04:15.331: INFO: Pod downwardapi-volume-6c0d041e-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:04:15.331: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-2xtjw" for this suite.
+Jul  4 20:04:21.345: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:04:21.414: INFO: namespace: e2e-tests-downward-api-2xtjw, resource: bindings, ignored listing per whitelist
+Jul  4 20:04:21.444: INFO: namespace e2e-tests-downward-api-2xtjw deletion completed in 6.110776287s
+
+• [SLOW TEST:8.216 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:04:21.446: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:04:21.535: INFO: Waiting up to 5m0s for pod "downwardapi-volume-70f54d2f-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-w8j7g" to be "success or failure"
+Jul  4 20:04:21.548: INFO: Pod "downwardapi-volume-70f54d2f-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 12.699953ms
+Jul  4 20:04:23.552: INFO: Pod "downwardapi-volume-70f54d2f-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.016673013s
+STEP: Saw pod success
+Jul  4 20:04:23.552: INFO: Pod "downwardapi-volume-70f54d2f-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:04:23.554: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-70f54d2f-7fc5-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:04:23.574: INFO: Waiting for pod downwardapi-volume-70f54d2f-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:04:23.576: INFO: Pod downwardapi-volume-70f54d2f-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:04:23.577: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-w8j7g" for this suite.
+Jul  4 20:04:29.593: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:04:29.671: INFO: namespace: e2e-tests-downward-api-w8j7g, resource: bindings, ignored listing per whitelist
+Jul  4 20:04:29.699: INFO: namespace e2e-tests-downward-api-w8j7g deletion completed in 6.118476796s
+
+• [SLOW TEST:8.253 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:04:29.701: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-map-75e6df77-7fc5-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:04:29.832: INFO: Waiting up to 5m0s for pod "pod-secrets-75e7a518-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-secrets-8qrmp" to be "success or failure"
+Jul  4 20:04:29.844: INFO: Pod "pod-secrets-75e7a518-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 12.223538ms
+Jul  4 20:04:31.849: INFO: Pod "pod-secrets-75e7a518-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.016642641s
+Jul  4 20:04:33.852: INFO: Pod "pod-secrets-75e7a518-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.020215306s
+STEP: Saw pod success
+Jul  4 20:04:33.852: INFO: Pod "pod-secrets-75e7a518-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:04:33.855: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-secrets-75e7a518-7fc5-11e8-a4f0-6eaac417783a container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:04:33.881: INFO: Waiting for pod pod-secrets-75e7a518-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:04:33.883: INFO: Pod pod-secrets-75e7a518-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:04:33.883: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-8qrmp" for this suite.
+Jul  4 20:04:39.902: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:04:39.955: INFO: namespace: e2e-tests-secrets-8qrmp, resource: bindings, ignored listing per whitelist
+Jul  4 20:04:39.975: INFO: namespace e2e-tests-secrets-8qrmp deletion completed in 6.087068248s
+
+• [SLOW TEST:10.274 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:04:39.980: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:04:40.049: INFO: Waiting up to 5m0s for pod "downwardapi-volume-7bff6949-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-k88gv" to be "success or failure"
+Jul  4 20:04:40.061: INFO: Pod "downwardapi-volume-7bff6949-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 11.774351ms
+Jul  4 20:04:42.065: INFO: Pod "downwardapi-volume-7bff6949-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.015685559s
+STEP: Saw pod success
+Jul  4 20:04:42.065: INFO: Pod "downwardapi-volume-7bff6949-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:04:42.067: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-7bff6949-7fc5-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:04:42.097: INFO: Waiting for pod downwardapi-volume-7bff6949-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:04:42.100: INFO: Pod downwardapi-volume-7bff6949-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:04:42.100: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-k88gv" for this suite.
+Jul  4 20:04:48.113: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:04:48.140: INFO: namespace: e2e-tests-projected-k88gv, resource: bindings, ignored listing per whitelist
+Jul  4 20:04:48.192: INFO: namespace e2e-tests-projected-k88gv deletion completed in 6.089227685s
+
+• [SLOW TEST:8.213 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:04:48.194: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Jul  4 20:04:48.252: INFO: Waiting up to 5m0s for pod "pod-80e3404d-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-l2tvb" to be "success or failure"
+Jul  4 20:04:48.259: INFO: Pod "pod-80e3404d-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 6.257121ms
+Jul  4 20:04:50.262: INFO: Pod "pod-80e3404d-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009739945s
+STEP: Saw pod success
+Jul  4 20:04:50.262: INFO: Pod "pod-80e3404d-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:04:50.265: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-80e3404d-7fc5-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:04:50.314: INFO: Waiting for pod pod-80e3404d-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:04:50.317: INFO: Pod pod-80e3404d-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:04:50.317: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-l2tvb" for this suite.
+Jul  4 20:04:56.343: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:04:56.407: INFO: namespace: e2e-tests-emptydir-l2tvb, resource: bindings, ignored listing per whitelist
+Jul  4 20:04:56.414: INFO: namespace e2e-tests-emptydir-l2tvb deletion completed in 6.084258455s
+
+• [SLOW TEST:8.221 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:04:56.416: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  4 20:04:56.475: INFO: Creating ReplicaSet my-hostname-basic-85cae8ed-7fc5-11e8-a4f0-6eaac417783a
+Jul  4 20:04:56.485: INFO: Pod name my-hostname-basic-85cae8ed-7fc5-11e8-a4f0-6eaac417783a: Found 0 pods out of 1
+Jul  4 20:05:01.489: INFO: Pod name my-hostname-basic-85cae8ed-7fc5-11e8-a4f0-6eaac417783a: Found 1 pods out of 1
+Jul  4 20:05:01.489: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-85cae8ed-7fc5-11e8-a4f0-6eaac417783a" is running
+Jul  4 20:05:01.491: INFO: Pod "my-hostname-basic-85cae8ed-7fc5-11e8-a4f0-6eaac417783a-xff8j" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-04 20:04:56 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-04 20:04:58 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-04 20:04:56 +0000 UTC Reason: Message:}])
+Jul  4 20:05:01.491: INFO: Trying to dial the pod
+Jul  4 20:05:06.502: INFO: Controller my-hostname-basic-85cae8ed-7fc5-11e8-a4f0-6eaac417783a: Got expected result from replica 1 [my-hostname-basic-85cae8ed-7fc5-11e8-a4f0-6eaac417783a-xff8j]: "my-hostname-basic-85cae8ed-7fc5-11e8-a4f0-6eaac417783a-xff8j", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:05:06.502: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-9r92h" for this suite.
+Jul  4 20:05:12.519: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:05:12.589: INFO: namespace: e2e-tests-replicaset-9r92h, resource: bindings, ignored listing per whitelist
+Jul  4 20:05:12.589: INFO: namespace e2e-tests-replicaset-9r92h deletion completed in 6.082619423s
+
+• [SLOW TEST:16.174 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:05:12.589: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: getting the auto-created API token
+Jul  4 20:05:13.167: INFO: created pod pod-service-account-defaultsa
+Jul  4 20:05:13.167: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Jul  4 20:05:13.182: INFO: created pod pod-service-account-mountsa
+Jul  4 20:05:13.182: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Jul  4 20:05:13.226: INFO: created pod pod-service-account-nomountsa
+Jul  4 20:05:13.226: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Jul  4 20:05:13.244: INFO: created pod pod-service-account-defaultsa-mountspec
+Jul  4 20:05:13.244: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Jul  4 20:05:13.259: INFO: created pod pod-service-account-mountsa-mountspec
+Jul  4 20:05:13.260: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Jul  4 20:05:13.274: INFO: created pod pod-service-account-nomountsa-mountspec
+Jul  4 20:05:13.274: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Jul  4 20:05:13.286: INFO: created pod pod-service-account-defaultsa-nomountspec
+Jul  4 20:05:13.286: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Jul  4 20:05:13.302: INFO: created pod pod-service-account-mountsa-nomountspec
+Jul  4 20:05:13.302: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Jul  4 20:05:13.328: INFO: created pod pod-service-account-nomountsa-nomountspec
+Jul  4 20:05:13.328: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:05:13.328: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-77r5f" for this suite.
+Jul  4 20:05:19.396: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:05:19.424: INFO: namespace: e2e-tests-svcaccounts-77r5f, resource: bindings, ignored listing per whitelist
+Jul  4 20:05:19.497: INFO: namespace e2e-tests-svcaccounts-77r5f deletion completed in 6.152929751s
+
+• [SLOW TEST:6.908 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:05:19.498: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-938df10d-7fc5-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:05:19.574: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-938e796a-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-z6j2x" to be "success or failure"
+Jul  4 20:05:19.584: INFO: Pod "pod-projected-secrets-938e796a-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 9.130824ms
+Jul  4 20:05:21.590: INFO: Pod "pod-projected-secrets-938e796a-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01557566s
+Jul  4 20:05:23.594: INFO: Pod "pod-projected-secrets-938e796a-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.019376181s
+STEP: Saw pod success
+Jul  4 20:05:23.594: INFO: Pod "pod-projected-secrets-938e796a-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:05:23.596: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-secrets-938e796a-7fc5-11e8-a4f0-6eaac417783a container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:05:23.619: INFO: Waiting for pod pod-projected-secrets-938e796a-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:05:23.622: INFO: Pod pod-projected-secrets-938e796a-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:05:23.623: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-z6j2x" for this suite.
+Jul  4 20:05:29.636: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:05:29.700: INFO: namespace: e2e-tests-projected-z6j2x, resource: bindings, ignored listing per whitelist
+Jul  4 20:05:29.704: INFO: namespace e2e-tests-projected-z6j2x deletion completed in 6.078753078s
+
+• [SLOW TEST:10.207 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:05:29.706: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:05:29.769: INFO: Waiting up to 5m0s for pod "downwardapi-volume-99a1f7c4-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-xq5n9" to be "success or failure"
+Jul  4 20:05:29.777: INFO: Pod "downwardapi-volume-99a1f7c4-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.087268ms
+Jul  4 20:05:31.780: INFO: Pod "downwardapi-volume-99a1f7c4-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011377154s
+Jul  4 20:05:33.783: INFO: Pod "downwardapi-volume-99a1f7c4-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014404312s
+STEP: Saw pod success
+Jul  4 20:05:33.783: INFO: Pod "downwardapi-volume-99a1f7c4-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:05:33.785: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-99a1f7c4-7fc5-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:05:33.804: INFO: Waiting for pod downwardapi-volume-99a1f7c4-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:05:33.806: INFO: Pod downwardapi-volume-99a1f7c4-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:05:33.807: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-xq5n9" for this suite.
+Jul  4 20:05:39.828: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:05:39.905: INFO: namespace: e2e-tests-downward-api-xq5n9, resource: bindings, ignored listing per whitelist
+Jul  4 20:05:39.907: INFO: namespace e2e-tests-downward-api-xq5n9 deletion completed in 6.097187292s
+
+• [SLOW TEST:10.201 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:05:39.908: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-9fb6569f-7fc5-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:05:39.971: INFO: Waiting up to 5m0s for pod "pod-secrets-9fb6d35e-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-secrets-x9lx2" to be "success or failure"
+Jul  4 20:05:39.978: INFO: Pod "pod-secrets-9fb6d35e-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 6.938167ms
+Jul  4 20:05:41.981: INFO: Pod "pod-secrets-9fb6d35e-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010302508s
+Jul  4 20:05:43.984: INFO: Pod "pod-secrets-9fb6d35e-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013737544s
+STEP: Saw pod success
+Jul  4 20:05:43.984: INFO: Pod "pod-secrets-9fb6d35e-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:05:43.986: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-secrets-9fb6d35e-7fc5-11e8-a4f0-6eaac417783a container secret-env-test: <nil>
+STEP: delete the pod
+Jul  4 20:05:44.012: INFO: Waiting for pod pod-secrets-9fb6d35e-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:05:44.015: INFO: Pod pod-secrets-9fb6d35e-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:05:44.015: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-x9lx2" for this suite.
+Jul  4 20:05:50.031: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:05:50.093: INFO: namespace: e2e-tests-secrets-x9lx2, resource: bindings, ignored listing per whitelist
+Jul  4 20:05:50.132: INFO: namespace e2e-tests-secrets-x9lx2 deletion completed in 6.113196231s
+
+• [SLOW TEST:10.224 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:05:50.133: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  4 20:05:50.205: INFO: Waiting up to 5m0s for pod "downward-api-a5d088c4-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-plhvj" to be "success or failure"
+Jul  4 20:05:50.212: INFO: Pod "downward-api-a5d088c4-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 6.620198ms
+Jul  4 20:05:52.219: INFO: Pod "downward-api-a5d088c4-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013207028s
+Jul  4 20:05:54.222: INFO: Pod "downward-api-a5d088c4-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016477767s
+STEP: Saw pod success
+Jul  4 20:05:54.222: INFO: Pod "downward-api-a5d088c4-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:05:54.224: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downward-api-a5d088c4-7fc5-11e8-a4f0-6eaac417783a container dapi-container: <nil>
+STEP: delete the pod
+Jul  4 20:05:54.242: INFO: Waiting for pod downward-api-a5d088c4-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:05:54.244: INFO: Pod downward-api-a5d088c4-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:05:54.244: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-plhvj" for this suite.
+Jul  4 20:06:00.258: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:06:00.312: INFO: namespace: e2e-tests-downward-api-plhvj, resource: bindings, ignored listing per whitelist
+Jul  4 20:06:00.323: INFO: namespace e2e-tests-downward-api-plhvj deletion completed in 6.075916635s
+
+• [SLOW TEST:10.190 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:06:00.325: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Jul  4 20:06:00.403: INFO: Waiting up to 5m0s for pod "pod-abe42b18-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-kdrq2" to be "success or failure"
+Jul  4 20:06:00.412: INFO: Pod "pod-abe42b18-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.217489ms
+Jul  4 20:06:02.415: INFO: Pod "pod-abe42b18-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011295369s
+STEP: Saw pod success
+Jul  4 20:06:02.415: INFO: Pod "pod-abe42b18-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:06:02.417: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-abe42b18-7fc5-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:06:02.437: INFO: Waiting for pod pod-abe42b18-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:06:02.440: INFO: Pod pod-abe42b18-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:06:02.440: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-kdrq2" for this suite.
+Jul  4 20:06:08.463: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:06:08.478: INFO: namespace: e2e-tests-emptydir-kdrq2, resource: bindings, ignored listing per whitelist
+Jul  4 20:06:08.529: INFO: namespace e2e-tests-emptydir-kdrq2 deletion completed in 6.086498565s
+
+• [SLOW TEST:8.205 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:06:08.531: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating server pod server in namespace e2e-tests-prestop-mrxdg
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-mrxdg
+STEP: Deleting pre-stop pod
+Jul  4 20:06:21.687: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:06:21.696: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-mrxdg" for this suite.
+Jul  4 20:06:59.737: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:06:59.777: INFO: namespace: e2e-tests-prestop-mrxdg, resource: bindings, ignored listing per whitelist
+Jul  4 20:06:59.815: INFO: namespace e2e-tests-prestop-mrxdg deletion completed in 38.113463142s
+
+• [SLOW TEST:51.285 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:06:59.817: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:06:59.884: INFO: Waiting up to 5m0s for pod "downwardapi-volume-cf588b1b-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-kh9gd" to be "success or failure"
+Jul  4 20:06:59.892: INFO: Pod "downwardapi-volume-cf588b1b-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.84799ms
+Jul  4 20:07:01.895: INFO: Pod "downwardapi-volume-cf588b1b-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011175532s
+Jul  4 20:07:03.898: INFO: Pod "downwardapi-volume-cf588b1b-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01388594s
+STEP: Saw pod success
+Jul  4 20:07:03.898: INFO: Pod "downwardapi-volume-cf588b1b-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:07:03.900: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-cf588b1b-7fc5-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:07:03.933: INFO: Waiting for pod downwardapi-volume-cf588b1b-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:07:03.936: INFO: Pod downwardapi-volume-cf588b1b-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:07:03.936: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-kh9gd" for this suite.
+Jul  4 20:07:09.952: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:07:09.987: INFO: namespace: e2e-tests-downward-api-kh9gd, resource: bindings, ignored listing per whitelist
+Jul  4 20:07:10.019: INFO: namespace e2e-tests-downward-api-kh9gd deletion completed in 6.080158987s
+
+• [SLOW TEST:10.202 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:07:10.021: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Jul  4 20:07:10.079: INFO: Waiting up to 5m0s for pod "pod-d56c61f6-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-dshms" to be "success or failure"
+Jul  4 20:07:10.083: INFO: Pod "pod-d56c61f6-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 3.609181ms
+Jul  4 20:07:12.086: INFO: Pod "pod-d56c61f6-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007181759s
+Jul  4 20:07:14.090: INFO: Pod "pod-d56c61f6-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010471151s
+STEP: Saw pod success
+Jul  4 20:07:14.090: INFO: Pod "pod-d56c61f6-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:07:14.092: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-d56c61f6-7fc5-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:07:14.109: INFO: Waiting for pod pod-d56c61f6-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:07:14.112: INFO: Pod pod-d56c61f6-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:07:14.114: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-dshms" for this suite.
+Jul  4 20:07:20.128: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:07:20.170: INFO: namespace: e2e-tests-emptydir-dshms, resource: bindings, ignored listing per whitelist
+Jul  4 20:07:20.208: INFO: namespace e2e-tests-emptydir-dshms deletion completed in 6.090777717s
+
+• [SLOW TEST:10.187 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:07:20.211: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:07:20.276: INFO: Waiting up to 5m0s for pod "downwardapi-volume-db801940-7fc5-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-l6wtk" to be "success or failure"
+Jul  4 20:07:20.286: INFO: Pod "downwardapi-volume-db801940-7fc5-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 9.137409ms
+Jul  4 20:07:22.289: INFO: Pod "downwardapi-volume-db801940-7fc5-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012622469s
+STEP: Saw pod success
+Jul  4 20:07:22.289: INFO: Pod "downwardapi-volume-db801940-7fc5-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:07:22.293: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-db801940-7fc5-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:07:22.319: INFO: Waiting for pod downwardapi-volume-db801940-7fc5-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:07:22.322: INFO: Pod downwardapi-volume-db801940-7fc5-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:07:22.322: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-l6wtk" for this suite.
+Jul  4 20:07:28.341: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:07:28.402: INFO: namespace: e2e-tests-projected-l6wtk, resource: bindings, ignored listing per whitelist
+Jul  4 20:07:28.412: INFO: namespace e2e-tests-projected-l6wtk deletion completed in 6.086653361s
+
+• [SLOW TEST:8.202 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:07:28.414: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:08:28.526: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-k5hxb" for this suite.
+Jul  4 20:08:50.542: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:08:50.585: INFO: namespace: e2e-tests-container-probe-k5hxb, resource: bindings, ignored listing per whitelist
+Jul  4 20:08:50.609: INFO: namespace e2e-tests-container-probe-k5hxb deletion completed in 22.079723967s
+
+• [SLOW TEST:82.195 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:08:50.610: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  4 20:08:55.220: INFO: Successfully updated pod "labelsupdate1161b3bb-7fc6-11e8-a4f0-6eaac417783a"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:08:57.238: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-bjrcx" for this suite.
+Jul  4 20:09:19.253: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:09:19.310: INFO: namespace: e2e-tests-downward-api-bjrcx, resource: bindings, ignored listing per whitelist
+Jul  4 20:09:19.346: INFO: namespace e2e-tests-downward-api-bjrcx deletion completed in 22.104580717s
+
+• [SLOW TEST:28.736 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:09:19.348: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for all rs to be garbage collected
+STEP: expected 0 rs, got 1 rs
+STEP: expected 0 Pods, got 2 Pods
+STEP: Gathering metrics
+W0704 20:09:20.447516      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  4 20:09:20.447: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:09:20.447: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-p98v5" for this suite.
+Jul  4 20:09:26.462: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:09:26.499: INFO: namespace: e2e-tests-gc-p98v5, resource: bindings, ignored listing per whitelist
+Jul  4 20:09:26.533: INFO: namespace e2e-tests-gc-p98v5 deletion completed in 6.082834385s
+
+• [SLOW TEST:7.186 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:09:26.535: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  4 20:09:29.180: INFO: Successfully updated pod "annotationupdate26d31b8b-7fc6-11e8-a4f0-6eaac417783a"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:09:31.227: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xp7qt" for this suite.
+Jul  4 20:09:53.252: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:09:53.317: INFO: namespace: e2e-tests-projected-xp7qt, resource: bindings, ignored listing per whitelist
+Jul  4 20:09:53.326: INFO: namespace e2e-tests-projected-xp7qt deletion completed in 22.093074712s
+
+• [SLOW TEST:26.792 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:09:53.328: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-36c2abdd-7fc6-11e8-a4f0-6eaac417783a,GenerateName:,Namespace:e2e-tests-events-vtz8s,SelfLink:/api/v1/namespaces/e2e-tests-events-vtz8s/pods/send-events-36c2abdd-7fc6-11e8-a4f0-6eaac417783a,UID:36d3bd11-7fc6-11e8-94db-42010a800002,ResourceVersion:3284,Generation:0,CreationTimestamp:2018-07-04 20:09:53 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 377998776,},Annotations:map[string]string{cni.projectcalico.org/podIP: 10.2.1.36/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-vmvn2 {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-vmvn2,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-vmvn2 true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:jakku-worker-f0tz.c.dghubble-io.internal,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,Sysctls:[],},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc421a0fdc0} {node.kubernetes.io/unreachable Exists  NoExecute 0xc421a0fde0}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,ReadinessGates:[],},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:09:53 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:09:54 +0000 UTC  } {ContainersReady True 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:09:53 +0000 UTC  }],Message:,Reason:,HostIP:10.128.0.4,PodIP:10.2.1.36,StartTime:2018-07-04 20:09:53 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-07-04 20:09:54 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://801115f44c7003e773fb9d6012a5ef9882e5124a79b5244b495f5c1e2da5361a}],QOSClass:BestEffort,InitContainerStatuses:[],NominatedNodeName:,},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:09:59.425: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-vtz8s" for this suite.
+Jul  4 20:10:05.450: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:10:05.495: INFO: namespace: e2e-tests-events-vtz8s, resource: bindings, ignored listing per whitelist
+Jul  4 20:10:05.524: INFO: namespace e2e-tests-events-vtz8s deletion completed in 6.09191878s
+
+• [SLOW TEST:12.196 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:10:05.525: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test substitution in container's command
+Jul  4 20:10:05.584: INFO: Waiting up to 5m0s for pod "var-expansion-3e082e44-7fc6-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-var-expansion-zhj9l" to be "success or failure"
+Jul  4 20:10:05.591: INFO: Pod "var-expansion-3e082e44-7fc6-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 6.767488ms
+Jul  4 20:10:07.594: INFO: Pod "var-expansion-3e082e44-7fc6-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01045742s
+Jul  4 20:10:09.597: INFO: Pod "var-expansion-3e082e44-7fc6-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013491231s
+STEP: Saw pod success
+Jul  4 20:10:09.597: INFO: Pod "var-expansion-3e082e44-7fc6-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:10:09.599: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod var-expansion-3e082e44-7fc6-11e8-a4f0-6eaac417783a container dapi-container: <nil>
+STEP: delete the pod
+Jul  4 20:10:09.619: INFO: Waiting for pod var-expansion-3e082e44-7fc6-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:10:09.622: INFO: Pod var-expansion-3e082e44-7fc6-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:10:09.622: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-zhj9l" for this suite.
+Jul  4 20:10:15.638: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:10:15.667: INFO: namespace: e2e-tests-var-expansion-zhj9l, resource: bindings, ignored listing per whitelist
+Jul  4 20:10:15.716: INFO: namespace e2e-tests-var-expansion-zhj9l deletion completed in 6.090658726s
+
+• [SLOW TEST:10.191 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:10:15.718: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  4 20:10:15.775: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  4 20:11:15.813: INFO: Waiting for terminating namespaces to be deleted...
+Jul  4 20:11:15.818: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  4 20:11:15.839: INFO: 16 / 16 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  4 20:11:15.839: INFO: expected 5 pod replicas in namespace 'kube-system', 5 are Running and Ready.
+Jul  4 20:11:15.848: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  4 20:11:15.848: INFO: 
+Logging pods the kubelet thinks is on node jakku-worker-8tmm.c.dghubble-io.internal before test
+Jul  4 20:11:15.924: INFO: sonobuoy-systemd-logs-daemon-set-ee1900e8dc834edd-w7cqr from heptio-sonobuoy started at 2018-07-04 19:59:21 +0000 UTC (2 container statuses recorded)
+Jul  4 20:11:15.924: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 0
+Jul  4 20:11:15.924: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  4 20:11:15.924: INFO: sonobuoy-e2e-job-fd38b8fecef545c4 from heptio-sonobuoy started at 2018-07-04 19:59:21 +0000 UTC (2 container statuses recorded)
+Jul  4 20:11:15.924: INFO: 	Container e2e ready: true, restart count 0
+Jul  4 20:11:15.924: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  4 20:11:15.924: INFO: kube-proxy-72hkz from kube-system started at 2018-07-04 19:56:01 +0000 UTC (1 container statuses recorded)
+Jul  4 20:11:15.924: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  4 20:11:15.924: INFO: calico-node-kc252 from kube-system started at 2018-07-04 19:56:01 +0000 UTC (2 container statuses recorded)
+Jul  4 20:11:15.924: INFO: 	Container calico-node ready: true, restart count 0
+Jul  4 20:11:15.924: INFO: 	Container install-cni ready: true, restart count 0
+Jul  4 20:11:15.924: INFO: 
+Logging pods the kubelet thinks is on node jakku-worker-f0tz.c.dghubble-io.internal before test
+Jul  4 20:11:15.931: INFO: kube-proxy-4ptlm from kube-system started at 2018-07-04 19:56:01 +0000 UTC (1 container statuses recorded)
+Jul  4 20:11:15.931: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  4 20:11:15.931: INFO: calico-node-w7vpr from kube-system started at 2018-07-04 19:56:02 +0000 UTC (2 container statuses recorded)
+Jul  4 20:11:15.931: INFO: 	Container calico-node ready: true, restart count 0
+Jul  4 20:11:15.931: INFO: 	Container install-cni ready: true, restart count 0
+Jul  4 20:11:15.931: INFO: sonobuoy-systemd-logs-daemon-set-ee1900e8dc834edd-zlpw9 from heptio-sonobuoy started at 2018-07-04 19:59:21 +0000 UTC (2 container statuses recorded)
+Jul  4 20:11:15.931: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 0
+Jul  4 20:11:15.931: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  4 20:11:15.932: INFO: 
+Logging pods the kubelet thinks is on node jakku-worker-ktmr.c.dghubble-io.internal before test
+Jul  4 20:11:15.956: INFO: kube-proxy-gszcd from kube-system started at 2018-07-04 19:56:01 +0000 UTC (1 container statuses recorded)
+Jul  4 20:11:15.956: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  4 20:11:15.956: INFO: calico-node-8dl78 from kube-system started at 2018-07-04 19:56:02 +0000 UTC (2 container statuses recorded)
+Jul  4 20:11:15.956: INFO: 	Container calico-node ready: true, restart count 0
+Jul  4 20:11:15.956: INFO: 	Container install-cni ready: true, restart count 0
+Jul  4 20:11:15.956: INFO: sonobuoy from heptio-sonobuoy started at 2018-07-04 19:59:09 +0000 UTC (1 container statuses recorded)
+Jul  4 20:11:15.956: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Jul  4 20:11:15.956: INFO: sonobuoy-systemd-logs-daemon-set-ee1900e8dc834edd-grqmh from heptio-sonobuoy started at 2018-07-04 19:59:21 +0000 UTC (2 container statuses recorded)
+Jul  4 20:11:15.956: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 0
+Jul  4 20:11:15.956: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-69327d45-7fc6-11e8-a4f0-6eaac417783a 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-69327d45-7fc6-11e8-a4f0-6eaac417783a off the node jakku-worker-f0tz.c.dghubble-io.internal
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-69327d45-7fc6-11e8-a4f0-6eaac417783a
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:11:20.092: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-mcldj" for this suite.
+Jul  4 20:11:42.107: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:11:42.162: INFO: namespace: e2e-tests-sched-pred-mcldj, resource: bindings, ignored listing per whitelist
+Jul  4 20:11:42.178: INFO: namespace e2e-tests-sched-pred-mcldj deletion completed in 22.083629692s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:86.461 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:11:42.180: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-kjrps
+[It] should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a new StatefulSet
+Jul  4 20:11:42.275: INFO: Found 0 stateful pods, waiting for 3
+Jul  4 20:11:52.279: INFO: Found 2 stateful pods, waiting for 3
+Jul  4 20:12:02.279: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:12:02.279: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:12:02.279: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=false
+Jul  4 20:12:12.279: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:12:12.279: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:12:12.279: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:12:12.291: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-kjrps ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  4 20:12:12.530: INFO: stderr: ""
+Jul  4 20:12:12.530: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  4 20:12:12.530: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+STEP: Updating StatefulSet template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Jul  4 20:12:22.563: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Updating Pods in reverse ordinal order
+Jul  4 20:12:32.582: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-kjrps ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:12:32.868: INFO: stderr: ""
+Jul  4 20:12:32.868: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  4 20:12:32.868: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  4 20:12:42.885: INFO: Waiting for StatefulSet e2e-tests-statefulset-kjrps/ss2 to complete update
+Jul  4 20:12:42.886: INFO: Waiting for Pod e2e-tests-statefulset-kjrps/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  4 20:12:42.886: INFO: Waiting for Pod e2e-tests-statefulset-kjrps/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  4 20:12:52.892: INFO: Waiting for StatefulSet e2e-tests-statefulset-kjrps/ss2 to complete update
+Jul  4 20:12:52.893: INFO: Waiting for Pod e2e-tests-statefulset-kjrps/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  4 20:12:52.893: INFO: Waiting for Pod e2e-tests-statefulset-kjrps/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  4 20:13:02.892: INFO: Waiting for StatefulSet e2e-tests-statefulset-kjrps/ss2 to complete update
+STEP: Rolling back to a previous revision
+Jul  4 20:13:12.893: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-kjrps ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  4 20:13:13.137: INFO: stderr: ""
+Jul  4 20:13:13.137: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  4 20:13:13.137: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  4 20:13:23.171: INFO: Updating stateful set ss2
+STEP: Rolling back update in reverse ordinal order
+Jul  4 20:13:33.190: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-kjrps ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:13:33.432: INFO: stderr: ""
+Jul  4 20:13:33.432: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  4 20:13:33.432: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  4 20:13:53.451: INFO: Deleting all statefulset in ns e2e-tests-statefulset-kjrps
+Jul  4 20:13:53.453: INFO: Scaling statefulset ss2 to 0
+Jul  4 20:14:23.482: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  4 20:14:23.484: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:14:23.503: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-kjrps" for this suite.
+Jul  4 20:14:29.531: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:14:29.610: INFO: namespace: e2e-tests-statefulset-kjrps, resource: bindings, ignored listing per whitelist
+Jul  4 20:14:29.610: INFO: namespace e2e-tests-statefulset-kjrps deletion completed in 6.099676219s
+
+• [SLOW TEST:167.431 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should perform rolling updates and roll backs of template modifications [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:14:29.613: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:14:29.678: INFO: Waiting up to 5m0s for pod "downwardapi-volume-db716bd2-7fc6-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-dzd7p" to be "success or failure"
+Jul  4 20:14:29.685: INFO: Pod "downwardapi-volume-db716bd2-7fc6-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 6.182602ms
+Jul  4 20:14:31.688: INFO: Pod "downwardapi-volume-db716bd2-7fc6-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00949278s
+STEP: Saw pod success
+Jul  4 20:14:31.688: INFO: Pod "downwardapi-volume-db716bd2-7fc6-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:14:31.690: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-db716bd2-7fc6-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:14:31.716: INFO: Waiting for pod downwardapi-volume-db716bd2-7fc6-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:14:31.718: INFO: Pod downwardapi-volume-db716bd2-7fc6-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:14:31.718: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-dzd7p" for this suite.
+Jul  4 20:14:37.735: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:14:37.783: INFO: namespace: e2e-tests-projected-dzd7p, resource: bindings, ignored listing per whitelist
+Jul  4 20:14:37.858: INFO: namespace e2e-tests-projected-dzd7p deletion completed in 6.134946993s
+
+• [SLOW TEST:8.246 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:14:37.858: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-e05cc884-7fc6-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 20:14:37.937: INFO: Waiting up to 5m0s for pod "pod-configmaps-e05d71e1-7fc6-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-configmap-2qzwh" to be "success or failure"
+Jul  4 20:14:37.944: INFO: Pod "pod-configmaps-e05d71e1-7fc6-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.312131ms
+Jul  4 20:14:39.947: INFO: Pod "pod-configmaps-e05d71e1-7fc6-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010540763s
+STEP: Saw pod success
+Jul  4 20:14:39.947: INFO: Pod "pod-configmaps-e05d71e1-7fc6-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:14:39.950: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-configmaps-e05d71e1-7fc6-11e8-a4f0-6eaac417783a container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:14:39.970: INFO: Waiting for pod pod-configmaps-e05d71e1-7fc6-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:14:39.974: INFO: Pod pod-configmaps-e05d71e1-7fc6-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:14:39.974: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-2qzwh" for this suite.
+Jul  4 20:14:45.991: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:14:46.057: INFO: namespace: e2e-tests-configmap-2qzwh, resource: bindings, ignored listing per whitelist
+Jul  4 20:14:46.063: INFO: namespace e2e-tests-configmap-2qzwh deletion completed in 6.085777852s
+
+• [SLOW TEST:8.205 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:14:46.065: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  4 20:14:46.162: INFO: (0) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 13.089984ms)
+Jul  4 20:14:46.165: INFO: (1) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.453483ms)
+Jul  4 20:14:46.169: INFO: (2) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.617603ms)
+Jul  4 20:14:46.173: INFO: (3) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.299698ms)
+Jul  4 20:14:46.175: INFO: (4) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.826909ms)
+Jul  4 20:14:46.178: INFO: (5) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.857084ms)
+Jul  4 20:14:46.183: INFO: (6) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.332869ms)
+Jul  4 20:14:46.187: INFO: (7) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.233962ms)
+Jul  4 20:14:46.190: INFO: (8) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.316475ms)
+Jul  4 20:14:46.194: INFO: (9) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.426891ms)
+Jul  4 20:14:46.198: INFO: (10) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.778602ms)
+Jul  4 20:14:46.201: INFO: (11) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.207696ms)
+Jul  4 20:14:46.204: INFO: (12) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.871661ms)
+Jul  4 20:14:46.207: INFO: (13) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.964602ms)
+Jul  4 20:14:46.210: INFO: (14) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.965963ms)
+Jul  4 20:14:46.213: INFO: (15) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.673419ms)
+Jul  4 20:14:46.216: INFO: (16) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.854285ms)
+Jul  4 20:14:46.218: INFO: (17) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.805959ms)
+Jul  4 20:14:46.222: INFO: (18) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.962009ms)
+Jul  4 20:14:46.225: INFO: (19) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.948403ms)
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:14:46.225: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-m72pq" for this suite.
+Jul  4 20:14:52.241: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:14:52.284: INFO: namespace: e2e-tests-proxy-m72pq, resource: bindings, ignored listing per whitelist
+Jul  4 20:14:52.309: INFO: namespace e2e-tests-proxy-m72pq deletion completed in 6.081022535s
+
+• [SLOW TEST:6.244 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:14:52.312: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  4 20:14:52.433: INFO: Waiting up to 5m0s for pod "downward-api-e901a89e-7fc6-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-wg268" to be "success or failure"
+Jul  4 20:14:52.435: INFO: Pod "downward-api-e901a89e-7fc6-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.608618ms
+Jul  4 20:14:54.439: INFO: Pod "downward-api-e901a89e-7fc6-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006007s
+Jul  4 20:14:56.443: INFO: Pod "downward-api-e901a89e-7fc6-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009857443s
+STEP: Saw pod success
+Jul  4 20:14:56.443: INFO: Pod "downward-api-e901a89e-7fc6-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:14:56.445: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downward-api-e901a89e-7fc6-11e8-a4f0-6eaac417783a container dapi-container: <nil>
+STEP: delete the pod
+Jul  4 20:14:56.500: INFO: Waiting for pod downward-api-e901a89e-7fc6-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:14:56.504: INFO: Pod downward-api-e901a89e-7fc6-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:14:56.504: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-wg268" for this suite.
+Jul  4 20:15:02.524: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:15:02.539: INFO: namespace: e2e-tests-downward-api-wg268, resource: bindings, ignored listing per whitelist
+Jul  4 20:15:02.600: INFO: namespace e2e-tests-downward-api-wg268 deletion completed in 6.091693054s
+
+• [SLOW TEST:10.289 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:15:02.603: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-ml6tt
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  4 20:15:02.685: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  4 20:15:24.875: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.2.1.49:8080/dial?request=hostName&protocol=udp&host=10.2.0.10&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-ml6tt PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:15:24.876: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:15:25.020: INFO: Waiting for endpoints: map[]
+Jul  4 20:15:25.024: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.2.1.49:8080/dial?request=hostName&protocol=udp&host=10.2.3.10&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-ml6tt PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:15:25.024: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:15:25.130: INFO: Waiting for endpoints: map[]
+Jul  4 20:15:25.133: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.2.1.49:8080/dial?request=hostName&protocol=udp&host=10.2.1.48&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-ml6tt PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:15:25.134: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:15:25.229: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:15:25.229: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-ml6tt" for this suite.
+Jul  4 20:15:47.269: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:15:47.310: INFO: namespace: e2e-tests-pod-network-test-ml6tt, resource: bindings, ignored listing per whitelist
+Jul  4 20:15:47.346: INFO: namespace e2e-tests-pod-network-test-ml6tt deletion completed in 22.098788727s
+
+• [SLOW TEST:44.744 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:15:47.348: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  4 20:15:47.436: INFO: Waiting up to 5m0s for pod "downward-api-09c9de99-7fc7-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-chp8p" to be "success or failure"
+Jul  4 20:15:47.443: INFO: Pod "downward-api-09c9de99-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 6.90468ms
+Jul  4 20:15:49.447: INFO: Pod "downward-api-09c9de99-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010714515s
+Jul  4 20:15:51.451: INFO: Pod "downward-api-09c9de99-7fc7-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014171401s
+STEP: Saw pod success
+Jul  4 20:15:51.451: INFO: Pod "downward-api-09c9de99-7fc7-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:15:51.455: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downward-api-09c9de99-7fc7-11e8-a4f0-6eaac417783a container dapi-container: <nil>
+STEP: delete the pod
+Jul  4 20:15:51.478: INFO: Waiting for pod downward-api-09c9de99-7fc7-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:15:51.480: INFO: Pod downward-api-09c9de99-7fc7-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:15:51.481: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-chp8p" for this suite.
+Jul  4 20:15:57.499: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:15:57.591: INFO: namespace: e2e-tests-downward-api-chp8p, resource: bindings, ignored listing per whitelist
+Jul  4 20:15:57.596: INFO: namespace e2e-tests-downward-api-chp8p deletion completed in 6.109931349s
+
+• [SLOW TEST:10.249 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:15:57.598: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-0fe4f3b7-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:15:57.680: INFO: Waiting up to 5m0s for pod "pod-secrets-0fe58e3e-7fc7-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-secrets-vmqvh" to be "success or failure"
+Jul  4 20:15:57.689: INFO: Pod "pod-secrets-0fe58e3e-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.905661ms
+Jul  4 20:15:59.692: INFO: Pod "pod-secrets-0fe58e3e-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.012242747s
+Jul  4 20:16:01.696: INFO: Pod "pod-secrets-0fe58e3e-7fc7-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015794451s
+STEP: Saw pod success
+Jul  4 20:16:01.696: INFO: Pod "pod-secrets-0fe58e3e-7fc7-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:16:01.698: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-secrets-0fe58e3e-7fc7-11e8-a4f0-6eaac417783a container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:16:01.718: INFO: Waiting for pod pod-secrets-0fe58e3e-7fc7-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:16:01.725: INFO: Pod pod-secrets-0fe58e3e-7fc7-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:16:01.725: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-vmqvh" for this suite.
+Jul  4 20:16:07.746: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:16:07.778: INFO: namespace: e2e-tests-secrets-vmqvh, resource: bindings, ignored listing per whitelist
+Jul  4 20:16:07.826: INFO: namespace e2e-tests-secrets-vmqvh deletion completed in 6.096856701s
+
+• [SLOW TEST:10.229 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:16:07.828: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Jul  4 20:16:07.886: INFO: Waiting up to 5m0s for pod "pod-15fb2002-7fc7-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-qtmpc" to be "success or failure"
+Jul  4 20:16:07.896: INFO: Pod "pod-15fb2002-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.874842ms
+Jul  4 20:16:09.910: INFO: Pod "pod-15fb2002-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.023342915s
+Jul  4 20:16:11.914: INFO: Pod "pod-15fb2002-7fc7-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.027023591s
+STEP: Saw pod success
+Jul  4 20:16:11.914: INFO: Pod "pod-15fb2002-7fc7-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:16:11.916: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-15fb2002-7fc7-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:16:11.939: INFO: Waiting for pod pod-15fb2002-7fc7-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:16:11.942: INFO: Pod pod-15fb2002-7fc7-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:16:11.942: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-qtmpc" for this suite.
+Jul  4 20:16:17.959: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:16:18.048: INFO: namespace: e2e-tests-emptydir-qtmpc, resource: bindings, ignored listing per whitelist
+Jul  4 20:16:18.055: INFO: namespace e2e-tests-emptydir-qtmpc deletion completed in 6.108652232s
+
+• [SLOW TEST:10.227 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:16:18.056: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name projected-secret-test-1c1610d5-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:16:18.135: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-1c16a909-7fc7-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-m6cp6" to be "success or failure"
+Jul  4 20:16:18.140: INFO: Pod "pod-projected-secrets-1c16a909-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 4.612661ms
+Jul  4 20:16:20.144: INFO: Pod "pod-projected-secrets-1c16a909-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008235862s
+Jul  4 20:16:22.147: INFO: Pod "pod-projected-secrets-1c16a909-7fc7-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011645138s
+STEP: Saw pod success
+Jul  4 20:16:22.147: INFO: Pod "pod-projected-secrets-1c16a909-7fc7-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:16:22.150: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-secrets-1c16a909-7fc7-11e8-a4f0-6eaac417783a container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:16:22.182: INFO: Waiting for pod pod-projected-secrets-1c16a909-7fc7-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:16:22.187: INFO: Pod pod-projected-secrets-1c16a909-7fc7-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:16:22.187: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-m6cp6" for this suite.
+Jul  4 20:16:28.212: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:16:28.239: INFO: namespace: e2e-tests-projected-m6cp6, resource: bindings, ignored listing per whitelist
+Jul  4 20:16:28.306: INFO: namespace e2e-tests-projected-m6cp6 deletion completed in 6.112021727s
+
+• [SLOW TEST:10.250 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:16:28.307: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap e2e-tests-configmap-khlp6/configmap-test-22342e95-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 20:16:28.400: INFO: Waiting up to 5m0s for pod "pod-configmaps-2234b4ac-7fc7-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-configmap-khlp6" to be "success or failure"
+Jul  4 20:16:28.409: INFO: Pod "pod-configmaps-2234b4ac-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.796764ms
+Jul  4 20:16:30.412: INFO: Pod "pod-configmaps-2234b4ac-7fc7-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012087097s
+STEP: Saw pod success
+Jul  4 20:16:30.412: INFO: Pod "pod-configmaps-2234b4ac-7fc7-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:16:30.415: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-configmaps-2234b4ac-7fc7-11e8-a4f0-6eaac417783a container env-test: <nil>
+STEP: delete the pod
+Jul  4 20:16:30.454: INFO: Waiting for pod pod-configmaps-2234b4ac-7fc7-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:16:30.456: INFO: Pod pod-configmaps-2234b4ac-7fc7-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:16:30.457: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-khlp6" for this suite.
+Jul  4 20:16:36.474: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:16:36.523: INFO: namespace: e2e-tests-configmap-khlp6, resource: bindings, ignored listing per whitelist
+Jul  4 20:16:36.541: INFO: namespace e2e-tests-configmap-khlp6 deletion completed in 6.079811587s
+
+• [SLOW TEST:8.234 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:16:36.542: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating secret e2e-tests-secrets-kjmh9/secret-test-272948c5-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:16:36.714: INFO: Waiting up to 5m0s for pod "pod-configmaps-2729c73c-7fc7-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-secrets-kjmh9" to be "success or failure"
+Jul  4 20:16:36.720: INFO: Pod "pod-configmaps-2729c73c-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 5.417217ms
+Jul  4 20:16:38.724: INFO: Pod "pod-configmaps-2729c73c-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009424466s
+Jul  4 20:16:40.731: INFO: Pod "pod-configmaps-2729c73c-7fc7-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01684672s
+STEP: Saw pod success
+Jul  4 20:16:40.731: INFO: Pod "pod-configmaps-2729c73c-7fc7-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:16:40.736: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-configmaps-2729c73c-7fc7-11e8-a4f0-6eaac417783a container env-test: <nil>
+STEP: delete the pod
+Jul  4 20:16:40.758: INFO: Waiting for pod pod-configmaps-2729c73c-7fc7-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:16:40.762: INFO: Pod pod-configmaps-2729c73c-7fc7-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:16:40.763: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-kjmh9" for this suite.
+Jul  4 20:16:46.782: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:16:46.853: INFO: namespace: e2e-tests-secrets-kjmh9, resource: bindings, ignored listing per whitelist
+Jul  4 20:16:46.871: INFO: namespace e2e-tests-secrets-kjmh9 deletion completed in 6.100403159s
+
+• [SLOW TEST:10.329 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:16:46.872: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-2d417071-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 20:16:46.938: INFO: Waiting up to 5m0s for pod "pod-configmaps-2d41e7c9-7fc7-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-configmap-rcm9n" to be "success or failure"
+Jul  4 20:16:46.947: INFO: Pod "pod-configmaps-2d41e7c9-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.174313ms
+Jul  4 20:16:48.950: INFO: Pod "pod-configmaps-2d41e7c9-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011408819s
+Jul  4 20:16:50.954: INFO: Pod "pod-configmaps-2d41e7c9-7fc7-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015282337s
+STEP: Saw pod success
+Jul  4 20:16:50.954: INFO: Pod "pod-configmaps-2d41e7c9-7fc7-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:16:50.957: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-configmaps-2d41e7c9-7fc7-11e8-a4f0-6eaac417783a container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:16:50.983: INFO: Waiting for pod pod-configmaps-2d41e7c9-7fc7-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:16:50.987: INFO: Pod pod-configmaps-2d41e7c9-7fc7-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:16:50.987: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-rcm9n" for this suite.
+Jul  4 20:16:57.010: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:16:57.024: INFO: namespace: e2e-tests-configmap-rcm9n, resource: bindings, ignored listing per whitelist
+Jul  4 20:16:57.109: INFO: namespace e2e-tests-configmap-rcm9n deletion completed in 6.116801103s
+
+• [SLOW TEST:10.237 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:16:57.111: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-upd-335d8e18-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-335d8e18-7fc7-11e8-a4f0-6eaac417783a
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:17:01.244: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-ks6d2" for this suite.
+Jul  4 20:17:23.260: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:17:23.306: INFO: namespace: e2e-tests-configmap-ks6d2, resource: bindings, ignored listing per whitelist
+Jul  4 20:17:23.336: INFO: namespace e2e-tests-configmap-ks6d2 deletion completed in 22.087810795s
+
+• [SLOW TEST:26.226 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:17:23.338: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name s-test-opt-del-43007ef7-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating secret with name s-test-opt-upd-43007f3a-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-43007ef7-7fc7-11e8-a4f0-6eaac417783a
+STEP: Updating secret s-test-opt-upd-43007f3a-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating secret with name s-test-opt-create-43007f4e-7fc7-11e8-a4f0-6eaac417783a
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:18:43.876: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-l9vg2" for this suite.
+Jul  4 20:19:05.891: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:19:05.902: INFO: namespace: e2e-tests-secrets-l9vg2, resource: bindings, ignored listing per whitelist
+Jul  4 20:19:05.964: INFO: namespace e2e-tests-secrets-l9vg2 deletion completed in 22.084612416s
+
+• [SLOW TEST:102.626 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:19:05.965: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  4 20:19:06.024: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:19:07.143: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-2hh6j" for this suite.
+Jul  4 20:19:13.158: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:19:13.201: INFO: namespace: e2e-tests-custom-resource-definition-2hh6j, resource: bindings, ignored listing per whitelist
+Jul  4 20:19:13.290: INFO: namespace e2e-tests-custom-resource-definition-2hh6j deletion completed in 6.143366663s
+
+• [SLOW TEST:7.325 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:19:13.290: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  4 20:19:13.419: INFO: Waiting up to 5m0s for pod "downward-api-8490c3e4-7fc7-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-pg4sj" to be "success or failure"
+Jul  4 20:19:13.428: INFO: Pod "downward-api-8490c3e4-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 9.561987ms
+Jul  4 20:19:15.432: INFO: Pod "downward-api-8490c3e4-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013141665s
+Jul  4 20:19:17.436: INFO: Pod "downward-api-8490c3e4-7fc7-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016673216s
+STEP: Saw pod success
+Jul  4 20:19:17.436: INFO: Pod "downward-api-8490c3e4-7fc7-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:19:17.438: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downward-api-8490c3e4-7fc7-11e8-a4f0-6eaac417783a container dapi-container: <nil>
+STEP: delete the pod
+Jul  4 20:19:17.462: INFO: Waiting for pod downward-api-8490c3e4-7fc7-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:19:17.464: INFO: Pod downward-api-8490c3e4-7fc7-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:19:17.464: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-pg4sj" for this suite.
+Jul  4 20:19:23.479: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:19:23.513: INFO: namespace: e2e-tests-downward-api-pg4sj, resource: bindings, ignored listing per whitelist
+Jul  4 20:19:23.544: INFO: namespace e2e-tests-downward-api-pg4sj deletion completed in 6.075653037s
+
+• [SLOW TEST:10.254 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:19:23.545: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Jul  4 20:19:26.132: INFO: Successfully updated pod "pod-update-activedeadlineseconds-8aa3d1e4-7fc7-11e8-a4f0-6eaac417783a"
+Jul  4 20:19:26.132: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-8aa3d1e4-7fc7-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-pods-8zm2s" to be "terminated due to deadline exceeded"
+Jul  4 20:19:26.137: INFO: Pod "pod-update-activedeadlineseconds-8aa3d1e4-7fc7-11e8-a4f0-6eaac417783a": Phase="Running", Reason="", readiness=true. Elapsed: 5.27574ms
+Jul  4 20:19:28.141: INFO: Pod "pod-update-activedeadlineseconds-8aa3d1e4-7fc7-11e8-a4f0-6eaac417783a": Phase="Running", Reason="", readiness=true. Elapsed: 2.008639482s
+Jul  4 20:19:30.144: INFO: Pod "pod-update-activedeadlineseconds-8aa3d1e4-7fc7-11e8-a4f0-6eaac417783a": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 4.01235252s
+Jul  4 20:19:30.145: INFO: Pod "pod-update-activedeadlineseconds-8aa3d1e4-7fc7-11e8-a4f0-6eaac417783a" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:19:30.145: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-8zm2s" for this suite.
+Jul  4 20:19:36.160: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:19:36.205: INFO: namespace: e2e-tests-pods-8zm2s, resource: bindings, ignored listing per whitelist
+Jul  4 20:19:36.237: INFO: namespace e2e-tests-pods-8zm2s deletion completed in 6.089033408s
+
+• [SLOW TEST:12.692 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:19:36.237: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:19:36.321: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-kbrll" for this suite.
+Jul  4 20:19:58.338: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:19:58.371: INFO: namespace: e2e-tests-pods-kbrll, resource: bindings, ignored listing per whitelist
+Jul  4 20:19:58.408: INFO: namespace e2e-tests-pods-kbrll deletion completed in 22.082678871s
+
+• [SLOW TEST:22.171 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:19:58.409: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the rs
+STEP: Gathering metrics
+W0704 20:20:29.010363      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  4 20:20:29.010: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:20:29.010: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-bbgww" for this suite.
+Jul  4 20:20:35.026: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:20:35.085: INFO: namespace: e2e-tests-gc-bbgww, resource: bindings, ignored listing per whitelist
+Jul  4 20:20:35.102: INFO: namespace e2e-tests-gc-bbgww deletion completed in 6.08850975s
+
+• [SLOW TEST:36.694 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:20:35.103: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  4 20:20:35.164: INFO: Creating simple daemon set daemon-set
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  4 20:20:35.173: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:35.176: INFO: Number of nodes with available pods: 0
+Jul  4 20:20:35.176: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:20:36.179: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:36.183: INFO: Number of nodes with available pods: 0
+Jul  4 20:20:36.183: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:20:37.180: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:37.184: INFO: Number of nodes with available pods: 3
+Jul  4 20:20:37.184: INFO: Number of running nodes: 3, number of available pods: 3
+STEP: Update daemon pods image.
+STEP: Check that daemon pods images are updated.
+Jul  4 20:20:37.219: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:37.219: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:37.219: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:37.229: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:38.233: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:38.233: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:38.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:38.236: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:39.233: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:39.233: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:39.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:39.235: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:40.233: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:40.233: INFO: Pod daemon-set-76d64 is not available
+Jul  4 20:20:40.233: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:40.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:40.236: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:41.234: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:41.234: INFO: Pod daemon-set-76d64 is not available
+Jul  4 20:20:41.234: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:41.234: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:41.236: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:42.233: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:42.233: INFO: Pod daemon-set-76d64 is not available
+Jul  4 20:20:42.233: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:42.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:42.249: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:43.233: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:43.233: INFO: Pod daemon-set-76d64 is not available
+Jul  4 20:20:43.233: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:43.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:43.237: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:44.234: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:44.234: INFO: Pod daemon-set-76d64 is not available
+Jul  4 20:20:44.234: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:44.234: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:44.238: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:45.234: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:45.234: INFO: Pod daemon-set-76d64 is not available
+Jul  4 20:20:45.234: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:45.234: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:45.237: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:46.234: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:46.234: INFO: Pod daemon-set-76d64 is not available
+Jul  4 20:20:46.234: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:46.234: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:46.237: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:47.237: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:47.237: INFO: Pod daemon-set-76d64 is not available
+Jul  4 20:20:47.237: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:47.237: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:47.243: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:48.233: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:48.233: INFO: Pod daemon-set-76d64 is not available
+Jul  4 20:20:48.233: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:48.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:48.236: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:49.262: INFO: Wrong image for pod: daemon-set-76d64. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:49.262: INFO: Pod daemon-set-76d64 is not available
+Jul  4 20:20:49.262: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:49.262: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:49.269: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:50.233: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:50.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:50.233: INFO: Pod daemon-set-vnqp2 is not available
+Jul  4 20:20:50.235: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:51.233: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:51.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:51.233: INFO: Pod daemon-set-vnqp2 is not available
+Jul  4 20:20:51.237: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:52.233: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:52.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:52.236: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:53.233: INFO: Wrong image for pod: daemon-set-mmjt9. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:53.233: INFO: Pod daemon-set-mmjt9 is not available
+Jul  4 20:20:53.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:53.235: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:54.233: INFO: Pod daemon-set-ng8gv is not available
+Jul  4 20:20:54.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:54.236: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:55.233: INFO: Pod daemon-set-ng8gv is not available
+Jul  4 20:20:55.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:55.236: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:56.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:56.236: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:57.232: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:57.236: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:58.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:58.233: INFO: Pod daemon-set-tn5dn is not available
+Jul  4 20:20:58.239: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:20:59.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:20:59.233: INFO: Pod daemon-set-tn5dn is not available
+Jul  4 20:20:59.235: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:21:00.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:21:00.233: INFO: Pod daemon-set-tn5dn is not available
+Jul  4 20:21:00.236: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:21:01.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:21:01.233: INFO: Pod daemon-set-tn5dn is not available
+Jul  4 20:21:01.236: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:21:02.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:21:02.233: INFO: Pod daemon-set-tn5dn is not available
+Jul  4 20:21:02.237: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:21:03.233: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:21:03.233: INFO: Pod daemon-set-tn5dn is not available
+Jul  4 20:21:03.235: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:21:04.236: INFO: Wrong image for pod: daemon-set-tn5dn. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  4 20:21:04.236: INFO: Pod daemon-set-tn5dn is not available
+Jul  4 20:21:04.240: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:21:05.233: INFO: Pod daemon-set-4nt8h is not available
+Jul  4 20:21:05.236: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+STEP: Check that daemon pods are still running on every node of the cluster.
+Jul  4 20:21:05.239: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:21:05.241: INFO: Number of nodes with available pods: 2
+Jul  4 20:21:05.241: INFO: Node jakku-worker-ktmr.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:21:06.246: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:21:06.248: INFO: Number of nodes with available pods: 2
+Jul  4 20:21:06.249: INFO: Node jakku-worker-ktmr.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:21:07.245: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:21:07.248: INFO: Number of nodes with available pods: 2
+Jul  4 20:21:07.248: INFO: Node jakku-worker-ktmr.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:21:08.245: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:21:08.249: INFO: Number of nodes with available pods: 3
+Jul  4 20:21:08.250: INFO: Number of running nodes: 3, number of available pods: 3
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-4xj7l, will wait for the garbage collector to delete the pods
+Jul  4 20:21:08.324: INFO: Deleting {extensions DaemonSet} daemon-set took: 8.616268ms
+Jul  4 20:21:08.424: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.199101ms
+Jul  4 20:21:19.327: INFO: Number of nodes with available pods: 0
+Jul  4 20:21:19.327: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  4 20:21:19.329: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-4xj7l/daemonsets","resourceVersion":"5480"},"items":null}
+
+Jul  4 20:21:19.331: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-4xj7l/pods","resourceVersion":"5480"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:21:19.342: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-4xj7l" for this suite.
+Jul  4 20:21:25.358: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:21:25.447: INFO: namespace: e2e-tests-daemonsets-4xj7l, resource: bindings, ignored listing per whitelist
+Jul  4 20:21:25.491: INFO: namespace e2e-tests-daemonsets-4xj7l deletion completed in 6.144874537s
+
+• [SLOW TEST:50.389 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:21:25.494: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:21:25.556: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d353914a-7fc7-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-xnwqw" to be "success or failure"
+Jul  4 20:21:25.566: INFO: Pod "downwardapi-volume-d353914a-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 9.89382ms
+Jul  4 20:21:27.572: INFO: Pod "downwardapi-volume-d353914a-7fc7-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.016693615s
+STEP: Saw pod success
+Jul  4 20:21:27.572: INFO: Pod "downwardapi-volume-d353914a-7fc7-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:21:27.574: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-d353914a-7fc7-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:21:27.611: INFO: Waiting for pod downwardapi-volume-d353914a-7fc7-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:21:27.613: INFO: Pod downwardapi-volume-d353914a-7fc7-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:21:27.614: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-xnwqw" for this suite.
+Jul  4 20:21:33.629: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:21:33.646: INFO: namespace: e2e-tests-downward-api-xnwqw, resource: bindings, ignored listing per whitelist
+Jul  4 20:21:33.715: INFO: namespace e2e-tests-downward-api-xnwqw deletion completed in 6.096724721s
+
+• [SLOW TEST:8.221 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:21:33.715: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Jul  4 20:21:35.863: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-d84216d1-7fc7-11e8-a4f0-6eaac417783a", GenerateName:"", Namespace:"e2e-tests-pods-7mp92", SelfLink:"/api/v1/namespaces/e2e-tests-pods-7mp92/pods/pod-submit-remove-d84216d1-7fc7-11e8-a4f0-6eaac417783a", UID:"d85ce2b5-7fc7-11e8-94db-42010a800002", ResourceVersion:"5585", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63666332493, loc:(*time.Location)(0x642c9a0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"time":"822950335", "name":"foo"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"10.2.1.69/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-vzq2x", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc420efa100), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"k8s.gcr.io/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-vzq2x", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc42114a2f8), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"jakku-worker-f0tz.c.dghubble-io.internal", HostNetwork:false, HostPID:false, HostIPC:false, ShareProcessNamespace:(*bool)(nil), SecurityContext:(*v1.PodSecurityContext)(0xc421d918c0), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc42114a330)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc42114a350)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil), ReadinessGates:[]v1.PodReadinessGate(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666332493, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666332495, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"ContainersReady", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666332494, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"10.128.0.4", PodIP:"10.2.1.69", StartTime:(*v1.Time)(0xc420d18160), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc420d18180), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"k8s.gcr.io/nginx-slim-amd64:0.20", ImageID:"docker-pullable://k8s.gcr.io/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://0a8038c540806a659722da771b241993d3047f8179fc7b951d46cd3ca42749e8"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:21:43.884: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-7mp92" for this suite.
+Jul  4 20:21:49.906: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:21:49.978: INFO: namespace: e2e-tests-pods-7mp92, resource: bindings, ignored listing per whitelist
+Jul  4 20:21:49.994: INFO: namespace e2e-tests-pods-7mp92 deletion completed in 6.106200537s
+
+• [SLOW TEST:16.279 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:21:49.996: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-e1f0e1e2-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 20:21:50.077: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-e1f15b0a-7fc7-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-wcqsk" to be "success or failure"
+Jul  4 20:21:50.089: INFO: Pod "pod-projected-configmaps-e1f15b0a-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 11.069403ms
+Jul  4 20:21:52.092: INFO: Pod "pod-projected-configmaps-e1f15b0a-7fc7-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.014880182s
+STEP: Saw pod success
+Jul  4 20:21:52.093: INFO: Pod "pod-projected-configmaps-e1f15b0a-7fc7-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:21:52.095: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-configmaps-e1f15b0a-7fc7-11e8-a4f0-6eaac417783a container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:21:52.127: INFO: Waiting for pod pod-projected-configmaps-e1f15b0a-7fc7-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:21:52.129: INFO: Pod pod-projected-configmaps-e1f15b0a-7fc7-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:21:52.129: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wcqsk" for this suite.
+Jul  4 20:21:58.143: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:21:58.188: INFO: namespace: e2e-tests-projected-wcqsk, resource: bindings, ignored listing per whitelist
+Jul  4 20:21:58.222: INFO: namespace e2e-tests-projected-wcqsk deletion completed in 6.088789137s
+
+• [SLOW TEST:8.227 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:21:58.224: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:21:58.283: INFO: Waiting up to 5m0s for pod "downwardapi-volume-e6d554a1-7fc7-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-cfl2n" to be "success or failure"
+Jul  4 20:21:58.293: INFO: Pod "downwardapi-volume-e6d554a1-7fc7-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 9.447419ms
+Jul  4 20:22:00.297: INFO: Pod "downwardapi-volume-e6d554a1-7fc7-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.013053591s
+STEP: Saw pod success
+Jul  4 20:22:00.297: INFO: Pod "downwardapi-volume-e6d554a1-7fc7-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:22:00.299: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-e6d554a1-7fc7-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:22:00.329: INFO: Waiting for pod downwardapi-volume-e6d554a1-7fc7-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:22:00.332: INFO: Pod downwardapi-volume-e6d554a1-7fc7-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:22:00.333: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-cfl2n" for this suite.
+Jul  4 20:22:06.346: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:22:06.424: INFO: namespace: e2e-tests-projected-cfl2n, resource: bindings, ignored listing per whitelist
+Jul  4 20:22:06.437: INFO: namespace e2e-tests-projected-cfl2n deletion completed in 6.100197358s
+
+• [SLOW TEST:8.214 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:22:06.439: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name cm-test-opt-del-ebbcdf18-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating configMap with name cm-test-opt-upd-ebbcdf66-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-ebbcdf18-7fc7-11e8-a4f0-6eaac417783a
+STEP: Updating configmap cm-test-opt-upd-ebbcdf66-7fc7-11e8-a4f0-6eaac417783a
+STEP: Creating configMap with name cm-test-opt-create-ebbcdf8f-7fc7-11e8-a4f0-6eaac417783a
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:23:32.983: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-rgnwr" for this suite.
+Jul  4 20:23:54.997: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:23:55.069: INFO: namespace: e2e-tests-configmap-rgnwr, resource: bindings, ignored listing per whitelist
+Jul  4 20:23:55.076: INFO: namespace e2e-tests-configmap-rgnwr deletion completed in 22.090207915s
+
+• [SLOW TEST:108.637 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:23:55.078: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating replication controller my-hostname-basic-2c7cb620-7fc8-11e8-a4f0-6eaac417783a
+Jul  4 20:23:55.142: INFO: Pod name my-hostname-basic-2c7cb620-7fc8-11e8-a4f0-6eaac417783a: Found 0 pods out of 1
+Jul  4 20:24:00.146: INFO: Pod name my-hostname-basic-2c7cb620-7fc8-11e8-a4f0-6eaac417783a: Found 1 pods out of 1
+Jul  4 20:24:00.146: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-2c7cb620-7fc8-11e8-a4f0-6eaac417783a" are running
+Jul  4 20:24:00.148: INFO: Pod "my-hostname-basic-2c7cb620-7fc8-11e8-a4f0-6eaac417783a-4zm94" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-04 20:23:55 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-04 20:23:57 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-04 20:23:55 +0000 UTC Reason: Message:}])
+Jul  4 20:24:00.148: INFO: Trying to dial the pod
+Jul  4 20:24:05.159: INFO: Controller my-hostname-basic-2c7cb620-7fc8-11e8-a4f0-6eaac417783a: Got expected result from replica 1 [my-hostname-basic-2c7cb620-7fc8-11e8-a4f0-6eaac417783a-4zm94]: "my-hostname-basic-2c7cb620-7fc8-11e8-a4f0-6eaac417783a-4zm94", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:24:05.159: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-5xj9q" for this suite.
+Jul  4 20:24:11.174: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:24:11.226: INFO: namespace: e2e-tests-replication-controller-5xj9q, resource: bindings, ignored listing per whitelist
+Jul  4 20:24:11.246: INFO: namespace e2e-tests-replication-controller-5xj9q deletion completed in 6.082852863s
+
+• [SLOW TEST:16.169 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:24:11.247: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:24:11.309: INFO: Waiting up to 5m0s for pod "downwardapi-volume-361f88e4-7fc8-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-rnss9" to be "success or failure"
+Jul  4 20:24:11.317: INFO: Pod "downwardapi-volume-361f88e4-7fc8-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.748618ms
+Jul  4 20:24:13.321: INFO: Pod "downwardapi-volume-361f88e4-7fc8-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011236956s
+STEP: Saw pod success
+Jul  4 20:24:13.321: INFO: Pod "downwardapi-volume-361f88e4-7fc8-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:24:13.328: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-361f88e4-7fc8-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:24:13.348: INFO: Waiting for pod downwardapi-volume-361f88e4-7fc8-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:24:13.351: INFO: Pod downwardapi-volume-361f88e4-7fc8-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:24:13.351: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rnss9" for this suite.
+Jul  4 20:24:19.372: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:24:19.422: INFO: namespace: e2e-tests-projected-rnss9, resource: bindings, ignored listing per whitelist
+Jul  4 20:24:19.445: INFO: namespace e2e-tests-projected-rnss9 deletion completed in 6.089413549s
+
+• [SLOW TEST:8.198 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:24:19.447: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-3b0ae388-7fc8-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 20:24:19.567: INFO: Waiting up to 5m0s for pod "pod-configmaps-3b0b653e-7fc8-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-configmap-sgn5x" to be "success or failure"
+Jul  4 20:24:19.574: INFO: Pod "pod-configmaps-3b0b653e-7fc8-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.741734ms
+Jul  4 20:24:21.578: INFO: Pod "pod-configmaps-3b0b653e-7fc8-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.01097791s
+STEP: Saw pod success
+Jul  4 20:24:21.578: INFO: Pod "pod-configmaps-3b0b653e-7fc8-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:24:21.580: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-configmaps-3b0b653e-7fc8-11e8-a4f0-6eaac417783a container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:24:21.603: INFO: Waiting for pod pod-configmaps-3b0b653e-7fc8-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:24:21.606: INFO: Pod pod-configmaps-3b0b653e-7fc8-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:24:21.606: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-sgn5x" for this suite.
+Jul  4 20:24:27.621: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:24:27.705: INFO: namespace: e2e-tests-configmap-sgn5x, resource: bindings, ignored listing per whitelist
+Jul  4 20:24:27.706: INFO: namespace e2e-tests-configmap-sgn5x deletion completed in 6.096330184s
+
+• [SLOW TEST:8.259 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:24:27.707: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  4 20:24:27.761: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  4 20:25:27.779: INFO: Waiting for terminating namespaces to be deleted...
+Jul  4 20:25:27.782: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  4 20:25:27.791: INFO: 16 / 16 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  4 20:25:27.792: INFO: expected 5 pod replicas in namespace 'kube-system', 5 are Running and Ready.
+Jul  4 20:25:27.795: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  4 20:25:27.795: INFO: 
+Logging pods the kubelet thinks is on node jakku-worker-8tmm.c.dghubble-io.internal before test
+Jul  4 20:25:27.803: INFO: kube-proxy-72hkz from kube-system started at 2018-07-04 19:56:01 +0000 UTC (1 container statuses recorded)
+Jul  4 20:25:27.803: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  4 20:25:27.803: INFO: calico-node-kc252 from kube-system started at 2018-07-04 19:56:01 +0000 UTC (2 container statuses recorded)
+Jul  4 20:25:27.803: INFO: 	Container calico-node ready: true, restart count 0
+Jul  4 20:25:27.804: INFO: 	Container install-cni ready: true, restart count 0
+Jul  4 20:25:27.804: INFO: sonobuoy-systemd-logs-daemon-set-ee1900e8dc834edd-w7cqr from heptio-sonobuoy started at 2018-07-04 19:59:21 +0000 UTC (2 container statuses recorded)
+Jul  4 20:25:27.804: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 0
+Jul  4 20:25:27.804: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  4 20:25:27.804: INFO: sonobuoy-e2e-job-fd38b8fecef545c4 from heptio-sonobuoy started at 2018-07-04 19:59:21 +0000 UTC (2 container statuses recorded)
+Jul  4 20:25:27.804: INFO: 	Container e2e ready: true, restart count 0
+Jul  4 20:25:27.804: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  4 20:25:27.804: INFO: 
+Logging pods the kubelet thinks is on node jakku-worker-f0tz.c.dghubble-io.internal before test
+Jul  4 20:25:27.809: INFO: kube-proxy-4ptlm from kube-system started at 2018-07-04 19:56:01 +0000 UTC (1 container statuses recorded)
+Jul  4 20:25:27.809: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  4 20:25:27.809: INFO: calico-node-w7vpr from kube-system started at 2018-07-04 19:56:02 +0000 UTC (2 container statuses recorded)
+Jul  4 20:25:27.809: INFO: 	Container calico-node ready: true, restart count 0
+Jul  4 20:25:27.809: INFO: 	Container install-cni ready: true, restart count 0
+Jul  4 20:25:27.809: INFO: sonobuoy-systemd-logs-daemon-set-ee1900e8dc834edd-zlpw9 from heptio-sonobuoy started at 2018-07-04 19:59:21 +0000 UTC (2 container statuses recorded)
+Jul  4 20:25:27.809: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 0
+Jul  4 20:25:27.809: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  4 20:25:27.809: INFO: 
+Logging pods the kubelet thinks is on node jakku-worker-ktmr.c.dghubble-io.internal before test
+Jul  4 20:25:27.816: INFO: kube-proxy-gszcd from kube-system started at 2018-07-04 19:56:01 +0000 UTC (1 container statuses recorded)
+Jul  4 20:25:27.816: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  4 20:25:27.817: INFO: calico-node-8dl78 from kube-system started at 2018-07-04 19:56:02 +0000 UTC (2 container statuses recorded)
+Jul  4 20:25:27.817: INFO: 	Container calico-node ready: true, restart count 0
+Jul  4 20:25:27.817: INFO: 	Container install-cni ready: true, restart count 0
+Jul  4 20:25:27.817: INFO: sonobuoy from heptio-sonobuoy started at 2018-07-04 19:59:09 +0000 UTC (1 container statuses recorded)
+Jul  4 20:25:27.817: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Jul  4 20:25:27.817: INFO: sonobuoy-systemd-logs-daemon-set-ee1900e8dc834edd-grqmh from heptio-sonobuoy started at 2018-07-04 19:59:21 +0000 UTC (2 container statuses recorded)
+Jul  4 20:25:27.817: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 0
+Jul  4 20:25:27.817: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.153e4437630ef38b], Reason = [FailedScheduling], Message = [0/4 nodes are available: 4 node(s) didn't match node selector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:25:28.839: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-ppgnn" for this suite.
+Jul  4 20:25:50.853: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:25:50.909: INFO: namespace: e2e-tests-sched-pred-ppgnn, resource: bindings, ignored listing per whitelist
+Jul  4 20:25:50.924: INFO: namespace e2e-tests-sched-pred-ppgnn deletion completed in 22.081836909s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.218 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:25:50.925: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  4 20:25:53.026: INFO: Waiting up to 5m0s for pod "client-envvars-72bf2fcc-7fc8-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-pods-wl48j" to be "success or failure"
+Jul  4 20:25:53.043: INFO: Pod "client-envvars-72bf2fcc-7fc8-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 16.428723ms
+Jul  4 20:25:55.052: INFO: Pod "client-envvars-72bf2fcc-7fc8-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.025433601s
+Jul  4 20:25:57.055: INFO: Pod "client-envvars-72bf2fcc-7fc8-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.028818667s
+STEP: Saw pod success
+Jul  4 20:25:57.055: INFO: Pod "client-envvars-72bf2fcc-7fc8-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:25:57.057: INFO: Trying to get logs from node jakku-worker-ktmr.c.dghubble-io.internal pod client-envvars-72bf2fcc-7fc8-11e8-a4f0-6eaac417783a container env3cont: <nil>
+STEP: delete the pod
+Jul  4 20:25:57.075: INFO: Waiting for pod client-envvars-72bf2fcc-7fc8-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:25:57.078: INFO: Pod client-envvars-72bf2fcc-7fc8-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:25:57.078: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-wl48j" for this suite.
+Jul  4 20:26:19.093: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:26:19.111: INFO: namespace: e2e-tests-pods-wl48j, resource: bindings, ignored listing per whitelist
+Jul  4 20:26:19.164: INFO: namespace e2e-tests-pods-wl48j deletion completed in 22.081583899s
+
+• [SLOW TEST:28.239 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:26:19.167: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps with label A
+STEP: creating a watch on configmaps with label B
+STEP: creating a watch on configmaps with label A or B
+STEP: creating a configmap with label A and ensuring the correct watchers observe the notification
+Jul  4 20:26:19.234: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-8sjhp,SelfLink:/api/v1/namespaces/e2e-tests-watch-8sjhp/configmaps/e2e-watch-test-configmap-a,UID:827d97d6-7fc8-11e8-94db-42010a800002,ResourceVersion:6279,Generation:0,CreationTimestamp:2018-07-04 20:26:19 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  4 20:26:19.234: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-8sjhp,SelfLink:/api/v1/namespaces/e2e-tests-watch-8sjhp/configmaps/e2e-watch-test-configmap-a,UID:827d97d6-7fc8-11e8-94db-42010a800002,ResourceVersion:6279,Generation:0,CreationTimestamp:2018-07-04 20:26:19 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+STEP: modifying configmap A and ensuring the correct watchers observe the notification
+Jul  4 20:26:29.241: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-8sjhp,SelfLink:/api/v1/namespaces/e2e-tests-watch-8sjhp/configmaps/e2e-watch-test-configmap-a,UID:827d97d6-7fc8-11e8-94db-42010a800002,ResourceVersion:6295,Generation:0,CreationTimestamp:2018-07-04 20:26:19 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+Jul  4 20:26:29.241: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-8sjhp,SelfLink:/api/v1/namespaces/e2e-tests-watch-8sjhp/configmaps/e2e-watch-test-configmap-a,UID:827d97d6-7fc8-11e8-94db-42010a800002,ResourceVersion:6295,Generation:0,CreationTimestamp:2018-07-04 20:26:19 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying configmap A again and ensuring the correct watchers observe the notification
+Jul  4 20:26:39.248: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-8sjhp,SelfLink:/api/v1/namespaces/e2e-tests-watch-8sjhp/configmaps/e2e-watch-test-configmap-a,UID:827d97d6-7fc8-11e8-94db-42010a800002,ResourceVersion:6311,Generation:0,CreationTimestamp:2018-07-04 20:26:19 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  4 20:26:39.248: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-8sjhp,SelfLink:/api/v1/namespaces/e2e-tests-watch-8sjhp/configmaps/e2e-watch-test-configmap-a,UID:827d97d6-7fc8-11e8-94db-42010a800002,ResourceVersion:6311,Generation:0,CreationTimestamp:2018-07-04 20:26:19 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+STEP: deleting configmap A and ensuring the correct watchers observe the notification
+Jul  4 20:26:49.254: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-8sjhp,SelfLink:/api/v1/namespaces/e2e-tests-watch-8sjhp/configmaps/e2e-watch-test-configmap-a,UID:827d97d6-7fc8-11e8-94db-42010a800002,ResourceVersion:6327,Generation:0,CreationTimestamp:2018-07-04 20:26:19 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  4 20:26:49.255: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-8sjhp,SelfLink:/api/v1/namespaces/e2e-tests-watch-8sjhp/configmaps/e2e-watch-test-configmap-a,UID:827d97d6-7fc8-11e8-94db-42010a800002,ResourceVersion:6327,Generation:0,CreationTimestamp:2018-07-04 20:26:19 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+STEP: creating a configmap with label B and ensuring the correct watchers observe the notification
+Jul  4 20:26:59.260: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-8sjhp,SelfLink:/api/v1/namespaces/e2e-tests-watch-8sjhp/configmaps/e2e-watch-test-configmap-b,UID:9a597546-7fc8-11e8-94db-42010a800002,ResourceVersion:6344,Generation:0,CreationTimestamp:2018-07-04 20:26:59 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  4 20:26:59.261: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-8sjhp,SelfLink:/api/v1/namespaces/e2e-tests-watch-8sjhp/configmaps/e2e-watch-test-configmap-b,UID:9a597546-7fc8-11e8-94db-42010a800002,ResourceVersion:6344,Generation:0,CreationTimestamp:2018-07-04 20:26:59 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+STEP: deleting configmap B and ensuring the correct watchers observe the notification
+Jul  4 20:27:09.266: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-8sjhp,SelfLink:/api/v1/namespaces/e2e-tests-watch-8sjhp/configmaps/e2e-watch-test-configmap-b,UID:9a597546-7fc8-11e8-94db-42010a800002,ResourceVersion:6360,Generation:0,CreationTimestamp:2018-07-04 20:26:59 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  4 20:27:09.266: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-8sjhp,SelfLink:/api/v1/namespaces/e2e-tests-watch-8sjhp/configmaps/e2e-watch-test-configmap-b,UID:9a597546-7fc8-11e8-94db-42010a800002,ResourceVersion:6360,Generation:0,CreationTimestamp:2018-07-04 20:26:59 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:27:19.266: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-8sjhp" for this suite.
+Jul  4 20:27:25.281: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:27:25.354: INFO: namespace: e2e-tests-watch-8sjhp, resource: bindings, ignored listing per whitelist
+Jul  4 20:27:25.357: INFO: namespace e2e-tests-watch-8sjhp deletion completed in 6.087500823s
+
+• [SLOW TEST:66.191 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:27:25.357: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-jp9lz
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-jp9lz to expose endpoints map[]
+Jul  4 20:27:25.455: INFO: Get endpoints failed (8.098575ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Jul  4 20:27:26.458: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-jp9lz exposes endpoints map[] (1.011511923s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-jp9lz
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-jp9lz to expose endpoints map[pod1:[80]]
+Jul  4 20:27:29.494: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-jp9lz exposes endpoints map[pod1:[80]] (3.023936533s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-jp9lz
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-jp9lz to expose endpoints map[pod1:[80] pod2:[80]]
+Jul  4 20:27:31.532: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-jp9lz exposes endpoints map[pod1:[80] pod2:[80]] (2.031205562s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-jp9lz
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-jp9lz to expose endpoints map[pod2:[80]]
+Jul  4 20:27:32.569: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-jp9lz exposes endpoints map[pod2:[80]] (1.028454868s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-jp9lz
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-jp9lz to expose endpoints map[]
+Jul  4 20:27:33.586: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-jp9lz exposes endpoints map[] (1.010471643s elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:27:33.613: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-jp9lz" for this suite.
+Jul  4 20:27:53.642: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:27:53.699: INFO: namespace: e2e-tests-services-jp9lz, resource: bindings, ignored listing per whitelist
+Jul  4 20:27:53.725: INFO: namespace e2e-tests-services-jp9lz deletion completed in 20.102640397s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:28.368 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:27:53.727: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  4 20:27:58.322: INFO: Successfully updated pod "annotationupdatebabb576d-7fc8-11e8-a4f0-6eaac417783a"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:28:00.342: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-6q8k8" for this suite.
+Jul  4 20:28:22.358: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:28:22.430: INFO: namespace: e2e-tests-downward-api-6q8k8, resource: bindings, ignored listing per whitelist
+Jul  4 20:28:22.445: INFO: namespace e2e-tests-downward-api-6q8k8 deletion completed in 22.099330199s
+
+• [SLOW TEST:28.718 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:28:22.447: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Jul  4 20:28:22.520: INFO: Waiting up to 5m0s for pod "pod-cbdaee4c-7fc8-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-9g4lq" to be "success or failure"
+Jul  4 20:28:22.531: INFO: Pod "pod-cbdaee4c-7fc8-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 11.637184ms
+Jul  4 20:28:24.535: INFO: Pod "pod-cbdaee4c-7fc8-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.014858019s
+STEP: Saw pod success
+Jul  4 20:28:24.535: INFO: Pod "pod-cbdaee4c-7fc8-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:28:24.537: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-cbdaee4c-7fc8-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:28:24.555: INFO: Waiting for pod pod-cbdaee4c-7fc8-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:28:24.558: INFO: Pod pod-cbdaee4c-7fc8-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:28:24.559: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-9g4lq" for this suite.
+Jul  4 20:28:30.573: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:28:30.619: INFO: namespace: e2e-tests-emptydir-9g4lq, resource: bindings, ignored listing per whitelist
+Jul  4 20:28:30.642: INFO: namespace e2e-tests-emptydir-9g4lq deletion completed in 6.079189184s
+
+• [SLOW TEST:8.196 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:28:30.644: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override arguments
+Jul  4 20:28:30.708: INFO: Waiting up to 5m0s for pod "client-containers-d0bca0b4-7fc8-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-containers-ttnqj" to be "success or failure"
+Jul  4 20:28:30.718: INFO: Pod "client-containers-d0bca0b4-7fc8-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 9.531764ms
+Jul  4 20:28:32.721: INFO: Pod "client-containers-d0bca0b4-7fc8-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013004602s
+Jul  4 20:28:34.725: INFO: Pod "client-containers-d0bca0b4-7fc8-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017007295s
+STEP: Saw pod success
+Jul  4 20:28:34.725: INFO: Pod "client-containers-d0bca0b4-7fc8-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:28:34.728: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod client-containers-d0bca0b4-7fc8-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:28:34.749: INFO: Waiting for pod client-containers-d0bca0b4-7fc8-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:28:34.751: INFO: Pod client-containers-d0bca0b4-7fc8-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:28:34.752: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-ttnqj" for this suite.
+Jul  4 20:28:40.768: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:28:40.791: INFO: namespace: e2e-tests-containers-ttnqj, resource: bindings, ignored listing per whitelist
+Jul  4 20:28:40.846: INFO: namespace e2e-tests-containers-ttnqj deletion completed in 6.090726985s
+
+• [SLOW TEST:10.203 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:28:40.848: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-rxn5q
+[It] Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-rxn5q
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-rxn5q
+Jul  4 20:28:40.927: INFO: Found 0 stateful pods, waiting for 1
+Jul  4 20:28:50.930: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will not halt with unhealthy stateful pod
+Jul  4 20:28:50.933: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  4 20:28:51.186: INFO: stderr: ""
+Jul  4 20:28:51.186: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  4 20:28:51.186: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  4 20:28:51.189: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Jul  4 20:29:01.193: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  4 20:29:01.193: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  4 20:29:01.212: INFO: POD   NODE                                      PHASE    GRACE  CONDITIONS
+Jul  4 20:29:01.212: INFO: ss-0  jakku-worker-f0tz.c.dghubble-io.internal  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:28:41 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:28:52 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:28:41 +0000 UTC  }]
+Jul  4 20:29:01.213: INFO: ss-1                                            Pending         []
+Jul  4 20:29:01.213: INFO: 
+Jul  4 20:29:01.213: INFO: StatefulSet ss has not reached scale 3, at 2
+Jul  4 20:29:02.218: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.991537162s
+Jul  4 20:29:03.223: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.985958876s
+Jul  4 20:29:04.230: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.980936392s
+Jul  4 20:29:05.234: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.973540468s
+Jul  4 20:29:06.239: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.969481266s
+Jul  4 20:29:07.243: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.96500359s
+Jul  4 20:29:08.247: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.961182138s
+Jul  4 20:29:09.252: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.956368118s
+Jul  4 20:29:10.256: INFO: Verifying statefulset ss doesn't scale past 3 for another 951.903006ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-rxn5q
+Jul  4 20:29:11.260: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:29:11.479: INFO: stderr: ""
+Jul  4 20:29:11.479: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  4 20:29:11.479: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  4 20:29:11.479: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:29:11.695: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Jul  4 20:29:11.695: INFO: stdout: ""
+Jul  4 20:29:11.695: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: 
+Jul  4 20:29:11.695: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:29:11.939: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Jul  4 20:29:11.939: INFO: stdout: ""
+Jul  4 20:29:11.939: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Jul  4 20:29:11.943: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=false
+Jul  4 20:29:21.947: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:29:21.947: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:29:21.947: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Scale down will not halt with unhealthy stateful pod
+Jul  4 20:29:21.950: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  4 20:29:22.191: INFO: stderr: ""
+Jul  4 20:29:22.191: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  4 20:29:22.191: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  4 20:29:22.191: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  4 20:29:22.395: INFO: stderr: ""
+Jul  4 20:29:22.395: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  4 20:29:22.395: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  4 20:29:22.395: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  4 20:29:22.644: INFO: stderr: ""
+Jul  4 20:29:22.644: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  4 20:29:22.644: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  4 20:29:22.644: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  4 20:29:22.647: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 3
+Jul  4 20:29:32.653: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  4 20:29:32.653: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Jul  4 20:29:32.653: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Jul  4 20:29:32.677: INFO: POD   NODE                                      PHASE    GRACE  CONDITIONS
+Jul  4 20:29:32.677: INFO: ss-0  jakku-worker-f0tz.c.dghubble-io.internal  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:28:41 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:23 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:28:41 +0000 UTC  }]
+Jul  4 20:29:32.677: INFO: ss-1  jakku-worker-ktmr.c.dghubble-io.internal  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:23 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:32.677: INFO: ss-2  jakku-worker-8tmm.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:22 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:32.677: INFO: 
+Jul  4 20:29:32.677: INFO: StatefulSet ss has not reached scale 0, at 3
+Jul  4 20:29:33.681: INFO: POD   NODE                                      PHASE    GRACE  CONDITIONS
+Jul  4 20:29:33.681: INFO: ss-0  jakku-worker-f0tz.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:28:41 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:23 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:28:41 +0000 UTC  }]
+Jul  4 20:29:33.681: INFO: ss-1  jakku-worker-ktmr.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:23 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:33.681: INFO: ss-2  jakku-worker-8tmm.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:22 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:33.681: INFO: 
+Jul  4 20:29:33.681: INFO: StatefulSet ss has not reached scale 0, at 3
+Jul  4 20:29:34.684: INFO: POD   NODE                                      PHASE    GRACE  CONDITIONS
+Jul  4 20:29:34.684: INFO: ss-1  jakku-worker-ktmr.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:23 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:34.684: INFO: ss-2  jakku-worker-8tmm.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:22 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:34.684: INFO: 
+Jul  4 20:29:34.684: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  4 20:29:35.688: INFO: POD   NODE                                      PHASE    GRACE  CONDITIONS
+Jul  4 20:29:35.688: INFO: ss-1  jakku-worker-ktmr.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:23 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:35.688: INFO: ss-2  jakku-worker-8tmm.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:22 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:35.688: INFO: 
+Jul  4 20:29:35.688: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  4 20:29:36.693: INFO: POD   NODE                                      PHASE    GRACE  CONDITIONS
+Jul  4 20:29:36.693: INFO: ss-1  jakku-worker-ktmr.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:23 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:36.693: INFO: ss-2  jakku-worker-8tmm.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:22 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:36.693: INFO: 
+Jul  4 20:29:36.693: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  4 20:29:37.698: INFO: POD   NODE                                      PHASE    GRACE  CONDITIONS
+Jul  4 20:29:37.698: INFO: ss-1  jakku-worker-ktmr.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:23 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:37.698: INFO: ss-2  jakku-worker-8tmm.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:22 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:37.698: INFO: 
+Jul  4 20:29:37.698: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  4 20:29:38.702: INFO: POD   NODE                                      PHASE    GRACE  CONDITIONS
+Jul  4 20:29:38.702: INFO: ss-1  jakku-worker-ktmr.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:23 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:38.702: INFO: ss-2  jakku-worker-8tmm.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:22 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:38.702: INFO: 
+Jul  4 20:29:38.702: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  4 20:29:39.723: INFO: POD   NODE                                      PHASE    GRACE  CONDITIONS
+Jul  4 20:29:39.723: INFO: ss-1  jakku-worker-ktmr.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:23 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:39.723: INFO: 
+Jul  4 20:29:39.723: INFO: StatefulSet ss has not reached scale 0, at 1
+Jul  4 20:29:40.727: INFO: POD   NODE                                      PHASE    GRACE  CONDITIONS
+Jul  4 20:29:40.728: INFO: ss-1  jakku-worker-ktmr.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:23 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:40.728: INFO: 
+Jul  4 20:29:40.728: INFO: StatefulSet ss has not reached scale 0, at 1
+Jul  4 20:29:41.731: INFO: POD   NODE                                      PHASE    GRACE  CONDITIONS
+Jul  4 20:29:41.731: INFO: ss-1  jakku-worker-ktmr.c.dghubble-io.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:23 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-04 20:29:01 +0000 UTC  }]
+Jul  4 20:29:41.732: INFO: 
+Jul  4 20:29:41.732: INFO: StatefulSet ss has not reached scale 0, at 1
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-rxn5q
+Jul  4 20:29:42.741: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:29:42.937: INFO: rc: 1
+Jul  4 20:29:42.937: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  error: unable to upgrade connection: container not found ("nginx")
+ [] <nil> 0xc4219db470 exit status 1 <nil> <nil> true [0xc422524830 0xc422524870 0xc422524898] [0xc422524830 0xc422524870 0xc422524898] [0xc422524858 0xc422524880] [0x8f98d0 0x8f98d0] 0xc421e76cc0 <nil>}:
+Command stdout:
+
+stderr:
+error: unable to upgrade connection: container not found ("nginx")
+
+error:
+exit status 1
+
+Jul  4 20:29:52.938: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:29:53.038: INFO: rc: 1
+Jul  4 20:29:53.039: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4219dbbf0 exit status 1 <nil> <nil> true [0xc4225248b0 0xc4225248c8 0xc4225248e0] [0xc4225248b0 0xc4225248c8 0xc4225248e0] [0xc4225248c0 0xc4225248d8] [0x8f98d0 0x8f98d0] 0xc421e76de0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:30:03.039: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:30:03.142: INFO: rc: 1
+Jul  4 20:30:03.142: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209ac720 exit status 1 <nil> <nil> true [0xc421b58020 0xc421b58060 0xc421b580a0] [0xc421b58020 0xc421b58060 0xc421b580a0] [0xc421b58040 0xc421b58090] [0x8f98d0 0x8f98d0] 0xc4220fc3c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:30:13.143: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:30:13.274: INFO: rc: 1
+Jul  4 20:30:13.274: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209acdb0 exit status 1 <nil> <nil> true [0xc421b580b0 0xc421b580f8 0xc421b58140] [0xc421b580b0 0xc421b580f8 0xc421b58140] [0xc421b580e8 0xc421b58130] [0x8f98d0 0x8f98d0] 0xc4220fc660 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:30:23.274: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:30:23.377: INFO: rc: 1
+Jul  4 20:30:23.377: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209ad2c0 exit status 1 <nil> <nil> true [0xc421b58150 0xc421b58190 0xc421b581c0] [0xc421b58150 0xc421b58190 0xc421b581c0] [0xc421b58178 0xc421b581b0] [0x8f98d0 0x8f98d0] 0xc4220fc840 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:30:33.378: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:30:33.480: INFO: rc: 1
+Jul  4 20:30:33.480: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209ad740 exit status 1 <nil> <nil> true [0xc421b581d0 0xc421b58218 0xc421b58230] [0xc421b581d0 0xc421b58218 0xc421b58230] [0xc421b58210 0xc421b58228] [0x8f98d0 0x8f98d0] 0xc4220fc9c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:30:43.481: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:30:43.591: INFO: rc: 1
+Jul  4 20:30:43.592: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209adce0 exit status 1 <nil> <nil> true [0xc421b58240 0xc421b58270 0xc421b582a0] [0xc421b58240 0xc421b58270 0xc421b582a0] [0xc421b58260 0xc421b58290] [0x8f98d0 0x8f98d0] 0xc4220fcba0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:30:53.592: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:30:53.698: INFO: rc: 1
+Jul  4 20:30:53.698: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113e1b0 exit status 1 <nil> <nil> true [0xc421b582c0 0xc421b582f0 0xc421b58328] [0xc421b582c0 0xc421b582f0 0xc421b58328] [0xc421b582e0 0xc421b58318] [0x8f98d0 0x8f98d0] 0xc4220fcde0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:31:03.698: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:31:03.809: INFO: rc: 1
+Jul  4 20:31:03.809: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113e5d0 exit status 1 <nil> <nil> true [0xc421b58348 0xc421b583a8 0xc421b583c0] [0xc421b58348 0xc421b583a8 0xc421b583c0] [0xc421b58380 0xc421b583b8] [0x8f98d0 0x8f98d0] 0xc4220fcf60 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:31:13.809: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:31:13.909: INFO: rc: 1
+Jul  4 20:31:13.909: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113e9c0 exit status 1 <nil> <nil> true [0xc421b583c8 0xc421b583e0 0xc421b583f8] [0xc421b583c8 0xc421b583e0 0xc421b583f8] [0xc421b583d8 0xc421b583f0] [0x8f98d0 0x8f98d0] 0xc4220fd080 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:31:23.910: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:31:24.014: INFO: rc: 1
+Jul  4 20:31:24.014: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113edb0 exit status 1 <nil> <nil> true [0xc421b58400 0xc421b58418 0xc421b58430] [0xc421b58400 0xc421b58418 0xc421b58430] [0xc421b58410 0xc421b58428] [0x8f98d0 0x8f98d0] 0xc4220fd200 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:31:34.015: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:31:34.114: INFO: rc: 1
+Jul  4 20:31:34.114: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113f1a0 exit status 1 <nil> <nil> true [0xc421b58438 0xc421b58450 0xc421b58468] [0xc421b58438 0xc421b58450 0xc421b58468] [0xc421b58448 0xc421b58460] [0x8f98d0 0x8f98d0] 0xc4220fd380 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:31:44.114: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:31:44.219: INFO: rc: 1
+Jul  4 20:31:44.219: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113f590 exit status 1 <nil> <nil> true [0xc421b58470 0xc421b58488 0xc421b584a0] [0xc421b58470 0xc421b58488 0xc421b584a0] [0xc421b58480 0xc421b58498] [0x8f98d0 0x8f98d0] 0xc4220fd4a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:31:54.219: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:31:54.349: INFO: rc: 1
+Jul  4 20:31:54.349: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113f980 exit status 1 <nil> <nil> true [0xc421b584a8 0xc421b584c0 0xc421b584d8] [0xc421b584a8 0xc421b584c0 0xc421b584d8] [0xc421b584b8 0xc421b584d0] [0x8f98d0 0x8f98d0] 0xc4220fd620 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:32:04.349: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:32:04.447: INFO: rc: 1
+Jul  4 20:32:04.447: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209ac9c0 exit status 1 <nil> <nil> true [0xc421b58020 0xc421b58060 0xc421b580a0] [0xc421b58020 0xc421b58060 0xc421b580a0] [0xc421b58040 0xc421b58090] [0x8f98d0 0x8f98d0] 0xc4220fc3c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:32:14.447: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:32:14.549: INFO: rc: 1
+Jul  4 20:32:14.549: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209ad020 exit status 1 <nil> <nil> true [0xc421b580b0 0xc421b580f8 0xc421b58140] [0xc421b580b0 0xc421b580f8 0xc421b58140] [0xc421b580e8 0xc421b58130] [0x8f98d0 0x8f98d0] 0xc4220fc660 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:32:24.549: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:32:24.650: INFO: rc: 1
+Jul  4 20:32:24.650: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209ad530 exit status 1 <nil> <nil> true [0xc421b58150 0xc421b58190 0xc421b581c0] [0xc421b58150 0xc421b58190 0xc421b581c0] [0xc421b58178 0xc421b581b0] [0x8f98d0 0x8f98d0] 0xc4220fc840 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:32:34.650: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:32:34.748: INFO: rc: 1
+Jul  4 20:32:34.748: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209ad950 exit status 1 <nil> <nil> true [0xc421b581d0 0xc421b58218 0xc421b58230] [0xc421b581d0 0xc421b58218 0xc421b58230] [0xc421b58210 0xc421b58228] [0x8f98d0 0x8f98d0] 0xc4220fc9c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:32:44.749: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:32:44.849: INFO: rc: 1
+Jul  4 20:32:44.849: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc420c07e90 exit status 1 <nil> <nil> true [0xc421b58240 0xc421b58270 0xc421b582a0] [0xc421b58240 0xc421b58270 0xc421b582a0] [0xc421b58260 0xc421b58290] [0x8f98d0 0x8f98d0] 0xc4220fcba0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:32:54.849: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:32:54.951: INFO: rc: 1
+Jul  4 20:32:54.951: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113e300 exit status 1 <nil> <nil> true [0xc421b582c0 0xc421b582f0 0xc421b58328] [0xc421b582c0 0xc421b582f0 0xc421b58328] [0xc421b582e0 0xc421b58318] [0x8f98d0 0x8f98d0] 0xc4220fcde0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:33:04.951: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:33:05.052: INFO: rc: 1
+Jul  4 20:33:05.052: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113e720 exit status 1 <nil> <nil> true [0xc421b58348 0xc421b583a8 0xc421b583c0] [0xc421b58348 0xc421b583a8 0xc421b583c0] [0xc421b58380 0xc421b583b8] [0x8f98d0 0x8f98d0] 0xc4220fcf60 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:33:15.052: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:33:15.156: INFO: rc: 1
+Jul  4 20:33:15.156: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113eb40 exit status 1 <nil> <nil> true [0xc421b583c8 0xc421b583e0 0xc421b583f8] [0xc421b583c8 0xc421b583e0 0xc421b583f8] [0xc421b583d8 0xc421b583f0] [0x8f98d0 0x8f98d0] 0xc4220fd080 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:33:25.157: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:33:25.278: INFO: rc: 1
+Jul  4 20:33:25.278: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113ef60 exit status 1 <nil> <nil> true [0xc421b58400 0xc421b58418 0xc421b58430] [0xc421b58400 0xc421b58418 0xc421b58430] [0xc421b58410 0xc421b58428] [0x8f98d0 0x8f98d0] 0xc4220fd200 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:33:35.279: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:33:35.384: INFO: rc: 1
+Jul  4 20:33:35.385: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113f380 exit status 1 <nil> <nil> true [0xc421b58438 0xc421b58450 0xc421b58468] [0xc421b58438 0xc421b58450 0xc421b58468] [0xc421b58448 0xc421b58460] [0x8f98d0 0x8f98d0] 0xc4220fd380 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:33:45.385: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:33:45.484: INFO: rc: 1
+Jul  4 20:33:45.484: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113f800 exit status 1 <nil> <nil> true [0xc421b58470 0xc421b58488 0xc421b584a0] [0xc421b58470 0xc421b58488 0xc421b584a0] [0xc421b58480 0xc421b58498] [0x8f98d0 0x8f98d0] 0xc4220fd4a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:33:55.484: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:33:55.615: INFO: rc: 1
+Jul  4 20:33:55.615: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc42113fc20 exit status 1 <nil> <nil> true [0xc421b584b0 0xc421b584e8 0xc421b58500] [0xc421b584b0 0xc421b584e8 0xc421b58500] [0xc421b584e0 0xc421b584f8] [0x8f98d0 0x8f98d0] 0xc4220fd740 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:34:05.615: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:34:05.720: INFO: rc: 1
+Jul  4 20:34:05.721: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209ac750 exit status 1 <nil> <nil> true [0xc421b58020 0xc421b58060 0xc421b580a0] [0xc421b58020 0xc421b58060 0xc421b580a0] [0xc421b58040 0xc421b58090] [0x8f98d0 0x8f98d0] 0xc4220fc3c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:34:15.721: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:34:15.824: INFO: rc: 1
+Jul  4 20:34:15.824: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209ace70 exit status 1 <nil> <nil> true [0xc421b580b0 0xc421b580f8 0xc421b58140] [0xc421b580b0 0xc421b580f8 0xc421b58140] [0xc421b580e8 0xc421b58130] [0x8f98d0 0x8f98d0] 0xc4220fc660 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:34:25.824: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:34:25.928: INFO: rc: 1
+Jul  4 20:34:25.928: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209ad380 exit status 1 <nil> <nil> true [0xc421b58150 0xc421b58190 0xc421b581c0] [0xc421b58150 0xc421b58190 0xc421b581c0] [0xc421b58178 0xc421b581b0] [0x8f98d0 0x8f98d0] 0xc4220fc840 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:34:35.928: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:34:36.032: INFO: rc: 1
+Jul  4 20:34:36.032: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-1" not found
+ [] <nil> 0xc4209ad800 exit status 1 <nil> <nil> true [0xc421b581d0 0xc421b58218 0xc421b58230] [0xc421b581d0 0xc421b58218 0xc421b58230] [0xc421b58210 0xc421b58228] [0x8f98d0 0x8f98d0] 0xc4220fc9c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-1" not found
+
+error:
+exit status 1
+
+Jul  4 20:34:46.032: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-rxn5q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:34:46.162: INFO: rc: 1
+Jul  4 20:34:46.162: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: 
+Jul  4 20:34:46.162: INFO: Scaling statefulset ss to 0
+Jul  4 20:34:46.181: INFO: Waiting for statefulset status.replicas updated to 0
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  4 20:34:46.185: INFO: Deleting all statefulset in ns e2e-tests-statefulset-rxn5q
+Jul  4 20:34:46.188: INFO: Scaling statefulset ss to 0
+Jul  4 20:34:46.199: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  4 20:34:46.202: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:34:46.225: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-rxn5q" for this suite.
+Jul  4 20:34:52.274: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:34:52.336: INFO: namespace: e2e-tests-statefulset-rxn5q, resource: bindings, ignored listing per whitelist
+Jul  4 20:34:52.345: INFO: namespace e2e-tests-statefulset-rxn5q deletion completed in 6.099401827s
+
+• [SLOW TEST:371.497 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Burst scaling should run to completion even with unhealthy pods [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:34:52.345: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Jul  4 20:34:52.420: INFO: Waiting up to 5m0s for pod "pod-b44123e6-7fc9-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-ht7sn" to be "success or failure"
+Jul  4 20:34:52.429: INFO: Pod "pod-b44123e6-7fc9-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.495523ms
+Jul  4 20:34:54.432: INFO: Pod "pod-b44123e6-7fc9-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011793791s
+STEP: Saw pod success
+Jul  4 20:34:54.432: INFO: Pod "pod-b44123e6-7fc9-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:34:54.434: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-b44123e6-7fc9-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:34:54.457: INFO: Waiting for pod pod-b44123e6-7fc9-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:34:54.461: INFO: Pod pod-b44123e6-7fc9-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:34:54.461: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-ht7sn" for this suite.
+Jul  4 20:35:00.480: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:35:00.552: INFO: namespace: e2e-tests-emptydir-ht7sn, resource: bindings, ignored listing per whitelist
+Jul  4 20:35:00.558: INFO: namespace e2e-tests-emptydir-ht7sn deletion completed in 6.094295177s
+
+• [SLOW TEST:8.213 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:35:00.558: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Jul  4 20:35:00.680: INFO: Waiting up to 5m0s for pod "pod-b92db4f4-7fc9-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-zxm62" to be "success or failure"
+Jul  4 20:35:00.691: INFO: Pod "pod-b92db4f4-7fc9-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 10.771762ms
+Jul  4 20:35:02.694: INFO: Pod "pod-b92db4f4-7fc9-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.014160787s
+STEP: Saw pod success
+Jul  4 20:35:02.694: INFO: Pod "pod-b92db4f4-7fc9-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:35:02.696: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-b92db4f4-7fc9-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:35:02.715: INFO: Waiting for pod pod-b92db4f4-7fc9-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:35:02.718: INFO: Pod pod-b92db4f4-7fc9-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:35:02.718: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-zxm62" for this suite.
+Jul  4 20:35:08.733: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:35:08.790: INFO: namespace: e2e-tests-emptydir-zxm62, resource: bindings, ignored listing per whitelist
+Jul  4 20:35:08.797: INFO: namespace e2e-tests-emptydir-zxm62 deletion completed in 6.075354128s
+
+• [SLOW TEST:8.239 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:35:08.799: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-be0ed2ef-7fc9-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 20:35:08.871: INFO: Waiting up to 5m0s for pod "pod-configmaps-be0f4f28-7fc9-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-configmap-d6487" to be "success or failure"
+Jul  4 20:35:08.881: INFO: Pod "pod-configmaps-be0f4f28-7fc9-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 9.823273ms
+Jul  4 20:35:10.884: INFO: Pod "pod-configmaps-be0f4f28-7fc9-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012895796s
+STEP: Saw pod success
+Jul  4 20:35:10.884: INFO: Pod "pod-configmaps-be0f4f28-7fc9-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:35:10.885: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-configmaps-be0f4f28-7fc9-11e8-a4f0-6eaac417783a container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:35:10.904: INFO: Waiting for pod pod-configmaps-be0f4f28-7fc9-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:35:10.907: INFO: Pod pod-configmaps-be0f4f28-7fc9-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:35:10.907: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-d6487" for this suite.
+Jul  4 20:35:16.928: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:35:16.994: INFO: namespace: e2e-tests-configmap-d6487, resource: bindings, ignored listing per whitelist
+Jul  4 20:35:17.000: INFO: namespace e2e-tests-configmap-d6487 deletion completed in 6.089335014s
+
+• [SLOW TEST:8.201 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:35:17.002: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:35:17.066: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c2f1ece1-7fc9-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-qdd28" to be "success or failure"
+Jul  4 20:35:17.073: INFO: Pod "downwardapi-volume-c2f1ece1-7fc9-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 6.57673ms
+Jul  4 20:35:19.076: INFO: Pod "downwardapi-volume-c2f1ece1-7fc9-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010000347s
+STEP: Saw pod success
+Jul  4 20:35:19.077: INFO: Pod "downwardapi-volume-c2f1ece1-7fc9-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:35:19.079: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-c2f1ece1-7fc9-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:35:19.101: INFO: Waiting for pod downwardapi-volume-c2f1ece1-7fc9-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:35:19.104: INFO: Pod downwardapi-volume-c2f1ece1-7fc9-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:35:19.104: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-qdd28" for this suite.
+Jul  4 20:35:25.120: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:35:25.182: INFO: namespace: e2e-tests-downward-api-qdd28, resource: bindings, ignored listing per whitelist
+Jul  4 20:35:25.220: INFO: namespace e2e-tests-downward-api-qdd28 deletion completed in 6.112634207s
+
+• [SLOW TEST:8.219 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:35:25.220: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-c7db7167-7fc9-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:35:25.311: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-c7dbdfe7-7fc9-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-jgnqs" to be "success or failure"
+Jul  4 20:35:25.317: INFO: Pod "pod-projected-secrets-c7dbdfe7-7fc9-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 5.96802ms
+Jul  4 20:35:27.320: INFO: Pod "pod-projected-secrets-c7dbdfe7-7fc9-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008848957s
+STEP: Saw pod success
+Jul  4 20:35:27.320: INFO: Pod "pod-projected-secrets-c7dbdfe7-7fc9-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:35:27.322: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-secrets-c7dbdfe7-7fc9-11e8-a4f0-6eaac417783a container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:35:27.347: INFO: Waiting for pod pod-projected-secrets-c7dbdfe7-7fc9-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:35:27.351: INFO: Pod pod-projected-secrets-c7dbdfe7-7fc9-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:35:27.351: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jgnqs" for this suite.
+Jul  4 20:35:33.368: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:35:33.443: INFO: namespace: e2e-tests-projected-jgnqs, resource: bindings, ignored listing per whitelist
+Jul  4 20:35:33.445: INFO: namespace e2e-tests-projected-jgnqs deletion completed in 6.090418145s
+
+• [SLOW TEST:8.225 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:35:33.448: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: modifying the configmap a second time
+STEP: deleting the configmap
+STEP: creating a watch on configmaps from the resource version returned by the first update
+STEP: Expecting to observe notifications for all changes to the configmap after the first update
+Jul  4 20:35:33.533: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-resource-version,GenerateName:,Namespace:e2e-tests-watch-lh88x,SelfLink:/api/v1/namespaces/e2e-tests-watch-lh88x/configmaps/e2e-watch-test-resource-version,UID:cccfb0db-7fc9-11e8-94db-42010a800002,ResourceVersion:7557,Generation:0,CreationTimestamp:2018-07-04 20:35:33 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: from-resource-version,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  4 20:35:33.533: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-resource-version,GenerateName:,Namespace:e2e-tests-watch-lh88x,SelfLink:/api/v1/namespaces/e2e-tests-watch-lh88x/configmaps/e2e-watch-test-resource-version,UID:cccfb0db-7fc9-11e8-94db-42010a800002,ResourceVersion:7558,Generation:0,CreationTimestamp:2018-07-04 20:35:33 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: from-resource-version,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:35:33.533: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-lh88x" for this suite.
+Jul  4 20:35:39.563: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:35:39.625: INFO: namespace: e2e-tests-watch-lh88x, resource: bindings, ignored listing per whitelist
+Jul  4 20:35:39.651: INFO: namespace e2e-tests-watch-lh88x deletion completed in 6.112703612s
+
+• [SLOW TEST:6.203 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:35:39.653: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-d07d5a62-7fc9-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:35:39.795: INFO: Waiting up to 5m0s for pod "pod-secrets-d07de0f4-7fc9-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-secrets-hwl8w" to be "success or failure"
+Jul  4 20:35:39.814: INFO: Pod "pod-secrets-d07de0f4-7fc9-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 19.188975ms
+Jul  4 20:35:41.818: INFO: Pod "pod-secrets-d07de0f4-7fc9-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.02292739s
+STEP: Saw pod success
+Jul  4 20:35:41.818: INFO: Pod "pod-secrets-d07de0f4-7fc9-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:35:41.820: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-secrets-d07de0f4-7fc9-11e8-a4f0-6eaac417783a container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:35:41.838: INFO: Waiting for pod pod-secrets-d07de0f4-7fc9-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:35:41.842: INFO: Pod pod-secrets-d07de0f4-7fc9-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:35:41.842: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-hwl8w" for this suite.
+Jul  4 20:35:47.859: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:35:47.897: INFO: namespace: e2e-tests-secrets-hwl8w, resource: bindings, ignored listing per whitelist
+Jul  4 20:35:47.931: INFO: namespace e2e-tests-secrets-hwl8w deletion completed in 6.086024765s
+
+• [SLOW TEST:8.279 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:35:47.933: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Jul  4 20:35:48.517: INFO: Waiting up to 5m0s for pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-8qlch" in namespace "e2e-tests-svcaccounts-jclnr" to be "success or failure"
+Jul  4 20:35:48.525: INFO: Pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-8qlch": Phase="Pending", Reason="", readiness=false. Elapsed: 7.991372ms
+Jul  4 20:35:50.529: INFO: Pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-8qlch": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011782104s
+Jul  4 20:35:52.533: INFO: Pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-8qlch": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015712335s
+STEP: Saw pod success
+Jul  4 20:35:52.533: INFO: Pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-8qlch" satisfied condition "success or failure"
+Jul  4 20:35:52.536: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-8qlch container token-test: <nil>
+STEP: delete the pod
+Jul  4 20:35:52.567: INFO: Waiting for pod pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-8qlch to disappear
+Jul  4 20:35:52.571: INFO: Pod pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-8qlch no longer exists
+STEP: Creating a pod to test consume service account root CA
+Jul  4 20:35:52.579: INFO: Waiting up to 5m0s for pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-dg87p" in namespace "e2e-tests-svcaccounts-jclnr" to be "success or failure"
+Jul  4 20:35:52.588: INFO: Pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-dg87p": Phase="Pending", Reason="", readiness=false. Elapsed: 8.8594ms
+Jul  4 20:35:54.598: INFO: Pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-dg87p": Phase="Pending", Reason="", readiness=false. Elapsed: 2.019185805s
+Jul  4 20:35:56.602: INFO: Pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-dg87p": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.022648808s
+STEP: Saw pod success
+Jul  4 20:35:56.602: INFO: Pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-dg87p" satisfied condition "success or failure"
+Jul  4 20:35:56.604: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-dg87p container root-ca-test: <nil>
+STEP: delete the pod
+Jul  4 20:35:56.626: INFO: Waiting for pod pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-dg87p to disappear
+Jul  4 20:35:56.629: INFO: Pod pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-dg87p no longer exists
+STEP: Creating a pod to test consume service account namespace
+Jul  4 20:35:56.636: INFO: Waiting up to 5m0s for pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-qw6ht" in namespace "e2e-tests-svcaccounts-jclnr" to be "success or failure"
+Jul  4 20:35:56.646: INFO: Pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-qw6ht": Phase="Pending", Reason="", readiness=false. Elapsed: 9.142164ms
+Jul  4 20:35:58.650: INFO: Pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-qw6ht": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.013558396s
+STEP: Saw pod success
+Jul  4 20:35:58.650: INFO: Pod "pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-qw6ht" satisfied condition "success or failure"
+Jul  4 20:35:58.652: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-qw6ht container namespace-test: <nil>
+STEP: delete the pod
+Jul  4 20:35:58.671: INFO: Waiting for pod pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-qw6ht to disappear
+Jul  4 20:35:58.674: INFO: Pod pod-service-account-d5b0e999-7fc9-11e8-a4f0-6eaac417783a-qw6ht no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:35:58.674: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-jclnr" for this suite.
+Jul  4 20:36:04.691: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:36:04.753: INFO: namespace: e2e-tests-svcaccounts-jclnr, resource: bindings, ignored listing per whitelist
+Jul  4 20:36:04.765: INFO: namespace e2e-tests-svcaccounts-jclnr deletion completed in 6.087346248s
+
+• [SLOW TEST:16.832 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:36:04.767: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-9gf4g
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  4 20:36:04.833: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  4 20:36:26.943: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 10.2.3.17 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-9gf4g PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:36:26.943: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:36:28.051: INFO: Found all expected endpoints: [netserver-0]
+Jul  4 20:36:28.054: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 10.2.0.14 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-9gf4g PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:36:28.054: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:36:29.130: INFO: Found all expected endpoints: [netserver-1]
+Jul  4 20:36:29.133: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 10.2.1.91 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-9gf4g PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:36:29.133: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:36:30.247: INFO: Found all expected endpoints: [netserver-2]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:36:30.247: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-9gf4g" for this suite.
+Jul  4 20:36:52.267: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:36:52.331: INFO: namespace: e2e-tests-pod-network-test-9gf4g, resource: bindings, ignored listing per whitelist
+Jul  4 20:36:52.351: INFO: namespace e2e-tests-pod-network-test-9gf4g deletion completed in 22.099415086s
+
+• [SLOW TEST:47.584 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:36:52.354: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test use defaults
+Jul  4 20:36:52.430: INFO: Waiting up to 5m0s for pod "client-containers-fbc9697f-7fc9-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-containers-q7rjq" to be "success or failure"
+Jul  4 20:36:52.437: INFO: Pod "client-containers-fbc9697f-7fc9-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 6.47285ms
+Jul  4 20:36:54.440: INFO: Pod "client-containers-fbc9697f-7fc9-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010300043s
+STEP: Saw pod success
+Jul  4 20:36:54.441: INFO: Pod "client-containers-fbc9697f-7fc9-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:36:54.443: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod client-containers-fbc9697f-7fc9-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:36:54.464: INFO: Waiting for pod client-containers-fbc9697f-7fc9-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:36:54.467: INFO: Pod client-containers-fbc9697f-7fc9-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:36:54.467: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-q7rjq" for this suite.
+Jul  4 20:37:00.486: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:37:00.574: INFO: namespace: e2e-tests-containers-q7rjq, resource: bindings, ignored listing per whitelist
+Jul  4 20:37:00.577: INFO: namespace e2e-tests-containers-q7rjq deletion completed in 6.106147745s
+
+• [SLOW TEST:8.223 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:37:00.579: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-00b1a63c-7fca-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:37:00.668: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-00b230d4-7fca-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-66g95" to be "success or failure"
+Jul  4 20:37:00.682: INFO: Pod "pod-projected-secrets-00b230d4-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 13.293696ms
+Jul  4 20:37:02.685: INFO: Pod "pod-projected-secrets-00b230d4-7fca-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.017131855s
+STEP: Saw pod success
+Jul  4 20:37:02.686: INFO: Pod "pod-projected-secrets-00b230d4-7fca-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:37:02.688: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-secrets-00b230d4-7fca-11e8-a4f0-6eaac417783a container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:37:02.713: INFO: Waiting for pod pod-projected-secrets-00b230d4-7fca-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:37:02.715: INFO: Pod pod-projected-secrets-00b230d4-7fca-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:37:02.715: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-66g95" for this suite.
+Jul  4 20:37:08.731: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:37:08.769: INFO: namespace: e2e-tests-projected-66g95, resource: bindings, ignored listing per whitelist
+Jul  4 20:37:08.828: INFO: namespace e2e-tests-projected-66g95 deletion completed in 6.109144222s
+
+• [SLOW TEST:8.250 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:37:08.830: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-tdqps
+I0704 20:37:08.889343      14 runners.go:177] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-tdqps, replica count: 1
+I0704 20:37:09.939932      14 runners.go:177] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0704 20:37:10.940132      14 runners.go:177] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Jul  4 20:37:11.053: INFO: Created: latency-svc-xzb77
+Jul  4 20:37:11.073: INFO: Got endpoints: latency-svc-xzb77 [33.606323ms]
+Jul  4 20:37:11.104: INFO: Created: latency-svc-zc2hg
+Jul  4 20:37:11.117: INFO: Created: latency-svc-h9c27
+Jul  4 20:37:11.121: INFO: Got endpoints: latency-svc-zc2hg [46.940403ms]
+Jul  4 20:37:11.134: INFO: Created: latency-svc-zv9jg
+Jul  4 20:37:11.141: INFO: Created: latency-svc-kvcnk
+Jul  4 20:37:11.151: INFO: Got endpoints: latency-svc-h9c27 [76.168805ms]
+Jul  4 20:37:11.160: INFO: Got endpoints: latency-svc-kvcnk [85.413238ms]
+Jul  4 20:37:11.161: INFO: Got endpoints: latency-svc-zv9jg [86.14976ms]
+Jul  4 20:37:11.165: INFO: Created: latency-svc-twfdz
+Jul  4 20:37:11.185: INFO: Created: latency-svc-nhdqd
+Jul  4 20:37:11.187: INFO: Got endpoints: latency-svc-twfdz [110.449352ms]
+Jul  4 20:37:11.213: INFO: Got endpoints: latency-svc-nhdqd [138.265424ms]
+Jul  4 20:37:11.214: INFO: Created: latency-svc-h8swf
+Jul  4 20:37:11.221: INFO: Created: latency-svc-6jqj4
+Jul  4 20:37:11.232: INFO: Got endpoints: latency-svc-h8swf [156.733232ms]
+Jul  4 20:37:11.242: INFO: Got endpoints: latency-svc-6jqj4 [167.208786ms]
+Jul  4 20:37:11.243: INFO: Created: latency-svc-v4xpd
+Jul  4 20:37:11.257: INFO: Created: latency-svc-ssk5f
+Jul  4 20:37:11.260: INFO: Got endpoints: latency-svc-v4xpd [184.866182ms]
+Jul  4 20:37:11.272: INFO: Got endpoints: latency-svc-ssk5f [195.983502ms]
+Jul  4 20:37:11.287: INFO: Created: latency-svc-dh2pk
+Jul  4 20:37:11.298: INFO: Created: latency-svc-dwr8b
+Jul  4 20:37:11.304: INFO: Got endpoints: latency-svc-dh2pk [61.368675ms]
+Jul  4 20:37:11.319: INFO: Created: latency-svc-2tvhc
+Jul  4 20:37:11.321: INFO: Got endpoints: latency-svc-dwr8b [244.785419ms]
+Jul  4 20:37:11.332: INFO: Created: latency-svc-5hb7t
+Jul  4 20:37:11.339: INFO: Got endpoints: latency-svc-2tvhc [262.756203ms]
+Jul  4 20:37:11.348: INFO: Got endpoints: latency-svc-5hb7t [271.664636ms]
+Jul  4 20:37:11.360: INFO: Created: latency-svc-wbhsp
+Jul  4 20:37:11.371: INFO: Created: latency-svc-r668q
+Jul  4 20:37:11.371: INFO: Got endpoints: latency-svc-wbhsp [294.18383ms]
+Jul  4 20:37:11.392: INFO: Created: latency-svc-dwmws
+Jul  4 20:37:11.402: INFO: Got endpoints: latency-svc-dwmws [280.787105ms]
+Jul  4 20:37:11.403: INFO: Got endpoints: latency-svc-r668q [326.08937ms]
+Jul  4 20:37:11.409: INFO: Created: latency-svc-lttsq
+Jul  4 20:37:11.422: INFO: Created: latency-svc-rgnw8
+Jul  4 20:37:11.427: INFO: Got endpoints: latency-svc-lttsq [275.599546ms]
+Jul  4 20:37:11.444: INFO: Got endpoints: latency-svc-rgnw8 [283.363417ms]
+Jul  4 20:37:11.445: INFO: Created: latency-svc-hd2zp
+Jul  4 20:37:11.451: INFO: Got endpoints: latency-svc-hd2zp [290.818913ms]
+Jul  4 20:37:11.455: INFO: Created: latency-svc-b5ww9
+Jul  4 20:37:11.489: INFO: Got endpoints: latency-svc-b5ww9 [301.615834ms]
+Jul  4 20:37:11.502: INFO: Created: latency-svc-fhcfz
+Jul  4 20:37:11.521: INFO: Created: latency-svc-9r848
+Jul  4 20:37:11.529: INFO: Got endpoints: latency-svc-fhcfz [315.748127ms]
+Jul  4 20:37:11.568: INFO: Got endpoints: latency-svc-9r848 [336.110152ms]
+Jul  4 20:37:11.591: INFO: Created: latency-svc-46zxr
+Jul  4 20:37:11.625: INFO: Created: latency-svc-6lhdn
+Jul  4 20:37:11.630: INFO: Got endpoints: latency-svc-46zxr [369.993725ms]
+Jul  4 20:37:11.663: INFO: Created: latency-svc-jcc7v
+Jul  4 20:37:11.666: INFO: Got endpoints: latency-svc-6lhdn [393.616849ms]
+Jul  4 20:37:11.688: INFO: Got endpoints: latency-svc-jcc7v [383.561991ms]
+Jul  4 20:37:11.702: INFO: Created: latency-svc-ztnzc
+Jul  4 20:37:11.721: INFO: Created: latency-svc-9hzc5
+Jul  4 20:37:11.731: INFO: Created: latency-svc-44zlf
+Jul  4 20:37:11.737: INFO: Got endpoints: latency-svc-9hzc5 [397.769406ms]
+Jul  4 20:37:11.737: INFO: Got endpoints: latency-svc-ztnzc [416.070281ms]
+Jul  4 20:37:11.751: INFO: Got endpoints: latency-svc-44zlf [402.874841ms]
+Jul  4 20:37:11.754: INFO: Created: latency-svc-jffz8
+Jul  4 20:37:11.768: INFO: Created: latency-svc-m48fb
+Jul  4 20:37:11.771: INFO: Got endpoints: latency-svc-jffz8 [400.329613ms]
+Jul  4 20:37:11.783: INFO: Created: latency-svc-lzlhb
+Jul  4 20:37:11.787: INFO: Got endpoints: latency-svc-m48fb [384.750801ms]
+Jul  4 20:37:11.798: INFO: Got endpoints: latency-svc-lzlhb [394.833921ms]
+Jul  4 20:37:11.806: INFO: Created: latency-svc-sln5h
+Jul  4 20:37:11.815: INFO: Got endpoints: latency-svc-sln5h [388.334888ms]
+Jul  4 20:37:11.825: INFO: Created: latency-svc-22k6q
+Jul  4 20:37:11.850: INFO: Created: latency-svc-d5g59
+Jul  4 20:37:11.903: INFO: Got endpoints: latency-svc-22k6q [458.853814ms]
+Jul  4 20:37:11.920: INFO: Got endpoints: latency-svc-d5g59 [467.988762ms]
+Jul  4 20:37:11.953: INFO: Created: latency-svc-lwsmp
+Jul  4 20:37:11.996: INFO: Got endpoints: latency-svc-lwsmp [506.268843ms]
+Jul  4 20:37:11.998: INFO: Created: latency-svc-sb4v7
+Jul  4 20:37:12.009: INFO: Created: latency-svc-784l2
+Jul  4 20:37:12.092: INFO: Created: latency-svc-lrkhm
+Jul  4 20:37:12.098: INFO: Got endpoints: latency-svc-784l2 [530.0838ms]
+Jul  4 20:37:12.099: INFO: Got endpoints: latency-svc-sb4v7 [569.762448ms]
+Jul  4 20:37:12.114: INFO: Got endpoints: latency-svc-lrkhm [483.340811ms]
+Jul  4 20:37:12.206: INFO: Created: latency-svc-r89hg
+Jul  4 20:37:12.248: INFO: Got endpoints: latency-svc-r89hg [581.078164ms]
+Jul  4 20:37:12.258: INFO: Created: latency-svc-8wt5z
+Jul  4 20:37:12.265: INFO: Created: latency-svc-f57zb
+Jul  4 20:37:12.320: INFO: Created: latency-svc-qfjpl
+Jul  4 20:37:12.323: INFO: Got endpoints: latency-svc-f57zb [585.760266ms]
+Jul  4 20:37:12.323: INFO: Got endpoints: latency-svc-8wt5z [635.497271ms]
+Jul  4 20:37:12.358: INFO: Created: latency-svc-pggq6
+Jul  4 20:37:12.379: INFO: Got endpoints: latency-svc-qfjpl [640.718473ms]
+Jul  4 20:37:12.390: INFO: Got endpoints: latency-svc-pggq6 [638.899435ms]
+Jul  4 20:37:12.409: INFO: Created: latency-svc-4jxqn
+Jul  4 20:37:12.420: INFO: Got endpoints: latency-svc-4jxqn [648.307272ms]
+Jul  4 20:37:12.446: INFO: Created: latency-svc-jhsbz
+Jul  4 20:37:12.458: INFO: Got endpoints: latency-svc-jhsbz [670.369143ms]
+Jul  4 20:37:12.473: INFO: Created: latency-svc-h6zd2
+Jul  4 20:37:12.516: INFO: Got endpoints: latency-svc-h6zd2 [718.047578ms]
+Jul  4 20:37:12.518: INFO: Created: latency-svc-pq2fn
+Jul  4 20:37:12.544: INFO: Created: latency-svc-mb58s
+Jul  4 20:37:12.550: INFO: Got endpoints: latency-svc-pq2fn [734.764151ms]
+Jul  4 20:37:12.574: INFO: Got endpoints: latency-svc-mb58s [669.844977ms]
+Jul  4 20:37:12.587: INFO: Created: latency-svc-rfz8z
+Jul  4 20:37:12.625: INFO: Created: latency-svc-q274s
+Jul  4 20:37:12.649: INFO: Got endpoints: latency-svc-q274s [653.453095ms]
+Jul  4 20:37:12.650: INFO: Got endpoints: latency-svc-rfz8z [730.183518ms]
+Jul  4 20:37:12.693: INFO: Created: latency-svc-td5f6
+Jul  4 20:37:12.713: INFO: Created: latency-svc-747mg
+Jul  4 20:37:12.722: INFO: Got endpoints: latency-svc-td5f6 [623.307557ms]
+Jul  4 20:37:12.746: INFO: Created: latency-svc-z4srm
+Jul  4 20:37:12.757: INFO: Got endpoints: latency-svc-747mg [642.653509ms]
+Jul  4 20:37:12.779: INFO: Got endpoints: latency-svc-z4srm [680.40404ms]
+Jul  4 20:37:12.791: INFO: Created: latency-svc-2s8xm
+Jul  4 20:37:12.805: INFO: Got endpoints: latency-svc-2s8xm [557.283903ms]
+Jul  4 20:37:12.806: INFO: Created: latency-svc-g5wg7
+Jul  4 20:37:12.816: INFO: Created: latency-svc-qdsqk
+Jul  4 20:37:12.833: INFO: Created: latency-svc-g8ttj
+Jul  4 20:37:12.833: INFO: Got endpoints: latency-svc-qdsqk [509.519603ms]
+Jul  4 20:37:12.834: INFO: Got endpoints: latency-svc-g5wg7 [510.200761ms]
+Jul  4 20:37:12.848: INFO: Got endpoints: latency-svc-g8ttj [469.7409ms]
+Jul  4 20:37:12.868: INFO: Created: latency-svc-t6krn
+Jul  4 20:37:12.885: INFO: Got endpoints: latency-svc-t6krn [494.612569ms]
+Jul  4 20:37:12.887: INFO: Created: latency-svc-hcgtm
+Jul  4 20:37:12.906: INFO: Got endpoints: latency-svc-hcgtm [485.798043ms]
+Jul  4 20:37:12.909: INFO: Created: latency-svc-ph545
+Jul  4 20:37:12.925: INFO: Got endpoints: latency-svc-ph545 [467.194238ms]
+Jul  4 20:37:12.929: INFO: Created: latency-svc-95dfs
+Jul  4 20:37:12.948: INFO: Got endpoints: latency-svc-95dfs [431.771531ms]
+Jul  4 20:37:12.965: INFO: Created: latency-svc-25qmc
+Jul  4 20:37:12.988: INFO: Created: latency-svc-k5qxw
+Jul  4 20:37:12.991: INFO: Got endpoints: latency-svc-25qmc [440.762982ms]
+Jul  4 20:37:13.008: INFO: Got endpoints: latency-svc-k5qxw [434.633782ms]
+Jul  4 20:37:13.016: INFO: Created: latency-svc-mc28g
+Jul  4 20:37:13.027: INFO: Created: latency-svc-vkqgm
+Jul  4 20:37:13.029: INFO: Got endpoints: latency-svc-mc28g [379.598368ms]
+Jul  4 20:37:13.038: INFO: Created: latency-svc-qs447
+Jul  4 20:37:13.055: INFO: Got endpoints: latency-svc-qs447 [332.460925ms]
+Jul  4 20:37:13.055: INFO: Got endpoints: latency-svc-vkqgm [404.724789ms]
+Jul  4 20:37:13.064: INFO: Created: latency-svc-4fncj
+Jul  4 20:37:13.082: INFO: Got endpoints: latency-svc-4fncj [325.033482ms]
+Jul  4 20:37:13.083: INFO: Created: latency-svc-5c6qh
+Jul  4 20:37:13.095: INFO: Created: latency-svc-d9stb
+Jul  4 20:37:13.098: INFO: Got endpoints: latency-svc-5c6qh [318.701024ms]
+Jul  4 20:37:13.119: INFO: Created: latency-svc-k7w42
+Jul  4 20:37:13.131: INFO: Got endpoints: latency-svc-d9stb [325.879116ms]
+Jul  4 20:37:13.132: INFO: Created: latency-svc-8kvpb
+Jul  4 20:37:13.152: INFO: Created: latency-svc-lnbg7
+Jul  4 20:37:13.156: INFO: Created: latency-svc-72vnb
+Jul  4 20:37:13.170: INFO: Created: latency-svc-95pwz
+Jul  4 20:37:13.175: INFO: Got endpoints: latency-svc-k7w42 [341.907333ms]
+Jul  4 20:37:13.186: INFO: Created: latency-svc-6zx4j
+Jul  4 20:37:13.198: INFO: Created: latency-svc-wc9qb
+Jul  4 20:37:13.213: INFO: Created: latency-svc-hd8n4
+Jul  4 20:37:13.221: INFO: Got endpoints: latency-svc-8kvpb [386.774288ms]
+Jul  4 20:37:13.231: INFO: Created: latency-svc-rzxvg
+Jul  4 20:37:13.240: INFO: Created: latency-svc-zm9jq
+Jul  4 20:37:13.251: INFO: Created: latency-svc-m2c8t
+Jul  4 20:37:13.262: INFO: Created: latency-svc-ndffx
+Jul  4 20:37:13.277: INFO: Got endpoints: latency-svc-lnbg7 [428.255256ms]
+Jul  4 20:37:13.287: INFO: Created: latency-svc-gzssp
+Jul  4 20:37:13.298: INFO: Created: latency-svc-cb9kn
+Jul  4 20:37:13.305: INFO: Created: latency-svc-jzdpd
+Jul  4 20:37:13.315: INFO: Created: latency-svc-4r8pg
+Jul  4 20:37:13.322: INFO: Got endpoints: latency-svc-72vnb [436.30436ms]
+Jul  4 20:37:13.335: INFO: Created: latency-svc-65cd8
+Jul  4 20:37:13.340: INFO: Created: latency-svc-c7fmj
+Jul  4 20:37:13.348: INFO: Created: latency-svc-8c54l
+Jul  4 20:37:13.362: INFO: Got endpoints: latency-svc-95pwz [456.11101ms]
+Jul  4 20:37:13.380: INFO: Created: latency-svc-zc7bc
+Jul  4 20:37:13.413: INFO: Got endpoints: latency-svc-6zx4j [487.75587ms]
+Jul  4 20:37:13.426: INFO: Created: latency-svc-wpxwr
+Jul  4 20:37:13.470: INFO: Got endpoints: latency-svc-wc9qb [521.923561ms]
+Jul  4 20:37:13.496: INFO: Created: latency-svc-p26tr
+Jul  4 20:37:13.518: INFO: Got endpoints: latency-svc-hd8n4 [526.880992ms]
+Jul  4 20:37:13.533: INFO: Created: latency-svc-pxvpl
+Jul  4 20:37:13.564: INFO: Got endpoints: latency-svc-rzxvg [554.827433ms]
+Jul  4 20:37:13.575: INFO: Created: latency-svc-6w6lv
+Jul  4 20:37:13.613: INFO: Got endpoints: latency-svc-zm9jq [584.053685ms]
+Jul  4 20:37:13.627: INFO: Created: latency-svc-2gp6k
+Jul  4 20:37:13.662: INFO: Got endpoints: latency-svc-m2c8t [607.701617ms]
+Jul  4 20:37:13.676: INFO: Created: latency-svc-r8448
+Jul  4 20:37:13.721: INFO: Got endpoints: latency-svc-ndffx [666.498403ms]
+Jul  4 20:37:13.734: INFO: Created: latency-svc-qppfw
+Jul  4 20:37:13.762: INFO: Got endpoints: latency-svc-gzssp [679.794781ms]
+Jul  4 20:37:13.775: INFO: Created: latency-svc-kgfl8
+Jul  4 20:37:13.814: INFO: Got endpoints: latency-svc-cb9kn [715.306846ms]
+Jul  4 20:37:13.826: INFO: Created: latency-svc-8vwf7
+Jul  4 20:37:13.863: INFO: Got endpoints: latency-svc-jzdpd [731.741666ms]
+Jul  4 20:37:13.876: INFO: Created: latency-svc-9br65
+Jul  4 20:37:13.912: INFO: Got endpoints: latency-svc-4r8pg [736.734183ms]
+Jul  4 20:37:13.925: INFO: Created: latency-svc-rbklb
+Jul  4 20:37:13.963: INFO: Got endpoints: latency-svc-65cd8 [742.84076ms]
+Jul  4 20:37:13.985: INFO: Created: latency-svc-zwvnv
+Jul  4 20:37:14.012: INFO: Got endpoints: latency-svc-c7fmj [735.013282ms]
+Jul  4 20:37:14.024: INFO: Created: latency-svc-n94ht
+Jul  4 20:37:14.065: INFO: Got endpoints: latency-svc-8c54l [743.195341ms]
+Jul  4 20:37:14.079: INFO: Created: latency-svc-vjc7b
+Jul  4 20:37:14.114: INFO: Got endpoints: latency-svc-zc7bc [751.576055ms]
+Jul  4 20:37:14.126: INFO: Created: latency-svc-qzfb4
+Jul  4 20:37:14.163: INFO: Got endpoints: latency-svc-wpxwr [749.406862ms]
+Jul  4 20:37:14.177: INFO: Created: latency-svc-vs5f5
+Jul  4 20:37:14.213: INFO: Got endpoints: latency-svc-p26tr [742.608341ms]
+Jul  4 20:37:14.226: INFO: Created: latency-svc-455vp
+Jul  4 20:37:14.264: INFO: Got endpoints: latency-svc-pxvpl [745.567229ms]
+Jul  4 20:37:14.276: INFO: Created: latency-svc-6c66d
+Jul  4 20:37:14.313: INFO: Got endpoints: latency-svc-6w6lv [749.543909ms]
+Jul  4 20:37:14.326: INFO: Created: latency-svc-ksl48
+Jul  4 20:37:14.387: INFO: Got endpoints: latency-svc-2gp6k [773.790611ms]
+Jul  4 20:37:14.407: INFO: Created: latency-svc-2779k
+Jul  4 20:37:14.414: INFO: Got endpoints: latency-svc-r8448 [750.983782ms]
+Jul  4 20:37:14.427: INFO: Created: latency-svc-rcnqr
+Jul  4 20:37:14.462: INFO: Got endpoints: latency-svc-qppfw [740.716166ms]
+Jul  4 20:37:14.475: INFO: Created: latency-svc-dqktz
+Jul  4 20:37:14.513: INFO: Got endpoints: latency-svc-kgfl8 [750.097755ms]
+Jul  4 20:37:14.527: INFO: Created: latency-svc-lrtjc
+Jul  4 20:37:14.568: INFO: Got endpoints: latency-svc-8vwf7 [753.573314ms]
+Jul  4 20:37:14.579: INFO: Created: latency-svc-56tb8
+Jul  4 20:37:14.611: INFO: Got endpoints: latency-svc-9br65 [747.929039ms]
+Jul  4 20:37:14.625: INFO: Created: latency-svc-hwmfh
+Jul  4 20:37:14.665: INFO: Got endpoints: latency-svc-rbklb [752.420125ms]
+Jul  4 20:37:14.676: INFO: Created: latency-svc-rn5g5
+Jul  4 20:37:14.717: INFO: Got endpoints: latency-svc-zwvnv [753.02834ms]
+Jul  4 20:37:14.750: INFO: Created: latency-svc-mm2rz
+Jul  4 20:37:14.768: INFO: Got endpoints: latency-svc-n94ht [755.346264ms]
+Jul  4 20:37:14.791: INFO: Created: latency-svc-g2c8l
+Jul  4 20:37:14.820: INFO: Got endpoints: latency-svc-vjc7b [755.018997ms]
+Jul  4 20:37:14.834: INFO: Created: latency-svc-wr8hk
+Jul  4 20:37:14.864: INFO: Got endpoints: latency-svc-qzfb4 [750.087752ms]
+Jul  4 20:37:14.878: INFO: Created: latency-svc-2pmgh
+Jul  4 20:37:14.913: INFO: Got endpoints: latency-svc-vs5f5 [749.510049ms]
+Jul  4 20:37:14.925: INFO: Created: latency-svc-tfbd9
+Jul  4 20:37:14.964: INFO: Got endpoints: latency-svc-455vp [750.09017ms]
+Jul  4 20:37:14.976: INFO: Created: latency-svc-h5w64
+Jul  4 20:37:15.012: INFO: Got endpoints: latency-svc-6c66d [747.5149ms]
+Jul  4 20:37:15.025: INFO: Created: latency-svc-tthdf
+Jul  4 20:37:15.064: INFO: Got endpoints: latency-svc-ksl48 [750.759259ms]
+Jul  4 20:37:15.080: INFO: Created: latency-svc-fl4cr
+Jul  4 20:37:15.113: INFO: Got endpoints: latency-svc-2779k [725.729106ms]
+Jul  4 20:37:15.126: INFO: Created: latency-svc-lvtgw
+Jul  4 20:37:15.163: INFO: Got endpoints: latency-svc-rcnqr [749.248045ms]
+Jul  4 20:37:15.177: INFO: Created: latency-svc-nx8gp
+Jul  4 20:37:15.215: INFO: Got endpoints: latency-svc-dqktz [752.832936ms]
+Jul  4 20:37:15.229: INFO: Created: latency-svc-pkxjz
+Jul  4 20:37:15.262: INFO: Got endpoints: latency-svc-lrtjc [749.644553ms]
+Jul  4 20:37:15.275: INFO: Created: latency-svc-tt8r9
+Jul  4 20:37:15.314: INFO: Got endpoints: latency-svc-56tb8 [746.518632ms]
+Jul  4 20:37:15.327: INFO: Created: latency-svc-4bwf5
+Jul  4 20:37:15.363: INFO: Got endpoints: latency-svc-hwmfh [751.585119ms]
+Jul  4 20:37:15.374: INFO: Created: latency-svc-kjskp
+Jul  4 20:37:15.415: INFO: Got endpoints: latency-svc-rn5g5 [749.812127ms]
+Jul  4 20:37:15.428: INFO: Created: latency-svc-c7nd8
+Jul  4 20:37:15.474: INFO: Got endpoints: latency-svc-mm2rz [757.621786ms]
+Jul  4 20:37:15.502: INFO: Created: latency-svc-dc6bt
+Jul  4 20:37:15.515: INFO: Got endpoints: latency-svc-g2c8l [747.277647ms]
+Jul  4 20:37:15.536: INFO: Created: latency-svc-g9gpc
+Jul  4 20:37:15.564: INFO: Got endpoints: latency-svc-wr8hk [743.81825ms]
+Jul  4 20:37:15.583: INFO: Created: latency-svc-9bvvz
+Jul  4 20:37:15.612: INFO: Got endpoints: latency-svc-2pmgh [747.805714ms]
+Jul  4 20:37:15.628: INFO: Created: latency-svc-vqftz
+Jul  4 20:37:15.663: INFO: Got endpoints: latency-svc-tfbd9 [750.2718ms]
+Jul  4 20:37:15.676: INFO: Created: latency-svc-szk9h
+Jul  4 20:37:15.713: INFO: Got endpoints: latency-svc-h5w64 [749.420169ms]
+Jul  4 20:37:15.729: INFO: Created: latency-svc-nxcqk
+Jul  4 20:37:15.764: INFO: Got endpoints: latency-svc-tthdf [751.254102ms]
+Jul  4 20:37:15.785: INFO: Created: latency-svc-pjvgd
+Jul  4 20:37:15.813: INFO: Got endpoints: latency-svc-fl4cr [748.172809ms]
+Jul  4 20:37:15.827: INFO: Created: latency-svc-j6bpc
+Jul  4 20:37:15.868: INFO: Got endpoints: latency-svc-lvtgw [754.688909ms]
+Jul  4 20:37:15.885: INFO: Created: latency-svc-2ckgm
+Jul  4 20:37:15.914: INFO: Got endpoints: latency-svc-nx8gp [750.145541ms]
+Jul  4 20:37:15.928: INFO: Created: latency-svc-5n495
+Jul  4 20:37:15.963: INFO: Got endpoints: latency-svc-pkxjz [748.100299ms]
+Jul  4 20:37:15.977: INFO: Created: latency-svc-xcrv9
+Jul  4 20:37:16.013: INFO: Got endpoints: latency-svc-tt8r9 [750.315202ms]
+Jul  4 20:37:16.025: INFO: Created: latency-svc-znpfv
+Jul  4 20:37:16.064: INFO: Got endpoints: latency-svc-4bwf5 [749.452691ms]
+Jul  4 20:37:16.077: INFO: Created: latency-svc-lpkfb
+Jul  4 20:37:16.112: INFO: Got endpoints: latency-svc-kjskp [748.852178ms]
+Jul  4 20:37:16.125: INFO: Created: latency-svc-f5bf9
+Jul  4 20:37:16.163: INFO: Got endpoints: latency-svc-c7nd8 [747.782673ms]
+Jul  4 20:37:16.174: INFO: Created: latency-svc-7td6f
+Jul  4 20:37:16.217: INFO: Got endpoints: latency-svc-dc6bt [742.489485ms]
+Jul  4 20:37:16.233: INFO: Created: latency-svc-pfgm9
+Jul  4 20:37:16.263: INFO: Got endpoints: latency-svc-g9gpc [747.475818ms]
+Jul  4 20:37:16.280: INFO: Created: latency-svc-dlqk9
+Jul  4 20:37:16.313: INFO: Got endpoints: latency-svc-9bvvz [748.190832ms]
+Jul  4 20:37:16.325: INFO: Created: latency-svc-m7qps
+Jul  4 20:37:16.368: INFO: Got endpoints: latency-svc-vqftz [755.706949ms]
+Jul  4 20:37:16.383: INFO: Created: latency-svc-tmjp6
+Jul  4 20:37:16.413: INFO: Got endpoints: latency-svc-szk9h [748.940868ms]
+Jul  4 20:37:16.424: INFO: Created: latency-svc-xdvjd
+Jul  4 20:37:16.464: INFO: Got endpoints: latency-svc-nxcqk [750.733113ms]
+Jul  4 20:37:16.478: INFO: Created: latency-svc-d4fjp
+Jul  4 20:37:16.516: INFO: Got endpoints: latency-svc-pjvgd [752.503385ms]
+Jul  4 20:37:16.529: INFO: Created: latency-svc-52gdn
+Jul  4 20:37:16.563: INFO: Got endpoints: latency-svc-j6bpc [750.343246ms]
+Jul  4 20:37:16.576: INFO: Created: latency-svc-9ml5m
+Jul  4 20:37:16.613: INFO: Got endpoints: latency-svc-2ckgm [744.859113ms]
+Jul  4 20:37:16.628: INFO: Created: latency-svc-q262r
+Jul  4 20:37:16.665: INFO: Got endpoints: latency-svc-5n495 [751.679777ms]
+Jul  4 20:37:16.679: INFO: Created: latency-svc-pgv76
+Jul  4 20:37:16.717: INFO: Got endpoints: latency-svc-xcrv9 [753.429848ms]
+Jul  4 20:37:16.781: INFO: Got endpoints: latency-svc-znpfv [768.175595ms]
+Jul  4 20:37:16.782: INFO: Created: latency-svc-xkvzt
+Jul  4 20:37:16.802: INFO: Created: latency-svc-px5dx
+Jul  4 20:37:16.815: INFO: Got endpoints: latency-svc-lpkfb [750.66144ms]
+Jul  4 20:37:16.828: INFO: Created: latency-svc-9rwcb
+Jul  4 20:37:16.864: INFO: Got endpoints: latency-svc-f5bf9 [751.060293ms]
+Jul  4 20:37:16.878: INFO: Created: latency-svc-2prtn
+Jul  4 20:37:16.915: INFO: Got endpoints: latency-svc-7td6f [751.27096ms]
+Jul  4 20:37:16.929: INFO: Created: latency-svc-pw599
+Jul  4 20:37:16.963: INFO: Got endpoints: latency-svc-pfgm9 [745.97088ms]
+Jul  4 20:37:16.979: INFO: Created: latency-svc-ctlkt
+Jul  4 20:37:17.014: INFO: Got endpoints: latency-svc-dlqk9 [750.617214ms]
+Jul  4 20:37:17.028: INFO: Created: latency-svc-445w2
+Jul  4 20:37:17.064: INFO: Got endpoints: latency-svc-m7qps [751.302902ms]
+Jul  4 20:37:17.077: INFO: Created: latency-svc-c5x7t
+Jul  4 20:37:17.113: INFO: Got endpoints: latency-svc-tmjp6 [744.960253ms]
+Jul  4 20:37:17.125: INFO: Created: latency-svc-mvdd2
+Jul  4 20:37:17.164: INFO: Got endpoints: latency-svc-xdvjd [751.39968ms]
+Jul  4 20:37:17.177: INFO: Created: latency-svc-2trkx
+Jul  4 20:37:17.213: INFO: Got endpoints: latency-svc-d4fjp [748.398531ms]
+Jul  4 20:37:17.229: INFO: Created: latency-svc-j5l48
+Jul  4 20:37:17.271: INFO: Got endpoints: latency-svc-52gdn [754.646229ms]
+Jul  4 20:37:17.291: INFO: Created: latency-svc-c7wx9
+Jul  4 20:37:17.314: INFO: Got endpoints: latency-svc-9ml5m [750.007516ms]
+Jul  4 20:37:17.325: INFO: Created: latency-svc-jwjj7
+Jul  4 20:37:17.361: INFO: Got endpoints: latency-svc-q262r [747.695894ms]
+Jul  4 20:37:17.376: INFO: Created: latency-svc-k94zf
+Jul  4 20:37:17.413: INFO: Got endpoints: latency-svc-pgv76 [747.631106ms]
+Jul  4 20:37:17.428: INFO: Created: latency-svc-d7jrl
+Jul  4 20:37:17.470: INFO: Got endpoints: latency-svc-xkvzt [752.600269ms]
+Jul  4 20:37:17.503: INFO: Created: latency-svc-cz797
+Jul  4 20:37:17.523: INFO: Got endpoints: latency-svc-px5dx [741.652088ms]
+Jul  4 20:37:17.551: INFO: Created: latency-svc-ntkr6
+Jul  4 20:37:17.565: INFO: Got endpoints: latency-svc-9rwcb [749.970371ms]
+Jul  4 20:37:17.583: INFO: Created: latency-svc-hrqfz
+Jul  4 20:37:17.615: INFO: Got endpoints: latency-svc-2prtn [751.143542ms]
+Jul  4 20:37:17.629: INFO: Created: latency-svc-qst7f
+Jul  4 20:37:17.664: INFO: Got endpoints: latency-svc-pw599 [749.581891ms]
+Jul  4 20:37:17.678: INFO: Created: latency-svc-zf8lz
+Jul  4 20:37:17.713: INFO: Got endpoints: latency-svc-ctlkt [749.895719ms]
+Jul  4 20:37:17.727: INFO: Created: latency-svc-xcd48
+Jul  4 20:37:17.766: INFO: Got endpoints: latency-svc-445w2 [751.600644ms]
+Jul  4 20:37:17.781: INFO: Created: latency-svc-kgkxd
+Jul  4 20:37:17.814: INFO: Got endpoints: latency-svc-c5x7t [749.194228ms]
+Jul  4 20:37:17.850: INFO: Created: latency-svc-pllqw
+Jul  4 20:37:17.864: INFO: Got endpoints: latency-svc-mvdd2 [750.552487ms]
+Jul  4 20:37:17.878: INFO: Created: latency-svc-4n29q
+Jul  4 20:37:17.914: INFO: Got endpoints: latency-svc-2trkx [749.197693ms]
+Jul  4 20:37:17.931: INFO: Created: latency-svc-gh7n6
+Jul  4 20:37:17.966: INFO: Got endpoints: latency-svc-j5l48 [753.345401ms]
+Jul  4 20:37:17.992: INFO: Created: latency-svc-9mqzv
+Jul  4 20:37:18.015: INFO: Got endpoints: latency-svc-c7wx9 [743.748038ms]
+Jul  4 20:37:18.030: INFO: Created: latency-svc-gtxww
+Jul  4 20:37:18.064: INFO: Got endpoints: latency-svc-jwjj7 [750.604601ms]
+Jul  4 20:37:18.077: INFO: Created: latency-svc-kwm8r
+Jul  4 20:37:18.113: INFO: Got endpoints: latency-svc-k94zf [751.659923ms]
+Jul  4 20:37:18.125: INFO: Created: latency-svc-dqk2l
+Jul  4 20:37:18.165: INFO: Got endpoints: latency-svc-d7jrl [751.614009ms]
+Jul  4 20:37:18.178: INFO: Created: latency-svc-wrrx5
+Jul  4 20:37:18.214: INFO: Got endpoints: latency-svc-cz797 [744.00719ms]
+Jul  4 20:37:18.227: INFO: Created: latency-svc-8czhq
+Jul  4 20:37:18.267: INFO: Got endpoints: latency-svc-ntkr6 [743.8134ms]
+Jul  4 20:37:18.281: INFO: Created: latency-svc-cltzx
+Jul  4 20:37:18.320: INFO: Got endpoints: latency-svc-hrqfz [754.512978ms]
+Jul  4 20:37:18.348: INFO: Created: latency-svc-zq2bb
+Jul  4 20:37:18.363: INFO: Got endpoints: latency-svc-qst7f [748.193771ms]
+Jul  4 20:37:18.381: INFO: Created: latency-svc-lx5th
+Jul  4 20:37:18.412: INFO: Got endpoints: latency-svc-zf8lz [747.770739ms]
+Jul  4 20:37:18.451: INFO: Created: latency-svc-fslhr
+Jul  4 20:37:18.468: INFO: Got endpoints: latency-svc-xcd48 [754.707158ms]
+Jul  4 20:37:18.483: INFO: Created: latency-svc-v7k76
+Jul  4 20:37:18.514: INFO: Got endpoints: latency-svc-kgkxd [748.116002ms]
+Jul  4 20:37:18.528: INFO: Created: latency-svc-hznjr
+Jul  4 20:37:18.563: INFO: Got endpoints: latency-svc-pllqw [749.240014ms]
+Jul  4 20:37:18.578: INFO: Created: latency-svc-x9xk8
+Jul  4 20:37:18.621: INFO: Got endpoints: latency-svc-4n29q [755.989484ms]
+Jul  4 20:37:18.637: INFO: Created: latency-svc-hscxt
+Jul  4 20:37:18.663: INFO: Got endpoints: latency-svc-gh7n6 [748.507422ms]
+Jul  4 20:37:18.674: INFO: Created: latency-svc-w8wrr
+Jul  4 20:37:18.715: INFO: Got endpoints: latency-svc-9mqzv [748.512567ms]
+Jul  4 20:37:18.730: INFO: Created: latency-svc-xx5rw
+Jul  4 20:37:18.766: INFO: Got endpoints: latency-svc-gtxww [749.969161ms]
+Jul  4 20:37:18.781: INFO: Created: latency-svc-zzzf2
+Jul  4 20:37:18.830: INFO: Got endpoints: latency-svc-kwm8r [765.943904ms]
+Jul  4 20:37:18.869: INFO: Got endpoints: latency-svc-dqk2l [755.984248ms]
+Jul  4 20:37:18.883: INFO: Created: latency-svc-bmtzd
+Jul  4 20:37:18.893: INFO: Created: latency-svc-ngcvk
+Jul  4 20:37:18.915: INFO: Got endpoints: latency-svc-wrrx5 [749.741065ms]
+Jul  4 20:37:18.965: INFO: Got endpoints: latency-svc-8czhq [750.794496ms]
+Jul  4 20:37:19.014: INFO: Got endpoints: latency-svc-cltzx [746.779215ms]
+Jul  4 20:37:19.064: INFO: Got endpoints: latency-svc-zq2bb [743.733069ms]
+Jul  4 20:37:19.115: INFO: Got endpoints: latency-svc-lx5th [751.324359ms]
+Jul  4 20:37:19.168: INFO: Got endpoints: latency-svc-fslhr [755.756564ms]
+Jul  4 20:37:19.215: INFO: Got endpoints: latency-svc-v7k76 [746.38179ms]
+Jul  4 20:37:19.265: INFO: Got endpoints: latency-svc-hznjr [750.683277ms]
+Jul  4 20:37:19.314: INFO: Got endpoints: latency-svc-x9xk8 [750.562224ms]
+Jul  4 20:37:19.365: INFO: Got endpoints: latency-svc-hscxt [744.344262ms]
+Jul  4 20:37:19.415: INFO: Got endpoints: latency-svc-w8wrr [751.597993ms]
+Jul  4 20:37:19.469: INFO: Got endpoints: latency-svc-xx5rw [753.462669ms]
+Jul  4 20:37:19.514: INFO: Got endpoints: latency-svc-zzzf2 [748.46366ms]
+Jul  4 20:37:19.564: INFO: Got endpoints: latency-svc-bmtzd [733.527801ms]
+Jul  4 20:37:19.613: INFO: Got endpoints: latency-svc-ngcvk [743.971512ms]
+Jul  4 20:37:19.614: INFO: Latencies: [46.940403ms 61.368675ms 76.168805ms 85.413238ms 86.14976ms 110.449352ms 138.265424ms 156.733232ms 167.208786ms 184.866182ms 195.983502ms 244.785419ms 262.756203ms 271.664636ms 275.599546ms 280.787105ms 283.363417ms 290.818913ms 294.18383ms 301.615834ms 315.748127ms 318.701024ms 325.033482ms 325.879116ms 326.08937ms 332.460925ms 336.110152ms 341.907333ms 369.993725ms 379.598368ms 383.561991ms 384.750801ms 386.774288ms 388.334888ms 393.616849ms 394.833921ms 397.769406ms 400.329613ms 402.874841ms 404.724789ms 416.070281ms 428.255256ms 431.771531ms 434.633782ms 436.30436ms 440.762982ms 456.11101ms 458.853814ms 467.194238ms 467.988762ms 469.7409ms 483.340811ms 485.798043ms 487.75587ms 494.612569ms 506.268843ms 509.519603ms 510.200761ms 521.923561ms 526.880992ms 530.0838ms 554.827433ms 557.283903ms 569.762448ms 581.078164ms 584.053685ms 585.760266ms 607.701617ms 623.307557ms 635.497271ms 638.899435ms 640.718473ms 642.653509ms 648.307272ms 653.453095ms 666.498403ms 669.844977ms 670.369143ms 679.794781ms 680.40404ms 715.306846ms 718.047578ms 725.729106ms 730.183518ms 731.741666ms 733.527801ms 734.764151ms 735.013282ms 736.734183ms 740.716166ms 741.652088ms 742.489485ms 742.608341ms 742.84076ms 743.195341ms 743.733069ms 743.748038ms 743.8134ms 743.81825ms 743.971512ms 744.00719ms 744.344262ms 744.859113ms 744.960253ms 745.567229ms 745.97088ms 746.38179ms 746.518632ms 746.779215ms 747.277647ms 747.475818ms 747.5149ms 747.631106ms 747.695894ms 747.770739ms 747.782673ms 747.805714ms 747.929039ms 748.100299ms 748.116002ms 748.172809ms 748.190832ms 748.193771ms 748.398531ms 748.46366ms 748.507422ms 748.512567ms 748.852178ms 748.940868ms 749.194228ms 749.197693ms 749.240014ms 749.248045ms 749.406862ms 749.420169ms 749.452691ms 749.510049ms 749.543909ms 749.581891ms 749.644553ms 749.741065ms 749.812127ms 749.895719ms 749.969161ms 749.970371ms 750.007516ms 750.087752ms 750.09017ms 750.097755ms 750.145541ms 750.2718ms 750.315202ms 750.343246ms 750.552487ms 750.562224ms 750.604601ms 750.617214ms 750.66144ms 750.683277ms 750.733113ms 750.759259ms 750.794496ms 750.983782ms 751.060293ms 751.143542ms 751.254102ms 751.27096ms 751.302902ms 751.324359ms 751.39968ms 751.576055ms 751.585119ms 751.597993ms 751.600644ms 751.614009ms 751.659923ms 751.679777ms 752.420125ms 752.503385ms 752.600269ms 752.832936ms 753.02834ms 753.345401ms 753.429848ms 753.462669ms 753.573314ms 754.512978ms 754.646229ms 754.688909ms 754.707158ms 755.018997ms 755.346264ms 755.706949ms 755.756564ms 755.984248ms 755.989484ms 757.621786ms 765.943904ms 768.175595ms 773.790611ms]
+Jul  4 20:37:19.614: INFO: 50 %ile: 744.00719ms
+Jul  4 20:37:19.614: INFO: 90 %ile: 752.832936ms
+Jul  4 20:37:19.614: INFO: 99 %ile: 768.175595ms
+Jul  4 20:37:19.614: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:37:19.614: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-tdqps" for this suite.
+Jul  4 20:37:33.639: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:37:33.708: INFO: namespace: e2e-tests-svc-latency-tdqps, resource: bindings, ignored listing per whitelist
+Jul  4 20:37:33.714: INFO: namespace e2e-tests-svc-latency-tdqps deletion completed in 14.093580271s
+
+• [SLOW TEST:24.885 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:37:33.716: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for all pods to be garbage collected
+STEP: Gathering metrics
+W0704 20:37:43.832410      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  4 20:37:43.832: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:37:43.832: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-gszj6" for this suite.
+Jul  4 20:37:49.852: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:37:49.889: INFO: namespace: e2e-tests-gc-gszj6, resource: bindings, ignored listing per whitelist
+Jul  4 20:37:49.926: INFO: namespace e2e-tests-gc-gszj6 deletion completed in 6.090675728s
+
+• [SLOW TEST:16.210 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:37:49.926: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-fbhtt
+[It] Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Looking for a node to schedule stateful set and pod
+STEP: Creating pod with conflicting port in namespace e2e-tests-statefulset-fbhtt
+STEP: Creating statefulset with conflicting port in namespace e2e-tests-statefulset-fbhtt
+STEP: Waiting until pod test-pod will start running in namespace e2e-tests-statefulset-fbhtt
+STEP: Waiting until stateful pod ss-0 will be recreated and deleted at least once in namespace e2e-tests-statefulset-fbhtt
+Jul  4 20:37:52.036: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-fbhtt, name: ss-0, uid: 1e3c7c85-7fca-11e8-94db-42010a800002, status phase: Pending. Waiting for statefulset controller to delete.
+Jul  4 20:37:59.221: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-fbhtt, name: ss-0, uid: 1e3c7c85-7fca-11e8-94db-42010a800002, status phase: Failed. Waiting for statefulset controller to delete.
+Jul  4 20:37:59.232: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-fbhtt, name: ss-0, uid: 1e3c7c85-7fca-11e8-94db-42010a800002, status phase: Failed. Waiting for statefulset controller to delete.
+Jul  4 20:37:59.240: INFO: Observed delete event for stateful pod ss-0 in namespace e2e-tests-statefulset-fbhtt
+STEP: Removing pod with conflicting port in namespace e2e-tests-statefulset-fbhtt
+STEP: Waiting when stateful pod ss-0 will be recreated in namespace e2e-tests-statefulset-fbhtt and will be in running state
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  4 20:38:01.312: INFO: Deleting all statefulset in ns e2e-tests-statefulset-fbhtt
+Jul  4 20:38:01.314: INFO: Scaling statefulset ss to 0
+Jul  4 20:38:11.331: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  4 20:38:11.334: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:38:11.349: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-fbhtt" for this suite.
+Jul  4 20:38:17.375: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:38:17.439: INFO: namespace: e2e-tests-statefulset-fbhtt, resource: bindings, ignored listing per whitelist
+Jul  4 20:38:17.480: INFO: namespace e2e-tests-statefulset-fbhtt deletion completed in 6.12602145s
+
+• [SLOW TEST:27.554 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Should recreate evicted statefulset [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:38:17.482: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the pods
+STEP: Gathering metrics
+W0704 20:38:57.624547      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  4 20:38:57.624: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:38:57.624: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-dsvkt" for this suite.
+Jul  4 20:39:03.644: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:39:03.717: INFO: namespace: e2e-tests-gc-dsvkt, resource: bindings, ignored listing per whitelist
+Jul  4 20:39:03.739: INFO: namespace e2e-tests-gc-dsvkt deletion completed in 6.111354422s
+
+• [SLOW TEST:46.257 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:39:03.739: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:39:03.835: INFO: Waiting up to 5m0s for pod "downwardapi-volume-4a1c06c0-7fca-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-pkgz8" to be "success or failure"
+Jul  4 20:39:03.843: INFO: Pod "downwardapi-volume-4a1c06c0-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.010485ms
+Jul  4 20:39:05.847: INFO: Pod "downwardapi-volume-4a1c06c0-7fca-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011373617s
+STEP: Saw pod success
+Jul  4 20:39:05.847: INFO: Pod "downwardapi-volume-4a1c06c0-7fca-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:39:05.849: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-4a1c06c0-7fca-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:39:05.873: INFO: Waiting for pod downwardapi-volume-4a1c06c0-7fca-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:39:05.875: INFO: Pod downwardapi-volume-4a1c06c0-7fca-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:39:05.875: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-pkgz8" for this suite.
+Jul  4 20:39:11.892: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:39:11.943: INFO: namespace: e2e-tests-projected-pkgz8, resource: bindings, ignored listing per whitelist
+Jul  4 20:39:11.967: INFO: namespace e2e-tests-projected-pkgz8 deletion completed in 6.08730445s
+
+• [SLOW TEST:8.228 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:39:11.968: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-vtf86
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-vtf86 to expose endpoints map[]
+Jul  4 20:39:12.098: INFO: Get endpoints failed (6.300208ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Jul  4 20:39:13.101: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-vtf86 exposes endpoints map[] (1.00939973s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-vtf86
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-vtf86 to expose endpoints map[pod1:[100]]
+Jul  4 20:39:15.133: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-vtf86 exposes endpoints map[pod1:[100]] (2.024630952s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-vtf86
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-vtf86 to expose endpoints map[pod1:[100] pod2:[101]]
+Jul  4 20:39:17.187: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-vtf86 exposes endpoints map[pod2:[101] pod1:[100]] (2.043188307s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-vtf86
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-vtf86 to expose endpoints map[pod2:[101]]
+Jul  4 20:39:17.213: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-vtf86 exposes endpoints map[pod2:[101]] (18.3321ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-vtf86
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-vtf86 to expose endpoints map[]
+Jul  4 20:39:17.234: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-vtf86 exposes endpoints map[] (5.871331ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:39:17.257: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-vtf86" for this suite.
+Jul  4 20:39:39.278: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:39:39.314: INFO: namespace: e2e-tests-services-vtf86, resource: bindings, ignored listing per whitelist
+Jul  4 20:39:39.348: INFO: namespace e2e-tests-services-vtf86 deletion completed in 22.084499195s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:27.381 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:39:39.350: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  4 20:39:39.418: INFO: (0) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.971304ms)
+Jul  4 20:39:39.422: INFO: (1) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.384204ms)
+Jul  4 20:39:39.425: INFO: (2) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.677873ms)
+Jul  4 20:39:39.428: INFO: (3) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.859822ms)
+Jul  4 20:39:39.431: INFO: (4) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.625052ms)
+Jul  4 20:39:39.433: INFO: (5) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.648264ms)
+Jul  4 20:39:39.436: INFO: (6) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.512403ms)
+Jul  4 20:39:39.439: INFO: (7) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.752746ms)
+Jul  4 20:39:39.444: INFO: (8) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.761256ms)
+Jul  4 20:39:39.447: INFO: (9) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.954066ms)
+Jul  4 20:39:39.450: INFO: (10) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.724629ms)
+Jul  4 20:39:39.453: INFO: (11) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.546425ms)
+Jul  4 20:39:39.456: INFO: (12) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 2.711622ms)
+Jul  4 20:39:39.459: INFO: (13) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.006437ms)
+Jul  4 20:39:39.462: INFO: (14) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.126265ms)
+Jul  4 20:39:39.465: INFO: (15) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.010344ms)
+Jul  4 20:39:39.468: INFO: (16) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.21497ms)
+Jul  4 20:39:39.472: INFO: (17) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.395636ms)
+Jul  4 20:39:39.480: INFO: (18) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 8.073359ms)
+Jul  4 20:39:39.483: INFO: (19) /api/v1/nodes/jakku-worker-8tmm.c.dghubble-io.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.345325ms)
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:39:39.483: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-kb6jk" for this suite.
+Jul  4 20:39:45.500: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:39:45.560: INFO: namespace: e2e-tests-proxy-kb6jk, resource: bindings, ignored listing per whitelist
+Jul  4 20:39:45.566: INFO: namespace e2e-tests-proxy-kb6jk deletion completed in 6.079060236s
+
+• [SLOW TEST:6.216 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:39:45.568: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  4 20:39:45.696: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:39:45.703: INFO: Number of nodes with available pods: 0
+Jul  4 20:39:45.703: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:39:46.708: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:39:46.711: INFO: Number of nodes with available pods: 0
+Jul  4 20:39:46.711: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:39:47.707: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:39:47.710: INFO: Number of nodes with available pods: 3
+Jul  4 20:39:47.710: INFO: Number of running nodes: 3, number of available pods: 3
+STEP: Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.
+Jul  4 20:39:47.731: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:39:47.737: INFO: Number of nodes with available pods: 2
+Jul  4 20:39:47.737: INFO: Node jakku-worker-f0tz.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:39:48.742: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:39:48.746: INFO: Number of nodes with available pods: 2
+Jul  4 20:39:48.746: INFO: Node jakku-worker-f0tz.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:39:49.741: INFO: DaemonSet pods can't tolerate node jakku-controller-0.c.dghubble-io.internal with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Jul  4 20:39:49.744: INFO: Number of nodes with available pods: 3
+Jul  4 20:39:49.744: INFO: Number of running nodes: 3, number of available pods: 3
+STEP: Wait for the failed daemon pod to be completely deleted.
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-j7zdb, will wait for the garbage collector to delete the pods
+Jul  4 20:39:49.806: INFO: Deleting {extensions DaemonSet} daemon-set took: 5.743432ms
+Jul  4 20:39:49.906: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.289774ms
+Jul  4 20:40:03.910: INFO: Number of nodes with available pods: 0
+Jul  4 20:40:03.910: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  4 20:40:03.912: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-j7zdb/daemonsets","resourceVersion":"9985"},"items":null}
+
+Jul  4 20:40:03.914: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-j7zdb/pods","resourceVersion":"9985"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:40:03.925: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-j7zdb" for this suite.
+Jul  4 20:40:09.940: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:40:09.986: INFO: namespace: e2e-tests-daemonsets-j7zdb, resource: bindings, ignored listing per whitelist
+Jul  4 20:40:10.033: INFO: namespace e2e-tests-daemonsets-j7zdb deletion completed in 6.105220372s
+
+• [SLOW TEST:24.465 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:40:10.035: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-719bca86-7fca-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 20:40:10.108: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-719c5257-7fca-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-t5z8t" to be "success or failure"
+Jul  4 20:40:10.117: INFO: Pod "pod-projected-configmaps-719c5257-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.985499ms
+Jul  4 20:40:12.120: INFO: Pod "pod-projected-configmaps-719c5257-7fca-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.01145552s
+STEP: Saw pod success
+Jul  4 20:40:12.120: INFO: Pod "pod-projected-configmaps-719c5257-7fca-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:40:12.122: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-configmaps-719c5257-7fca-11e8-a4f0-6eaac417783a container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:40:12.150: INFO: Waiting for pod pod-projected-configmaps-719c5257-7fca-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:40:12.155: INFO: Pod pod-projected-configmaps-719c5257-7fca-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:40:12.155: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-t5z8t" for this suite.
+Jul  4 20:40:18.171: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:40:18.204: INFO: namespace: e2e-tests-projected-t5z8t, resource: bindings, ignored listing per whitelist
+Jul  4 20:40:18.256: INFO: namespace e2e-tests-projected-t5z8t deletion completed in 6.097104771s
+
+• [SLOW TEST:8.221 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:40:18.259: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override command
+Jul  4 20:40:18.385: INFO: Waiting up to 5m0s for pod "client-containers-768b6ae1-7fca-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-containers-8pfd4" to be "success or failure"
+Jul  4 20:40:18.397: INFO: Pod "client-containers-768b6ae1-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 11.765641ms
+Jul  4 20:40:20.400: INFO: Pod "client-containers-768b6ae1-7fca-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.014867815s
+STEP: Saw pod success
+Jul  4 20:40:20.400: INFO: Pod "client-containers-768b6ae1-7fca-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:40:20.402: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod client-containers-768b6ae1-7fca-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:40:20.436: INFO: Waiting for pod client-containers-768b6ae1-7fca-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:40:20.440: INFO: Pod client-containers-768b6ae1-7fca-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:40:20.440: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-8pfd4" for this suite.
+Jul  4 20:40:26.458: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:40:26.503: INFO: namespace: e2e-tests-containers-8pfd4, resource: bindings, ignored listing per whitelist
+Jul  4 20:40:26.545: INFO: namespace e2e-tests-containers-8pfd4 deletion completed in 6.100645691s
+
+• [SLOW TEST:8.287 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:40:26.547: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-7b74cfb1-7fca-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 20:40:26.631: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-7b75a987-7fca-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-nvq2g" to be "success or failure"
+Jul  4 20:40:26.637: INFO: Pod "pod-projected-configmaps-7b75a987-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 5.64104ms
+Jul  4 20:40:28.640: INFO: Pod "pod-projected-configmaps-7b75a987-7fca-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008996884s
+STEP: Saw pod success
+Jul  4 20:40:28.640: INFO: Pod "pod-projected-configmaps-7b75a987-7fca-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:40:28.643: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-configmaps-7b75a987-7fca-11e8-a4f0-6eaac417783a container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:40:28.665: INFO: Waiting for pod pod-projected-configmaps-7b75a987-7fca-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:40:28.668: INFO: Pod pod-projected-configmaps-7b75a987-7fca-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:40:28.668: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-nvq2g" for this suite.
+Jul  4 20:40:34.692: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:40:34.705: INFO: namespace: e2e-tests-projected-nvq2g, resource: bindings, ignored listing per whitelist
+Jul  4 20:40:34.765: INFO: namespace e2e-tests-projected-nvq2g deletion completed in 6.092979688s
+
+• [SLOW TEST:8.219 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:40:34.767: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Jul  4 20:40:34.836: INFO: Waiting up to 5m0s for pod "pod-8059e333-7fca-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-2rzwt" to be "success or failure"
+Jul  4 20:40:34.844: INFO: Pod "pod-8059e333-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.801395ms
+Jul  4 20:40:36.848: INFO: Pod "pod-8059e333-7fca-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011246269s
+STEP: Saw pod success
+Jul  4 20:40:36.848: INFO: Pod "pod-8059e333-7fca-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:40:36.850: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-8059e333-7fca-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:40:36.876: INFO: Waiting for pod pod-8059e333-7fca-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:40:36.879: INFO: Pod pod-8059e333-7fca-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:40:36.879: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-2rzwt" for this suite.
+Jul  4 20:40:42.896: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:40:42.920: INFO: namespace: e2e-tests-emptydir-2rzwt, resource: bindings, ignored listing per whitelist
+Jul  4 20:40:42.978: INFO: namespace e2e-tests-emptydir-2rzwt deletion completed in 6.094878557s
+
+• [SLOW TEST:8.212 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:40:42.979: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-p4g6j
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  4 20:40:43.036: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  4 20:41:05.146: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.2.1.109:8080/dial?request=hostName&protocol=http&host=10.2.3.25&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-p4g6j PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:41:05.146: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:41:05.263: INFO: Waiting for endpoints: map[]
+Jul  4 20:41:05.266: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.2.1.109:8080/dial?request=hostName&protocol=http&host=10.2.0.21&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-p4g6j PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:41:05.266: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:41:05.370: INFO: Waiting for endpoints: map[]
+Jul  4 20:41:05.373: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.2.1.109:8080/dial?request=hostName&protocol=http&host=10.2.1.108&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-p4g6j PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:41:05.373: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:41:05.464: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:41:05.465: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-p4g6j" for this suite.
+Jul  4 20:41:27.491: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:41:27.582: INFO: namespace: e2e-tests-pod-network-test-p4g6j, resource: bindings, ignored listing per whitelist
+Jul  4 20:41:27.582: INFO: namespace e2e-tests-pod-network-test-p4g6j deletion completed in 22.113516361s
+
+• [SLOW TEST:44.603 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:41:27.584: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-map-9fd48d66-7fca-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:41:27.653: INFO: Waiting up to 5m0s for pod "pod-secrets-9fd4f837-7fca-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-secrets-6d55z" to be "success or failure"
+Jul  4 20:41:27.659: INFO: Pod "pod-secrets-9fd4f837-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 5.491631ms
+Jul  4 20:41:29.668: INFO: Pod "pod-secrets-9fd4f837-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.014507218s
+Jul  4 20:41:31.672: INFO: Pod "pod-secrets-9fd4f837-7fca-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.018443522s
+STEP: Saw pod success
+Jul  4 20:41:31.672: INFO: Pod "pod-secrets-9fd4f837-7fca-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:41:31.675: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-secrets-9fd4f837-7fca-11e8-a4f0-6eaac417783a container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:41:31.696: INFO: Waiting for pod pod-secrets-9fd4f837-7fca-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:41:31.698: INFO: Pod pod-secrets-9fd4f837-7fca-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:41:31.698: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-6d55z" for this suite.
+Jul  4 20:41:37.714: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:41:37.768: INFO: namespace: e2e-tests-secrets-6d55z, resource: bindings, ignored listing per whitelist
+Jul  4 20:41:37.793: INFO: namespace e2e-tests-secrets-6d55z deletion completed in 6.092010952s
+
+• [SLOW TEST:10.210 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:41:37.796: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir volume type on node default medium
+Jul  4 20:41:37.857: INFO: Waiting up to 5m0s for pod "pod-a5ea08ff-7fca-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-7wlt9" to be "success or failure"
+Jul  4 20:41:37.866: INFO: Pod "pod-a5ea08ff-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.816448ms
+Jul  4 20:41:39.869: INFO: Pod "pod-a5ea08ff-7fca-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011416559s
+STEP: Saw pod success
+Jul  4 20:41:39.869: INFO: Pod "pod-a5ea08ff-7fca-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:41:39.871: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-a5ea08ff-7fca-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:41:39.891: INFO: Waiting for pod pod-a5ea08ff-7fca-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:41:39.893: INFO: Pod pod-a5ea08ff-7fca-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:41:39.894: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-7wlt9" for this suite.
+Jul  4 20:41:45.912: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:41:45.963: INFO: namespace: e2e-tests-emptydir-7wlt9, resource: bindings, ignored listing per whitelist
+Jul  4 20:41:45.985: INFO: namespace e2e-tests-emptydir-7wlt9 deletion completed in 6.088391657s
+
+• [SLOW TEST:8.190 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:41:45.987: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  4 20:41:46.049: INFO: Waiting up to 5m0s for pod "downward-api-aacbf14f-7fca-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-88fwn" to be "success or failure"
+Jul  4 20:41:46.060: INFO: Pod "downward-api-aacbf14f-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 10.290987ms
+Jul  4 20:41:48.063: INFO: Pod "downward-api-aacbf14f-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013627295s
+Jul  4 20:41:50.067: INFO: Pod "downward-api-aacbf14f-7fca-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017232407s
+STEP: Saw pod success
+Jul  4 20:41:50.067: INFO: Pod "downward-api-aacbf14f-7fca-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:41:50.068: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downward-api-aacbf14f-7fca-11e8-a4f0-6eaac417783a container dapi-container: <nil>
+STEP: delete the pod
+Jul  4 20:41:50.093: INFO: Waiting for pod downward-api-aacbf14f-7fca-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:41:50.096: INFO: Pod downward-api-aacbf14f-7fca-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:41:50.096: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-88fwn" for this suite.
+Jul  4 20:41:56.113: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:41:56.149: INFO: namespace: e2e-tests-downward-api-88fwn, resource: bindings, ignored listing per whitelist
+Jul  4 20:41:56.207: INFO: namespace e2e-tests-downward-api-88fwn deletion completed in 6.107088323s
+
+• [SLOW TEST:10.220 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:41:56.209: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Jul  4 20:41:56.275: INFO: Waiting up to 5m0s for pod "pod-b0e463ec-7fca-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-dp25p" to be "success or failure"
+Jul  4 20:41:56.279: INFO: Pod "pod-b0e463ec-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 3.582643ms
+Jul  4 20:41:58.283: INFO: Pod "pod-b0e463ec-7fca-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00750204s
+STEP: Saw pod success
+Jul  4 20:41:58.283: INFO: Pod "pod-b0e463ec-7fca-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:41:58.286: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-b0e463ec-7fca-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:41:58.310: INFO: Waiting for pod pod-b0e463ec-7fca-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:41:58.314: INFO: Pod pod-b0e463ec-7fca-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:41:58.314: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-dp25p" for this suite.
+Jul  4 20:42:04.330: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:42:04.342: INFO: namespace: e2e-tests-emptydir-dp25p, resource: bindings, ignored listing per whitelist
+Jul  4 20:42:04.398: INFO: namespace e2e-tests-emptydir-dp25p deletion completed in 6.080426639s
+
+• [SLOW TEST:8.190 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:42:04.400: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override all
+Jul  4 20:42:04.464: INFO: Waiting up to 5m0s for pod "client-containers-b5c5c86c-7fca-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-containers-gldmd" to be "success or failure"
+Jul  4 20:42:04.472: INFO: Pod "client-containers-b5c5c86c-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.17271ms
+Jul  4 20:42:06.475: INFO: Pod "client-containers-b5c5c86c-7fca-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010341944s
+STEP: Saw pod success
+Jul  4 20:42:06.475: INFO: Pod "client-containers-b5c5c86c-7fca-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:42:06.477: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod client-containers-b5c5c86c-7fca-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:42:06.498: INFO: Waiting for pod client-containers-b5c5c86c-7fca-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:42:06.501: INFO: Pod client-containers-b5c5c86c-7fca-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:42:06.501: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-gldmd" for this suite.
+Jul  4 20:42:12.522: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:42:12.563: INFO: namespace: e2e-tests-containers-gldmd, resource: bindings, ignored listing per whitelist
+Jul  4 20:42:12.601: INFO: namespace e2e-tests-containers-gldmd deletion completed in 6.094488532s
+
+• [SLOW TEST:8.202 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Watchers 
+  should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:42:12.603: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: closing the watch once it receives two notifications
+Jul  4 20:42:12.673: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-gfmhq,SelfLink:/api/v1/namespaces/e2e-tests-watch-gfmhq/configmaps/e2e-watch-test-watch-closed,UID:bab1d9a5-7fca-11e8-94db-42010a800002,ResourceVersion:10530,Generation:0,CreationTimestamp:2018-07-04 20:42:12 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  4 20:42:12.673: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-gfmhq,SelfLink:/api/v1/namespaces/e2e-tests-watch-gfmhq/configmaps/e2e-watch-test-watch-closed,UID:bab1d9a5-7fca-11e8-94db-42010a800002,ResourceVersion:10531,Generation:0,CreationTimestamp:2018-07-04 20:42:12 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying the configmap a second time, while the watch is closed
+STEP: creating a new watch on configmaps from the last resource version observed by the first watch
+STEP: deleting the configmap
+STEP: Expecting to observe notifications for all changes to the configmap since the first watch closed
+Jul  4 20:42:12.685: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-gfmhq,SelfLink:/api/v1/namespaces/e2e-tests-watch-gfmhq/configmaps/e2e-watch-test-watch-closed,UID:bab1d9a5-7fca-11e8-94db-42010a800002,ResourceVersion:10532,Generation:0,CreationTimestamp:2018-07-04 20:42:12 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  4 20:42:12.686: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-gfmhq,SelfLink:/api/v1/namespaces/e2e-tests-watch-gfmhq/configmaps/e2e-watch-test-watch-closed,UID:bab1d9a5-7fca-11e8-94db-42010a800002,ResourceVersion:10533,Generation:0,CreationTimestamp:2018-07-04 20:42:12 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:42:12.686: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-gfmhq" for this suite.
+Jul  4 20:42:18.701: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:42:18.772: INFO: namespace: e2e-tests-watch-gfmhq, resource: bindings, ignored listing per whitelist
+Jul  4 20:42:18.778: INFO: namespace e2e-tests-watch-gfmhq deletion completed in 6.089221284s
+
+• [SLOW TEST:6.176 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:42:18.782: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:42:18.845: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-m5tfd" for this suite.
+Jul  4 20:42:24.859: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:42:24.903: INFO: namespace: e2e-tests-services-m5tfd, resource: bindings, ignored listing per whitelist
+Jul  4 20:42:24.932: INFO: namespace e2e-tests-services-m5tfd deletion completed in 6.084376239s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:6.151 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:42:24.934: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-map-c2044688-7fca-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:42:25.009: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-c204b585-7fca-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-v57wx" to be "success or failure"
+Jul  4 20:42:25.028: INFO: Pod "pod-projected-secrets-c204b585-7fca-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 18.424784ms
+Jul  4 20:42:27.031: INFO: Pod "pod-projected-secrets-c204b585-7fca-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.021712479s
+STEP: Saw pod success
+Jul  4 20:42:27.031: INFO: Pod "pod-projected-secrets-c204b585-7fca-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:42:27.033: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-secrets-c204b585-7fca-11e8-a4f0-6eaac417783a container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:42:27.052: INFO: Waiting for pod pod-projected-secrets-c204b585-7fca-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:42:27.054: INFO: Pod pod-projected-secrets-c204b585-7fca-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:42:27.054: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-v57wx" for this suite.
+Jul  4 20:42:33.071: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:42:33.122: INFO: namespace: e2e-tests-projected-v57wx, resource: bindings, ignored listing per whitelist
+Jul  4 20:42:33.142: INFO: namespace e2e-tests-projected-v57wx deletion completed in 6.085035368s
+
+• [SLOW TEST:8.209 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:42:33.144: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-rqr4g in namespace e2e-tests-proxy-79d8j
+I0704 20:42:33.221034      14 runners.go:177] Created replication controller with name: proxy-service-rqr4g, namespace: e2e-tests-proxy-79d8j, replica count: 1
+I0704 20:42:34.272620      14 runners.go:177] proxy-service-rqr4g Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0704 20:42:35.272938      14 runners.go:177] proxy-service-rqr4g Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0704 20:42:36.273222      14 runners.go:177] proxy-service-rqr4g Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0704 20:42:37.273463      14 runners.go:177] proxy-service-rqr4g Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0704 20:42:38.273770      14 runners.go:177] proxy-service-rqr4g Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0704 20:42:39.274327      14 runners.go:177] proxy-service-rqr4g Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0704 20:42:40.274921      14 runners.go:177] proxy-service-rqr4g Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0704 20:42:41.275183      14 runners.go:177] proxy-service-rqr4g Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0704 20:42:42.275462      14 runners.go:177] proxy-service-rqr4g Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0704 20:42:43.275734      14 runners.go:177] proxy-service-rqr4g Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0704 20:42:44.275988      14 runners.go:177] proxy-service-rqr4g Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Jul  4 20:42:44.279: INFO: setup took 11.07698474s, starting test cases
+STEP: running 16 cases, 20 attempts per case, 320 total attempts
+Jul  4 20:42:44.313: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 30.32926ms)
+Jul  4 20:42:44.314: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 30.703993ms)
+Jul  4 20:42:44.316: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 36.607421ms)
+Jul  4 20:42:44.324: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 41.455095ms)
+Jul  4 20:42:44.326: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 43.468943ms)
+Jul  4 20:42:44.327: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 46.856621ms)
+Jul  4 20:42:44.327: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 47.088081ms)
+Jul  4 20:42:44.327: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 47.449283ms)
+Jul  4 20:42:44.327: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 47.479348ms)
+Jul  4 20:42:44.328: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 45.41366ms)
+Jul  4 20:42:44.330: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 46.760245ms)
+Jul  4 20:42:44.333: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 49.991002ms)
+Jul  4 20:42:44.334: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 51.243598ms)
+Jul  4 20:42:44.334: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 54.565606ms)
+Jul  4 20:42:44.334: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 51.69758ms)
+Jul  4 20:42:44.335: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 54.838138ms)
+Jul  4 20:42:44.351: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 15.881926ms)
+Jul  4 20:42:44.354: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 18.469557ms)
+Jul  4 20:42:44.354: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 19.523844ms)
+Jul  4 20:42:44.355: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 20.282565ms)
+Jul  4 20:42:44.356: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 20.666746ms)
+Jul  4 20:42:44.356: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 21.061096ms)
+Jul  4 20:42:44.356: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 20.940796ms)
+Jul  4 20:42:44.356: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 20.586746ms)
+Jul  4 20:42:44.356: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 21.023973ms)
+Jul  4 20:42:44.356: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 20.837662ms)
+Jul  4 20:42:44.356: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 21.356099ms)
+Jul  4 20:42:44.356: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 21.38456ms)
+Jul  4 20:42:44.357: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 22.267002ms)
+Jul  4 20:42:44.357: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 22.520594ms)
+Jul  4 20:42:44.358: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 22.250157ms)
+Jul  4 20:42:44.358: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 22.43192ms)
+Jul  4 20:42:44.377: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 19.528156ms)
+Jul  4 20:42:44.378: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 19.367992ms)
+Jul  4 20:42:44.378: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 19.818914ms)
+Jul  4 20:42:44.378: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 19.736761ms)
+Jul  4 20:42:44.379: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 20.324146ms)
+Jul  4 20:42:44.379: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 20.762306ms)
+Jul  4 20:42:44.380: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 21.340333ms)
+Jul  4 20:42:44.381: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 21.642989ms)
+Jul  4 20:42:44.381: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 21.856402ms)
+Jul  4 20:42:44.381: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 21.777434ms)
+Jul  4 20:42:44.381: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 21.743755ms)
+Jul  4 20:42:44.381: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 22.090382ms)
+Jul  4 20:42:44.381: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 22.060733ms)
+Jul  4 20:42:44.381: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 22.39425ms)
+Jul  4 20:42:44.381: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 22.846802ms)
+Jul  4 20:42:44.381: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 22.767274ms)
+Jul  4 20:42:44.398: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 16.939355ms)
+Jul  4 20:42:44.402: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 20.781309ms)
+Jul  4 20:42:44.403: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 21.643233ms)
+Jul  4 20:42:44.403: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 21.810265ms)
+Jul  4 20:42:44.403: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 22.171155ms)
+Jul  4 20:42:44.403: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 22.160123ms)
+Jul  4 20:42:44.404: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 22.210051ms)
+Jul  4 20:42:44.404: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 22.169613ms)
+Jul  4 20:42:44.404: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 22.497419ms)
+Jul  4 20:42:44.404: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 22.451379ms)
+Jul  4 20:42:44.404: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 23.021213ms)
+Jul  4 20:42:44.405: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 22.886822ms)
+Jul  4 20:42:44.405: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 23.058232ms)
+Jul  4 20:42:44.405: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 23.10866ms)
+Jul  4 20:42:44.405: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 23.317193ms)
+Jul  4 20:42:44.405: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 23.579096ms)
+Jul  4 20:42:44.427: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 20.840158ms)
+Jul  4 20:42:44.427: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 21.463145ms)
+Jul  4 20:42:44.427: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 21.542298ms)
+Jul  4 20:42:44.427: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 21.626121ms)
+Jul  4 20:42:44.427: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 20.744505ms)
+Jul  4 20:42:44.427: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 21.836545ms)
+Jul  4 20:42:44.428: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 22.062907ms)
+Jul  4 20:42:44.428: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 22.868691ms)
+Jul  4 20:42:44.429: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 22.580453ms)
+Jul  4 20:42:44.429: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 22.788606ms)
+Jul  4 20:42:44.429: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 23.201508ms)
+Jul  4 20:42:44.429: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 23.609042ms)
+Jul  4 20:42:44.429: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 23.480636ms)
+Jul  4 20:42:44.429: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 23.085294ms)
+Jul  4 20:42:44.429: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 23.711878ms)
+Jul  4 20:42:44.430: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 24.048065ms)
+Jul  4 20:42:44.446: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 15.803324ms)
+Jul  4 20:42:44.450: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 19.620358ms)
+Jul  4 20:42:44.451: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 20.822177ms)
+Jul  4 20:42:44.451: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 20.261136ms)
+Jul  4 20:42:44.451: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 21.012414ms)
+Jul  4 20:42:44.451: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 21.335065ms)
+Jul  4 20:42:44.451: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 21.198432ms)
+Jul  4 20:42:44.451: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 21.426821ms)
+Jul  4 20:42:44.452: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 21.905907ms)
+Jul  4 20:42:44.452: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 21.888711ms)
+Jul  4 20:42:44.452: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 21.652356ms)
+Jul  4 20:42:44.453: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 22.374888ms)
+Jul  4 20:42:44.453: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 22.704618ms)
+Jul  4 20:42:44.453: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 22.5348ms)
+Jul  4 20:42:44.453: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 23.014374ms)
+Jul  4 20:42:44.453: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 22.471487ms)
+Jul  4 20:42:44.469: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 16.122597ms)
+Jul  4 20:42:44.473: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 19.368017ms)
+Jul  4 20:42:44.473: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 19.455528ms)
+Jul  4 20:42:44.474: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 20.354622ms)
+Jul  4 20:42:44.474: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 20.186045ms)
+Jul  4 20:42:44.474: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 20.217676ms)
+Jul  4 20:42:44.474: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 20.390974ms)
+Jul  4 20:42:44.475: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 21.088186ms)
+Jul  4 20:42:44.475: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 20.949676ms)
+Jul  4 20:42:44.475: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 21.167258ms)
+Jul  4 20:42:44.476: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 21.513707ms)
+Jul  4 20:42:44.476: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 21.914572ms)
+Jul  4 20:42:44.476: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 21.743246ms)
+Jul  4 20:42:44.476: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 22.613702ms)
+Jul  4 20:42:44.476: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 22.841304ms)
+Jul  4 20:42:44.476: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 22.834246ms)
+Jul  4 20:42:44.492: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 15.171957ms)
+Jul  4 20:42:44.497: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 19.969108ms)
+Jul  4 20:42:44.497: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 20.255539ms)
+Jul  4 20:42:44.498: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 20.28246ms)
+Jul  4 20:42:44.498: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 20.821287ms)
+Jul  4 20:42:44.499: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 22.018187ms)
+Jul  4 20:42:44.499: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 22.048088ms)
+Jul  4 20:42:44.499: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 22.332533ms)
+Jul  4 20:42:44.499: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 22.313419ms)
+Jul  4 20:42:44.500: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 22.824137ms)
+Jul  4 20:42:44.500: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 22.457769ms)
+Jul  4 20:42:44.500: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 22.475357ms)
+Jul  4 20:42:44.500: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 22.607974ms)
+Jul  4 20:42:44.500: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 22.92575ms)
+Jul  4 20:42:44.500: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 23.121574ms)
+Jul  4 20:42:44.500: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 23.420907ms)
+Jul  4 20:42:44.516: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 15.911672ms)
+Jul  4 20:42:44.519: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 18.907952ms)
+Jul  4 20:42:44.520: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 18.646648ms)
+Jul  4 20:42:44.520: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 19.538121ms)
+Jul  4 20:42:44.520: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 19.503064ms)
+Jul  4 20:42:44.520: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 19.540824ms)
+Jul  4 20:42:44.521: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 19.97478ms)
+Jul  4 20:42:44.522: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 20.983428ms)
+Jul  4 20:42:44.522: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 21.191318ms)
+Jul  4 20:42:44.522: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 21.110614ms)
+Jul  4 20:42:44.522: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 21.318504ms)
+Jul  4 20:42:44.522: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 21.400991ms)
+Jul  4 20:42:44.522: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 21.219514ms)
+Jul  4 20:42:44.523: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 22.474507ms)
+Jul  4 20:42:44.523: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 22.715134ms)
+Jul  4 20:42:44.523: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 22.784173ms)
+Jul  4 20:42:44.540: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 16.08369ms)
+Jul  4 20:42:44.540: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 15.648926ms)
+Jul  4 20:42:44.543: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 19.598684ms)
+Jul  4 20:42:44.544: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 20.523791ms)
+Jul  4 20:42:44.545: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 20.49043ms)
+Jul  4 20:42:44.548: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 23.981475ms)
+Jul  4 20:42:44.548: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 23.526557ms)
+Jul  4 20:42:44.550: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 25.149206ms)
+Jul  4 20:42:44.550: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 25.884143ms)
+Jul  4 20:42:44.552: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 28.310768ms)
+Jul  4 20:42:44.553: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 28.939481ms)
+Jul  4 20:42:44.553: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 27.919748ms)
+Jul  4 20:42:44.553: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 28.572962ms)
+Jul  4 20:42:44.553: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 28.085601ms)
+Jul  4 20:42:44.556: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 30.981123ms)
+Jul  4 20:42:44.556: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 31.506839ms)
+Jul  4 20:42:44.571: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 15.446491ms)
+Jul  4 20:42:44.580: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 22.744674ms)
+Jul  4 20:42:44.583: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 25.960614ms)
+Jul  4 20:42:44.585: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 28.310975ms)
+Jul  4 20:42:44.585: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 28.804992ms)
+Jul  4 20:42:44.586: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 28.051679ms)
+Jul  4 20:42:44.587: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 30.607707ms)
+Jul  4 20:42:44.587: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 30.95566ms)
+Jul  4 20:42:44.588: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 31.030683ms)
+Jul  4 20:42:44.589: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 32.164137ms)
+Jul  4 20:42:44.590: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 33.278048ms)
+Jul  4 20:42:44.591: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 33.814503ms)
+Jul  4 20:42:44.593: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 35.652703ms)
+Jul  4 20:42:44.594: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 36.679764ms)
+Jul  4 20:42:44.594: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 37.053403ms)
+Jul  4 20:42:44.594: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 37.191641ms)
+Jul  4 20:42:44.609: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 14.513484ms)
+Jul  4 20:42:44.611: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 16.738629ms)
+Jul  4 20:42:44.613: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 18.272772ms)
+Jul  4 20:42:44.614: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 19.392574ms)
+Jul  4 20:42:44.614: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 19.622793ms)
+Jul  4 20:42:44.615: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 19.382431ms)
+Jul  4 20:42:44.615: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 20.251976ms)
+Jul  4 20:42:44.615: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 20.492603ms)
+Jul  4 20:42:44.615: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 20.202146ms)
+Jul  4 20:42:44.615: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 20.357798ms)
+Jul  4 20:42:44.617: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 22.61007ms)
+Jul  4 20:42:44.617: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 22.242871ms)
+Jul  4 20:42:44.618: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 22.741754ms)
+Jul  4 20:42:44.618: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 23.272039ms)
+Jul  4 20:42:44.618: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 23.322997ms)
+Jul  4 20:42:44.618: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 23.125901ms)
+Jul  4 20:42:44.638: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 19.52275ms)
+Jul  4 20:42:44.638: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 19.751845ms)
+Jul  4 20:42:44.638: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 19.967536ms)
+Jul  4 20:42:44.643: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 24.200658ms)
+Jul  4 20:42:44.643: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 24.586374ms)
+Jul  4 20:42:44.643: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 24.9146ms)
+Jul  4 20:42:44.644: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 25.416608ms)
+Jul  4 20:42:44.645: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 25.4947ms)
+Jul  4 20:42:44.645: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 26.001513ms)
+Jul  4 20:42:44.645: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 26.561056ms)
+Jul  4 20:42:44.645: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 26.405664ms)
+Jul  4 20:42:44.645: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 26.526634ms)
+Jul  4 20:42:44.645: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 26.542824ms)
+Jul  4 20:42:44.654: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 35.541624ms)
+Jul  4 20:42:44.654: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 35.627839ms)
+Jul  4 20:42:44.654: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 35.703824ms)
+Jul  4 20:42:44.669: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 14.01655ms)
+Jul  4 20:42:44.669: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 14.679062ms)
+Jul  4 20:42:44.669: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 14.732557ms)
+Jul  4 20:42:44.670: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 14.707475ms)
+Jul  4 20:42:44.670: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 14.988224ms)
+Jul  4 20:42:44.670: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 14.992983ms)
+Jul  4 20:42:44.684: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 29.389303ms)
+Jul  4 20:42:44.686: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 30.908121ms)
+Jul  4 20:42:44.686: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 30.71602ms)
+Jul  4 20:42:44.687: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 32.020894ms)
+Jul  4 20:42:44.688: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 32.261223ms)
+Jul  4 20:42:44.690: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 35.145751ms)
+Jul  4 20:42:44.690: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 35.432335ms)
+Jul  4 20:42:44.692: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 36.999941ms)
+Jul  4 20:42:44.692: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 37.31733ms)
+Jul  4 20:42:44.693: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 37.475553ms)
+Jul  4 20:42:44.708: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 15.136576ms)
+Jul  4 20:42:44.708: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 15.171739ms)
+Jul  4 20:42:44.711: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 17.459474ms)
+Jul  4 20:42:44.711: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 17.91915ms)
+Jul  4 20:42:44.711: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 18.222813ms)
+Jul  4 20:42:44.718: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 24.598846ms)
+Jul  4 20:42:44.718: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 24.94307ms)
+Jul  4 20:42:44.718: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 24.447591ms)
+Jul  4 20:42:44.718: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 24.634454ms)
+Jul  4 20:42:44.718: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 24.562674ms)
+Jul  4 20:42:44.718: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 24.630337ms)
+Jul  4 20:42:44.718: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 24.508404ms)
+Jul  4 20:42:44.718: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 24.917875ms)
+Jul  4 20:42:44.718: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 24.602778ms)
+Jul  4 20:42:44.718: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 24.532942ms)
+Jul  4 20:42:44.718: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 25.353136ms)
+Jul  4 20:42:44.734: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 14.60228ms)
+Jul  4 20:42:44.735: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 16.386344ms)
+Jul  4 20:42:44.735: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 16.528024ms)
+Jul  4 20:42:44.735: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 16.782665ms)
+Jul  4 20:42:44.737: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 18.341381ms)
+Jul  4 20:42:44.738: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 18.70928ms)
+Jul  4 20:42:44.738: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 18.794335ms)
+Jul  4 20:42:44.738: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 18.990533ms)
+Jul  4 20:42:44.738: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 18.854323ms)
+Jul  4 20:42:44.738: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 18.993618ms)
+Jul  4 20:42:44.739: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 19.674481ms)
+Jul  4 20:42:44.740: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 20.40856ms)
+Jul  4 20:42:44.740: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 20.403058ms)
+Jul  4 20:42:44.740: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 20.380884ms)
+Jul  4 20:42:44.740: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 20.847538ms)
+Jul  4 20:42:44.740: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 20.376745ms)
+Jul  4 20:42:44.764: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 22.769591ms)
+Jul  4 20:42:44.765: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 23.346206ms)
+Jul  4 20:42:44.765: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 23.177241ms)
+Jul  4 20:42:44.765: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 24.718916ms)
+Jul  4 20:42:44.765: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 24.119772ms)
+Jul  4 20:42:44.765: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 24.131859ms)
+Jul  4 20:42:44.765: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 25.225432ms)
+Jul  4 20:42:44.772: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 30.120355ms)
+Jul  4 20:42:44.772: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 28.507853ms)
+Jul  4 20:42:44.772: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 31.480619ms)
+Jul  4 20:42:44.773: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 30.798268ms)
+Jul  4 20:42:44.773: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 31.385393ms)
+Jul  4 20:42:44.773: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 31.235889ms)
+Jul  4 20:42:44.773: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 30.825611ms)
+Jul  4 20:42:44.775: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 33.058005ms)
+Jul  4 20:42:44.775: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 33.677467ms)
+Jul  4 20:42:44.790: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 14.552545ms)
+Jul  4 20:42:44.792: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 15.81328ms)
+Jul  4 20:42:44.793: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 17.165036ms)
+Jul  4 20:42:44.793: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 16.988429ms)
+Jul  4 20:42:44.793: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 17.380729ms)
+Jul  4 20:42:44.793: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 17.627964ms)
+Jul  4 20:42:44.793: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 17.399877ms)
+Jul  4 20:42:44.794: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 17.935493ms)
+Jul  4 20:42:44.795: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 18.516186ms)
+Jul  4 20:42:44.795: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 18.748642ms)
+Jul  4 20:42:44.796: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 19.836471ms)
+Jul  4 20:42:44.803: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 26.562371ms)
+Jul  4 20:42:44.803: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 27.017ms)
+Jul  4 20:42:44.804: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 27.898908ms)
+Jul  4 20:42:44.804: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 27.967663ms)
+Jul  4 20:42:44.806: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 29.311648ms)
+Jul  4 20:42:44.820: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 14.152538ms)
+Jul  4 20:42:44.821: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 15.582989ms)
+Jul  4 20:42:44.826: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 19.287095ms)
+Jul  4 20:42:44.827: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 19.991974ms)
+Jul  4 20:42:44.827: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 20.117442ms)
+Jul  4 20:42:44.827: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 20.57647ms)
+Jul  4 20:42:44.827: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 20.666934ms)
+Jul  4 20:42:44.827: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 20.858412ms)
+Jul  4 20:42:44.827: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 20.886744ms)
+Jul  4 20:42:44.828: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 21.115939ms)
+Jul  4 20:42:44.828: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 21.102728ms)
+Jul  4 20:42:44.831: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 24.685341ms)
+Jul  4 20:42:44.831: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 24.56275ms)
+Jul  4 20:42:44.832: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 25.715838ms)
+Jul  4 20:42:44.832: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 25.831222ms)
+Jul  4 20:42:44.833: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 26.668439ms)
+Jul  4 20:42:44.846: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 11.016555ms)
+Jul  4 20:42:44.847: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:1080/proxy/rewri... (200; 13.176159ms)
+Jul  4 20:42:44.847: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:443/proxy/... (200; 13.845046ms)
+Jul  4 20:42:44.848: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:1080/proxy/... (200; 13.386676ms)
+Jul  4 20:42:44.848: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:460/proxy/: tls baz (200; 13.93464ms)
+Jul  4 20:42:44.851: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 17.25123ms)
+Jul  4 20:42:44.852: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-79d8j/pods/proxy-service-rqr4g-v5w6h/proxy/rewriteme"... (200; 17.361167ms)
+Jul  4 20:42:44.852: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname1/proxy/: foo (200; 18.522894ms)
+Jul  4 20:42:44.854: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:162/proxy/: bar (200; 19.033356ms)
+Jul  4 20:42:44.855: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/https:proxy-service-rqr4g-v5w6h:462/proxy/: tls qux (200; 20.280649ms)
+Jul  4 20:42:44.855: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname2/proxy/: bar (200; 20.963289ms)
+Jul  4 20:42:44.855: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname1/proxy/: tls baz (200; 20.465701ms)
+Jul  4 20:42:44.855: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/pods/http:proxy-service-rqr4g-v5w6h:160/proxy/: foo (200; 20.461194ms)
+Jul  4 20:42:44.856: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/http:proxy-service-rqr4g:portname1/proxy/: foo (200; 21.174864ms)
+Jul  4 20:42:44.856: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/proxy-service-rqr4g:portname2/proxy/: bar (200; 21.210845ms)
+Jul  4 20:42:44.856: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-79d8j/services/https:proxy-service-rqr4g:tlsportname2/proxy/: tls qux (200; 22.346146ms)
+STEP: deleting { ReplicationController} proxy-service-rqr4g in namespace e2e-tests-proxy-79d8j, will wait for the garbage collector to delete the pods
+Jul  4 20:42:44.915: INFO: Deleting { ReplicationController} proxy-service-rqr4g took: 6.170187ms
+Jul  4 20:42:45.015: INFO: Terminating { ReplicationController} proxy-service-rqr4g pods took: 100.266832ms
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:42:46.716: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-79d8j" for this suite.
+Jul  4 20:42:52.741: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:42:52.811: INFO: namespace: e2e-tests-proxy-79d8j, resource: bindings, ignored listing per whitelist
+Jul  4 20:42:52.827: INFO: namespace e2e-tests-proxy-79d8j deletion completed in 6.106069738s
+
+• [SLOW TEST:19.683 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:42:52.829: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-qtzrv
+Jul  4 20:42:54.906: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-qtzrv
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  4 20:42:54.909: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:46:55.390: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-qtzrv" for this suite.
+Jul  4 20:47:01.409: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:47:01.437: INFO: namespace: e2e-tests-container-probe-qtzrv, resource: bindings, ignored listing per whitelist
+Jul  4 20:47:01.528: INFO: namespace e2e-tests-container-probe-qtzrv deletion completed in 6.133654343s
+
+• [SLOW TEST:248.699 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:47:01.530: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name s-test-opt-del-66eb80fa-7fcb-11e8-a4f0-6eaac417783a
+STEP: Creating secret with name s-test-opt-upd-66eb8137-7fcb-11e8-a4f0-6eaac417783a
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-66eb80fa-7fcb-11e8-a4f0-6eaac417783a
+STEP: Updating secret s-test-opt-upd-66eb8137-7fcb-11e8-a4f0-6eaac417783a
+STEP: Creating secret with name s-test-opt-create-66eb8151-7fcb-11e8-a4f0-6eaac417783a
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:47:05.783: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xc6rj" for this suite.
+Jul  4 20:47:27.806: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:47:27.847: INFO: namespace: e2e-tests-projected-xc6rj, resource: bindings, ignored listing per whitelist
+Jul  4 20:47:27.890: INFO: namespace e2e-tests-projected-xc6rj deletion completed in 22.1034997s
+
+• [SLOW TEST:26.361 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:47:27.892: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-7698640f-7fcb-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 20:47:27.968: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-7698ddb5-7fcb-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-jg92v" to be "success or failure"
+Jul  4 20:47:27.976: INFO: Pod "pod-projected-configmaps-7698ddb5-7fcb-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 6.883554ms
+Jul  4 20:47:29.979: INFO: Pod "pod-projected-configmaps-7698ddb5-7fcb-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.01068795s
+STEP: Saw pod success
+Jul  4 20:47:29.980: INFO: Pod "pod-projected-configmaps-7698ddb5-7fcb-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:47:29.982: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-configmaps-7698ddb5-7fcb-11e8-a4f0-6eaac417783a container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:47:30.061: INFO: Waiting for pod pod-projected-configmaps-7698ddb5-7fcb-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:47:30.065: INFO: Pod pod-projected-configmaps-7698ddb5-7fcb-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:47:30.065: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jg92v" for this suite.
+Jul  4 20:47:36.084: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:47:36.151: INFO: namespace: e2e-tests-projected-jg92v, resource: bindings, ignored listing per whitelist
+Jul  4 20:47:36.161: INFO: namespace e2e-tests-projected-jg92v deletion completed in 6.091811485s
+
+• [SLOW TEST:8.269 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:47:36.161: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Jul  4 20:47:36.280: INFO: Waiting up to 5m0s for pod "pod-7b8d18b3-7fcb-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-dzbc8" to be "success or failure"
+Jul  4 20:47:36.289: INFO: Pod "pod-7b8d18b3-7fcb-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.696907ms
+Jul  4 20:47:38.293: INFO: Pod "pod-7b8d18b3-7fcb-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012308907s
+STEP: Saw pod success
+Jul  4 20:47:38.293: INFO: Pod "pod-7b8d18b3-7fcb-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:47:38.295: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-7b8d18b3-7fcb-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:47:38.315: INFO: Waiting for pod pod-7b8d18b3-7fcb-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:47:38.318: INFO: Pod pod-7b8d18b3-7fcb-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:47:38.318: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-dzbc8" for this suite.
+Jul  4 20:47:44.333: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:47:44.353: INFO: namespace: e2e-tests-emptydir-dzbc8, resource: bindings, ignored listing per whitelist
+Jul  4 20:47:44.421: INFO: namespace e2e-tests-emptydir-dzbc8 deletion completed in 6.098966866s
+
+• [SLOW TEST:8.260 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:47:44.422: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Jul  4 20:47:44.513: INFO: Waiting up to 5m0s for pod "pod-80748e79-7fcb-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-lc8x7" to be "success or failure"
+Jul  4 20:47:44.529: INFO: Pod "pod-80748e79-7fcb-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 15.47164ms
+Jul  4 20:47:46.532: INFO: Pod "pod-80748e79-7fcb-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.018645655s
+STEP: Saw pod success
+Jul  4 20:47:46.532: INFO: Pod "pod-80748e79-7fcb-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:47:46.534: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-80748e79-7fcb-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:47:46.555: INFO: Waiting for pod pod-80748e79-7fcb-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:47:46.559: INFO: Pod pod-80748e79-7fcb-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:47:46.559: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-lc8x7" for this suite.
+Jul  4 20:47:52.574: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:47:52.625: INFO: namespace: e2e-tests-emptydir-lc8x7, resource: bindings, ignored listing per whitelist
+Jul  4 20:47:52.660: INFO: namespace e2e-tests-emptydir-lc8x7 deletion completed in 6.097368257s
+
+• [SLOW TEST:8.239 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:47:52.661: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:36
+[It] should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test hostPath mode
+Jul  4 20:47:52.787: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-ffm76" to be "success or failure"
+Jul  4 20:47:52.796: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 8.85591ms
+Jul  4 20:47:54.802: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 2.014580879s
+Jul  4 20:47:56.805: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.018246191s
+STEP: Saw pod success
+Jul  4 20:47:56.805: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Jul  4 20:47:56.808: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Jul  4 20:47:56.849: INFO: Waiting for pod pod-host-path-test to disappear
+Jul  4 20:47:56.853: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:47:56.853: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-ffm76" for this suite.
+Jul  4 20:48:02.872: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:48:02.916: INFO: namespace: e2e-tests-hostpath-ffm76, resource: bindings, ignored listing per whitelist
+Jul  4 20:48:02.941: INFO: namespace e2e-tests-hostpath-ffm76 deletion completed in 6.082800932s
+
+• [SLOW TEST:10.280 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:33
+  should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:48:02.942: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-8b7ac7a5-7fcb-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:48:03.007: INFO: Waiting up to 5m0s for pod "pod-secrets-8b7b3f26-7fcb-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-secrets-ctm4d" to be "success or failure"
+Jul  4 20:48:03.014: INFO: Pod "pod-secrets-8b7b3f26-7fcb-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.38555ms
+Jul  4 20:48:05.018: INFO: Pod "pod-secrets-8b7b3f26-7fcb-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010781745s
+STEP: Saw pod success
+Jul  4 20:48:05.018: INFO: Pod "pod-secrets-8b7b3f26-7fcb-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:48:05.020: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-secrets-8b7b3f26-7fcb-11e8-a4f0-6eaac417783a container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:48:05.041: INFO: Waiting for pod pod-secrets-8b7b3f26-7fcb-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:48:05.044: INFO: Pod pod-secrets-8b7b3f26-7fcb-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:48:05.044: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-ctm4d" for this suite.
+Jul  4 20:48:11.059: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:48:11.134: INFO: namespace: e2e-tests-secrets-ctm4d, resource: bindings, ignored listing per whitelist
+Jul  4 20:48:11.139: INFO: namespace e2e-tests-secrets-ctm4d deletion completed in 6.091476369s
+
+• [SLOW TEST:8.197 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:48:11.141: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-905debef-7fcb-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 20:48:11.207: INFO: Waiting up to 5m0s for pod "pod-configmaps-905e60af-7fcb-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-configmap-g4r2b" to be "success or failure"
+Jul  4 20:48:11.214: INFO: Pod "pod-configmaps-905e60af-7fcb-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.361685ms
+Jul  4 20:48:13.230: INFO: Pod "pod-configmaps-905e60af-7fcb-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.023312959s
+STEP: Saw pod success
+Jul  4 20:48:13.230: INFO: Pod "pod-configmaps-905e60af-7fcb-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:48:13.232: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-configmaps-905e60af-7fcb-11e8-a4f0-6eaac417783a container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:48:13.251: INFO: Waiting for pod pod-configmaps-905e60af-7fcb-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:48:13.253: INFO: Pod pod-configmaps-905e60af-7fcb-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:48:13.254: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-g4r2b" for this suite.
+Jul  4 20:48:19.275: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:48:19.287: INFO: namespace: e2e-tests-configmap-g4r2b, resource: bindings, ignored listing per whitelist
+Jul  4 20:48:19.358: INFO: namespace e2e-tests-configmap-g4r2b deletion completed in 6.101116s
+
+• [SLOW TEST:8.217 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:48:19.359: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test env composition
+Jul  4 20:48:19.432: INFO: Waiting up to 5m0s for pod "var-expansion-9545614c-7fcb-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-var-expansion-8z72g" to be "success or failure"
+Jul  4 20:48:19.439: INFO: Pod "var-expansion-9545614c-7fcb-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.03507ms
+Jul  4 20:48:21.442: INFO: Pod "var-expansion-9545614c-7fcb-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010318412s
+Jul  4 20:48:23.445: INFO: Pod "var-expansion-9545614c-7fcb-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013549631s
+STEP: Saw pod success
+Jul  4 20:48:23.445: INFO: Pod "var-expansion-9545614c-7fcb-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:48:23.448: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod var-expansion-9545614c-7fcb-11e8-a4f0-6eaac417783a container dapi-container: <nil>
+STEP: delete the pod
+Jul  4 20:48:23.472: INFO: Waiting for pod var-expansion-9545614c-7fcb-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:48:23.475: INFO: Pod var-expansion-9545614c-7fcb-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:48:23.475: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-8z72g" for this suite.
+Jul  4 20:48:29.493: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:48:29.553: INFO: namespace: e2e-tests-var-expansion-8z72g, resource: bindings, ignored listing per whitelist
+Jul  4 20:48:29.591: INFO: namespace e2e-tests-var-expansion-8z72g deletion completed in 6.109104331s
+
+• [SLOW TEST:10.232 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:48:29.591: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-6kg98
+[It] should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a new StaefulSet
+Jul  4 20:48:29.678: INFO: Found 0 stateful pods, waiting for 3
+Jul  4 20:48:39.682: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:48:39.682: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:48:39.682: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Updating stateful set template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Jul  4 20:48:39.709: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Not applying an update when the partition is greater than the number of replicas
+STEP: Performing a canary update
+Jul  4 20:48:49.742: INFO: Updating stateful set ss2
+Jul  4 20:48:49.751: INFO: Waiting for Pod e2e-tests-statefulset-6kg98/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Restoring Pods to the correct revision when they are deleted
+Jul  4 20:48:59.880: INFO: Found 2 stateful pods, waiting for 3
+Jul  4 20:49:09.885: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:49:09.885: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:49:09.885: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Performing a phased rolling update
+Jul  4 20:49:09.910: INFO: Updating stateful set ss2
+Jul  4 20:49:09.948: INFO: Waiting for Pod e2e-tests-statefulset-6kg98/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  4 20:49:19.990: INFO: Updating stateful set ss2
+Jul  4 20:49:20.005: INFO: Waiting for StatefulSet e2e-tests-statefulset-6kg98/ss2 to complete update
+Jul  4 20:49:20.005: INFO: Waiting for Pod e2e-tests-statefulset-6kg98/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  4 20:49:30.012: INFO: Deleting all statefulset in ns e2e-tests-statefulset-6kg98
+Jul  4 20:49:30.014: INFO: Scaling statefulset ss2 to 0
+Jul  4 20:50:00.031: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  4 20:50:00.035: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:50:00.057: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-6kg98" for this suite.
+Jul  4 20:50:06.082: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:50:06.105: INFO: namespace: e2e-tests-statefulset-6kg98, resource: bindings, ignored listing per whitelist
+Jul  4 20:50:06.147: INFO: namespace e2e-tests-statefulset-6kg98 deletion completed in 6.084242404s
+
+• [SLOW TEST:96.556 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should perform canary updates and phased rolling updates of template modifications [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:50:06.149: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  4 20:50:06.219: INFO: Creating daemon "daemon-set" with a node selector
+STEP: Initially, daemon pods should not be running on any nodes.
+Jul  4 20:50:06.227: INFO: Number of nodes with available pods: 0
+Jul  4 20:50:06.228: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Change node label to blue, check that daemon pod is launched.
+Jul  4 20:50:06.256: INFO: Number of nodes with available pods: 0
+Jul  4 20:50:06.256: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:50:07.260: INFO: Number of nodes with available pods: 0
+Jul  4 20:50:07.260: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:50:08.260: INFO: Number of nodes with available pods: 1
+Jul  4 20:50:08.260: INFO: Number of running nodes: 1, number of available pods: 1
+STEP: Update the node label to green, and wait for daemons to be unscheduled
+Jul  4 20:50:08.292: INFO: Number of nodes with available pods: 0
+Jul  4 20:50:08.293: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Update DaemonSet node selector to green, and change its update strategy to RollingUpdate
+Jul  4 20:50:08.304: INFO: Number of nodes with available pods: 0
+Jul  4 20:50:08.304: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:50:09.308: INFO: Number of nodes with available pods: 0
+Jul  4 20:50:09.308: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:50:10.308: INFO: Number of nodes with available pods: 0
+Jul  4 20:50:10.308: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:50:11.311: INFO: Number of nodes with available pods: 0
+Jul  4 20:50:11.311: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:50:12.308: INFO: Number of nodes with available pods: 0
+Jul  4 20:50:12.308: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:50:13.307: INFO: Number of nodes with available pods: 0
+Jul  4 20:50:13.307: INFO: Node jakku-worker-8tmm.c.dghubble-io.internal is running more than one daemon pod
+Jul  4 20:50:14.308: INFO: Number of nodes with available pods: 1
+Jul  4 20:50:14.308: INFO: Number of running nodes: 1, number of available pods: 1
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-2zvkc, will wait for the garbage collector to delete the pods
+Jul  4 20:50:14.371: INFO: Deleting {extensions DaemonSet} daemon-set took: 7.448176ms
+Jul  4 20:50:14.472: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.424378ms
+Jul  4 20:50:17.674: INFO: Number of nodes with available pods: 0
+Jul  4 20:50:17.675: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  4 20:50:17.677: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-2zvkc/daemonsets","resourceVersion":"11920"},"items":null}
+
+Jul  4 20:50:17.680: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-2zvkc/pods","resourceVersion":"11920"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:50:17.704: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-2zvkc" for this suite.
+Jul  4 20:50:23.717: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:50:23.768: INFO: namespace: e2e-tests-daemonsets-2zvkc, resource: bindings, ignored listing per whitelist
+Jul  4 20:50:23.786: INFO: namespace e2e-tests-daemonsets-2zvkc deletion completed in 6.079070011s
+
+• [SLOW TEST:17.637 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:50:23.788: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name cm-test-opt-del-df702aa2-7fcb-11e8-a4f0-6eaac417783a
+STEP: Creating configMap with name cm-test-opt-upd-df702adc-7fcb-11e8-a4f0-6eaac417783a
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-df702aa2-7fcb-11e8-a4f0-6eaac417783a
+STEP: Updating configmap cm-test-opt-upd-df702adc-7fcb-11e8-a4f0-6eaac417783a
+STEP: Creating configMap with name cm-test-opt-create-df702aed-7fcb-11e8-a4f0-6eaac417783a
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:50:27.955: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-x4vv4" for this suite.
+Jul  4 20:50:49.971: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:50:49.986: INFO: namespace: e2e-tests-projected-x4vv4, resource: bindings, ignored listing per whitelist
+Jul  4 20:50:50.049: INFO: namespace e2e-tests-projected-x4vv4 deletion completed in 22.09045493s
+
+• [SLOW TEST:26.262 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:50:50.052: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc1
+STEP: create the rc2
+STEP: set half of pods created by rc simpletest-rc-to-be-deleted to have rc simpletest-rc-to-stay as owner as well
+STEP: delete the rc simpletest-rc-to-be-deleted
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0704 20:51:00.211169      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  4 20:51:00.211: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:51:00.211: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-nsdl4" for this suite.
+Jul  4 20:51:06.231: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:51:06.265: INFO: namespace: e2e-tests-gc-nsdl4, resource: bindings, ignored listing per whitelist
+Jul  4 20:51:06.332: INFO: namespace e2e-tests-gc-nsdl4 deletion completed in 6.117801894s
+
+• [SLOW TEST:16.281 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:51:06.333: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0704 20:51:12.421288      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  4 20:51:12.421: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:51:12.421: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-5qr28" for this suite.
+Jul  4 20:51:18.437: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:51:18.488: INFO: namespace: e2e-tests-gc-5qr28, resource: bindings, ignored listing per whitelist
+Jul  4 20:51:18.581: INFO: namespace e2e-tests-gc-5qr28 deletion completed in 6.156733816s
+
+• [SLOW TEST:12.249 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:51:18.583: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-cxkbj
+Jul  4 20:51:20.753: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-cxkbj
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  4 20:51:20.763: INFO: Initial restart count of pod liveness-http is 0
+Jul  4 20:51:34.791: INFO: Restart count of pod e2e-tests-container-probe-cxkbj/liveness-http is now 1 (14.027499529s elapsed)
+Jul  4 20:51:52.820: INFO: Restart count of pod e2e-tests-container-probe-cxkbj/liveness-http is now 2 (32.056620165s elapsed)
+Jul  4 20:52:14.860: INFO: Restart count of pod e2e-tests-container-probe-cxkbj/liveness-http is now 3 (54.096246351s elapsed)
+Jul  4 20:52:34.894: INFO: Restart count of pod e2e-tests-container-probe-cxkbj/liveness-http is now 4 (1m14.130133275s elapsed)
+Jul  4 20:53:47.020: INFO: Restart count of pod e2e-tests-container-probe-cxkbj/liveness-http is now 5 (2m26.256073261s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:53:47.037: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-cxkbj" for this suite.
+Jul  4 20:53:53.055: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:53:53.082: INFO: namespace: e2e-tests-container-probe-cxkbj, resource: bindings, ignored listing per whitelist
+Jul  4 20:53:53.128: INFO: namespace e2e-tests-container-probe-cxkbj deletion completed in 6.08738848s
+
+• [SLOW TEST:154.546 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:53:53.130: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-nswt5
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  4 20:53:53.187: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  4 20:54:11.294: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://10.2.1.137:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-nswt5 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:54:11.294: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:54:11.432: INFO: Found all expected endpoints: [netserver-0]
+Jul  4 20:54:11.436: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://10.2.0.33:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-nswt5 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:54:11.436: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:54:11.523: INFO: Found all expected endpoints: [netserver-1]
+Jul  4 20:54:11.527: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://10.2.3.36:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-nswt5 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  4 20:54:11.527: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+Jul  4 20:54:11.619: INFO: Found all expected endpoints: [netserver-2]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:54:11.619: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-nswt5" for this suite.
+Jul  4 20:54:33.648: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:54:33.691: INFO: namespace: e2e-tests-pod-network-test-nswt5, resource: bindings, ignored listing per whitelist
+Jul  4 20:54:33.738: INFO: namespace e2e-tests-pod-network-test-nswt5 deletion completed in 22.114077439s
+
+• [SLOW TEST:40.608 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:54:33.740: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-27hsw
+[It] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Initializing watcher for selector baz=blah,foo=bar
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-27hsw
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-27hsw
+Jul  4 20:54:33.831: INFO: Found 0 stateful pods, waiting for 1
+Jul  4 20:54:43.835: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will halt with unhealthy stateful pod
+Jul  4 20:54:43.838: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-27hsw ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  4 20:54:44.109: INFO: stderr: ""
+Jul  4 20:54:44.109: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  4 20:54:44.109: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  4 20:54:44.113: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Jul  4 20:54:54.116: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  4 20:54:54.116: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  4 20:54:54.140: INFO: Verifying statefulset ss doesn't scale past 1 for another 9.999999775s
+Jul  4 20:54:55.143: INFO: Verifying statefulset ss doesn't scale past 1 for another 8.986098607s
+Jul  4 20:54:56.147: INFO: Verifying statefulset ss doesn't scale past 1 for another 7.982787163s
+Jul  4 20:54:57.151: INFO: Verifying statefulset ss doesn't scale past 1 for another 6.979242271s
+Jul  4 20:54:58.154: INFO: Verifying statefulset ss doesn't scale past 1 for another 5.975643139s
+Jul  4 20:54:59.157: INFO: Verifying statefulset ss doesn't scale past 1 for another 4.97237392s
+Jul  4 20:55:00.161: INFO: Verifying statefulset ss doesn't scale past 1 for another 3.968906461s
+Jul  4 20:55:01.167: INFO: Verifying statefulset ss doesn't scale past 1 for another 2.965572989s
+Jul  4 20:55:02.172: INFO: Verifying statefulset ss doesn't scale past 1 for another 1.959580206s
+Jul  4 20:55:03.176: INFO: Verifying statefulset ss doesn't scale past 1 for another 954.5392ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-27hsw
+Jul  4 20:55:04.180: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-27hsw ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:55:04.405: INFO: stderr: ""
+Jul  4 20:55:04.405: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  4 20:55:04.405: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  4 20:55:04.409: INFO: Found 1 stateful pods, waiting for 3
+Jul  4 20:55:14.413: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:55:14.413: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  4 20:55:14.413: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Verifying that stateful set ss was scaled up in order
+STEP: Scale down will halt with unhealthy stateful pod
+Jul  4 20:55:14.419: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-27hsw ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  4 20:55:14.649: INFO: stderr: ""
+Jul  4 20:55:14.649: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  4 20:55:14.649: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  4 20:55:14.650: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-27hsw ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  4 20:55:14.864: INFO: stderr: ""
+Jul  4 20:55:14.864: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  4 20:55:14.864: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  4 20:55:14.864: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-27hsw ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  4 20:55:15.068: INFO: stderr: ""
+Jul  4 20:55:15.068: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  4 20:55:15.068: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  4 20:55:15.068: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  4 20:55:15.071: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 3
+Jul  4 20:55:25.077: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  4 20:55:25.077: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Jul  4 20:55:25.077: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Jul  4 20:55:25.095: INFO: Verifying statefulset ss doesn't scale past 3 for another 9.999999526s
+Jul  4 20:55:26.098: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.99179146s
+Jul  4 20:55:27.102: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.988348276s
+Jul  4 20:55:28.105: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.984869087s
+Jul  4 20:55:29.109: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.98124576s
+Jul  4 20:55:30.113: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.977558048s
+Jul  4 20:55:31.117: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.973667258s
+Jul  4 20:55:32.121: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.969162203s
+Jul  4 20:55:33.125: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.965170694s
+Jul  4 20:55:34.137: INFO: Verifying statefulset ss doesn't scale past 3 for another 961.525582ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-27hsw
+Jul  4 20:55:35.141: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-27hsw ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:55:35.394: INFO: stderr: ""
+Jul  4 20:55:35.395: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  4 20:55:35.395: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  4 20:55:35.395: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-27hsw ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:55:35.605: INFO: stderr: ""
+Jul  4 20:55:35.605: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  4 20:55:35.605: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  4 20:55:35.605: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-830667735 exec --namespace=e2e-tests-statefulset-27hsw ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  4 20:55:35.810: INFO: stderr: ""
+Jul  4 20:55:35.810: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  4 20:55:35.810: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  4 20:55:35.810: INFO: Scaling statefulset ss to 0
+STEP: Verifying that stateful set ss was scaled down in reverse order
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  4 20:56:05.823: INFO: Deleting all statefulset in ns e2e-tests-statefulset-27hsw
+Jul  4 20:56:05.825: INFO: Scaling statefulset ss to 0
+Jul  4 20:56:05.833: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  4 20:56:05.835: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:56:05.851: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-27hsw" for this suite.
+Jul  4 20:56:11.881: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:56:11.918: INFO: namespace: e2e-tests-statefulset-27hsw, resource: bindings, ignored listing per whitelist
+Jul  4 20:56:11.953: INFO: namespace e2e-tests-statefulset-27hsw deletion completed in 6.098382805s
+
+• [SLOW TEST:98.214 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:56:11.957: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-d22x8
+Jul  4 20:56:14.043: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-d22x8
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  4 20:56:14.047: INFO: Initial restart count of pod liveness-http is 0
+Jul  4 20:56:36.091: INFO: Restart count of pod e2e-tests-container-probe-d22x8/liveness-http is now 1 (22.044355694s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:56:36.103: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-d22x8" for this suite.
+Jul  4 20:56:42.117: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:56:42.168: INFO: namespace: e2e-tests-container-probe-d22x8, resource: bindings, ignored listing per whitelist
+Jul  4 20:56:42.192: INFO: namespace e2e-tests-container-probe-d22x8 deletion completed in 6.086127829s
+
+• [SLOW TEST:30.235 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:56:42.193: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-c0fbf7ad-7fcc-11e8-a4f0-6eaac417783a
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-c0fbf7ad-7fcc-11e8-a4f0-6eaac417783a
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:56:46.316: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-flmzh" for this suite.
+Jul  4 20:57:08.332: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:57:08.369: INFO: namespace: e2e-tests-projected-flmzh, resource: bindings, ignored listing per whitelist
+Jul  4 20:57:08.424: INFO: namespace e2e-tests-projected-flmzh deletion completed in 22.103817352s
+
+• [SLOW TEST:26.231 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:57:08.425: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:57:08.494: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d09e16b5-7fcc-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-6qrdt" to be "success or failure"
+Jul  4 20:57:08.503: INFO: Pod "downwardapi-volume-d09e16b5-7fcc-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.564953ms
+Jul  4 20:57:10.507: INFO: Pod "downwardapi-volume-d09e16b5-7fcc-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012256808s
+STEP: Saw pod success
+Jul  4 20:57:10.507: INFO: Pod "downwardapi-volume-d09e16b5-7fcc-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:57:10.509: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-d09e16b5-7fcc-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:57:10.530: INFO: Waiting for pod downwardapi-volume-d09e16b5-7fcc-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:57:10.535: INFO: Pod downwardapi-volume-d09e16b5-7fcc-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:57:10.535: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-6qrdt" for this suite.
+Jul  4 20:57:16.554: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:57:16.636: INFO: namespace: e2e-tests-downward-api-6qrdt, resource: bindings, ignored listing per whitelist
+Jul  4 20:57:16.667: INFO: namespace e2e-tests-downward-api-6qrdt deletion completed in 6.12759988s
+
+• [SLOW TEST:8.242 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:57:16.669: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-map-d5914def-7fcc-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 20:57:16.810: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-d591ff38-7fcc-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-fb8wr" to be "success or failure"
+Jul  4 20:57:16.822: INFO: Pod "pod-projected-secrets-d591ff38-7fcc-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 11.87319ms
+Jul  4 20:57:18.826: INFO: Pod "pod-projected-secrets-d591ff38-7fcc-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.015487416s
+STEP: Saw pod success
+Jul  4 20:57:18.826: INFO: Pod "pod-projected-secrets-d591ff38-7fcc-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:57:18.829: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-secrets-d591ff38-7fcc-11e8-a4f0-6eaac417783a container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:57:18.853: INFO: Waiting for pod pod-projected-secrets-d591ff38-7fcc-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:57:18.855: INFO: Pod pod-projected-secrets-d591ff38-7fcc-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:57:18.855: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fb8wr" for this suite.
+Jul  4 20:57:24.872: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:57:24.903: INFO: namespace: e2e-tests-projected-fb8wr, resource: bindings, ignored listing per whitelist
+Jul  4 20:57:24.940: INFO: namespace e2e-tests-projected-fb8wr deletion completed in 6.079896528s
+
+• [SLOW TEST:8.272 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:57:24.942: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-da75dda1-7fcc-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 20:57:25.010: INFO: Waiting up to 5m0s for pod "pod-configmaps-da765533-7fcc-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-configmap-fsmnt" to be "success or failure"
+Jul  4 20:57:25.019: INFO: Pod "pod-configmaps-da765533-7fcc-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 9.138889ms
+Jul  4 20:57:27.023: INFO: Pod "pod-configmaps-da765533-7fcc-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012540232s
+STEP: Saw pod success
+Jul  4 20:57:27.023: INFO: Pod "pod-configmaps-da765533-7fcc-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:57:27.025: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-configmaps-da765533-7fcc-11e8-a4f0-6eaac417783a container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 20:57:27.043: INFO: Waiting for pod pod-configmaps-da765533-7fcc-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:57:27.046: INFO: Pod pod-configmaps-da765533-7fcc-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:57:27.047: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-fsmnt" for this suite.
+Jul  4 20:57:33.062: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:57:33.131: INFO: namespace: e2e-tests-configmap-fsmnt, resource: bindings, ignored listing per whitelist
+Jul  4 20:57:33.140: INFO: namespace e2e-tests-configmap-fsmnt deletion completed in 6.090420314s
+
+• [SLOW TEST:8.199 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:57:33.143: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap e2e-tests-configmap-v75c8/configmap-test-df57fd63-7fcc-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 20:57:33.204: INFO: Waiting up to 5m0s for pod "pod-configmaps-df5861a6-7fcc-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-configmap-v75c8" to be "success or failure"
+Jul  4 20:57:33.213: INFO: Pod "pod-configmaps-df5861a6-7fcc-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.499547ms
+Jul  4 20:57:35.216: INFO: Pod "pod-configmaps-df5861a6-7fcc-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011532649s
+Jul  4 20:57:37.219: INFO: Pod "pod-configmaps-df5861a6-7fcc-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014978409s
+STEP: Saw pod success
+Jul  4 20:57:37.219: INFO: Pod "pod-configmaps-df5861a6-7fcc-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:57:37.221: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-configmaps-df5861a6-7fcc-11e8-a4f0-6eaac417783a container env-test: <nil>
+STEP: delete the pod
+Jul  4 20:57:37.238: INFO: Waiting for pod pod-configmaps-df5861a6-7fcc-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:57:37.242: INFO: Pod pod-configmaps-df5861a6-7fcc-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:57:37.242: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-v75c8" for this suite.
+Jul  4 20:57:43.256: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:57:43.280: INFO: namespace: e2e-tests-configmap-v75c8, resource: bindings, ignored listing per whitelist
+Jul  4 20:57:43.330: INFO: namespace e2e-tests-configmap-v75c8 deletion completed in 6.085401436s
+
+• [SLOW TEST:10.188 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:57:43.332: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Jul  4 20:57:43.406: INFO: Waiting up to 5m0s for pod "pod-e56d0307-7fcc-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-emptydir-lt7h4" to be "success or failure"
+Jul  4 20:57:43.414: INFO: Pod "pod-e56d0307-7fcc-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 7.189921ms
+Jul  4 20:57:45.418: INFO: Pod "pod-e56d0307-7fcc-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010930099s
+STEP: Saw pod success
+Jul  4 20:57:45.418: INFO: Pod "pod-e56d0307-7fcc-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:57:45.420: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-e56d0307-7fcc-11e8-a4f0-6eaac417783a container test-container: <nil>
+STEP: delete the pod
+Jul  4 20:57:45.451: INFO: Waiting for pod pod-e56d0307-7fcc-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:57:45.455: INFO: Pod pod-e56d0307-7fcc-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:57:45.455: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-lt7h4" for this suite.
+Jul  4 20:57:51.470: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:57:51.565: INFO: namespace: e2e-tests-emptydir-lt7h4, resource: bindings, ignored listing per whitelist
+Jul  4 20:57:51.574: INFO: namespace e2e-tests-emptydir-lt7h4 deletion completed in 6.115093268s
+
+• [SLOW TEST:8.242 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:57:51.575: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 20:57:51.647: INFO: Waiting up to 5m0s for pod "downwardapi-volume-ea56b769-7fcc-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-downward-api-rx69f" to be "success or failure"
+Jul  4 20:57:51.653: INFO: Pod "downwardapi-volume-ea56b769-7fcc-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 4.955716ms
+Jul  4 20:57:53.657: INFO: Pod "downwardapi-volume-ea56b769-7fcc-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008795842s
+Jul  4 20:57:55.660: INFO: Pod "downwardapi-volume-ea56b769-7fcc-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011751827s
+STEP: Saw pod success
+Jul  4 20:57:55.660: INFO: Pod "downwardapi-volume-ea56b769-7fcc-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 20:57:55.663: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-ea56b769-7fcc-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 20:57:55.688: INFO: Waiting for pod downwardapi-volume-ea56b769-7fcc-11e8-a4f0-6eaac417783a to disappear
+Jul  4 20:57:55.691: INFO: Pod downwardapi-volume-ea56b769-7fcc-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 20:57:55.691: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-rx69f" for this suite.
+Jul  4 20:58:01.707: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 20:58:01.730: INFO: namespace: e2e-tests-downward-api-rx69f, resource: bindings, ignored listing per whitelist
+Jul  4 20:58:01.780: INFO: namespace e2e-tests-downward-api-rx69f deletion completed in 6.086104364s
+
+• [SLOW TEST:10.205 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 20:58:01.781: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-qvchp
+Jul  4 20:58:05.848: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-qvchp
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  4 20:58:05.850: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:02:06.280: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-qvchp" for this suite.
+Jul  4 21:02:12.299: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:02:12.353: INFO: namespace: e2e-tests-container-probe-qvchp, resource: bindings, ignored listing per whitelist
+Jul  4 21:02:12.370: INFO: namespace e2e-tests-container-probe-qvchp deletion completed in 6.085528092s
+
+• [SLOW TEST:250.589 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 21:02:12.371: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test substitution in container's args
+Jul  4 21:02:12.470: INFO: Waiting up to 5m0s for pod "var-expansion-85cc3ef8-7fcd-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-var-expansion-5wcp7" to be "success or failure"
+Jul  4 21:02:12.492: INFO: Pod "var-expansion-85cc3ef8-7fcd-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 21.615277ms
+Jul  4 21:02:14.495: INFO: Pod "var-expansion-85cc3ef8-7fcd-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 2.024815857s
+Jul  4 21:02:16.498: INFO: Pod "var-expansion-85cc3ef8-7fcd-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.028198991s
+STEP: Saw pod success
+Jul  4 21:02:16.498: INFO: Pod "var-expansion-85cc3ef8-7fcd-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 21:02:16.500: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod var-expansion-85cc3ef8-7fcd-11e8-a4f0-6eaac417783a container dapi-container: <nil>
+STEP: delete the pod
+Jul  4 21:02:16.519: INFO: Waiting for pod var-expansion-85cc3ef8-7fcd-11e8-a4f0-6eaac417783a to disappear
+Jul  4 21:02:16.522: INFO: Pod var-expansion-85cc3ef8-7fcd-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:02:16.522: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-5wcp7" for this suite.
+Jul  4 21:02:22.537: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:02:22.611: INFO: namespace: e2e-tests-var-expansion-5wcp7, resource: bindings, ignored listing per whitelist
+Jul  4 21:02:22.626: INFO: namespace e2e-tests-var-expansion-5wcp7 deletion completed in 6.100378394s
+
+• [SLOW TEST:10.255 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 21:02:22.627: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-8be49be4-7fcd-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 21:02:22.700: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-8be5c954-7fcd-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-56jjl" to be "success or failure"
+Jul  4 21:02:22.708: INFO: Pod "pod-projected-configmaps-8be5c954-7fcd-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.291767ms
+Jul  4 21:02:24.712: INFO: Pod "pod-projected-configmaps-8be5c954-7fcd-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011542055s
+STEP: Saw pod success
+Jul  4 21:02:24.712: INFO: Pod "pod-projected-configmaps-8be5c954-7fcd-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 21:02:24.714: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-configmaps-8be5c954-7fcd-11e8-a4f0-6eaac417783a container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 21:02:24.737: INFO: Waiting for pod pod-projected-configmaps-8be5c954-7fcd-11e8-a4f0-6eaac417783a to disappear
+Jul  4 21:02:24.739: INFO: Pod pod-projected-configmaps-8be5c954-7fcd-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:02:24.740: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-56jjl" for this suite.
+Jul  4 21:02:30.756: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:02:30.813: INFO: namespace: e2e-tests-projected-56jjl, resource: bindings, ignored listing per whitelist
+Jul  4 21:02:30.833: INFO: namespace e2e-tests-projected-56jjl deletion completed in 6.08930145s
+
+• [SLOW TEST:8.206 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 21:02:30.834: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-90cf9590-7fcd-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 21:02:30.944: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-90d0040d-7fcd-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-ckhpg" to be "success or failure"
+Jul  4 21:02:30.949: INFO: Pod "pod-projected-configmaps-90d0040d-7fcd-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 5.637296ms
+Jul  4 21:02:32.953: INFO: Pod "pod-projected-configmaps-90d0040d-7fcd-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00892562s
+STEP: Saw pod success
+Jul  4 21:02:32.953: INFO: Pod "pod-projected-configmaps-90d0040d-7fcd-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 21:02:32.954: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-projected-configmaps-90d0040d-7fcd-11e8-a4f0-6eaac417783a container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 21:02:32.973: INFO: Waiting for pod pod-projected-configmaps-90d0040d-7fcd-11e8-a4f0-6eaac417783a to disappear
+Jul  4 21:02:32.975: INFO: Pod pod-projected-configmaps-90d0040d-7fcd-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:02:32.976: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-ckhpg" for this suite.
+Jul  4 21:02:38.990: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:02:39.029: INFO: namespace: e2e-tests-projected-ckhpg, resource: bindings, ignored listing per whitelist
+Jul  4 21:02:39.057: INFO: namespace e2e-tests-projected-ckhpg deletion completed in 6.077499523s
+
+• [SLOW TEST:8.223 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 21:02:39.059: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-95afb12b-7fcd-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume configMaps
+Jul  4 21:02:39.130: INFO: Waiting up to 5m0s for pod "pod-configmaps-95b0d4c8-7fcd-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-configmap-q9mgp" to be "success or failure"
+Jul  4 21:02:39.138: INFO: Pod "pod-configmaps-95b0d4c8-7fcd-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.424621ms
+Jul  4 21:02:41.142: INFO: Pod "pod-configmaps-95b0d4c8-7fcd-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011850912s
+STEP: Saw pod success
+Jul  4 21:02:41.142: INFO: Pod "pod-configmaps-95b0d4c8-7fcd-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 21:02:41.143: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-configmaps-95b0d4c8-7fcd-11e8-a4f0-6eaac417783a container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  4 21:02:41.169: INFO: Waiting for pod pod-configmaps-95b0d4c8-7fcd-11e8-a4f0-6eaac417783a to disappear
+Jul  4 21:02:41.172: INFO: Pod pod-configmaps-95b0d4c8-7fcd-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:02:41.172: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-q9mgp" for this suite.
+Jul  4 21:02:47.188: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:02:47.245: INFO: namespace: e2e-tests-configmap-q9mgp, resource: bindings, ignored listing per whitelist
+Jul  4 21:02:47.261: INFO: namespace e2e-tests-configmap-q9mgp deletion completed in 6.085679951s
+
+• [SLOW TEST:8.203 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 21:02:47.263: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-4zdwj A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-4zdwj;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-4zdwj A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-4zdwj;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-4zdwj.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-4zdwj.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-4zdwj.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-4zdwj.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-4zdwj.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-4zdwj.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-4zdwj.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-4zdwj.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-4zdwj.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 186.112.3.10.in-addr.arpa. PTR)" && echo OK > /results/10.3.112.186_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 186.112.3.10.in-addr.arpa. PTR)" && echo OK > /results/10.3.112.186_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-4zdwj A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-4zdwj;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-4zdwj A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-4zdwj.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-4zdwj.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-4zdwj.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-4zdwj.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-4zdwj.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-4zdwj.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-4zdwj.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-4zdwj.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 186.112.3.10.in-addr.arpa. PTR)" && echo OK > /results/10.3.112.186_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 186.112.3.10.in-addr.arpa. PTR)" && echo OK > /results/10.3.112.186_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Jul  4 21:02:59.442: INFO: Unable to read wheezy_udp@dns-test-service from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.445: INFO: Unable to read wheezy_tcp@dns-test-service from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.448: INFO: Unable to read wheezy_udp@dns-test-service.e2e-tests-dns-4zdwj from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.451: INFO: Unable to read wheezy_tcp@dns-test-service.e2e-tests-dns-4zdwj from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.454: INFO: Unable to read wheezy_udp@dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.457: INFO: Unable to read wheezy_tcp@dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.460: INFO: Unable to read wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.463: INFO: Unable to read wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.487: INFO: Unable to read jessie_udp@dns-test-service from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.490: INFO: Unable to read jessie_tcp@dns-test-service from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.493: INFO: Unable to read jessie_udp@dns-test-service.e2e-tests-dns-4zdwj from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.497: INFO: Unable to read jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.499: INFO: Unable to read jessie_udp@dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.503: INFO: Unable to read jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.510: INFO: Unable to read jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.514: INFO: Unable to read jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:02:59.535: INFO: Lookups using dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a failed for: [wheezy_udp@dns-test-service wheezy_tcp@dns-test-service wheezy_udp@dns-test-service.e2e-tests-dns-4zdwj wheezy_tcp@dns-test-service.e2e-tests-dns-4zdwj wheezy_udp@dns-test-service.e2e-tests-dns-4zdwj.svc wheezy_tcp@dns-test-service.e2e-tests-dns-4zdwj.svc wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc jessie_udp@dns-test-service jessie_tcp@dns-test-service jessie_udp@dns-test-service.e2e-tests-dns-4zdwj jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj jessie_udp@dns-test-service.e2e-tests-dns-4zdwj.svc jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj.svc jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc]
+
+Jul  4 21:03:09.443: INFO: Unable to read wheezy_udp@dns-test-service from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.448: INFO: Unable to read wheezy_tcp@dns-test-service from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.453: INFO: Unable to read wheezy_udp@dns-test-service.e2e-tests-dns-4zdwj from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.458: INFO: Unable to read wheezy_tcp@dns-test-service.e2e-tests-dns-4zdwj from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.462: INFO: Unable to read wheezy_udp@dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.465: INFO: Unable to read wheezy_tcp@dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.468: INFO: Unable to read wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.471: INFO: Unable to read wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.493: INFO: Unable to read jessie_udp@dns-test-service from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.496: INFO: Unable to read jessie_tcp@dns-test-service from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.499: INFO: Unable to read jessie_udp@dns-test-service.e2e-tests-dns-4zdwj from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.501: INFO: Unable to read jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.508: INFO: Unable to read jessie_udp@dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.511: INFO: Unable to read jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.514: INFO: Unable to read jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.517: INFO: Unable to read jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:09.544: INFO: Lookups using dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a failed for: [wheezy_udp@dns-test-service wheezy_tcp@dns-test-service wheezy_udp@dns-test-service.e2e-tests-dns-4zdwj wheezy_tcp@dns-test-service.e2e-tests-dns-4zdwj wheezy_udp@dns-test-service.e2e-tests-dns-4zdwj.svc wheezy_tcp@dns-test-service.e2e-tests-dns-4zdwj.svc wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc jessie_udp@dns-test-service jessie_tcp@dns-test-service jessie_udp@dns-test-service.e2e-tests-dns-4zdwj jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj jessie_udp@dns-test-service.e2e-tests-dns-4zdwj.svc jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj.svc jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc]
+
+Jul  4 21:03:19.528: INFO: Unable to read jessie_udp@dns-test-service from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:19.532: INFO: Unable to read jessie_tcp@dns-test-service from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:19.535: INFO: Unable to read jessie_udp@dns-test-service.e2e-tests-dns-4zdwj from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:19.539: INFO: Unable to read jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:19.541: INFO: Unable to read jessie_udp@dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:19.545: INFO: Unable to read jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:19.548: INFO: Unable to read jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:19.552: INFO: Unable to read jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc from pod dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a: the server could not find the requested resource (get pods dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a)
+Jul  4 21:03:19.574: INFO: Lookups using dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a failed for: [jessie_udp@dns-test-service jessie_tcp@dns-test-service jessie_udp@dns-test-service.e2e-tests-dns-4zdwj jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj jessie_udp@dns-test-service.e2e-tests-dns-4zdwj.svc jessie_tcp@dns-test-service.e2e-tests-dns-4zdwj.svc jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-4zdwj.svc]
+
+Jul  4 21:03:29.556: INFO: DNS probes using dns-test-9a9f5033-7fcd-11e8-a4f0-6eaac417783a succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:03:29.635: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-4zdwj" for this suite.
+Jul  4 21:03:35.669: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:03:35.680: INFO: namespace: e2e-tests-dns-4zdwj, resource: bindings, ignored listing per whitelist
+Jul  4 21:03:35.739: INFO: namespace e2e-tests-dns-4zdwj deletion completed in 6.096695679s
+
+• [SLOW TEST:48.476 seconds]
+[sig-network] DNS
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 21:03:35.741: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-b779ca04-7fcd-11e8-a4f0-6eaac417783a
+STEP: Creating a pod to test consume secrets
+Jul  4 21:03:35.812: INFO: Waiting up to 5m0s for pod "pod-secrets-b77a2eb2-7fcd-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-secrets-l4dg4" to be "success or failure"
+Jul  4 21:03:35.821: INFO: Pod "pod-secrets-b77a2eb2-7fcd-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 8.967606ms
+Jul  4 21:03:37.829: INFO: Pod "pod-secrets-b77a2eb2-7fcd-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.017338084s
+STEP: Saw pod success
+Jul  4 21:03:37.830: INFO: Pod "pod-secrets-b77a2eb2-7fcd-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 21:03:37.832: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod pod-secrets-b77a2eb2-7fcd-11e8-a4f0-6eaac417783a container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  4 21:03:37.852: INFO: Waiting for pod pod-secrets-b77a2eb2-7fcd-11e8-a4f0-6eaac417783a to disappear
+Jul  4 21:03:37.855: INFO: Pod pod-secrets-b77a2eb2-7fcd-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:03:37.855: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-l4dg4" for this suite.
+Jul  4 21:03:43.871: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:03:43.951: INFO: namespace: e2e-tests-secrets-l4dg4, resource: bindings, ignored listing per whitelist
+Jul  4 21:03:43.951: INFO: namespace e2e-tests-secrets-l4dg4 deletion completed in 6.091737085s
+
+• [SLOW TEST:8.210 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 21:03:43.953: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Jul  4 21:03:46.592: INFO: Successfully updated pod "pod-update-bc647b2e-7fcd-11e8-a4f0-6eaac417783a"
+STEP: verifying the updated pod is in kubernetes
+Jul  4 21:03:46.599: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:03:46.599: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-rs7nb" for this suite.
+Jul  4 21:04:08.614: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:04:08.657: INFO: namespace: e2e-tests-pods-rs7nb, resource: bindings, ignored listing per whitelist
+Jul  4 21:04:08.696: INFO: namespace e2e-tests-pods-rs7nb deletion completed in 22.093913935s
+
+• [SLOW TEST:24.744 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 21:04:08.698: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  4 21:04:11.296: INFO: Successfully updated pod "labelsupdatecb1e3c60-7fcd-11e8-a4f0-6eaac417783a"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:04:13.313: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wkk6q" for this suite.
+Jul  4 21:04:35.335: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:04:35.407: INFO: namespace: e2e-tests-projected-wkk6q, resource: bindings, ignored listing per whitelist
+Jul  4 21:04:35.409: INFO: namespace e2e-tests-projected-wkk6q deletion completed in 22.091395057s
+
+• [SLOW TEST:26.711 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 21:04:35.411: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  4 21:04:35.466: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  4 21:05:35.488: INFO: Waiting for terminating namespaces to be deleted...
+Jul  4 21:05:35.492: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  4 21:05:35.508: INFO: 16 / 16 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  4 21:05:35.509: INFO: expected 5 pod replicas in namespace 'kube-system', 5 are Running and Ready.
+Jul  4 21:05:35.513: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  4 21:05:35.513: INFO: 
+Logging pods the kubelet thinks is on node jakku-worker-8tmm.c.dghubble-io.internal before test
+Jul  4 21:05:35.520: INFO: kube-proxy-72hkz from kube-system started at 2018-07-04 19:56:01 +0000 UTC (1 container statuses recorded)
+Jul  4 21:05:35.521: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  4 21:05:35.521: INFO: calico-node-kc252 from kube-system started at 2018-07-04 19:56:01 +0000 UTC (2 container statuses recorded)
+Jul  4 21:05:35.521: INFO: 	Container calico-node ready: true, restart count 0
+Jul  4 21:05:35.521: INFO: 	Container install-cni ready: true, restart count 0
+Jul  4 21:05:35.521: INFO: sonobuoy-systemd-logs-daemon-set-ee1900e8dc834edd-w7cqr from heptio-sonobuoy started at 2018-07-04 19:59:21 +0000 UTC (2 container statuses recorded)
+Jul  4 21:05:35.521: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 1
+Jul  4 21:05:35.521: INFO: 	Container sonobuoy-worker ready: true, restart count 1
+Jul  4 21:05:35.521: INFO: sonobuoy-e2e-job-fd38b8fecef545c4 from heptio-sonobuoy started at 2018-07-04 19:59:21 +0000 UTC (2 container statuses recorded)
+Jul  4 21:05:35.521: INFO: 	Container e2e ready: true, restart count 0
+Jul  4 21:05:35.521: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  4 21:05:35.522: INFO: 
+Logging pods the kubelet thinks is on node jakku-worker-f0tz.c.dghubble-io.internal before test
+Jul  4 21:05:35.527: INFO: sonobuoy-systemd-logs-daemon-set-ee1900e8dc834edd-zlpw9 from heptio-sonobuoy started at 2018-07-04 19:59:21 +0000 UTC (2 container statuses recorded)
+Jul  4 21:05:35.527: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 1
+Jul  4 21:05:35.527: INFO: 	Container sonobuoy-worker ready: true, restart count 1
+Jul  4 21:05:35.527: INFO: kube-proxy-4ptlm from kube-system started at 2018-07-04 19:56:01 +0000 UTC (1 container statuses recorded)
+Jul  4 21:05:35.527: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  4 21:05:35.528: INFO: calico-node-w7vpr from kube-system started at 2018-07-04 19:56:02 +0000 UTC (2 container statuses recorded)
+Jul  4 21:05:35.528: INFO: 	Container calico-node ready: true, restart count 0
+Jul  4 21:05:35.528: INFO: 	Container install-cni ready: true, restart count 0
+Jul  4 21:05:35.528: INFO: 
+Logging pods the kubelet thinks is on node jakku-worker-ktmr.c.dghubble-io.internal before test
+Jul  4 21:05:35.539: INFO: sonobuoy from heptio-sonobuoy started at 2018-07-04 19:59:09 +0000 UTC (1 container statuses recorded)
+Jul  4 21:05:35.539: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Jul  4 21:05:35.540: INFO: sonobuoy-systemd-logs-daemon-set-ee1900e8dc834edd-grqmh from heptio-sonobuoy started at 2018-07-04 19:59:21 +0000 UTC (2 container statuses recorded)
+Jul  4 21:05:35.540: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 1
+Jul  4 21:05:35.540: INFO: 	Container sonobuoy-worker ready: true, restart count 1
+Jul  4 21:05:35.540: INFO: kube-proxy-gszcd from kube-system started at 2018-07-04 19:56:01 +0000 UTC (1 container statuses recorded)
+Jul  4 21:05:35.540: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  4 21:05:35.540: INFO: calico-node-8dl78 from kube-system started at 2018-07-04 19:56:02 +0000 UTC (2 container statuses recorded)
+Jul  4 21:05:35.540: INFO: 	Container calico-node ready: true, restart count 0
+Jul  4 21:05:35.540: INFO: 	Container install-cni ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: verifying the node has the label node jakku-worker-8tmm.c.dghubble-io.internal
+STEP: verifying the node has the label node jakku-worker-f0tz.c.dghubble-io.internal
+STEP: verifying the node has the label node jakku-worker-ktmr.c.dghubble-io.internal
+Jul  4 21:05:35.638: INFO: Pod sonobuoy requesting resource cpu=0m on Node jakku-worker-ktmr.c.dghubble-io.internal
+Jul  4 21:05:35.638: INFO: Pod sonobuoy-e2e-job-fd38b8fecef545c4 requesting resource cpu=0m on Node jakku-worker-8tmm.c.dghubble-io.internal
+Jul  4 21:05:35.638: INFO: Pod sonobuoy-systemd-logs-daemon-set-ee1900e8dc834edd-grqmh requesting resource cpu=0m on Node jakku-worker-ktmr.c.dghubble-io.internal
+Jul  4 21:05:35.638: INFO: Pod sonobuoy-systemd-logs-daemon-set-ee1900e8dc834edd-w7cqr requesting resource cpu=0m on Node jakku-worker-8tmm.c.dghubble-io.internal
+Jul  4 21:05:35.638: INFO: Pod sonobuoy-systemd-logs-daemon-set-ee1900e8dc834edd-zlpw9 requesting resource cpu=0m on Node jakku-worker-f0tz.c.dghubble-io.internal
+Jul  4 21:05:35.638: INFO: Pod calico-node-8dl78 requesting resource cpu=250m on Node jakku-worker-ktmr.c.dghubble-io.internal
+Jul  4 21:05:35.639: INFO: Pod calico-node-kc252 requesting resource cpu=250m on Node jakku-worker-8tmm.c.dghubble-io.internal
+Jul  4 21:05:35.639: INFO: Pod calico-node-w7vpr requesting resource cpu=250m on Node jakku-worker-f0tz.c.dghubble-io.internal
+Jul  4 21:05:35.639: INFO: Pod kube-proxy-4ptlm requesting resource cpu=0m on Node jakku-worker-f0tz.c.dghubble-io.internal
+Jul  4 21:05:35.639: INFO: Pod kube-proxy-72hkz requesting resource cpu=0m on Node jakku-worker-8tmm.c.dghubble-io.internal
+Jul  4 21:05:35.639: INFO: Pod kube-proxy-gszcd requesting resource cpu=0m on Node jakku-worker-ktmr.c.dghubble-io.internal
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fee74d00-7fcd-11e8-a4f0-6eaac417783a.153e4667f6ef9f25], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-7bkll/filler-pod-fee74d00-7fcd-11e8-a4f0-6eaac417783a to jakku-worker-ktmr.c.dghubble-io.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fee74d00-7fcd-11e8-a4f0-6eaac417783a.153e46683b56b8e2], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fee74d00-7fcd-11e8-a4f0-6eaac417783a.153e46683e6c34be], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fee74d00-7fcd-11e8-a4f0-6eaac417783a.153e46684a994e07], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fee89bd1-7fcd-11e8-a4f0-6eaac417783a.153e4667f8207df0], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-7bkll/filler-pod-fee89bd1-7fcd-11e8-a4f0-6eaac417783a to jakku-worker-8tmm.c.dghubble-io.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fee89bd1-7fcd-11e8-a4f0-6eaac417783a.153e46682c391857], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fee89bd1-7fcd-11e8-a4f0-6eaac417783a.153e46682f2bd28a], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fee89bd1-7fcd-11e8-a4f0-6eaac417783a.153e466839dac015], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fee98f4e-7fcd-11e8-a4f0-6eaac417783a.153e4667f854bed8], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-7bkll/filler-pod-fee98f4e-7fcd-11e8-a4f0-6eaac417783a to jakku-worker-f0tz.c.dghubble-io.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fee98f4e-7fcd-11e8-a4f0-6eaac417783a.153e466831bca2bb], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fee98f4e-7fcd-11e8-a4f0-6eaac417783a.153e4668351d0b77], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fee98f4e-7fcd-11e8-a4f0-6eaac417783a.153e466840cb5306], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.153e4668e7ee7c83], Reason = [FailedScheduling], Message = [0/4 nodes are available: 1 node(s) had taints that the pod didn't tolerate, 3 Insufficient cpu.]
+STEP: removing the label node off the node jakku-worker-ktmr.c.dghubble-io.internal
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node jakku-worker-8tmm.c.dghubble-io.internal
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node jakku-worker-f0tz.c.dghubble-io.internal
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:05:40.787: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-7bkll" for this suite.
+Jul  4 21:06:02.804: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:06:02.867: INFO: namespace: e2e-tests-sched-pred-7bkll, resource: bindings, ignored listing per whitelist
+Jul  4 21:06:02.877: INFO: namespace e2e-tests-sched-pred-7bkll deletion completed in 22.086215562s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:87.467 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 21:06:02.879: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  4 21:06:02.943: INFO: Waiting up to 5m0s for pod "downwardapi-volume-0f2c5b72-7fce-11e8-a4f0-6eaac417783a" in namespace "e2e-tests-projected-nh2rl" to be "success or failure"
+Jul  4 21:06:02.955: INFO: Pod "downwardapi-volume-0f2c5b72-7fce-11e8-a4f0-6eaac417783a": Phase="Pending", Reason="", readiness=false. Elapsed: 11.843649ms
+Jul  4 21:06:04.959: INFO: Pod "downwardapi-volume-0f2c5b72-7fce-11e8-a4f0-6eaac417783a": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.015533092s
+STEP: Saw pod success
+Jul  4 21:06:04.959: INFO: Pod "downwardapi-volume-0f2c5b72-7fce-11e8-a4f0-6eaac417783a" satisfied condition "success or failure"
+Jul  4 21:06:04.962: INFO: Trying to get logs from node jakku-worker-f0tz.c.dghubble-io.internal pod downwardapi-volume-0f2c5b72-7fce-11e8-a4f0-6eaac417783a container client-container: <nil>
+STEP: delete the pod
+Jul  4 21:06:04.986: INFO: Waiting for pod downwardapi-volume-0f2c5b72-7fce-11e8-a4f0-6eaac417783a to disappear
+Jul  4 21:06:04.988: INFO: Pod downwardapi-volume-0f2c5b72-7fce-11e8-a4f0-6eaac417783a no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:06:04.988: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-nh2rl" for this suite.
+Jul  4 21:06:11.005: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:06:11.071: INFO: namespace: e2e-tests-projected-nh2rl, resource: bindings, ignored listing per whitelist
+Jul  4 21:06:11.075: INFO: namespace e2e-tests-projected-nh2rl deletion completed in 6.083540881s
+
+• [SLOW TEST:8.197 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 21:06:11.077: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  4 21:06:11.155: INFO: Requires at least 2 nodes (not -1)
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+Jul  4 21:06:11.162: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-k9nmv/daemonsets","resourceVersion":"15052"},"items":null}
+
+Jul  4 21:06:11.164: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-k9nmv/pods","resourceVersion":"15052"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:06:11.174: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-k9nmv" for this suite.
+Jul  4 21:06:17.189: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:06:17.224: INFO: namespace: e2e-tests-daemonsets-k9nmv, resource: bindings, ignored listing per whitelist
+Jul  4 21:06:17.273: INFO: namespace e2e-tests-daemonsets-k9nmv deletion completed in 6.095571871s
+
+S [SKIPPING] [6.196 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should rollback without unnecessary restarts [Conformance] [It]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+
+  Jul  4 21:06:11.155: Requires at least 2 nodes (not -1)
+
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:305
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  4 21:06:17.274: INFO: >>> kubeConfig: /tmp/kubeconfig-830667735
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-6qv4m
+Jul  4 21:06:21.357: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-6qv4m
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  4 21:06:21.359: INFO: Initial restart count of pod liveness-exec is 0
+Jul  4 21:07:09.452: INFO: Restart count of pod e2e-tests-container-probe-6qv4m/liveness-exec is now 1 (48.092155625s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  4 21:07:09.476: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-6qv4m" for this suite.
+Jul  4 21:07:15.498: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  4 21:07:15.552: INFO: namespace: e2e-tests-container-probe-6qv4m, resource: bindings, ignored listing per whitelist
+Jul  4 21:07:15.606: INFO: namespace e2e-tests-container-probe-6qv4m deletion completed in 6.125023024s
+
+• [SLOW TEST:58.332 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSJul  4 21:07:15.607: INFO: Running AfterSuite actions on all node
+Jul  4 21:07:15.607: INFO: Running AfterSuite actions on node 1
+Jul  4 21:07:15.607: INFO: Skipping dumping logs from cluster
+
+Ran 143 of 998 Specs in 4042.463 seconds
+SUCCESS! -- 143 Passed | 0 Failed | 0 Pending | 855 Skipped PASS
+
+Ginkgo ran 1 suite in 1h7m23.721337117s
+Test Suite Passed

--- a/v1.11/typhoon/junit_01.xml
+++ b/v1.11/typhoon/junit_01.xml
@@ -1,0 +1,2711 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="143" failures="0" time="4042.463208844">
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.317871285"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify &#34;immediate&#34; deletion of a PV that is not bound to a PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Forward external name lookup should forward externalname lookup to upstream nameserver [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="30.352996441"></testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle [Conformance]" classname="Kubernetes e2e suite" time="11.364926074"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create none metrics for pvc controller before creating any PV or PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="61.151933289"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Forward PTR lookup should forward PTR records lookup to upstream nameserver [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have accelerator metrics [Feature:StackdriverAcceleratorMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]" classname="Kubernetes e2e suite" time="17.191129676"></testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.186825946"></testcase>
+      <testcase name="[k8s.io] Pods should get a host IP [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="24.192677647"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates lower priority pod preemption by critical pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection][NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.212825482"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning Block volume provisioning [Feature:BlockVolume] should create and delete block persistent volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.212680282"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existing secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should deny crd creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="42.154993457"></testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.176899789"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.238842027"></testcase>
+      <testcase name="[sig-api-machinery] Watchers should observe an object deletion if it stops meeting the requirements of the selector [Conformance]" classname="Kubernetes e2e suite" time="16.185519842"></testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.216105151"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha runtime/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for external metrics [Feature:StackdriverExternalMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support proportional scaling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.253092601"></testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.274400475"></testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape container metrics from all nodes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.212580617"></testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent configmap should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.22088765"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.173584452"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="6.908155003"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.206500556"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.201431031"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.223904539"></testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.190497768"></testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.205037857"></testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with projected pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="51.284632022"></testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.202359954"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 Scalability GCE [Slow] [Serial] [Feature:IngressScale] Creating and updating ingresses should happen promptly with small/medium/large amount of ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.187420946"></testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.201794895"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster [Feature:InfluxdbMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="82.195000588"></testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.736337702"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="7.185814706"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate custom resource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.792072078"></testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should update ingress while sync failures occur on other ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="12.196242734"></testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.191492193"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="86.460634098"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to create a ClusterIP service [Unreleased]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should not create local persistent volume for filesystem volume that was not bind mounted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance]" classname="Kubernetes e2e suite" time="167.430696943"></testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.245618935"></testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.205271262"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.244463682"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow][NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD RegionalPD should provision storage [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.288534342"></testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete another node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should support configurable pod resolv.conf" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] single and multi-cluster ingresses should be able to exist together" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support orphan deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] [Feature:PerformanceDNS] Should answer DNS query for maximum number of services per cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="44.744023485"></testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.248553821"></testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [DisabledForLargeClusters] kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.22894014"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should contain correct container CPU metric." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.227364892"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.250277112"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.233716649"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.328848366999999"></testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with secret pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.237168328"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.225620421"></testcase>
+      <testcase name="[sig-scheduling] PodPriorityResolution [Serial] [Feature:PodPreemption] validates critical system priorities are created and resolved" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for old resource model [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Mounted volume expand[Slow] Should verify mounted devices can be resized" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with downward pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="102.626127317"></testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="7.324607346"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.253754795"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume expand [Slow] Verify if editing PVC allows resize" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="12.691519527"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner deletion should be idempotent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.171220438"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]" classname="Kubernetes e2e suite" time="36.693531864"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]" classname="Kubernetes e2e suite" time="50.388569044"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] cluster upgrade should be able to run gpu pod after upgrade [Feature:GPUClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.221286635"></testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="16.278868424"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.22658082"></testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.213669751"></testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="108.637450792"></testcase>
+      <testcase name="[sig-network] Services should have session affinity work for NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should discover dynamicly created local persistent volume mountpoint in discovery directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.168581208"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.198465618"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape metrics from annotated pods." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.258913303"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.217969093"></testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.239310777"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should observe add, update, and delete watch notifications on configmaps [Conformance]" classname="Kubernetes e2e suite" time="66.190597779"></testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="28.368098778"></testcase>
+      <testcase name="[sig-storage] PVC Protection Verify &#34;immediate&#34; deletion of a PVC that is not in active use by a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD RegionalPD should failover to a different zone when all nodes in one zone become unreachable [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.718492996"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.195974068"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.20299497"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods [Conformance]" classname="Kubernetes e2e suite" time="371.496915633"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.212578251"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.239042664"></testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with backend HTTPS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify that PV bound to a PVC is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.200862968"></testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.218586601"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should support https-only annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.225048405"></testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : projected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support subPath [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for service with type clusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Stress with local volume provisioner [Serial] should use be able to process many pods and reuse local volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should be able to start watching from a specific resource version [Conformance]" classname="Kubernetes e2e suite" time="6.203428582"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.278918378"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="16.832284294"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="47.584387744"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should create ingress with backend HTTPS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existing configmap should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape metrics from annotated services." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition Watch CustomResourceDefinition Watch watch on custom resource definition objects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.223050277"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should remove clusters as expected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.249710876"></testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="24.885116994"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should not reconcile manually modified health check for ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="16.210291339"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes CSI plugin test using CSI driver: [Feature: GCE PD CSI Plugin] gcePD should provision storage" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset [Conformance]" classname="Kubernetes e2e suite" time="27.554086074"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so [Conformance]" classname="Kubernetes e2e suite" time="46.25702983"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.227884313"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="27.380577039"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.21615337"></testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for service with type clusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods [Conformance]" classname="Kubernetes e2e suite" time="24.465065881"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should successfully scrape all targets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.220962151"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Upgrade [Feature:IngressUpgrade] ingress upgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command (docker entrypoint) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.286959931"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.218963041"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.211575948"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="44.603121546"></testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create another node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.209541185"></testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow][NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning [k8s.io] GlusterDynamicProvisioner should create and delete persistent volumes [fast]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.189861957"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive] node unregister" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should support multiple TLS certs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.220026329"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should not be able to prevent deleting validating-webhook-configurations or mutating-webhook-configurations" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.189867574"></testcase>
+      <testcase name="[k8s.io] Variable Expansion should fail substituting values in a volume subpath with absolute path [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.202198617"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should be able to restart watching from the last resource version observed by the previous watch [Conformance]" classname="Kubernetes e2e suite" time="6.175699962"></testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.150872487"></testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Downgrade [Feature:IngressDowngrade] ingress downgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Change stubDomain should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.208692076"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="19.683199207"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="248.699485869"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.361019603"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.268861976"></testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.260143288"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.238566351"></testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.280065747"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.197026961"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.217456487"></testcase>
+      <testcase name="[k8s.io] PrivilegedPod [NodeConformance] should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.231689942"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications [Conformance]" classname="Kubernetes e2e suite" time="96.556388055"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]" classname="Kubernetes e2e suite" time="17.637232652"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.262322859"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted [Conformance]" classname="Kubernetes e2e suite" time="16.280686057"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with External Metric with target average value from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] master upgrade should NOT disrupt gpu pod [Feature:GPUMasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]" classname="Kubernetes e2e suite" time="12.248520846"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two External metrics from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="154.546095481"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="40.608487943"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]" classname="Kubernetes e2e suite" time="98.213567275"></testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="30.235248846"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.230965108"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.241994553"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.271676742"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.1989226"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes CSI plugin test using CSI driver: hostPath should provision storage" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  StatefulSet with pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for new resource model [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.187531463"></testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap binary data should be reflected in volume [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.241845612"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.205311048"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod with mountPath of existing file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should be able to switch between HTTPS and HTTP2 modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="250.589059693"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.254791227"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.205964575"></testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a volume subpath [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.222964975"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that PVC in active use by a pod is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.202708251"></testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pv count metrics for pvc controller after creating pv only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="48.476245842"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.209747553"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pvc count metrics for pvc controller after creating pvc only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should fail substituting values in a volume subpath with backticks [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Verify Volume Attach Through vpxd Restart [Feature:vsphere][Serial][Disruptive] verify volume remains attached through vpxd restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="24.743534227"></testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.711294455"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with External Metric with target value from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="87.467387074"></testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.197112365"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.196014844">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="58.33152616"></testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.11/typhoon/version.txt
+++ b/v1.11/typhoon/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.0", GitCommit:"91e7b4fd31fcd3d5f436da26c980becec37ceefe", GitTreeState:"clean", BuildDate:"2018-06-27T20:17:28Z", GoVersion:"go1.10.2", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.0", GitCommit:"91e7b4fd31fcd3d5f436da26c980becec37ceefe", GitTreeState:"clean", BuildDate:"2018-06-27T20:08:34Z", GoVersion:"go1.10.2", Compiler:"gc", Platform:"linux/amd64"}


### PR DESCRIPTION
[Poseidon](https://landscape.cncf.io/grouping=organization&organization=poseidon) organization's [Typhoon](https://typhoon.psdn.io/) distro, refreshed to show v1.11 results. :clinking_glasses:  

```
vendor: Poseidon
name: Typhoon
version: v1.11.0
website_url: https://typhoon.psdn.io/
documentation_url: https://typhoon.psdn.io/
product_logo_url: https://storage.googleapis.com/poseidon/typhoon.png
type: distro
description: Minimal and free Kubernetes distribution via Terraform
```