### PR TITLE
Adding Azure Stack acs-engine v1.11 conformance test results

### DIFF
--- a/v1.11/acs-engine-azurestack/PRODUCT.yaml
+++ b/v1.11/acs-engine-azurestack/PRODUCT.yaml
@@ -1,0 +1,11 @@
+vendor: Microsoft
+
+name: Azure acs-egine
+
+version: v0.20.2
+
+website_url: https://github.com/msazurestackworkloads/acs-engine/tree/acs-engine-v0206
+
+documentation_url: https://github.com/msazurestackworkloads/acs-engine/tree/acs-engine-v0206  
+
+product_logo_url: https://i1.wp.com/buildazure.com/wp-content/uploads/2017/09/Azure.png

--- a/v1.11/acs-engine-azurestack/PRODUCT.yaml
+++ b/v1.11/acs-engine-azurestack/PRODUCT.yaml
@@ -1,6 +1,6 @@
 vendor: Microsoft
 
-name: Azure acs-egine
+name: Azure Stack acs-egine
 
 version: v0.20.2
 

--- a/v1.11/acs-engine-azurestack/PRODUCT.yaml
+++ b/v1.11/acs-engine-azurestack/PRODUCT.yaml
@@ -1,6 +1,6 @@
 vendor: Microsoft
 
-name: Azure Stack acs-egine
+name: Azure Stack acs-engine
 
 version: v0.20.2
 

--- a/v1.11/acs-engine-azurestack/README.MD
+++ b/v1.11/acs-engine-azurestack/README.MD
@@ -1,0 +1,39 @@
+To reproduce:
+
+```
+# Install Azure CLI and connect to Azure Stack based on https://docs.microsoft.com/en-us/azure/azure-stack/user/azure-stack-version-profiles-azurecli2
+
+# [Optional] To learn details on how to use the ACS Engine see "Usage" in https://github.com/msazurestackworkloads/acs-engine/blob/master/docs/acsengine.md
+
+# To install the Azure Stack ACS Engine use the curl command below and unpack content
+curl -L -o acs-engine.tgz https://raw.githubusercontent.com/msazurestackworkloads/acs-engine/acs-engine-v0206/examples/azurestack/acs-engine.tgz 
+
+# Get the Kubernetes 1.11 install json
+
+curl -o kubernetes1.11.json https://raw.githubusercontent.com/msazurestackworkloads/acs-engine/acs-engine-v0206/examples/azurestack/azurestack-kubernetes1.11.json
+
+# To run the sonobuoy tests follow these steps:
+
+# 1. Get the current Azure Stack subscription ID 
+
+$ az login
+
+$ SUBID=`az account list --all -o table |grep True |awk -F '  ' '{print $3}'`
+
+# 2. Deploy the kubernetes cluster
+
+$ acs-engine deploy --subscription-id $SUBID \
+    --dns-prefix conformance --location westus2 \
+    --auto-suffix --api-model kubernetes1.11.json 
+
+# 3. Run the tests
+
+$ curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+
+$ kubectl logs -f -n sonobuoy sonobuoy
+
+# wait for "no-exit was specified, sonobuoy is now blocking"
+
+$ kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy ./results
+
+# untar the tarball, then add plugins/e2e/results/{e2e.log,junit_01.xml}

--- a/v1.11/acs-engine-azurestack/e2e.log
+++ b/v1.11/acs-engine-azurestack/e2e.log
@@ -1,0 +1,7177 @@
+Aug  8 19:51:24.356: INFO: Overriding default scale value of zero to 1
+Aug  8 19:51:24.356: INFO: Overriding default milliseconds value of zero to 5000
+I0808 19:51:24.479631      17 test_context.go:382] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-499033417
+I0808 19:51:24.479727      17 e2e.go:333] Starting e2e run "6e27b037-9b44-11e8-bae8-8697d7d38a55" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1533757884 - Will randomize all specs
+Will run 144 of 999 specs
+
+Aug  8 19:51:24.542: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 19:51:24.545: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
+Aug  8 19:51:24.570: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Aug  8 19:51:24.593: INFO: 12 / 12 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Aug  8 19:51:24.593: INFO: expected 5 pod replicas in namespace 'kube-system', 5 are Running and Ready.
+Aug  8 19:51:24.596: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Aug  8 19:51:24.596: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Aug  8 19:51:24.598: INFO: e2e test version: v1.11.1
+Aug  8 19:51:24.600: INFO: kube-apiserver version: v1.11.2-azs-1808
+SSSSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:51:24.601: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+Aug  8 19:51:24.685: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating server pod server in namespace e2e-tests-prestop-zfg8q
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-zfg8q
+STEP: Deleting pre-stop pod
+Aug  8 19:51:41.719: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:51:41.725: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-zfg8q" for this suite.
+Aug  8 19:52:19.742: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:52:19.754: INFO: namespace: e2e-tests-prestop-zfg8q, resource: bindings, ignored listing per whitelist
+Aug  8 19:52:19.823: INFO: namespace e2e-tests-prestop-zfg8q deletion completed in 38.091993748s
+
+• [SLOW TEST:55.223 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:52:19.824: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Aug  8 19:52:19.911: INFO: Creating ReplicaSet my-hostname-basic-8f4d9f5c-9b44-11e8-bae8-8697d7d38a55
+Aug  8 19:52:19.916: INFO: Pod name my-hostname-basic-8f4d9f5c-9b44-11e8-bae8-8697d7d38a55: Found 0 pods out of 1
+Aug  8 19:52:24.920: INFO: Pod name my-hostname-basic-8f4d9f5c-9b44-11e8-bae8-8697d7d38a55: Found 1 pods out of 1
+Aug  8 19:52:24.920: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-8f4d9f5c-9b44-11e8-bae8-8697d7d38a55" is running
+Aug  8 19:52:24.922: INFO: Pod "my-hostname-basic-8f4d9f5c-9b44-11e8-bae8-8697d7d38a55-pz4vw" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-08-08 19:52:19 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-08-08 19:52:23 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-08-08 19:52:19 +0000 UTC Reason: Message:}])
+Aug  8 19:52:24.923: INFO: Trying to dial the pod
+Aug  8 19:52:29.932: INFO: Controller my-hostname-basic-8f4d9f5c-9b44-11e8-bae8-8697d7d38a55: Got expected result from replica 1 [my-hostname-basic-8f4d9f5c-9b44-11e8-bae8-8697d7d38a55-pz4vw]: "my-hostname-basic-8f4d9f5c-9b44-11e8-bae8-8697d7d38a55-pz4vw", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:52:29.932: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-4hvc2" for this suite.
+Aug  8 19:52:35.944: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:52:35.973: INFO: namespace: e2e-tests-replicaset-4hvc2, resource: bindings, ignored listing per whitelist
+Aug  8 19:52:36.026: INFO: namespace e2e-tests-replicaset-4hvc2 deletion completed in 6.09174723s
+
+• [SLOW TEST:16.203 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:52:36.027: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Aug  8 19:52:36.119: INFO: Waiting up to 5m0s for pod "downward-api-98f5bc2f-9b44-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-2qrb9" to be "success or failure"
+Aug  8 19:52:36.127: INFO: Pod "downward-api-98f5bc2f-9b44-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 7.875661ms
+Aug  8 19:52:38.131: INFO: Pod "downward-api-98f5bc2f-9b44-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011741297s
+Aug  8 19:52:40.134: INFO: Pod "downward-api-98f5bc2f-9b44-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015410177s
+STEP: Saw pod success
+Aug  8 19:52:40.134: INFO: Pod "downward-api-98f5bc2f-9b44-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 19:52:40.137: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downward-api-98f5bc2f-9b44-11e8-bae8-8697d7d38a55 container dapi-container: <nil>
+STEP: delete the pod
+Aug  8 19:52:40.181: INFO: Waiting for pod downward-api-98f5bc2f-9b44-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 19:52:40.185: INFO: Pod downward-api-98f5bc2f-9b44-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:52:40.185: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-2qrb9" for this suite.
+Aug  8 19:52:46.196: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:52:46.248: INFO: namespace: e2e-tests-downward-api-2qrb9, resource: bindings, ignored listing per whitelist
+Aug  8 19:52:46.292: INFO: namespace e2e-tests-downward-api-2qrb9 deletion completed in 6.104508047s
+
+• [SLOW TEST:10.266 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:52:46.293: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-sf4wz
+[It] should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a new StaefulSet
+Aug  8 19:52:46.381: INFO: Found 0 stateful pods, waiting for 3
+Aug  8 19:52:56.386: INFO: Found 1 stateful pods, waiting for 3
+Aug  8 19:53:06.384: INFO: Found 2 stateful pods, waiting for 3
+Aug  8 19:53:16.385: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Aug  8 19:53:16.385: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Aug  8 19:53:16.385: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Updating stateful set template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Aug  8 19:53:16.409: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Not applying an update when the partition is greater than the number of replicas
+STEP: Performing a canary update
+Aug  8 19:53:26.437: INFO: Updating stateful set ss2
+Aug  8 19:53:26.457: INFO: Waiting for Pod e2e-tests-statefulset-sf4wz/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Restoring Pods to the correct revision when they are deleted
+Aug  8 19:53:36.487: INFO: Found 1 stateful pods, waiting for 3
+Aug  8 19:53:46.492: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Aug  8 19:53:46.492: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Aug  8 19:53:46.492: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Performing a phased rolling update
+Aug  8 19:53:46.513: INFO: Updating stateful set ss2
+Aug  8 19:53:46.522: INFO: Waiting for Pod e2e-tests-statefulset-sf4wz/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Aug  8 19:53:56.544: INFO: Updating stateful set ss2
+Aug  8 19:53:56.550: INFO: Waiting for StatefulSet e2e-tests-statefulset-sf4wz/ss2 to complete update
+Aug  8 19:53:56.550: INFO: Waiting for Pod e2e-tests-statefulset-sf4wz/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Aug  8 19:54:06.556: INFO: Waiting for StatefulSet e2e-tests-statefulset-sf4wz/ss2 to complete update
+Aug  8 19:54:06.556: INFO: Waiting for Pod e2e-tests-statefulset-sf4wz/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Aug  8 19:54:16.556: INFO: Deleting all statefulset in ns e2e-tests-statefulset-sf4wz
+Aug  8 19:54:16.559: INFO: Scaling statefulset ss2 to 0
+Aug  8 19:54:36.575: INFO: Waiting for statefulset status.replicas updated to 0
+Aug  8 19:54:36.578: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:54:36.586: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-sf4wz" for this suite.
+Aug  8 19:54:42.596: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:54:42.610: INFO: namespace: e2e-tests-statefulset-sf4wz, resource: bindings, ignored listing per whitelist
+Aug  8 19:54:42.671: INFO: namespace e2e-tests-statefulset-sf4wz deletion completed in 6.083104504s
+
+• [SLOW TEST:116.379 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should perform canary updates and phased rolling updates of template modifications [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:54:42.671: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-hdtm6
+[It] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Initializing watcher for selector baz=blah,foo=bar
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-hdtm6
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-hdtm6
+Aug  8 19:54:42.759: INFO: Found 0 stateful pods, waiting for 1
+Aug  8 19:54:52.763: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will halt with unhealthy stateful pod
+Aug  8 19:54:52.765: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-hdtm6 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Aug  8 19:54:52.988: INFO: stderr: ""
+Aug  8 19:54:52.988: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Aug  8 19:54:52.988: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Aug  8 19:54:52.991: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Aug  8 19:55:02.995: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Aug  8 19:55:02.995: INFO: Waiting for statefulset status.replicas updated to 0
+Aug  8 19:55:03.007: INFO: Verifying statefulset ss doesn't scale past 1 for another 9.9999998s
+Aug  8 19:55:04.010: INFO: Verifying statefulset ss doesn't scale past 1 for another 8.995631374s
+Aug  8 19:55:05.016: INFO: Verifying statefulset ss doesn't scale past 1 for another 7.992293438s
+Aug  8 19:55:06.020: INFO: Verifying statefulset ss doesn't scale past 1 for another 6.986348006s
+Aug  8 19:55:07.023: INFO: Verifying statefulset ss doesn't scale past 1 for another 5.982831659s
+Aug  8 19:55:08.026: INFO: Verifying statefulset ss doesn't scale past 1 for another 4.979809304s
+Aug  8 19:55:09.030: INFO: Verifying statefulset ss doesn't scale past 1 for another 3.976164345s
+Aug  8 19:55:10.034: INFO: Verifying statefulset ss doesn't scale past 1 for another 2.972570579s
+Aug  8 19:55:11.037: INFO: Verifying statefulset ss doesn't scale past 1 for another 1.968921608s
+Aug  8 19:55:12.041: INFO: Verifying statefulset ss doesn't scale past 1 for another 965.36633ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-hdtm6
+Aug  8 19:55:13.045: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-hdtm6 ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Aug  8 19:55:13.279: INFO: stderr: ""
+Aug  8 19:55:13.279: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Aug  8 19:55:13.279: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Aug  8 19:55:13.283: INFO: Found 1 stateful pods, waiting for 3
+Aug  8 19:55:23.287: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Aug  8 19:55:23.287: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Aug  8 19:55:23.287: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Verifying that stateful set ss was scaled up in order
+STEP: Scale down will halt with unhealthy stateful pod
+Aug  8 19:55:23.291: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-hdtm6 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Aug  8 19:55:23.511: INFO: stderr: ""
+Aug  8 19:55:23.511: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Aug  8 19:55:23.511: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Aug  8 19:55:23.511: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-hdtm6 ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Aug  8 19:55:23.734: INFO: stderr: ""
+Aug  8 19:55:23.734: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Aug  8 19:55:23.734: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Aug  8 19:55:23.734: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-hdtm6 ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Aug  8 19:55:23.974: INFO: stderr: ""
+Aug  8 19:55:23.974: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Aug  8 19:55:23.974: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Aug  8 19:55:23.974: INFO: Waiting for statefulset status.replicas updated to 0
+Aug  8 19:55:23.977: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 1
+Aug  8 19:55:33.983: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Aug  8 19:55:33.983: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Aug  8 19:55:33.983: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Aug  8 19:55:33.995: INFO: Verifying statefulset ss doesn't scale past 3 for another 9.9999997s
+Aug  8 19:55:34.998: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.9938053s
+Aug  8 19:55:36.002: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.990447585s
+Aug  8 19:55:37.005: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.986762965s
+Aug  8 19:55:38.009: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.983051141s
+Aug  8 19:55:39.013: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.97949201s
+Aug  8 19:55:40.018: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.975061077s
+Aug  8 19:55:41.022: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.970703938s
+Aug  8 19:55:42.025: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.966583993s
+Aug  8 19:55:43.029: INFO: Verifying statefulset ss doesn't scale past 3 for another 963.140441ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-hdtm6
+Aug  8 19:55:44.034: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-hdtm6 ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Aug  8 19:55:44.243: INFO: stderr: ""
+Aug  8 19:55:44.243: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Aug  8 19:55:44.243: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Aug  8 19:55:44.243: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-hdtm6 ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Aug  8 19:55:44.483: INFO: stderr: ""
+Aug  8 19:55:44.483: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Aug  8 19:55:44.483: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Aug  8 19:55:44.483: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-hdtm6 ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Aug  8 19:55:44.671: INFO: stderr: ""
+Aug  8 19:55:44.671: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Aug  8 19:55:44.671: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Aug  8 19:55:44.671: INFO: Scaling statefulset ss to 0
+STEP: Verifying that stateful set ss was scaled down in reverse order
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Aug  8 19:56:04.684: INFO: Deleting all statefulset in ns e2e-tests-statefulset-hdtm6
+Aug  8 19:56:04.689: INFO: Scaling statefulset ss to 0
+Aug  8 19:56:04.697: INFO: Waiting for statefulset status.replicas updated to 0
+Aug  8 19:56:04.698: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:56:04.707: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-hdtm6" for this suite.
+Aug  8 19:56:10.719: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:56:10.759: INFO: namespace: e2e-tests-statefulset-hdtm6, resource: bindings, ignored listing per whitelist
+Aug  8 19:56:10.792: INFO: namespace e2e-tests-statefulset-hdtm6 deletion completed in 6.080829572s
+
+• [SLOW TEST:88.121 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:56:10.792: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: closing the watch once it receives two notifications
+Aug  8 19:56:10.873: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-8cd5n,SelfLink:/api/v1/namespaces/e2e-tests-watch-8cd5n/configmaps/e2e-watch-test-watch-closed,UID:18f7693c-9b45-11e8-ad47-001dd8b71c0d,ResourceVersion:2491,Generation:0,CreationTimestamp:2018-08-08 19:56:10 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Aug  8 19:56:10.873: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-8cd5n,SelfLink:/api/v1/namespaces/e2e-tests-watch-8cd5n/configmaps/e2e-watch-test-watch-closed,UID:18f7693c-9b45-11e8-ad47-001dd8b71c0d,ResourceVersion:2492,Generation:0,CreationTimestamp:2018-08-08 19:56:10 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying the configmap a second time, while the watch is closed
+STEP: creating a new watch on configmaps from the last resource version observed by the first watch
+STEP: deleting the configmap
+STEP: Expecting to observe notifications for all changes to the configmap since the first watch closed
+Aug  8 19:56:10.883: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-8cd5n,SelfLink:/api/v1/namespaces/e2e-tests-watch-8cd5n/configmaps/e2e-watch-test-watch-closed,UID:18f7693c-9b45-11e8-ad47-001dd8b71c0d,ResourceVersion:2493,Generation:0,CreationTimestamp:2018-08-08 19:56:10 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Aug  8 19:56:10.883: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-8cd5n,SelfLink:/api/v1/namespaces/e2e-tests-watch-8cd5n/configmaps/e2e-watch-test-watch-closed,UID:18f7693c-9b45-11e8-ad47-001dd8b71c0d,ResourceVersion:2494,Generation:0,CreationTimestamp:2018-08-08 19:56:10 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:56:10.883: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-8cd5n" for this suite.
+Aug  8 19:56:16.893: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:56:16.939: INFO: namespace: e2e-tests-watch-8cd5n, resource: bindings, ignored listing per whitelist
+Aug  8 19:56:16.990: INFO: namespace e2e-tests-watch-8cd5n deletion completed in 6.10455437s
+
+• [SLOW TEST:6.198 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:56:16.990: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Aug  8 19:56:17.084: INFO: Waiting up to 5m0s for pod "downward-api-1ca9cbfb-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-t4tfn" to be "success or failure"
+Aug  8 19:56:17.086: INFO: Pod "downward-api-1ca9cbfb-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.099793ms
+Aug  8 19:56:19.090: INFO: Pod "downward-api-1ca9cbfb-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005683461s
+Aug  8 19:56:21.094: INFO: Pod "downward-api-1ca9cbfb-9b45-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009175247s
+STEP: Saw pod success
+Aug  8 19:56:21.094: INFO: Pod "downward-api-1ca9cbfb-9b45-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 19:56:21.096: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downward-api-1ca9cbfb-9b45-11e8-bae8-8697d7d38a55 container dapi-container: <nil>
+STEP: delete the pod
+Aug  8 19:56:21.112: INFO: Waiting for pod downward-api-1ca9cbfb-9b45-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 19:56:21.114: INFO: Pod downward-api-1ca9cbfb-9b45-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:56:21.114: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-t4tfn" for this suite.
+Aug  8 19:56:27.128: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:56:27.182: INFO: namespace: e2e-tests-downward-api-t4tfn, resource: bindings, ignored listing per whitelist
+Aug  8 19:56:27.214: INFO: namespace e2e-tests-downward-api-t4tfn deletion completed in 6.097954278s
+
+• [SLOW TEST:10.225 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:56:27.215: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-mrrpm A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-mrrpm;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-mrrpm A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-mrrpm;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-mrrpm.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-mrrpm.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-mrrpm.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-mrrpm.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-mrrpm.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-mrrpm.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-mrrpm.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-mrrpm.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-mrrpm.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-mrrpm.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-mrrpm.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-mrrpm.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-mrrpm.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 110.114.0.10.in-addr.arpa. PTR)" && echo OK > /results/10.0.114.110_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 110.114.0.10.in-addr.arpa. PTR)" && echo OK > /results/10.0.114.110_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-mrrpm A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-mrrpm;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-mrrpm A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-mrrpm;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-mrrpm.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-mrrpm.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-mrrpm.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-mrrpm.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-mrrpm.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-mrrpm.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-mrrpm.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-mrrpm.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-mrrpm.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-mrrpm.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-mrrpm.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-mrrpm.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-mrrpm.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 110.114.0.10.in-addr.arpa. PTR)" && echo OK > /results/10.0.114.110_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 110.114.0.10.in-addr.arpa. PTR)" && echo OK > /results/10.0.114.110_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Aug  8 19:56:47.457: INFO: DNS probes using dns-test-22c51dc0-9b45-11e8-bae8-8697d7d38a55 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:56:47.499: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-mrrpm" for this suite.
+Aug  8 19:56:53.510: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:56:53.570: INFO: namespace: e2e-tests-dns-mrrpm, resource: bindings, ignored listing per whitelist
+Aug  8 19:56:53.576: INFO: namespace e2e-tests-dns-mrrpm deletion completed in 6.074801037s
+
+• [SLOW TEST:26.362 seconds]
+[sig-network] DNS
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:56:53.577: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-32760a51-9b45-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 19:56:53.650: INFO: Waiting up to 5m0s for pod "pod-configmaps-32766700-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-configmap-wd8pp" to be "success or failure"
+Aug  8 19:56:53.655: INFO: Pod "pod-configmaps-32766700-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 4.415085ms
+Aug  8 19:56:55.658: INFO: Pod "pod-configmaps-32766700-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007641768s
+Aug  8 19:56:57.661: INFO: Pod "pod-configmaps-32766700-9b45-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010989465s
+STEP: Saw pod success
+Aug  8 19:56:57.661: INFO: Pod "pod-configmaps-32766700-9b45-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 19:56:57.663: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-configmaps-32766700-9b45-11e8-bae8-8697d7d38a55 container configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 19:56:57.689: INFO: Waiting for pod pod-configmaps-32766700-9b45-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 19:56:57.700: INFO: Pod pod-configmaps-32766700-9b45-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:56:57.700: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-wd8pp" for this suite.
+Aug  8 19:57:03.717: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:57:03.786: INFO: namespace: e2e-tests-configmap-wd8pp, resource: bindings, ignored listing per whitelist
+Aug  8 19:57:03.791: INFO: namespace e2e-tests-configmap-wd8pp deletion completed in 6.081497162s
+
+• [SLOW TEST:10.214 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:57:03.791: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-388dbf40-9b45-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 19:57:03.875: INFO: Waiting up to 5m0s for pod "pod-configmaps-388e20e5-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-configmap-w4zhn" to be "success or failure"
+Aug  8 19:57:03.878: INFO: Pod "pod-configmaps-388e20e5-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 3.311789ms
+Aug  8 19:57:05.886: INFO: Pod "pod-configmaps-388e20e5-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011326536s
+Aug  8 19:57:07.890: INFO: Pod "pod-configmaps-388e20e5-9b45-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015104912s
+STEP: Saw pod success
+Aug  8 19:57:07.890: INFO: Pod "pod-configmaps-388e20e5-9b45-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 19:57:07.892: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-configmaps-388e20e5-9b45-11e8-bae8-8697d7d38a55 container configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 19:57:07.911: INFO: Waiting for pod pod-configmaps-388e20e5-9b45-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 19:57:07.917: INFO: Pod pod-configmaps-388e20e5-9b45-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:57:07.917: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-w4zhn" for this suite.
+Aug  8 19:57:13.931: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:57:13.962: INFO: namespace: e2e-tests-configmap-w4zhn, resource: bindings, ignored listing per whitelist
+Aug  8 19:57:14.007: INFO: namespace e2e-tests-configmap-w4zhn deletion completed in 6.086606182s
+
+• [SLOW TEST:10.216 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:57:14.007: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 19:57:14.091: INFO: Waiting up to 5m0s for pod "downwardapi-volume-3ea53862-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-zb77n" to be "success or failure"
+Aug  8 19:57:14.093: INFO: Pod "downwardapi-volume-3ea53862-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 1.876994ms
+Aug  8 19:57:16.096: INFO: Pod "downwardapi-volume-3ea53862-9b45-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004828434s
+STEP: Saw pod success
+Aug  8 19:57:16.096: INFO: Pod "downwardapi-volume-3ea53862-9b45-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 19:57:16.098: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-3ea53862-9b45-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 19:57:16.121: INFO: Waiting for pod downwardapi-volume-3ea53862-9b45-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 19:57:16.123: INFO: Pod downwardapi-volume-3ea53862-9b45-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:57:16.123: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-zb77n" for this suite.
+Aug  8 19:57:22.138: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:57:22.211: INFO: namespace: e2e-tests-downward-api-zb77n, resource: bindings, ignored listing per whitelist
+Aug  8 19:57:22.240: INFO: namespace e2e-tests-downward-api-zb77n deletion completed in 6.11432268s
+
+• [SLOW TEST:8.233 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:57:22.240: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 19:57:22.328: INFO: Waiting up to 5m0s for pod "downwardapi-volume-438dedae-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-lb84x" to be "success or failure"
+Aug  8 19:57:22.334: INFO: Pod "downwardapi-volume-438dedae-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.755482ms
+Aug  8 19:57:24.338: INFO: Pod "downwardapi-volume-438dedae-9b45-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009526379s
+STEP: Saw pod success
+Aug  8 19:57:24.338: INFO: Pod "downwardapi-volume-438dedae-9b45-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 19:57:24.340: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-438dedae-9b45-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 19:57:24.364: INFO: Waiting for pod downwardapi-volume-438dedae-9b45-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 19:57:24.367: INFO: Pod downwardapi-volume-438dedae-9b45-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:57:24.367: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lb84x" for this suite.
+Aug  8 19:57:30.385: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:57:30.412: INFO: namespace: e2e-tests-projected-lb84x, resource: bindings, ignored listing per whitelist
+Aug  8 19:57:30.456: INFO: namespace e2e-tests-projected-lb84x deletion completed in 6.082236158s
+
+• [SLOW TEST:8.216 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:57:30.456: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Aug  8 19:57:33.063: INFO: Successfully updated pod "pod-update-activedeadlineseconds-4872fd6d-9b45-11e8-bae8-8697d7d38a55"
+Aug  8 19:57:33.063: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-4872fd6d-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-pods-h7424" to be "terminated due to deadline exceeded"
+Aug  8 19:57:33.065: INFO: Pod "pod-update-activedeadlineseconds-4872fd6d-9b45-11e8-bae8-8697d7d38a55": Phase="Running", Reason="", readiness=true. Elapsed: 1.721995ms
+Aug  8 19:57:35.067: INFO: Pod "pod-update-activedeadlineseconds-4872fd6d-9b45-11e8-bae8-8697d7d38a55": Phase="Running", Reason="", readiness=true. Elapsed: 2.00455127s
+Aug  8 19:57:37.070: INFO: Pod "pod-update-activedeadlineseconds-4872fd6d-9b45-11e8-bae8-8697d7d38a55": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 4.007514158s
+Aug  8 19:57:37.071: INFO: Pod "pod-update-activedeadlineseconds-4872fd6d-9b45-11e8-bae8-8697d7d38a55" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:57:37.071: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-h7424" for this suite.
+Aug  8 19:57:43.082: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:57:43.111: INFO: namespace: e2e-tests-pods-h7424, resource: bindings, ignored listing per whitelist
+Aug  8 19:57:43.154: INFO: namespace e2e-tests-pods-h7424 deletion completed in 6.080587527s
+
+• [SLOW TEST:12.698 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:57:43.154: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:80
+Aug  8 19:57:43.222: INFO: Waiting up to 1m0s for all nodes to be ready
+Aug  8 19:58:43.244: INFO: Waiting for terminating namespaces to be deleted...
+Aug  8 19:58:43.248: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Aug  8 19:58:43.258: INFO: 12 / 12 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Aug  8 19:58:43.258: INFO: expected 5 pod replicas in namespace 'kube-system', 5 are Running and Ready.
+Aug  8 19:58:43.261: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Aug  8 19:58:43.261: INFO: 
+Logging pods the kubelet thinks is on node k8s-linuxpool-37994001-0 before test
+Aug  8 19:58:43.296: INFO: kube-proxy-82rx2 from kube-system started at 2018-08-08 19:42:39 +0000 UTC (1 container statuses recorded)
+Aug  8 19:58:43.296: INFO: 	Container kube-proxy ready: true, restart count 0
+Aug  8 19:58:43.296: INFO: tiller-deploy-54c57f6dc5-tzhx7 from kube-system started at 2018-08-08 19:43:12 +0000 UTC (1 container statuses recorded)
+Aug  8 19:58:43.296: INFO: 	Container tiller ready: true, restart count 0
+Aug  8 19:58:43.296: INFO: heapster-855c6c8b5b-hhzdf from kube-system started at 2018-08-08 19:43:17 +0000 UTC (2 container statuses recorded)
+Aug  8 19:58:43.296: INFO: 	Container heapster ready: true, restart count 0
+Aug  8 19:58:43.296: INFO: 	Container heapster-nanny ready: true, restart count 0
+Aug  8 19:58:43.296: INFO: kubernetes-dashboard-86cdd7799c-j47fh from kube-system started at 2018-08-08 19:43:18 +0000 UTC (1 container statuses recorded)
+Aug  8 19:58:43.296: INFO: 	Container kubernetes-dashboard ready: true, restart count 0
+Aug  8 19:58:43.296: INFO: metrics-server-789c47657d-4z2vr from kube-system started at 2018-08-08 19:43:18 +0000 UTC (1 container statuses recorded)
+Aug  8 19:58:43.296: INFO: 	Container metrics-server ready: true, restart count 0
+Aug  8 19:58:43.296: INFO: kube-dns-5c89bdc645-zpbwn from kube-system started at 2018-08-08 19:43:18 +0000 UTC (3 container statuses recorded)
+Aug  8 19:58:43.296: INFO: 	Container dnsmasq ready: true, restart count 0
+Aug  8 19:58:43.296: INFO: 	Container kubedns ready: true, restart count 0
+Aug  8 19:58:43.296: INFO: 	Container sidecar ready: true, restart count 0
+Aug  8 19:58:43.296: INFO: sonobuoy-systemd-logs-daemon-set-806020c23a614e67-8xmpb from heptio-sonobuoy started at 2018-08-08 19:50:30 +0000 UTC (2 container statuses recorded)
+Aug  8 19:58:43.297: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 0
+Aug  8 19:58:43.297: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Aug  8 19:58:43.297: INFO: 
+Logging pods the kubelet thinks is on node k8s-linuxpool-37994001-1 before test
+Aug  8 19:58:43.303: INFO: kube-proxy-mtjsn from kube-system started at 2018-08-08 19:42:39 +0000 UTC (1 container statuses recorded)
+Aug  8 19:58:43.303: INFO: 	Container kube-proxy ready: true, restart count 0
+Aug  8 19:58:43.304: INFO: sonobuoy from heptio-sonobuoy started at 2018-08-08 19:50:24 +0000 UTC (1 container statuses recorded)
+Aug  8 19:58:43.304: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Aug  8 19:58:43.304: INFO: sonobuoy-e2e-job-d01c3492ba7e47ed from heptio-sonobuoy started at 2018-08-08 19:50:30 +0000 UTC (2 container statuses recorded)
+Aug  8 19:58:43.304: INFO: 	Container e2e ready: true, restart count 0
+Aug  8 19:58:43.304: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Aug  8 19:58:43.304: INFO: sonobuoy-systemd-logs-daemon-set-806020c23a614e67-xhd79 from heptio-sonobuoy started at 2018-08-08 19:50:30 +0000 UTC (2 container statuses recorded)
+Aug  8 19:58:43.304: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 0
+Aug  8 19:58:43.304: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-7638e3a6-9b45-11e8-bae8-8697d7d38a55 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-7638e3a6-9b45-11e8-bae8-8697d7d38a55 off the node k8s-linuxpool-37994001-1
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-7638e3a6-9b45-11e8-bae8-8697d7d38a55
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:58:51.357: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-p69cb" for this suite.
+Aug  8 19:58:59.368: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:58:59.394: INFO: namespace: e2e-tests-sched-pred-p69cb, resource: bindings, ignored listing per whitelist
+Aug  8 19:58:59.431: INFO: namespace e2e-tests-sched-pred-p69cb deletion completed in 8.07191443s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:71
+
+• [SLOW TEST:76.277 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:58:59.431: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-7d7a161b-9b45-11e8-bae8-8697d7d38a55,GenerateName:,Namespace:e2e-tests-events-k7tl7,SelfLink:/api/v1/namespaces/e2e-tests-events-k7tl7/pods/send-events-7d7a161b-9b45-11e8-bae8-8697d7d38a55,UID:7d7b6f1b-9b45-11e8-ad47-001dd8b71c0d,ResourceVersion:3040,Generation:0,CreationTimestamp:2018-08-08 19:58:59 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 500192103,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-g428g {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-g428g,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-g428g true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File Always nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:k8s-linuxpool-37994001-1,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,Sysctls:[],},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc4210b7f20} {node.kubernetes.io/unreachable Exists  NoExecute 0xc4210b7f40}],HostAliases:[],PriorityClassName:,Priority:*0,DNSConfig:nil,ShareProcessNamespace:nil,ReadinessGates:[],},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 19:58:59 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 19:59:01 +0000 UTC  } {ContainersReady True 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 19:58:59 +0000 UTC  }],Message:,Reason:,HostIP:10.240.0.4,PodIP:10.244.1.27,StartTime:2018-08-08 19:58:59 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-08-08 19:59:01 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://c83411566bc4b8550a9723b6d89c617859df0328342d0d738f723ad1b2e69d21}],QOSClass:BestEffort,InitContainerStatuses:[],NominatedNodeName:,},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:59:07.530: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-k7tl7" for this suite.
+Aug  8 19:59:29.549: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:59:29.619: INFO: namespace: e2e-tests-events-k7tl7, resource: bindings, ignored listing per whitelist
+Aug  8 19:59:29.647: INFO: namespace e2e-tests-events-k7tl7 deletion completed in 22.113136033s
+
+• [SLOW TEST:30.216 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:59:29.647: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test env composition
+Aug  8 19:59:29.745: INFO: Waiting up to 5m0s for pod "var-expansion-8f8059e1-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-var-expansion-pwpjf" to be "success or failure"
+Aug  8 19:59:29.751: INFO: Pod "var-expansion-8f8059e1-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.505784ms
+Aug  8 19:59:31.755: INFO: Pod "var-expansion-8f8059e1-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009077197s
+Aug  8 19:59:33.759: INFO: Pod "var-expansion-8f8059e1-9b45-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013175016s
+STEP: Saw pod success
+Aug  8 19:59:33.759: INFO: Pod "var-expansion-8f8059e1-9b45-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 19:59:33.761: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod var-expansion-8f8059e1-9b45-11e8-bae8-8697d7d38a55 container dapi-container: <nil>
+STEP: delete the pod
+Aug  8 19:59:33.787: INFO: Waiting for pod var-expansion-8f8059e1-9b45-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 19:59:33.790: INFO: Pod var-expansion-8f8059e1-9b45-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:59:33.790: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-pwpjf" for this suite.
+Aug  8 19:59:39.802: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:59:39.818: INFO: namespace: e2e-tests-var-expansion-pwpjf, resource: bindings, ignored listing per whitelist
+Aug  8 19:59:39.885: INFO: namespace e2e-tests-var-expansion-pwpjf deletion completed in 6.092588892s
+
+• [SLOW TEST:10.238 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:59:39.885: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Aug  8 19:59:39.970: INFO: Waiting up to 5m0s for pod "pod-959885da-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-5gklc" to be "success or failure"
+Aug  8 19:59:39.974: INFO: Pod "pod-959885da-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 3.69639ms
+Aug  8 19:59:41.977: INFO: Pod "pod-959885da-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007171746s
+Aug  8 19:59:43.980: INFO: Pod "pod-959885da-9b45-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01035981s
+STEP: Saw pod success
+Aug  8 19:59:43.980: INFO: Pod "pod-959885da-9b45-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 19:59:43.983: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-959885da-9b45-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 19:59:43.997: INFO: Waiting for pod pod-959885da-9b45-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 19:59:43.999: INFO: Pod pod-959885da-9b45-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 19:59:43.999: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-5gklc" for this suite.
+Aug  8 19:59:50.013: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 19:59:50.023: INFO: namespace: e2e-tests-emptydir-5gklc, resource: bindings, ignored listing per whitelist
+Aug  8 19:59:50.094: INFO: namespace e2e-tests-emptydir-5gklc deletion completed in 6.092083721s
+
+• [SLOW TEST:10.208 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 19:59:50.094: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Aug  8 19:59:50.683: INFO: Waiting up to 5m0s for pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-dnx4m" in namespace "e2e-tests-svcaccounts-ltvds" to be "success or failure"
+Aug  8 19:59:50.693: INFO: Pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-dnx4m": Phase="Pending", Reason="", readiness=false. Elapsed: 9.473975ms
+Aug  8 19:59:52.696: INFO: Pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-dnx4m": Phase="Pending", Reason="", readiness=false. Elapsed: 2.012551675s
+Aug  8 19:59:54.700: INFO: Pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-dnx4m": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016275582s
+STEP: Saw pod success
+Aug  8 19:59:54.700: INFO: Pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-dnx4m" satisfied condition "success or failure"
+Aug  8 19:59:54.702: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-dnx4m container token-test: <nil>
+STEP: delete the pod
+Aug  8 19:59:54.722: INFO: Waiting for pod pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-dnx4m to disappear
+Aug  8 19:59:54.724: INFO: Pod pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-dnx4m no longer exists
+STEP: Creating a pod to test consume service account root CA
+Aug  8 19:59:54.727: INFO: Waiting up to 5m0s for pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-q6htn" in namespace "e2e-tests-svcaccounts-ltvds" to be "success or failure"
+Aug  8 19:59:54.733: INFO: Pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-q6htn": Phase="Pending", Reason="", readiness=false. Elapsed: 6.512182ms
+Aug  8 19:59:56.737: INFO: Pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-q6htn": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010094897s
+Aug  8 19:59:58.740: INFO: Pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-q6htn": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01382432s
+STEP: Saw pod success
+Aug  8 19:59:58.740: INFO: Pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-q6htn" satisfied condition "success or failure"
+Aug  8 19:59:58.743: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-q6htn container root-ca-test: <nil>
+STEP: delete the pod
+Aug  8 19:59:58.760: INFO: Waiting for pod pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-q6htn to disappear
+Aug  8 19:59:58.762: INFO: Pod pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-q6htn no longer exists
+STEP: Creating a pod to test consume service account namespace
+Aug  8 19:59:58.767: INFO: Waiting up to 5m0s for pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-gsbst" in namespace "e2e-tests-svcaccounts-ltvds" to be "success or failure"
+Aug  8 19:59:58.775: INFO: Pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-gsbst": Phase="Pending", Reason="", readiness=false. Elapsed: 8.511978ms
+Aug  8 20:00:00.778: INFO: Pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-gsbst": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011574409s
+Aug  8 20:00:02.783: INFO: Pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-gsbst": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016159346s
+STEP: Saw pod success
+Aug  8 20:00:02.783: INFO: Pod "pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-gsbst" satisfied condition "success or failure"
+Aug  8 20:00:02.786: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-gsbst container namespace-test: <nil>
+STEP: delete the pod
+Aug  8 20:00:02.804: INFO: Waiting for pod pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-gsbst to disappear
+Aug  8 20:00:02.806: INFO: Pod pod-service-account-9bfaf001-9b45-11e8-bae8-8697d7d38a55-gsbst no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:00:02.806: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-ltvds" for this suite.
+Aug  8 20:00:08.822: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:00:08.900: INFO: namespace: e2e-tests-svcaccounts-ltvds, resource: bindings, ignored listing per whitelist
+Aug  8 20:00:08.910: INFO: namespace e2e-tests-svcaccounts-ltvds deletion completed in 6.100270824s
+
+• [SLOW TEST:18.816 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:00:08.911: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Aug  8 20:00:17.038: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-blg7m PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:00:17.038: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:00:17.166: INFO: Exec stderr: ""
+Aug  8 20:00:17.166: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-blg7m PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:00:17.166: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:00:17.274: INFO: Exec stderr: ""
+Aug  8 20:00:17.274: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-blg7m PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:00:17.275: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:00:17.387: INFO: Exec stderr: ""
+Aug  8 20:00:17.388: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-blg7m PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:00:17.388: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:00:17.516: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Aug  8 20:00:17.516: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-blg7m PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:00:17.516: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:00:17.630: INFO: Exec stderr: ""
+Aug  8 20:00:17.630: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-blg7m PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:00:17.630: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:00:17.748: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Aug  8 20:00:17.748: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-blg7m PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:00:17.748: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:00:17.874: INFO: Exec stderr: ""
+Aug  8 20:00:17.875: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-blg7m PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:00:17.875: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:00:18.034: INFO: Exec stderr: ""
+Aug  8 20:00:18.034: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-blg7m PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:00:18.034: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:00:18.147: INFO: Exec stderr: ""
+Aug  8 20:00:18.147: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-blg7m PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:00:18.147: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:00:18.278: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:00:18.278: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-blg7m" for this suite.
+Aug  8 20:01:08.290: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:01:08.336: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-blg7m, resource: bindings, ignored listing per whitelist
+Aug  8 20:01:08.362: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-blg7m deletion completed in 50.080259831s
+
+• [SLOW TEST:59.451 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:01:08.362: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:01:08.446: INFO: Waiting up to 5m0s for pod "downwardapi-volume-ca54fbf2-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-kwgwl" to be "success or failure"
+Aug  8 20:01:08.450: INFO: Pod "downwardapi-volume-ca54fbf2-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 3.502691ms
+Aug  8 20:01:10.454: INFO: Pod "downwardapi-volume-ca54fbf2-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007706157s
+Aug  8 20:01:12.458: INFO: Pod "downwardapi-volume-ca54fbf2-9b45-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011043229s
+STEP: Saw pod success
+Aug  8 20:01:12.458: INFO: Pod "downwardapi-volume-ca54fbf2-9b45-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:01:12.460: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-ca54fbf2-9b45-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:01:12.477: INFO: Waiting for pod downwardapi-volume-ca54fbf2-9b45-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:01:12.480: INFO: Pod downwardapi-volume-ca54fbf2-9b45-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:01:12.480: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-kwgwl" for this suite.
+Aug  8 20:01:18.489: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:01:18.549: INFO: namespace: e2e-tests-projected-kwgwl, resource: bindings, ignored listing per whitelist
+Aug  8 20:01:18.564: INFO: namespace e2e-tests-projected-kwgwl deletion completed in 6.082004771s
+
+• [SLOW TEST:10.202 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:01:18.564: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Aug  8 20:01:18.659: INFO: Waiting up to 5m0s for pod "downward-api-d06b444a-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-pg6jx" to be "success or failure"
+Aug  8 20:01:18.665: INFO: Pod "downward-api-d06b444a-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 6.574483ms
+Aug  8 20:01:20.668: INFO: Pod "downward-api-d06b444a-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009624481s
+Aug  8 20:01:22.672: INFO: Pod "downward-api-d06b444a-9b45-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012854483s
+STEP: Saw pod success
+Aug  8 20:01:22.672: INFO: Pod "downward-api-d06b444a-9b45-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:01:22.674: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downward-api-d06b444a-9b45-11e8-bae8-8697d7d38a55 container dapi-container: <nil>
+STEP: delete the pod
+Aug  8 20:01:22.692: INFO: Waiting for pod downward-api-d06b444a-9b45-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:01:22.694: INFO: Pod downward-api-d06b444a-9b45-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:01:22.694: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-pg6jx" for this suite.
+Aug  8 20:01:28.704: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:01:28.766: INFO: namespace: e2e-tests-downward-api-pg6jx, resource: bindings, ignored listing per whitelist
+Aug  8 20:01:28.795: INFO: namespace e2e-tests-downward-api-pg6jx deletion completed in 6.099044314s
+
+• [SLOW TEST:10.231 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:01:28.796: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-d682c96b-9b45-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:01:28.882: INFO: Waiting up to 5m0s for pod "pod-configmaps-d6833879-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-configmap-mb6z6" to be "success or failure"
+Aug  8 20:01:28.887: INFO: Pod "pod-configmaps-d6833879-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.152187ms
+Aug  8 20:01:30.891: INFO: Pod "pod-configmaps-d6833879-9b45-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00920991s
+STEP: Saw pod success
+Aug  8 20:01:30.891: INFO: Pod "pod-configmaps-d6833879-9b45-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:01:30.894: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-configmaps-d6833879-9b45-11e8-bae8-8697d7d38a55 container configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:01:30.915: INFO: Waiting for pod pod-configmaps-d6833879-9b45-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:01:30.921: INFO: Pod pod-configmaps-d6833879-9b45-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:01:30.921: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-mb6z6" for this suite.
+Aug  8 20:01:36.941: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:01:36.975: INFO: namespace: e2e-tests-configmap-mb6z6, resource: bindings, ignored listing per whitelist
+Aug  8 20:01:37.019: INFO: namespace e2e-tests-configmap-mb6z6 deletion completed in 6.088495709s
+
+• [SLOW TEST:8.224 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:01:37.019: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir volume type on node default medium
+Aug  8 20:01:37.096: INFO: Waiting up to 5m0s for pod "pod-db687703-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-kx65l" to be "success or failure"
+Aug  8 20:01:37.099: INFO: Pod "pod-db687703-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 3.125492ms
+Aug  8 20:01:39.103: INFO: Pod "pod-db687703-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006673339s
+Aug  8 20:01:41.109: INFO: Pod "pod-db687703-9b45-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013033783s
+STEP: Saw pod success
+Aug  8 20:01:41.109: INFO: Pod "pod-db687703-9b45-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:01:41.111: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-db687703-9b45-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:01:41.127: INFO: Waiting for pod pod-db687703-9b45-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:01:41.129: INFO: Pod pod-db687703-9b45-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:01:41.129: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-kx65l" for this suite.
+Aug  8 20:01:47.143: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:01:47.152: INFO: namespace: e2e-tests-emptydir-kx65l, resource: bindings, ignored listing per whitelist
+Aug  8 20:01:47.248: INFO: namespace e2e-tests-emptydir-kx65l deletion completed in 6.116989819s
+
+• [SLOW TEST:10.229 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:01:47.249: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Aug  8 20:02:11.347: INFO: Container started at 2018-08-08 20:01:49 +0000 UTC, pod became ready at 2018-08-08 20:02:11 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:02:11.347: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-jx9t2" for this suite.
+Aug  8 20:02:33.365: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:02:33.407: INFO: namespace: e2e-tests-container-probe-jx9t2, resource: bindings, ignored listing per whitelist
+Aug  8 20:02:33.447: INFO: namespace e2e-tests-container-probe-jx9t2 deletion completed in 22.094833446s
+
+• [SLOW TEST:46.199 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:02:33.449: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:02:33.549: INFO: Waiting up to 5m0s for pod "downwardapi-volume-fd0ec583-9b45-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-qq9gb" to be "success or failure"
+Aug  8 20:02:33.555: INFO: Pod "downwardapi-volume-fd0ec583-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.728686ms
+Aug  8 20:02:35.558: INFO: Pod "downwardapi-volume-fd0ec583-9b45-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008871267s
+Aug  8 20:02:37.561: INFO: Pod "downwardapi-volume-fd0ec583-9b45-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012034451s
+STEP: Saw pod success
+Aug  8 20:02:37.562: INFO: Pod "downwardapi-volume-fd0ec583-9b45-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:02:37.566: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-fd0ec583-9b45-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:02:37.587: INFO: Waiting for pod downwardapi-volume-fd0ec583-9b45-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:02:37.590: INFO: Pod downwardapi-volume-fd0ec583-9b45-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:02:37.591: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qq9gb" for this suite.
+Aug  8 20:02:43.614: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:02:43.674: INFO: namespace: e2e-tests-projected-qq9gb, resource: bindings, ignored listing per whitelist
+Aug  8 20:02:43.692: INFO: namespace e2e-tests-projected-qq9gb deletion completed in 6.098143262s
+
+• [SLOW TEST:10.243 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:02:43.692: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: getting the auto-created API token
+Aug  8 20:02:44.287: INFO: created pod pod-service-account-defaultsa
+Aug  8 20:02:44.287: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Aug  8 20:02:44.291: INFO: created pod pod-service-account-mountsa
+Aug  8 20:02:44.291: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Aug  8 20:02:44.297: INFO: created pod pod-service-account-nomountsa
+Aug  8 20:02:44.297: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Aug  8 20:02:44.303: INFO: created pod pod-service-account-defaultsa-mountspec
+Aug  8 20:02:44.303: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Aug  8 20:02:44.312: INFO: created pod pod-service-account-mountsa-mountspec
+Aug  8 20:02:44.312: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Aug  8 20:02:44.320: INFO: created pod pod-service-account-nomountsa-mountspec
+Aug  8 20:02:44.320: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Aug  8 20:02:44.326: INFO: created pod pod-service-account-defaultsa-nomountspec
+Aug  8 20:02:44.326: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Aug  8 20:02:44.331: INFO: created pod pod-service-account-mountsa-nomountspec
+Aug  8 20:02:44.331: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Aug  8 20:02:44.337: INFO: created pod pod-service-account-nomountsa-nomountspec
+Aug  8 20:02:44.337: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:02:44.337: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-xwjs8" for this suite.
+Aug  8 20:03:06.358: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:03:06.437: INFO: namespace: e2e-tests-svcaccounts-xwjs8, resource: bindings, ignored listing per whitelist
+Aug  8 20:03:06.439: INFO: namespace e2e-tests-svcaccounts-xwjs8 deletion completed in 22.0953974s
+
+• [SLOW TEST:22.747 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:03:06.440: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-5rr2r
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-5rr2r to expose endpoints map[]
+Aug  8 20:03:06.538: INFO: Get endpoints failed (2.105095ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Aug  8 20:03:07.541: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-5rr2r exposes endpoints map[] (1.005473663s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-5rr2r
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-5rr2r to expose endpoints map[pod1:[100]]
+Aug  8 20:03:10.586: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-5rr2r exposes endpoints map[pod1:[100]] (3.036599345s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-5rr2r
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-5rr2r to expose endpoints map[pod1:[100] pod2:[101]]
+Aug  8 20:03:13.627: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-5rr2r exposes endpoints map[pod1:[100] pod2:[101]] (3.038589149s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-5rr2r
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-5rr2r to expose endpoints map[pod2:[101]]
+Aug  8 20:03:14.644: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-5rr2r exposes endpoints map[pod2:[101]] (1.01332745s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-5rr2r
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-5rr2r to expose endpoints map[]
+Aug  8 20:03:15.658: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-5rr2r exposes endpoints map[] (1.010367259s elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:03:15.673: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-5rr2r" for this suite.
+Aug  8 20:03:37.688: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:03:37.790: INFO: namespace: e2e-tests-services-5rr2r, resource: bindings, ignored listing per whitelist
+Aug  8 20:03:37.807: INFO: namespace e2e-tests-services-5rr2r deletion completed in 22.129982748s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:31.367 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:03:37.807: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-map-2369c6e2-9b46-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:03:37.908: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-236a6f9d-9b46-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-t2tqx" to be "success or failure"
+Aug  8 20:03:37.913: INFO: Pod "pod-projected-secrets-236a6f9d-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.000888ms
+Aug  8 20:03:39.916: INFO: Pod "pod-projected-secrets-236a6f9d-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008149388s
+Aug  8 20:03:41.919: INFO: Pod "pod-projected-secrets-236a6f9d-9b46-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011623091s
+STEP: Saw pod success
+Aug  8 20:03:41.919: INFO: Pod "pod-projected-secrets-236a6f9d-9b46-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:03:41.923: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-secrets-236a6f9d-9b46-11e8-bae8-8697d7d38a55 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:03:41.936: INFO: Waiting for pod pod-projected-secrets-236a6f9d-9b46-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:03:41.938: INFO: Pod pod-projected-secrets-236a6f9d-9b46-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:03:41.938: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-t2tqx" for this suite.
+Aug  8 20:03:47.950: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:03:47.998: INFO: namespace: e2e-tests-projected-t2tqx, resource: bindings, ignored listing per whitelist
+Aug  8 20:03:48.019: INFO: namespace e2e-tests-projected-t2tqx deletion completed in 6.077094869s
+
+• [SLOW TEST:10.212 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:03:48.019: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:03:48.104: INFO: Waiting up to 5m0s for pod "downwardapi-volume-297f0001-9b46-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-q88gr" to be "success or failure"
+Aug  8 20:03:48.109: INFO: Pod "downwardapi-volume-297f0001-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 4.629289ms
+Aug  8 20:03:50.112: INFO: Pod "downwardapi-volume-297f0001-9b46-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007207907s
+STEP: Saw pod success
+Aug  8 20:03:50.112: INFO: Pod "downwardapi-volume-297f0001-9b46-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:03:50.114: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-297f0001-9b46-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:03:50.128: INFO: Waiting for pod downwardapi-volume-297f0001-9b46-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:03:50.130: INFO: Pod downwardapi-volume-297f0001-9b46-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:03:50.130: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-q88gr" for this suite.
+Aug  8 20:03:56.142: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:03:56.168: INFO: namespace: e2e-tests-projected-q88gr, resource: bindings, ignored listing per whitelist
+Aug  8 20:03:56.237: INFO: namespace e2e-tests-projected-q88gr deletion completed in 6.103732645s
+
+• [SLOW TEST:8.217 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:03:56.237: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name projected-secret-test-2e647926-9b46-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:03:56.324: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-2e64eeae-9b46-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-dhzm9" to be "success or failure"
+Aug  8 20:03:56.329: INFO: Pod "pod-projected-secrets-2e64eeae-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 4.482089ms
+Aug  8 20:03:58.332: INFO: Pod "pod-projected-secrets-2e64eeae-9b46-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007847918s
+STEP: Saw pod success
+Aug  8 20:03:58.332: INFO: Pod "pod-projected-secrets-2e64eeae-9b46-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:03:58.335: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-secrets-2e64eeae-9b46-11e8-bae8-8697d7d38a55 container secret-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:03:58.350: INFO: Waiting for pod pod-projected-secrets-2e64eeae-9b46-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:03:58.355: INFO: Pod pod-projected-secrets-2e64eeae-9b46-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:03:58.355: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-dhzm9" for this suite.
+Aug  8 20:04:04.366: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:04:04.406: INFO: namespace: e2e-tests-projected-dhzm9, resource: bindings, ignored listing per whitelist
+Aug  8 20:04:04.451: INFO: namespace e2e-tests-projected-dhzm9 deletion completed in 6.093445606s
+
+• [SLOW TEST:8.214 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:04:04.452: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Aug  8 20:04:04.545: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:04.547: INFO: Number of nodes with available pods: 0
+Aug  8 20:04:04.547: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:04:05.551: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:05.554: INFO: Number of nodes with available pods: 0
+Aug  8 20:04:05.554: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:04:06.551: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:06.557: INFO: Number of nodes with available pods: 1
+Aug  8 20:04:06.557: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:04:07.551: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:07.553: INFO: Number of nodes with available pods: 2
+Aug  8 20:04:07.553: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Stop a daemon pod, check that the daemon pod is revived.
+Aug  8 20:04:07.567: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:07.570: INFO: Number of nodes with available pods: 1
+Aug  8 20:04:07.570: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:04:08.574: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:08.577: INFO: Number of nodes with available pods: 1
+Aug  8 20:04:08.577: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:04:09.576: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:09.587: INFO: Number of nodes with available pods: 1
+Aug  8 20:04:09.587: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:04:10.574: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:10.577: INFO: Number of nodes with available pods: 1
+Aug  8 20:04:10.577: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:04:11.573: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:11.576: INFO: Number of nodes with available pods: 1
+Aug  8 20:04:11.576: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:04:12.573: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:12.580: INFO: Number of nodes with available pods: 1
+Aug  8 20:04:12.580: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:04:13.573: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:13.576: INFO: Number of nodes with available pods: 1
+Aug  8 20:04:13.576: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:04:14.573: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:14.577: INFO: Number of nodes with available pods: 1
+Aug  8 20:04:14.577: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:04:15.573: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:04:15.577: INFO: Number of nodes with available pods: 2
+Aug  8 20:04:15.577: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-tswcg, will wait for the garbage collector to delete the pods
+Aug  8 20:04:15.639: INFO: Deleting {extensions DaemonSet} daemon-set took: 6.023186ms
+Aug  8 20:04:15.739: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.243162ms
+Aug  8 20:04:19.343: INFO: Number of nodes with available pods: 0
+Aug  8 20:04:19.343: INFO: Number of running nodes: 0, number of available pods: 0
+Aug  8 20:04:19.348: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-tswcg/daemonsets","resourceVersion":"4209"},"items":null}
+
+Aug  8 20:04:19.351: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-tswcg/pods","resourceVersion":"4209"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:04:19.365: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-tswcg" for this suite.
+Aug  8 20:04:25.383: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:04:25.444: INFO: namespace: e2e-tests-daemonsets-tswcg, resource: bindings, ignored listing per whitelist
+Aug  8 20:04:25.459: INFO: namespace e2e-tests-daemonsets-tswcg deletion completed in 6.090145507s
+
+• [SLOW TEST:21.007 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:04:25.459: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Aug  8 20:04:29.570: INFO: Waiting up to 5m0s for pod "client-envvars-42362c17-9b46-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-pods-v958p" to be "success or failure"
+Aug  8 20:04:29.578: INFO: Pod "client-envvars-42362c17-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 7.924881ms
+Aug  8 20:04:31.582: INFO: Pod "client-envvars-42362c17-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011642357s
+Aug  8 20:04:33.586: INFO: Pod "client-envvars-42362c17-9b46-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015496134s
+STEP: Saw pod success
+Aug  8 20:04:33.586: INFO: Pod "client-envvars-42362c17-9b46-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:04:33.591: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod client-envvars-42362c17-9b46-11e8-bae8-8697d7d38a55 container env3cont: <nil>
+STEP: delete the pod
+Aug  8 20:04:33.609: INFO: Waiting for pod client-envvars-42362c17-9b46-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:04:33.611: INFO: Pod client-envvars-42362c17-9b46-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:04:33.612: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-v958p" for this suite.
+Aug  8 20:04:55.632: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:04:55.671: INFO: namespace: e2e-tests-pods-v958p, resource: bindings, ignored listing per whitelist
+Aug  8 20:04:55.738: INFO: namespace e2e-tests-pods-v958p deletion completed in 22.121119245s
+
+• [SLOW TEST:30.279 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:04:55.738: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-h8sfj
+Aug  8 20:04:59.848: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-h8sfj
+STEP: checking the pod's current state and verifying that restartCount is present
+Aug  8 20:04:59.850: INFO: Initial restart count of pod liveness-http is 0
+Aug  8 20:05:25.900: INFO: Restart count of pod e2e-tests-container-probe-h8sfj/liveness-http is now 1 (26.049534158s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:05:25.910: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-h8sfj" for this suite.
+Aug  8 20:05:31.928: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:05:31.964: INFO: namespace: e2e-tests-container-probe-h8sfj, resource: bindings, ignored listing per whitelist
+Aug  8 20:05:32.015: INFO: namespace e2e-tests-container-probe-h8sfj deletion completed in 6.101065627s
+
+• [SLOW TEST:36.276 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Pods 
+  should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:05:32.015: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating pod
+Aug  8 20:05:36.120: INFO: Pod pod-hostip-677c9ede-9b46-11e8-bae8-8697d7d38a55 has hostIP: 10.240.0.4
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:05:36.120: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-bz2lq" for this suite.
+Aug  8 20:05:58.138: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:05:58.146: INFO: namespace: e2e-tests-pods-bz2lq, resource: bindings, ignored listing per whitelist
+Aug  8 20:05:58.212: INFO: namespace e2e-tests-pods-bz2lq deletion completed in 22.088588095s
+
+• [SLOW TEST:26.197 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:05:58.212: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-np6mj
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-np6mj to expose endpoints map[]
+Aug  8 20:05:58.304: INFO: Get endpoints failed (2.956593ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Aug  8 20:05:59.307: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-np6mj exposes endpoints map[] (1.006477377s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-np6mj
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-np6mj to expose endpoints map[pod1:[80]]
+Aug  8 20:06:01.329: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-np6mj exposes endpoints map[pod1:[80]] (2.015608749s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-np6mj
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-np6mj to expose endpoints map[pod1:[80] pod2:[80]]
+Aug  8 20:06:04.375: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-np6mj exposes endpoints map[pod1:[80] pod2:[80]] (3.042503584s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-np6mj
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-np6mj to expose endpoints map[pod2:[80]]
+Aug  8 20:06:05.393: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-np6mj exposes endpoints map[pod2:[80]] (1.014503761s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-np6mj
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-np6mj to expose endpoints map[]
+Aug  8 20:06:06.408: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-np6mj exposes endpoints map[] (1.01114307s elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:06:06.424: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-np6mj" for this suite.
+Aug  8 20:06:28.449: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:06:28.477: INFO: namespace: e2e-tests-services-np6mj, resource: bindings, ignored listing per whitelist
+Aug  8 20:06:28.528: INFO: namespace e2e-tests-services-np6mj deletion completed in 22.093681595s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:30.316 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:06:28.528: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:06:28.611: INFO: Waiting up to 5m0s for pod "downwardapi-volume-892a4e7c-9b46-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-mr76q" to be "success or failure"
+Aug  8 20:06:28.613: INFO: Pod "downwardapi-volume-892a4e7c-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.139495ms
+Aug  8 20:06:30.616: INFO: Pod "downwardapi-volume-892a4e7c-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005481599s
+Aug  8 20:06:32.620: INFO: Pod "downwardapi-volume-892a4e7c-9b46-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009144704s
+STEP: Saw pod success
+Aug  8 20:06:32.620: INFO: Pod "downwardapi-volume-892a4e7c-9b46-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:06:32.622: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-892a4e7c-9b46-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:06:32.650: INFO: Waiting for pod downwardapi-volume-892a4e7c-9b46-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:06:32.652: INFO: Pod downwardapi-volume-892a4e7c-9b46-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:06:32.652: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-mr76q" for this suite.
+Aug  8 20:06:38.664: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:06:38.750: INFO: namespace: e2e-tests-downward-api-mr76q, resource: bindings, ignored listing per whitelist
+Aug  8 20:06:38.768: INFO: namespace e2e-tests-downward-api-mr76q deletion completed in 6.112178393s
+
+• [SLOW TEST:10.240 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:06:38.769: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-8f48a2bd-9b46-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:06:38.884: INFO: Waiting up to 5m0s for pod "pod-configmaps-8f495297-9b46-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-configmap-sb8k4" to be "success or failure"
+Aug  8 20:06:38.889: INFO: Pod "pod-configmaps-8f495297-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.150089ms
+Aug  8 20:06:40.892: INFO: Pod "pod-configmaps-8f495297-9b46-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008248801s
+STEP: Saw pod success
+Aug  8 20:06:40.892: INFO: Pod "pod-configmaps-8f495297-9b46-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:06:40.894: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-configmaps-8f495297-9b46-11e8-bae8-8697d7d38a55 container configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:06:40.910: INFO: Waiting for pod pod-configmaps-8f495297-9b46-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:06:40.912: INFO: Pod pod-configmaps-8f495297-9b46-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:06:40.912: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-sb8k4" for this suite.
+Aug  8 20:06:46.925: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:06:46.945: INFO: namespace: e2e-tests-configmap-sb8k4, resource: bindings, ignored listing per whitelist
+Aug  8 20:06:47.011: INFO: namespace e2e-tests-configmap-sb8k4 deletion completed in 6.095945467s
+
+• [SLOW TEST:8.242 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:06:47.012: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-9430ca79-9b46-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:06:47.115: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-94318509-9b46-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-g6z92" to be "success or failure"
+Aug  8 20:06:47.118: INFO: Pod "pod-projected-configmaps-94318509-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.894325ms
+Aug  8 20:06:49.122: INFO: Pod "pod-projected-configmaps-94318509-9b46-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00648s
+STEP: Saw pod success
+Aug  8 20:06:49.122: INFO: Pod "pod-projected-configmaps-94318509-9b46-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:06:49.124: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-configmaps-94318509-9b46-11e8-bae8-8697d7d38a55 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:06:49.140: INFO: Waiting for pod pod-projected-configmaps-94318509-9b46-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:06:49.142: INFO: Pod pod-projected-configmaps-94318509-9b46-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:06:49.142: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-g6z92" for this suite.
+Aug  8 20:06:55.157: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:06:55.173: INFO: namespace: e2e-tests-projected-g6z92, resource: bindings, ignored listing per whitelist
+Aug  8 20:06:55.224: INFO: namespace e2e-tests-projected-g6z92 deletion completed in 6.077949741s
+
+• [SLOW TEST:8.212 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:06:55.224: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-k4jlc
+I0808 20:06:55.306729      17 runners.go:177] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-k4jlc, replica count: 1
+I0808 20:06:56.357236      17 runners.go:177] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0808 20:06:57.357419      17 runners.go:177] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Aug  8 20:06:57.470: INFO: Created: latency-svc-9krq7
+Aug  8 20:06:57.479: INFO: Got endpoints: latency-svc-9krq7 [22.024284ms]
+Aug  8 20:06:57.493: INFO: Created: latency-svc-5vr4q
+Aug  8 20:06:57.502: INFO: Got endpoints: latency-svc-5vr4q [22.320687ms]
+Aug  8 20:06:57.505: INFO: Created: latency-svc-r8x67
+Aug  8 20:06:57.511: INFO: Got endpoints: latency-svc-r8x67 [31.362762ms]
+Aug  8 20:06:57.511: INFO: Created: latency-svc-smbng
+Aug  8 20:06:57.516: INFO: Got endpoints: latency-svc-smbng [36.425504ms]
+Aug  8 20:06:57.517: INFO: Created: latency-svc-jtvlz
+Aug  8 20:06:57.522: INFO: Got endpoints: latency-svc-jtvlz [42.801057ms]
+Aug  8 20:06:57.524: INFO: Created: latency-svc-hphf5
+Aug  8 20:06:57.529: INFO: Got endpoints: latency-svc-hphf5 [49.156211ms]
+Aug  8 20:06:57.529: INFO: Created: latency-svc-2vw9k
+Aug  8 20:06:57.541: INFO: Got endpoints: latency-svc-2vw9k [24.781407ms]
+Aug  8 20:06:57.541: INFO: Created: latency-svc-xg6ph
+Aug  8 20:06:57.554: INFO: Got endpoints: latency-svc-xg6ph [74.545622ms]
+Aug  8 20:06:57.563: INFO: Created: latency-svc-xs4zj
+Aug  8 20:06:57.569: INFO: Got endpoints: latency-svc-xs4zj [89.030543ms]
+Aug  8 20:06:57.570: INFO: Created: latency-svc-6xlpm
+Aug  8 20:06:57.576: INFO: Got endpoints: latency-svc-6xlpm [96.379005ms]
+Aug  8 20:06:57.580: INFO: Created: latency-svc-mj5rg
+Aug  8 20:06:57.580: INFO: Got endpoints: latency-svc-mj5rg [100.006635ms]
+Aug  8 20:06:57.596: INFO: Created: latency-svc-dtckl
+Aug  8 20:06:57.618: INFO: Created: latency-svc-x6kvk
+Aug  8 20:06:57.621: INFO: Got endpoints: latency-svc-dtckl [141.611983ms]
+Aug  8 20:06:57.622: INFO: Got endpoints: latency-svc-x6kvk [142.282988ms]
+Aug  8 20:06:57.636: INFO: Created: latency-svc-rtbpw
+Aug  8 20:06:57.638: INFO: Created: latency-svc-mgjdh
+Aug  8 20:06:57.638: INFO: Got endpoints: latency-svc-rtbpw [158.313722ms]
+Aug  8 20:06:57.649: INFO: Got endpoints: latency-svc-mgjdh [169.139012ms]
+Aug  8 20:06:57.652: INFO: Created: latency-svc-dvtbs
+Aug  8 20:06:57.654: INFO: Got endpoints: latency-svc-dvtbs [173.973753ms]
+Aug  8 20:06:57.654: INFO: Created: latency-svc-96kn6
+Aug  8 20:06:57.663: INFO: Created: latency-svc-dshtq
+Aug  8 20:06:57.665: INFO: Got endpoints: latency-svc-96kn6 [185.388447ms]
+Aug  8 20:06:57.670: INFO: Created: latency-svc-fxw7f
+Aug  8 20:06:57.670: INFO: Got endpoints: latency-svc-dshtq [168.721309ms]
+Aug  8 20:06:57.674: INFO: Got endpoints: latency-svc-fxw7f [163.432265ms]
+Aug  8 20:06:57.680: INFO: Created: latency-svc-g8gx9
+Aug  8 20:06:57.686: INFO: Created: latency-svc-vv4h8
+Aug  8 20:06:57.688: INFO: Got endpoints: latency-svc-g8gx9 [165.795384ms]
+Aug  8 20:06:57.701: INFO: Got endpoints: latency-svc-vv4h8 [171.963736ms]
+Aug  8 20:06:57.701: INFO: Created: latency-svc-b24j8
+Aug  8 20:06:57.709: INFO: Got endpoints: latency-svc-b24j8 [167.769701ms]
+Aug  8 20:06:57.711: INFO: Created: latency-svc-n9pj4
+Aug  8 20:06:57.725: INFO: Got endpoints: latency-svc-n9pj4 [170.507623ms]
+Aug  8 20:06:57.729: INFO: Created: latency-svc-qv7m8
+Aug  8 20:06:57.734: INFO: Created: latency-svc-6cwxv
+Aug  8 20:06:57.734: INFO: Got endpoints: latency-svc-qv7m8 [165.081578ms]
+Aug  8 20:06:57.736: INFO: Got endpoints: latency-svc-6cwxv [160.068737ms]
+Aug  8 20:06:57.746: INFO: Created: latency-svc-csn6j
+Aug  8 20:06:57.751: INFO: Got endpoints: latency-svc-csn6j [171.795934ms]
+Aug  8 20:06:57.752: INFO: Created: latency-svc-qnb27
+Aug  8 20:06:57.760: INFO: Created: latency-svc-hr64v
+Aug  8 20:06:57.760: INFO: Got endpoints: latency-svc-qnb27 [138.91996ms]
+Aug  8 20:06:57.766: INFO: Got endpoints: latency-svc-hr64v [143.799301ms]
+Aug  8 20:06:57.777: INFO: Created: latency-svc-frrmv
+Aug  8 20:06:57.777: INFO: Got endpoints: latency-svc-frrmv [139.104262ms]
+Aug  8 20:06:57.785: INFO: Created: latency-svc-jzspp
+Aug  8 20:06:57.791: INFO: Got endpoints: latency-svc-jzspp [142.267088ms]
+Aug  8 20:06:57.794: INFO: Created: latency-svc-fxbt4
+Aug  8 20:06:57.794: INFO: Got endpoints: latency-svc-fxbt4 [140.259772ms]
+Aug  8 20:06:57.801: INFO: Created: latency-svc-qvssk
+Aug  8 20:06:57.808: INFO: Got endpoints: latency-svc-qvssk [142.444189ms]
+Aug  8 20:06:57.808: INFO: Created: latency-svc-5x7wv
+Aug  8 20:06:57.810: INFO: Got endpoints: latency-svc-5x7wv [139.184862ms]
+Aug  8 20:06:57.821: INFO: Created: latency-svc-j4htc
+Aug  8 20:06:57.833: INFO: Got endpoints: latency-svc-j4htc [159.26023ms]
+Aug  8 20:06:57.837: INFO: Created: latency-svc-8jm9q
+Aug  8 20:06:57.842: INFO: Got endpoints: latency-svc-8jm9q [153.997986ms]
+Aug  8 20:06:57.843: INFO: Created: latency-svc-n27f8
+Aug  8 20:06:57.848: INFO: Got endpoints: latency-svc-n27f8 [147.148229ms]
+Aug  8 20:06:57.850: INFO: Created: latency-svc-dxntt
+Aug  8 20:06:57.856: INFO: Got endpoints: latency-svc-dxntt [147.354431ms]
+Aug  8 20:06:57.856: INFO: Created: latency-svc-pgnrr
+Aug  8 20:06:57.868: INFO: Created: latency-svc-frdmr
+Aug  8 20:06:57.873: INFO: Got endpoints: latency-svc-pgnrr [148.665341ms]
+Aug  8 20:06:57.878: INFO: Created: latency-svc-c8tdw
+Aug  8 20:06:57.884: INFO: Created: latency-svc-t8bl9
+Aug  8 20:06:57.894: INFO: Created: latency-svc-sq592
+Aug  8 20:06:57.910: INFO: Created: latency-svc-bgwn7
+Aug  8 20:06:57.915: INFO: Created: latency-svc-qngf4
+Aug  8 20:06:57.925: INFO: Created: latency-svc-lw7qw
+Aug  8 20:06:57.926: INFO: Got endpoints: latency-svc-frdmr [191.930202ms]
+Aug  8 20:06:57.942: INFO: Created: latency-svc-6cbgc
+Aug  8 20:06:57.952: INFO: Created: latency-svc-sflvs
+Aug  8 20:06:57.959: INFO: Created: latency-svc-5wr6s
+Aug  8 20:06:57.966: INFO: Created: latency-svc-xvktj
+Aug  8 20:06:57.977: INFO: Created: latency-svc-qzswq
+Aug  8 20:06:57.978: INFO: Got endpoints: latency-svc-c8tdw [241.565017ms]
+Aug  8 20:06:57.995: INFO: Created: latency-svc-gwgmf
+Aug  8 20:06:58.004: INFO: Created: latency-svc-fzsc4
+Aug  8 20:06:58.015: INFO: Created: latency-svc-stbfq
+Aug  8 20:06:58.030: INFO: Got endpoints: latency-svc-t8bl9 [278.755127ms]
+Aug  8 20:06:58.030: INFO: Created: latency-svc-hp2zb
+Aug  8 20:06:58.037: INFO: Created: latency-svc-5fg8g
+Aug  8 20:06:58.066: INFO: Created: latency-svc-jvw2x
+Aug  8 20:06:58.074: INFO: Got endpoints: latency-svc-sq592 [313.470116ms]
+Aug  8 20:06:58.085: INFO: Created: latency-svc-9dpcp
+Aug  8 20:06:58.123: INFO: Got endpoints: latency-svc-bgwn7 [357.463683ms]
+Aug  8 20:06:58.139: INFO: Created: latency-svc-2c4b6
+Aug  8 20:06:58.174: INFO: Got endpoints: latency-svc-qngf4 [396.78351ms]
+Aug  8 20:06:58.183: INFO: Created: latency-svc-sg5tc
+Aug  8 20:06:58.225: INFO: Got endpoints: latency-svc-lw7qw [434.086121ms]
+Aug  8 20:06:58.236: INFO: Created: latency-svc-lrmsl
+Aug  8 20:06:58.279: INFO: Got endpoints: latency-svc-6cbgc [485.101045ms]
+Aug  8 20:06:58.298: INFO: Created: latency-svc-nmtfg
+Aug  8 20:06:58.324: INFO: Got endpoints: latency-svc-sflvs [516.336105ms]
+Aug  8 20:06:58.342: INFO: Created: latency-svc-mcntb
+Aug  8 20:06:58.373: INFO: Got endpoints: latency-svc-5wr6s [563.265496ms]
+Aug  8 20:06:58.390: INFO: Created: latency-svc-nz5fq
+Aug  8 20:06:58.425: INFO: Got endpoints: latency-svc-xvktj [591.218929ms]
+Aug  8 20:06:58.435: INFO: Created: latency-svc-jwq77
+Aug  8 20:06:58.474: INFO: Got endpoints: latency-svc-qzswq [631.358363ms]
+Aug  8 20:06:58.488: INFO: Created: latency-svc-zmd76
+Aug  8 20:06:58.523: INFO: Got endpoints: latency-svc-gwgmf [675.43823ms]
+Aug  8 20:06:58.541: INFO: Created: latency-svc-d47hk
+Aug  8 20:06:58.576: INFO: Got endpoints: latency-svc-fzsc4 [719.626998ms]
+Aug  8 20:06:58.589: INFO: Created: latency-svc-t4b64
+Aug  8 20:06:58.625: INFO: Got endpoints: latency-svc-stbfq [751.350163ms]
+Aug  8 20:06:58.641: INFO: Created: latency-svc-j7x46
+Aug  8 20:06:58.672: INFO: Got endpoints: latency-svc-hp2zb [746.41242ms]
+Aug  8 20:06:58.685: INFO: Created: latency-svc-2gxlw
+Aug  8 20:06:58.727: INFO: Got endpoints: latency-svc-5fg8g [748.860839ms]
+Aug  8 20:06:58.740: INFO: Created: latency-svc-4j2vl
+Aug  8 20:06:58.773: INFO: Got endpoints: latency-svc-jvw2x [742.881589ms]
+Aug  8 20:06:58.794: INFO: Created: latency-svc-zf8tt
+Aug  8 20:06:58.833: INFO: Got endpoints: latency-svc-9dpcp [758.855323ms]
+Aug  8 20:06:58.846: INFO: Created: latency-svc-5zrwb
+Aug  8 20:06:58.873: INFO: Got endpoints: latency-svc-2c4b6 [749.850348ms]
+Aug  8 20:06:58.884: INFO: Created: latency-svc-q488f
+Aug  8 20:06:58.923: INFO: Got endpoints: latency-svc-sg5tc [748.98504ms]
+Aug  8 20:06:58.944: INFO: Created: latency-svc-qh2s7
+Aug  8 20:06:58.974: INFO: Got endpoints: latency-svc-lrmsl [748.188633ms]
+Aug  8 20:06:58.985: INFO: Created: latency-svc-zqgbp
+Aug  8 20:06:59.024: INFO: Got endpoints: latency-svc-nmtfg [745.160108ms]
+Aug  8 20:06:59.037: INFO: Created: latency-svc-xtw2n
+Aug  8 20:06:59.072: INFO: Got endpoints: latency-svc-mcntb [748.320533ms]
+Aug  8 20:06:59.086: INFO: Created: latency-svc-fdrvf
+Aug  8 20:06:59.123: INFO: Got endpoints: latency-svc-nz5fq [750.309949ms]
+Aug  8 20:06:59.137: INFO: Created: latency-svc-swgkd
+Aug  8 20:06:59.176: INFO: Got endpoints: latency-svc-jwq77 [751.382957ms]
+Aug  8 20:06:59.197: INFO: Created: latency-svc-2zp8z
+Aug  8 20:06:59.224: INFO: Got endpoints: latency-svc-zmd76 [750.135246ms]
+Aug  8 20:06:59.238: INFO: Created: latency-svc-p9z46
+Aug  8 20:06:59.280: INFO: Got endpoints: latency-svc-d47hk [756.917601ms]
+Aug  8 20:06:59.298: INFO: Created: latency-svc-hr4sm
+Aug  8 20:06:59.323: INFO: Got endpoints: latency-svc-t4b64 [747.618823ms]
+Aug  8 20:06:59.334: INFO: Created: latency-svc-nxxqb
+Aug  8 20:06:59.375: INFO: Got endpoints: latency-svc-j7x46 [749.918141ms]
+Aug  8 20:06:59.396: INFO: Created: latency-svc-297lk
+Aug  8 20:06:59.423: INFO: Got endpoints: latency-svc-2gxlw [750.859048ms]
+Aug  8 20:06:59.438: INFO: Created: latency-svc-9xbpr
+Aug  8 20:06:59.475: INFO: Got endpoints: latency-svc-4j2vl [747.797222ms]
+Aug  8 20:06:59.494: INFO: Created: latency-svc-hnmmx
+Aug  8 20:06:59.523: INFO: Got endpoints: latency-svc-zf8tt [749.894738ms]
+Aug  8 20:06:59.537: INFO: Created: latency-svc-8rr7s
+Aug  8 20:06:59.574: INFO: Got endpoints: latency-svc-5zrwb [741.722869ms]
+Aug  8 20:06:59.588: INFO: Created: latency-svc-5tp9j
+Aug  8 20:06:59.623: INFO: Got endpoints: latency-svc-q488f [749.181631ms]
+Aug  8 20:06:59.636: INFO: Created: latency-svc-q8jts
+Aug  8 20:06:59.677: INFO: Got endpoints: latency-svc-qh2s7 [754.141371ms]
+Aug  8 20:06:59.695: INFO: Created: latency-svc-ff8gr
+Aug  8 20:06:59.722: INFO: Got endpoints: latency-svc-zqgbp [748.435922ms]
+Aug  8 20:06:59.735: INFO: Created: latency-svc-4lknm
+Aug  8 20:06:59.773: INFO: Got endpoints: latency-svc-xtw2n [748.165219ms]
+Aug  8 20:06:59.784: INFO: Created: latency-svc-sbhsl
+Aug  8 20:06:59.823: INFO: Got endpoints: latency-svc-fdrvf [750.307437ms]
+Aug  8 20:06:59.832: INFO: Created: latency-svc-nwm4d
+Aug  8 20:06:59.874: INFO: Got endpoints: latency-svc-swgkd [749.879133ms]
+Aug  8 20:06:59.887: INFO: Created: latency-svc-98tpc
+Aug  8 20:06:59.948: INFO: Got endpoints: latency-svc-2zp8z [772.146918ms]
+Aug  8 20:06:59.967: INFO: Created: latency-svc-rtkpr
+Aug  8 20:06:59.974: INFO: Got endpoints: latency-svc-p9z46 [750.150836ms]
+Aug  8 20:06:59.988: INFO: Created: latency-svc-thp6t
+Aug  8 20:07:00.024: INFO: Got endpoints: latency-svc-hr4sm [743.516381ms]
+Aug  8 20:07:00.042: INFO: Created: latency-svc-rd7bk
+Aug  8 20:07:00.073: INFO: Got endpoints: latency-svc-nxxqb [749.270727ms]
+Aug  8 20:07:00.089: INFO: Created: latency-svc-qhfpc
+Aug  8 20:07:00.127: INFO: Got endpoints: latency-svc-297lk [752.234051ms]
+Aug  8 20:07:00.144: INFO: Created: latency-svc-jn5cs
+Aug  8 20:07:00.173: INFO: Got endpoints: latency-svc-9xbpr [750.007632ms]
+Aug  8 20:07:00.184: INFO: Created: latency-svc-jqhbl
+Aug  8 20:07:00.223: INFO: Got endpoints: latency-svc-hnmmx [748.408718ms]
+Aug  8 20:07:00.238: INFO: Created: latency-svc-xgb4z
+Aug  8 20:07:00.274: INFO: Got endpoints: latency-svc-8rr7s [751.083539ms]
+Aug  8 20:07:00.286: INFO: Created: latency-svc-ppvzf
+Aug  8 20:07:00.322: INFO: Got endpoints: latency-svc-5tp9j [747.777511ms]
+Aug  8 20:07:00.335: INFO: Created: latency-svc-xbcv2
+Aug  8 20:07:00.381: INFO: Got endpoints: latency-svc-q8jts [758.056695ms]
+Aug  8 20:07:00.398: INFO: Created: latency-svc-m8zqg
+Aug  8 20:07:00.427: INFO: Got endpoints: latency-svc-ff8gr [749.728525ms]
+Aug  8 20:07:00.444: INFO: Created: latency-svc-mbmdd
+Aug  8 20:07:00.474: INFO: Got endpoints: latency-svc-4lknm [751.325337ms]
+Aug  8 20:07:00.494: INFO: Created: latency-svc-lzh9n
+Aug  8 20:07:00.523: INFO: Got endpoints: latency-svc-sbhsl [749.897625ms]
+Aug  8 20:07:00.537: INFO: Created: latency-svc-kl625
+Aug  8 20:07:00.573: INFO: Got endpoints: latency-svc-nwm4d [750.63703ms]
+Aug  8 20:07:00.589: INFO: Created: latency-svc-ck4nv
+Aug  8 20:07:00.625: INFO: Got endpoints: latency-svc-98tpc [751.705738ms]
+Aug  8 20:07:00.640: INFO: Created: latency-svc-wcbr5
+Aug  8 20:07:00.673: INFO: Got endpoints: latency-svc-rtkpr [724.813514ms]
+Aug  8 20:07:00.686: INFO: Created: latency-svc-gd8xl
+Aug  8 20:07:00.722: INFO: Got endpoints: latency-svc-thp6t [748.073106ms]
+Aug  8 20:07:00.734: INFO: Created: latency-svc-xdjdf
+Aug  8 20:07:00.773: INFO: Got endpoints: latency-svc-rd7bk [748.69611ms]
+Aug  8 20:07:00.792: INFO: Created: latency-svc-zg9wr
+Aug  8 20:07:00.823: INFO: Got endpoints: latency-svc-qhfpc [750.043121ms]
+Aug  8 20:07:00.837: INFO: Created: latency-svc-g9n97
+Aug  8 20:07:00.876: INFO: Got endpoints: latency-svc-jn5cs [748.898112ms]
+Aug  8 20:07:00.888: INFO: Created: latency-svc-q929g
+Aug  8 20:07:00.926: INFO: Got endpoints: latency-svc-jqhbl [753.006846ms]
+Aug  8 20:07:00.938: INFO: Created: latency-svc-nkjcq
+Aug  8 20:07:00.973: INFO: Got endpoints: latency-svc-xgb4z [749.89502ms]
+Aug  8 20:07:00.985: INFO: Created: latency-svc-k8fbw
+Aug  8 20:07:01.023: INFO: Got endpoints: latency-svc-ppvzf [748.951212ms]
+Aug  8 20:07:01.045: INFO: Created: latency-svc-k69lb
+Aug  8 20:07:01.072: INFO: Got endpoints: latency-svc-xbcv2 [749.648417ms]
+Aug  8 20:07:01.090: INFO: Created: latency-svc-wwz64
+Aug  8 20:07:01.122: INFO: Got endpoints: latency-svc-m8zqg [741.61275ms]
+Aug  8 20:07:01.146: INFO: Created: latency-svc-bgnvv
+Aug  8 20:07:01.173: INFO: Got endpoints: latency-svc-mbmdd [745.712283ms]
+Aug  8 20:07:01.185: INFO: Created: latency-svc-zxqj4
+Aug  8 20:07:01.223: INFO: Got endpoints: latency-svc-lzh9n [749.181611ms]
+Aug  8 20:07:01.236: INFO: Created: latency-svc-z22db
+Aug  8 20:07:01.272: INFO: Got endpoints: latency-svc-kl625 [749.421812ms]
+Aug  8 20:07:01.287: INFO: Created: latency-svc-5xh4z
+Aug  8 20:07:01.323: INFO: Got endpoints: latency-svc-ck4nv [749.395911ms]
+Aug  8 20:07:01.334: INFO: Created: latency-svc-5h8zh
+Aug  8 20:07:01.377: INFO: Got endpoints: latency-svc-wcbr5 [751.268125ms]
+Aug  8 20:07:01.389: INFO: Created: latency-svc-lcgkw
+Aug  8 20:07:01.422: INFO: Got endpoints: latency-svc-gd8xl [748.944605ms]
+Aug  8 20:07:01.435: INFO: Created: latency-svc-hz28p
+Aug  8 20:07:01.480: INFO: Got endpoints: latency-svc-xdjdf [757.305273ms]
+Aug  8 20:07:01.495: INFO: Created: latency-svc-xnd2k
+Aug  8 20:07:01.524: INFO: Got endpoints: latency-svc-zg9wr [751.539024ms]
+Aug  8 20:07:01.539: INFO: Created: latency-svc-lcscj
+Aug  8 20:07:01.572: INFO: Got endpoints: latency-svc-g9n97 [749.498107ms]
+Aug  8 20:07:01.589: INFO: Created: latency-svc-hx45b
+Aug  8 20:07:01.625: INFO: Got endpoints: latency-svc-q929g [748.995202ms]
+Aug  8 20:07:01.639: INFO: Created: latency-svc-v5wws
+Aug  8 20:07:01.683: INFO: Got endpoints: latency-svc-nkjcq [756.591864ms]
+Aug  8 20:07:01.707: INFO: Created: latency-svc-h6925
+Aug  8 20:07:01.722: INFO: Got endpoints: latency-svc-k8fbw [748.717097ms]
+Aug  8 20:07:01.733: INFO: Created: latency-svc-v8kgk
+Aug  8 20:07:01.778: INFO: Got endpoints: latency-svc-k69lb [754.328444ms]
+Aug  8 20:07:01.792: INFO: Created: latency-svc-lwn28
+Aug  8 20:07:01.826: INFO: Got endpoints: latency-svc-wwz64 [753.87154ms]
+Aug  8 20:07:01.840: INFO: Created: latency-svc-w9fj7
+Aug  8 20:07:01.872: INFO: Got endpoints: latency-svc-bgnvv [749.527103ms]
+Aug  8 20:07:01.882: INFO: Created: latency-svc-nwqzk
+Aug  8 20:07:01.922: INFO: Got endpoints: latency-svc-zxqj4 [749.387202ms]
+Aug  8 20:07:01.935: INFO: Created: latency-svc-jnhpr
+Aug  8 20:07:01.974: INFO: Got endpoints: latency-svc-z22db [750.880215ms]
+Aug  8 20:07:01.990: INFO: Created: latency-svc-npq82
+Aug  8 20:07:02.022: INFO: Got endpoints: latency-svc-5xh4z [749.758006ms]
+Aug  8 20:07:02.036: INFO: Created: latency-svc-4vrc5
+Aug  8 20:07:02.075: INFO: Got endpoints: latency-svc-5h8zh [751.69232ms]
+Aug  8 20:07:02.096: INFO: Created: latency-svc-znhdh
+Aug  8 20:07:02.122: INFO: Got endpoints: latency-svc-lcgkw [745.103165ms]
+Aug  8 20:07:02.141: INFO: Created: latency-svc-9rvnq
+Aug  8 20:07:02.172: INFO: Got endpoints: latency-svc-hz28p [749.860803ms]
+Aug  8 20:07:02.185: INFO: Created: latency-svc-vxxr2
+Aug  8 20:07:02.224: INFO: Got endpoints: latency-svc-xnd2k [744.524358ms]
+Aug  8 20:07:02.262: INFO: Created: latency-svc-799wl
+Aug  8 20:07:02.272: INFO: Got endpoints: latency-svc-lcscj [747.645583ms]
+Aug  8 20:07:02.283: INFO: Created: latency-svc-6m7fz
+Aug  8 20:07:02.323: INFO: Got endpoints: latency-svc-hx45b [749.944902ms]
+Aug  8 20:07:02.335: INFO: Created: latency-svc-clgxv
+Aug  8 20:07:02.372: INFO: Got endpoints: latency-svc-v5wws [746.839275ms]
+Aug  8 20:07:02.387: INFO: Created: latency-svc-7rm8p
+Aug  8 20:07:02.426: INFO: Got endpoints: latency-svc-h6925 [742.70664ms]
+Aug  8 20:07:02.440: INFO: Created: latency-svc-97vcs
+Aug  8 20:07:02.480: INFO: Got endpoints: latency-svc-v8kgk [758.022666ms]
+Aug  8 20:07:02.495: INFO: Created: latency-svc-qrm56
+Aug  8 20:07:02.525: INFO: Got endpoints: latency-svc-lwn28 [746.792772ms]
+Aug  8 20:07:02.540: INFO: Created: latency-svc-dmhw6
+Aug  8 20:07:02.574: INFO: Got endpoints: latency-svc-w9fj7 [748.013281ms]
+Aug  8 20:07:02.593: INFO: Created: latency-svc-2jjn9
+Aug  8 20:07:02.622: INFO: Got endpoints: latency-svc-nwqzk [749.978196ms]
+Aug  8 20:07:02.634: INFO: Created: latency-svc-rhl7g
+Aug  8 20:07:02.678: INFO: Got endpoints: latency-svc-jnhpr [755.261639ms]
+Aug  8 20:07:02.691: INFO: Created: latency-svc-z7mw7
+Aug  8 20:07:02.723: INFO: Got endpoints: latency-svc-npq82 [749.160787ms]
+Aug  8 20:07:02.749: INFO: Created: latency-svc-nf9qw
+Aug  8 20:07:02.773: INFO: Got endpoints: latency-svc-4vrc5 [750.416397ms]
+Aug  8 20:07:02.787: INFO: Created: latency-svc-2p9s8
+Aug  8 20:07:02.824: INFO: Got endpoints: latency-svc-znhdh [748.876384ms]
+Aug  8 20:07:02.837: INFO: Created: latency-svc-hb9jr
+Aug  8 20:07:02.873: INFO: Got endpoints: latency-svc-9rvnq [750.802101ms]
+Aug  8 20:07:02.881: INFO: Created: latency-svc-ln79w
+Aug  8 20:07:02.923: INFO: Got endpoints: latency-svc-vxxr2 [750.7467ms]
+Aug  8 20:07:02.944: INFO: Created: latency-svc-xwqs9
+Aug  8 20:07:02.975: INFO: Got endpoints: latency-svc-799wl [750.676499ms]
+Aug  8 20:07:02.990: INFO: Created: latency-svc-whc4b
+Aug  8 20:07:03.023: INFO: Got endpoints: latency-svc-6m7fz [751.071602ms]
+Aug  8 20:07:03.034: INFO: Created: latency-svc-clgh7
+Aug  8 20:07:03.076: INFO: Got endpoints: latency-svc-clgxv [753.604322ms]
+Aug  8 20:07:03.094: INFO: Created: latency-svc-d6mv5
+Aug  8 20:07:03.122: INFO: Got endpoints: latency-svc-7rm8p [750.050493ms]
+Aug  8 20:07:03.136: INFO: Created: latency-svc-bz4gh
+Aug  8 20:07:03.172: INFO: Got endpoints: latency-svc-97vcs [746.23086ms]
+Aug  8 20:07:03.185: INFO: Created: latency-svc-2t868
+Aug  8 20:07:03.223: INFO: Got endpoints: latency-svc-qrm56 [742.344027ms]
+Aug  8 20:07:03.238: INFO: Created: latency-svc-4p5sm
+Aug  8 20:07:03.276: INFO: Got endpoints: latency-svc-dmhw6 [751.756504ms]
+Aug  8 20:07:03.287: INFO: Created: latency-svc-wfprw
+Aug  8 20:07:03.322: INFO: Got endpoints: latency-svc-2jjn9 [748.237373ms]
+Aug  8 20:07:03.336: INFO: Created: latency-svc-grs28
+Aug  8 20:07:03.377: INFO: Got endpoints: latency-svc-rhl7g [755.006728ms]
+Aug  8 20:07:03.392: INFO: Created: latency-svc-cl7fg
+Aug  8 20:07:03.423: INFO: Got endpoints: latency-svc-z7mw7 [745.48975ms]
+Aug  8 20:07:03.446: INFO: Created: latency-svc-9qw82
+Aug  8 20:07:03.478: INFO: Got endpoints: latency-svc-nf9qw [755.012327ms]
+Aug  8 20:07:03.491: INFO: Created: latency-svc-bd5j5
+Aug  8 20:07:03.524: INFO: Got endpoints: latency-svc-2p9s8 [750.757691ms]
+Aug  8 20:07:03.540: INFO: Created: latency-svc-6wrhg
+Aug  8 20:07:03.574: INFO: Got endpoints: latency-svc-hb9jr [750.122085ms]
+Aug  8 20:07:03.591: INFO: Created: latency-svc-5jwr4
+Aug  8 20:07:03.625: INFO: Got endpoints: latency-svc-ln79w [752.231301ms]
+Aug  8 20:07:03.640: INFO: Created: latency-svc-wztvk
+Aug  8 20:07:03.672: INFO: Got endpoints: latency-svc-xwqs9 [748.999574ms]
+Aug  8 20:07:03.683: INFO: Created: latency-svc-jrgtt
+Aug  8 20:07:03.723: INFO: Got endpoints: latency-svc-whc4b [748.192766ms]
+Aug  8 20:07:03.735: INFO: Created: latency-svc-vm2lj
+Aug  8 20:07:03.772: INFO: Got endpoints: latency-svc-clgh7 [749.078173ms]
+Aug  8 20:07:03.784: INFO: Created: latency-svc-pfs6k
+Aug  8 20:07:03.826: INFO: Got endpoints: latency-svc-d6mv5 [750.183982ms]
+Aug  8 20:07:03.840: INFO: Created: latency-svc-ck77d
+Aug  8 20:07:03.875: INFO: Got endpoints: latency-svc-bz4gh [752.104598ms]
+Aug  8 20:07:03.887: INFO: Created: latency-svc-zwl65
+Aug  8 20:07:03.922: INFO: Got endpoints: latency-svc-2t868 [749.779579ms]
+Aug  8 20:07:03.932: INFO: Created: latency-svc-l6kr7
+Aug  8 20:07:03.972: INFO: Got endpoints: latency-svc-4p5sm [749.747678ms]
+Aug  8 20:07:03.983: INFO: Created: latency-svc-5xdcs
+Aug  8 20:07:04.023: INFO: Got endpoints: latency-svc-wfprw [746.27935ms]
+Aug  8 20:07:04.034: INFO: Created: latency-svc-45wnl
+Aug  8 20:07:04.073: INFO: Got endpoints: latency-svc-grs28 [749.894579ms]
+Aug  8 20:07:04.089: INFO: Created: latency-svc-2r59v
+Aug  8 20:07:04.131: INFO: Got endpoints: latency-svc-cl7fg [752.813402ms]
+Aug  8 20:07:04.144: INFO: Created: latency-svc-vjc9h
+Aug  8 20:07:04.174: INFO: Got endpoints: latency-svc-9qw82 [750.648683ms]
+Aug  8 20:07:04.185: INFO: Created: latency-svc-dhgcd
+Aug  8 20:07:04.225: INFO: Got endpoints: latency-svc-bd5j5 [747.063153ms]
+Aug  8 20:07:04.244: INFO: Created: latency-svc-6qtfh
+Aug  8 20:07:04.284: INFO: Got endpoints: latency-svc-6wrhg [760.470462ms]
+Aug  8 20:07:04.304: INFO: Created: latency-svc-wtrzj
+Aug  8 20:07:04.322: INFO: Got endpoints: latency-svc-5jwr4 [747.777857ms]
+Aug  8 20:07:04.335: INFO: Created: latency-svc-hfjtb
+Aug  8 20:07:04.373: INFO: Got endpoints: latency-svc-wztvk [748.278559ms]
+Aug  8 20:07:04.386: INFO: Created: latency-svc-hgzzb
+Aug  8 20:07:04.426: INFO: Got endpoints: latency-svc-jrgtt [753.630303ms]
+Aug  8 20:07:04.439: INFO: Created: latency-svc-r6dj2
+Aug  8 20:07:04.476: INFO: Got endpoints: latency-svc-vm2lj [752.929696ms]
+Aug  8 20:07:04.492: INFO: Created: latency-svc-jxp44
+Aug  8 20:07:04.523: INFO: Got endpoints: latency-svc-pfs6k [750.580476ms]
+Aug  8 20:07:04.536: INFO: Created: latency-svc-rnrzm
+Aug  8 20:07:04.573: INFO: Got endpoints: latency-svc-ck77d [746.166539ms]
+Aug  8 20:07:04.585: INFO: Created: latency-svc-6l2b7
+Aug  8 20:07:04.624: INFO: Got endpoints: latency-svc-zwl65 [749.449365ms]
+Aug  8 20:07:04.640: INFO: Created: latency-svc-xljwz
+Aug  8 20:07:04.673: INFO: Got endpoints: latency-svc-l6kr7 [751.011476ms]
+Aug  8 20:07:04.682: INFO: Created: latency-svc-rrlj7
+Aug  8 20:07:04.725: INFO: Got endpoints: latency-svc-5xdcs [752.363987ms]
+Aug  8 20:07:04.739: INFO: Created: latency-svc-6hl7h
+Aug  8 20:07:04.775: INFO: Got endpoints: latency-svc-45wnl [751.361478ms]
+Aug  8 20:07:04.789: INFO: Created: latency-svc-vcpgm
+Aug  8 20:07:04.823: INFO: Got endpoints: latency-svc-2r59v [750.014267ms]
+Aug  8 20:07:04.835: INFO: Created: latency-svc-gpc8j
+Aug  8 20:07:04.876: INFO: Got endpoints: latency-svc-vjc9h [745.577431ms]
+Aug  8 20:07:04.896: INFO: Created: latency-svc-9m55f
+Aug  8 20:07:04.924: INFO: Got endpoints: latency-svc-dhgcd [749.536763ms]
+Aug  8 20:07:04.937: INFO: Created: latency-svc-zhhm6
+Aug  8 20:07:04.973: INFO: Got endpoints: latency-svc-6qtfh [747.498846ms]
+Aug  8 20:07:04.992: INFO: Created: latency-svc-pjf28
+Aug  8 20:07:05.023: INFO: Got endpoints: latency-svc-wtrzj [739.063176ms]
+Aug  8 20:07:05.036: INFO: Created: latency-svc-fx89z
+Aug  8 20:07:05.073: INFO: Got endpoints: latency-svc-hfjtb [751.475478ms]
+Aug  8 20:07:05.084: INFO: Created: latency-svc-v72p2
+Aug  8 20:07:05.124: INFO: Got endpoints: latency-svc-hgzzb [750.181866ms]
+Aug  8 20:07:05.137: INFO: Created: latency-svc-xmb2n
+Aug  8 20:07:05.173: INFO: Got endpoints: latency-svc-r6dj2 [746.854238ms]
+Aug  8 20:07:05.189: INFO: Created: latency-svc-478gn
+Aug  8 20:07:05.223: INFO: Got endpoints: latency-svc-jxp44 [746.415434ms]
+Aug  8 20:07:05.246: INFO: Created: latency-svc-2lkq7
+Aug  8 20:07:05.273: INFO: Got endpoints: latency-svc-rnrzm [749.499458ms]
+Aug  8 20:07:05.284: INFO: Created: latency-svc-4xf5p
+Aug  8 20:07:05.323: INFO: Got endpoints: latency-svc-6l2b7 [749.715359ms]
+Aug  8 20:07:05.373: INFO: Got endpoints: latency-svc-xljwz [749.102452ms]
+Aug  8 20:07:05.424: INFO: Got endpoints: latency-svc-rrlj7 [750.821766ms]
+Aug  8 20:07:05.473: INFO: Got endpoints: latency-svc-6hl7h [747.71444ms]
+Aug  8 20:07:05.523: INFO: Got endpoints: latency-svc-vcpgm [748.167243ms]
+Aug  8 20:07:05.574: INFO: Got endpoints: latency-svc-gpc8j [750.631762ms]
+Aug  8 20:07:05.623: INFO: Got endpoints: latency-svc-9m55f [746.469427ms]
+Aug  8 20:07:05.673: INFO: Got endpoints: latency-svc-zhhm6 [749.264049ms]
+Aug  8 20:07:05.723: INFO: Got endpoints: latency-svc-pjf28 [750.405057ms]
+Aug  8 20:07:05.774: INFO: Got endpoints: latency-svc-fx89z [751.071062ms]
+Aug  8 20:07:05.823: INFO: Got endpoints: latency-svc-v72p2 [749.56735ms]
+Aug  8 20:07:05.873: INFO: Got endpoints: latency-svc-xmb2n [749.395649ms]
+Aug  8 20:07:05.922: INFO: Got endpoints: latency-svc-478gn [749.417749ms]
+Aug  8 20:07:05.975: INFO: Got endpoints: latency-svc-2lkq7 [751.705767ms]
+Aug  8 20:07:06.022: INFO: Got endpoints: latency-svc-4xf5p [749.57775ms]
+Aug  8 20:07:06.022: INFO: Latencies: [22.320687ms 24.781407ms 31.362762ms 36.425504ms 42.801057ms 49.156211ms 74.545622ms 89.030543ms 96.379005ms 100.006635ms 138.91996ms 139.104262ms 139.184862ms 140.259772ms 141.611983ms 142.267088ms 142.282988ms 142.444189ms 143.799301ms 147.148229ms 147.354431ms 148.665341ms 153.997986ms 158.313722ms 159.26023ms 160.068737ms 163.432265ms 165.081578ms 165.795384ms 167.769701ms 168.721309ms 169.139012ms 170.507623ms 171.795934ms 171.963736ms 173.973753ms 185.388447ms 191.930202ms 241.565017ms 278.755127ms 313.470116ms 357.463683ms 396.78351ms 434.086121ms 485.101045ms 516.336105ms 563.265496ms 591.218929ms 631.358363ms 675.43823ms 719.626998ms 724.813514ms 739.063176ms 741.61275ms 741.722869ms 742.344027ms 742.70664ms 742.881589ms 743.516381ms 744.524358ms 745.103165ms 745.160108ms 745.48975ms 745.577431ms 745.712283ms 746.166539ms 746.23086ms 746.27935ms 746.41242ms 746.415434ms 746.469427ms 746.792772ms 746.839275ms 746.854238ms 747.063153ms 747.498846ms 747.618823ms 747.645583ms 747.71444ms 747.777511ms 747.777857ms 747.797222ms 748.013281ms 748.073106ms 748.165219ms 748.167243ms 748.188633ms 748.192766ms 748.237373ms 748.278559ms 748.320533ms 748.408718ms 748.435922ms 748.69611ms 748.717097ms 748.860839ms 748.876384ms 748.898112ms 748.944605ms 748.951212ms 748.98504ms 748.995202ms 748.999574ms 749.078173ms 749.102452ms 749.160787ms 749.181611ms 749.181631ms 749.264049ms 749.270727ms 749.387202ms 749.395649ms 749.395911ms 749.417749ms 749.421812ms 749.449365ms 749.498107ms 749.499458ms 749.527103ms 749.536763ms 749.56735ms 749.57775ms 749.648417ms 749.715359ms 749.728525ms 749.747678ms 749.758006ms 749.779579ms 749.850348ms 749.860803ms 749.879133ms 749.894579ms 749.894738ms 749.89502ms 749.897625ms 749.918141ms 749.944902ms 749.978196ms 750.007632ms 750.014267ms 750.043121ms 750.050493ms 750.122085ms 750.135246ms 750.150836ms 750.181866ms 750.183982ms 750.307437ms 750.309949ms 750.405057ms 750.416397ms 750.580476ms 750.631762ms 750.63703ms 750.648683ms 750.676499ms 750.7467ms 750.757691ms 750.802101ms 750.821766ms 750.859048ms 750.880215ms 751.011476ms 751.071062ms 751.071602ms 751.083539ms 751.268125ms 751.325337ms 751.350163ms 751.361478ms 751.382957ms 751.475478ms 751.539024ms 751.69232ms 751.705738ms 751.705767ms 751.756504ms 752.104598ms 752.231301ms 752.234051ms 752.363987ms 752.813402ms 752.929696ms 753.006846ms 753.604322ms 753.630303ms 753.87154ms 754.141371ms 754.328444ms 755.006728ms 755.012327ms 755.261639ms 756.591864ms 756.917601ms 757.305273ms 758.022666ms 758.056695ms 758.855323ms 760.470462ms 772.146918ms]
+Aug  8 20:07:06.023: INFO: 50 %ile: 748.98504ms
+Aug  8 20:07:06.023: INFO: 90 %ile: 752.363987ms
+Aug  8 20:07:06.023: INFO: 99 %ile: 760.470462ms
+Aug  8 20:07:06.023: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:07:06.023: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-k4jlc" for this suite.
+Aug  8 20:07:28.036: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:07:28.080: INFO: namespace: e2e-tests-svc-latency-k4jlc, resource: bindings, ignored listing per whitelist
+Aug  8 20:07:28.117: INFO: namespace e2e-tests-svc-latency-k4jlc deletion completed in 22.089105008s
+
+• [SLOW TEST:32.893 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:07:28.119: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override all
+Aug  8 20:07:28.214: INFO: Waiting up to 5m0s for pod "client-containers-acb0db0f-9b46-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-containers-wn2x7" to be "success or failure"
+Aug  8 20:07:28.223: INFO: Pod "client-containers-acb0db0f-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 8.251364ms
+Aug  8 20:07:30.229: INFO: Pod "client-containers-acb0db0f-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.014536889s
+Aug  8 20:07:32.233: INFO: Pod "client-containers-acb0db0f-9b46-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.018297126s
+STEP: Saw pod success
+Aug  8 20:07:32.233: INFO: Pod "client-containers-acb0db0f-9b46-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:07:32.236: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod client-containers-acb0db0f-9b46-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:07:32.270: INFO: Waiting for pod client-containers-acb0db0f-9b46-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:07:32.273: INFO: Pod client-containers-acb0db0f-9b46-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:07:32.273: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-wn2x7" for this suite.
+Aug  8 20:07:38.285: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:07:38.395: INFO: namespace: e2e-tests-containers-wn2x7, resource: bindings, ignored listing per whitelist
+Aug  8 20:07:38.401: INFO: namespace e2e-tests-containers-wn2x7 deletion completed in 6.125262266s
+
+• [SLOW TEST:10.283 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:07:38.401: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Aug  8 20:07:38.531: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:07:38.541: INFO: Number of nodes with available pods: 0
+Aug  8 20:07:38.541: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:07:39.544: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:07:39.551: INFO: Number of nodes with available pods: 0
+Aug  8 20:07:39.551: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:07:40.545: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:07:40.550: INFO: Number of nodes with available pods: 1
+Aug  8 20:07:40.550: INFO: Node k8s-linuxpool-37994001-1 is running more than one daemon pod
+Aug  8 20:07:41.544: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:07:41.547: INFO: Number of nodes with available pods: 2
+Aug  8 20:07:41.547: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.
+Aug  8 20:07:41.564: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:07:41.566: INFO: Number of nodes with available pods: 1
+Aug  8 20:07:41.566: INFO: Node k8s-linuxpool-37994001-1 is running more than one daemon pod
+Aug  8 20:07:42.570: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:07:42.573: INFO: Number of nodes with available pods: 1
+Aug  8 20:07:42.573: INFO: Node k8s-linuxpool-37994001-1 is running more than one daemon pod
+Aug  8 20:07:43.570: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:07:43.572: INFO: Number of nodes with available pods: 1
+Aug  8 20:07:43.572: INFO: Node k8s-linuxpool-37994001-1 is running more than one daemon pod
+Aug  8 20:07:44.570: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:07:44.573: INFO: Number of nodes with available pods: 2
+Aug  8 20:07:44.573: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Wait for the failed daemon pod to be completely deleted.
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-zlg4l, will wait for the garbage collector to delete the pods
+Aug  8 20:07:44.637: INFO: Deleting {extensions DaemonSet} daemon-set took: 7.211754ms
+Aug  8 20:07:44.737: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.235455ms
+Aug  8 20:07:52.641: INFO: Number of nodes with available pods: 0
+Aug  8 20:07:52.641: INFO: Number of running nodes: 0, number of available pods: 0
+Aug  8 20:07:52.643: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-zlg4l/daemonsets","resourceVersion":"6116"},"items":null}
+
+Aug  8 20:07:52.646: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-zlg4l/pods","resourceVersion":"6116"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:07:52.653: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-zlg4l" for this suite.
+Aug  8 20:07:58.664: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:07:58.714: INFO: namespace: e2e-tests-daemonsets-zlg4l, resource: bindings, ignored listing per whitelist
+Aug  8 20:07:58.743: INFO: namespace e2e-tests-daemonsets-zlg4l deletion completed in 6.087758418s
+
+• [SLOW TEST:20.342 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:07:58.743: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-bef1fd95-9b46-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:07:58.846: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-bef2e8a2-9b46-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-frzp5" to be "success or failure"
+Aug  8 20:07:58.859: INFO: Pod "pod-projected-configmaps-bef2e8a2-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 13.076295ms
+Aug  8 20:08:00.863: INFO: Pod "pod-projected-configmaps-bef2e8a2-9b46-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.016938179s
+STEP: Saw pod success
+Aug  8 20:08:00.863: INFO: Pod "pod-projected-configmaps-bef2e8a2-9b46-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:08:00.866: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-configmaps-bef2e8a2-9b46-11e8-bae8-8697d7d38a55 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:08:00.881: INFO: Waiting for pod pod-projected-configmaps-bef2e8a2-9b46-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:08:00.883: INFO: Pod pod-projected-configmaps-bef2e8a2-9b46-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:08:00.883: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-frzp5" for this suite.
+Aug  8 20:08:06.896: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:08:06.955: INFO: namespace: e2e-tests-projected-frzp5, resource: bindings, ignored listing per whitelist
+Aug  8 20:08:06.972: INFO: namespace e2e-tests-projected-frzp5 deletion completed in 6.084776287s
+
+• [SLOW TEST:8.229 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:08:06.972: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-c3d973ff-9b46-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:08:07.080: INFO: Waiting up to 5m0s for pod "pod-secrets-c3d9ddb2-9b46-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-secrets-x4kbt" to be "success or failure"
+Aug  8 20:08:07.084: INFO: Pod "pod-secrets-c3d9ddb2-9b46-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 4.13423ms
+Aug  8 20:08:09.087: INFO: Pod "pod-secrets-c3d9ddb2-9b46-11e8-bae8-8697d7d38a55": Phase="Running", Reason="", readiness=true. Elapsed: 2.007721248s
+Aug  8 20:08:11.091: INFO: Pod "pod-secrets-c3d9ddb2-9b46-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011148901s
+STEP: Saw pod success
+Aug  8 20:08:11.091: INFO: Pod "pod-secrets-c3d9ddb2-9b46-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:08:11.093: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-secrets-c3d9ddb2-9b46-11e8-bae8-8697d7d38a55 container secret-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:08:11.117: INFO: Waiting for pod pod-secrets-c3d9ddb2-9b46-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:08:11.121: INFO: Pod pod-secrets-c3d9ddb2-9b46-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:08:11.121: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-x4kbt" for this suite.
+Aug  8 20:08:17.139: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:08:17.157: INFO: namespace: e2e-tests-secrets-x4kbt, resource: bindings, ignored listing per whitelist
+Aug  8 20:08:17.210: INFO: namespace e2e-tests-secrets-x4kbt deletion completed in 6.081782276s
+
+• [SLOW TEST:10.238 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:08:17.210: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-lc944
+[It] Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-lc944
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-lc944
+Aug  8 20:08:17.302: INFO: Found 0 stateful pods, waiting for 1
+Aug  8 20:08:27.306: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will not halt with unhealthy stateful pod
+Aug  8 20:08:27.309: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-lc944 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Aug  8 20:08:27.523: INFO: stderr: ""
+Aug  8 20:08:27.523: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Aug  8 20:08:27.523: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Aug  8 20:08:27.526: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Aug  8 20:08:37.530: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Aug  8 20:08:37.530: INFO: Waiting for statefulset status.replicas updated to 0
+Aug  8 20:08:37.543: INFO: POD   NODE                      PHASE    GRACE  CONDITIONS
+Aug  8 20:08:37.543: INFO: ss-0  k8s-linuxpool-37994001-1  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:17 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:27 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:17 +0000 UTC  }]
+Aug  8 20:08:37.543: INFO: 
+Aug  8 20:08:37.543: INFO: StatefulSet ss has not reached scale 3, at 1
+Aug  8 20:08:38.554: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.995666287s
+Aug  8 20:08:39.557: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.985577652s
+Aug  8 20:08:40.561: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.981683473s
+Aug  8 20:08:41.566: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.977376206s
+Aug  8 20:08:42.570: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.973206555s
+Aug  8 20:08:43.577: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.96910102s
+Aug  8 20:08:44.581: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.96210798s
+Aug  8 20:08:45.585: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.958264376s
+Aug  8 20:08:46.589: INFO: Verifying statefulset ss doesn't scale past 3 for another 954.151485ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-lc944
+Aug  8 20:08:47.593: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-lc944 ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Aug  8 20:08:47.815: INFO: stderr: ""
+Aug  8 20:08:47.815: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Aug  8 20:08:47.815: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Aug  8 20:08:47.815: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-lc944 ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Aug  8 20:08:48.026: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Aug  8 20:08:48.026: INFO: stdout: ""
+Aug  8 20:08:48.026: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: 
+Aug  8 20:08:48.026: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-lc944 ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Aug  8 20:08:48.238: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Aug  8 20:08:48.238: INFO: stdout: ""
+Aug  8 20:08:48.238: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Aug  8 20:08:48.241: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=false
+Aug  8 20:08:58.245: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Aug  8 20:08:58.245: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Aug  8 20:08:58.246: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Scale down will not halt with unhealthy stateful pod
+Aug  8 20:08:58.249: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-lc944 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Aug  8 20:08:58.446: INFO: stderr: ""
+Aug  8 20:08:58.446: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Aug  8 20:08:58.446: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Aug  8 20:08:58.446: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-lc944 ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Aug  8 20:08:58.640: INFO: stderr: ""
+Aug  8 20:08:58.640: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Aug  8 20:08:58.641: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Aug  8 20:08:58.641: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-lc944 ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Aug  8 20:08:58.831: INFO: stderr: ""
+Aug  8 20:08:58.831: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Aug  8 20:08:58.831: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Aug  8 20:08:58.831: INFO: Waiting for statefulset status.replicas updated to 0
+Aug  8 20:08:58.834: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 2
+Aug  8 20:09:08.840: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Aug  8 20:09:08.840: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Aug  8 20:09:08.840: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Aug  8 20:09:08.851: INFO: POD   NODE                      PHASE    GRACE  CONDITIONS
+Aug  8 20:09:08.851: INFO: ss-0  k8s-linuxpool-37994001-1  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:17 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:17 +0000 UTC  }]
+Aug  8 20:09:08.851: INFO: ss-1  k8s-linuxpool-37994001-0  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:59 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  }]
+Aug  8 20:09:08.851: INFO: ss-2  k8s-linuxpool-37994001-1  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:59 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  }]
+Aug  8 20:09:08.851: INFO: 
+Aug  8 20:09:08.851: INFO: StatefulSet ss has not reached scale 0, at 3
+Aug  8 20:09:09.855: INFO: POD   NODE                      PHASE    GRACE  CONDITIONS
+Aug  8 20:09:09.855: INFO: ss-0  k8s-linuxpool-37994001-1  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:17 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:17 +0000 UTC  }]
+Aug  8 20:09:09.855: INFO: ss-1  k8s-linuxpool-37994001-0  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:59 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  }]
+Aug  8 20:09:09.855: INFO: ss-2  k8s-linuxpool-37994001-1  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:59 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  }]
+Aug  8 20:09:09.855: INFO: 
+Aug  8 20:09:09.855: INFO: StatefulSet ss has not reached scale 0, at 3
+Aug  8 20:09:10.859: INFO: POD   NODE                      PHASE    GRACE  CONDITIONS
+Aug  8 20:09:10.859: INFO: ss-0  k8s-linuxpool-37994001-1  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:17 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:17 +0000 UTC  }]
+Aug  8 20:09:10.859: INFO: ss-1  k8s-linuxpool-37994001-0  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:59 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  }]
+Aug  8 20:09:10.859: INFO: ss-2  k8s-linuxpool-37994001-1  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:59 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  }]
+Aug  8 20:09:10.859: INFO: 
+Aug  8 20:09:10.859: INFO: StatefulSet ss has not reached scale 0, at 3
+Aug  8 20:09:11.863: INFO: POD   NODE                      PHASE    GRACE  CONDITIONS
+Aug  8 20:09:11.863: INFO: ss-0  k8s-linuxpool-37994001-1  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:17 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:17 +0000 UTC  }]
+Aug  8 20:09:11.863: INFO: ss-2  k8s-linuxpool-37994001-1  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:59 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  }]
+Aug  8 20:09:11.863: INFO: 
+Aug  8 20:09:11.863: INFO: StatefulSet ss has not reached scale 0, at 2
+Aug  8 20:09:12.867: INFO: POD   NODE                      PHASE    GRACE  CONDITIONS
+Aug  8 20:09:12.867: INFO: ss-0  k8s-linuxpool-37994001-1  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:17 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:58 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:17 +0000 UTC  }]
+Aug  8 20:09:12.867: INFO: ss-2  k8s-linuxpool-37994001-1  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:59 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-08-08 20:08:37 +0000 UTC  }]
+Aug  8 20:09:12.867: INFO: 
+Aug  8 20:09:12.867: INFO: StatefulSet ss has not reached scale 0, at 2
+Aug  8 20:09:13.870: INFO: Verifying statefulset ss doesn't scale past 0 for another 4.981014983s
+Aug  8 20:09:14.874: INFO: Verifying statefulset ss doesn't scale past 0 for another 3.977464803s
+Aug  8 20:09:15.877: INFO: Verifying statefulset ss doesn't scale past 0 for another 2.974028538s
+Aug  8 20:09:16.881: INFO: Verifying statefulset ss doesn't scale past 0 for another 1.970128285s
+Aug  8 20:09:17.884: INFO: Verifying statefulset ss doesn't scale past 0 for another 966.742949ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-lc944
+Aug  8 20:09:18.887: INFO: Scaling statefulset ss to 0
+Aug  8 20:09:18.893: INFO: Waiting for statefulset status.replicas updated to 0
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Aug  8 20:09:18.895: INFO: Deleting all statefulset in ns e2e-tests-statefulset-lc944
+Aug  8 20:09:18.897: INFO: Scaling statefulset ss to 0
+Aug  8 20:09:18.904: INFO: Waiting for statefulset status.replicas updated to 0
+Aug  8 20:09:18.906: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:09:18.916: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-lc944" for this suite.
+Aug  8 20:09:24.927: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:09:24.999: INFO: namespace: e2e-tests-statefulset-lc944, resource: bindings, ignored listing per whitelist
+Aug  8 20:09:25.015: INFO: namespace e2e-tests-statefulset-lc944 deletion completed in 6.095485892s
+
+• [SLOW TEST:67.805 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Burst scaling should run to completion even with unhealthy pods [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:09:25.016: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name cm-test-opt-del-f25caf85-9b46-11e8-bae8-8697d7d38a55
+STEP: Creating configMap with name cm-test-opt-upd-f25cafc0-9b46-11e8-bae8-8697d7d38a55
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-f25caf85-9b46-11e8-bae8-8697d7d38a55
+STEP: Updating configmap cm-test-opt-upd-f25cafc0-9b46-11e8-bae8-8697d7d38a55
+STEP: Creating configMap with name cm-test-opt-create-f25cafd2-9b46-11e8-bae8-8697d7d38a55
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:10:57.568: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-njzcx" for this suite.
+Aug  8 20:11:19.579: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:11:19.610: INFO: namespace: e2e-tests-projected-njzcx, resource: bindings, ignored listing per whitelist
+Aug  8 20:11:19.647: INFO: namespace e2e-tests-projected-njzcx deletion completed in 22.076432772s
+
+• [SLOW TEST:114.632 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:11:19.647: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for all rs to be garbage collected
+STEP: expected 0 rs, got 1 rs
+STEP: expected 0 Pods, got 2 Pods
+STEP: Gathering metrics
+W0808 20:11:20.750669      17 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Aug  8 20:11:20.750: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:11:20.750: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-fm8fs" for this suite.
+Aug  8 20:11:26.762: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:11:26.846: INFO: namespace: e2e-tests-gc-fm8fs, resource: bindings, ignored listing per whitelist
+Aug  8 20:11:26.854: INFO: namespace e2e-tests-gc-fm8fs deletion completed in 6.101310023s
+
+• [SLOW TEST:7.207 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:11:26.855: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Aug  8 20:11:26.947: INFO: Waiting up to 5m0s for pod "pod-3afcba5a-9b47-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-4tjn9" to be "success or failure"
+Aug  8 20:11:26.952: INFO: Pod "pod-3afcba5a-9b47-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 4.40192ms
+Aug  8 20:11:28.955: INFO: Pod "pod-3afcba5a-9b47-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007999566s
+Aug  8 20:11:30.959: INFO: Pod "pod-3afcba5a-9b47-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011342468s
+STEP: Saw pod success
+Aug  8 20:11:30.959: INFO: Pod "pod-3afcba5a-9b47-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:11:30.961: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-3afcba5a-9b47-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:11:30.976: INFO: Waiting for pod pod-3afcba5a-9b47-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:11:30.984: INFO: Pod pod-3afcba5a-9b47-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:11:30.984: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-4tjn9" for this suite.
+Aug  8 20:11:36.996: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:11:37.019: INFO: namespace: e2e-tests-emptydir-4tjn9, resource: bindings, ignored listing per whitelist
+Aug  8 20:11:37.123: INFO: namespace e2e-tests-emptydir-4tjn9 deletion completed in 6.13702021s
+
+• [SLOW TEST:10.269 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:11:37.124: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-411fc0fe-9b47-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:11:37.246: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-412024ba-9b47-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-97jhc" to be "success or failure"
+Aug  8 20:11:37.249: INFO: Pod "pod-projected-secrets-412024ba-9b47-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.833913ms
+Aug  8 20:11:39.257: INFO: Pod "pod-projected-secrets-412024ba-9b47-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010913459s
+Aug  8 20:11:41.261: INFO: Pod "pod-projected-secrets-412024ba-9b47-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014497044s
+STEP: Saw pod success
+Aug  8 20:11:41.261: INFO: Pod "pod-projected-secrets-412024ba-9b47-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:11:41.263: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-secrets-412024ba-9b47-11e8-bae8-8697d7d38a55 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:11:41.291: INFO: Waiting for pod pod-projected-secrets-412024ba-9b47-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:11:41.294: INFO: Pod pod-projected-secrets-412024ba-9b47-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:11:41.294: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-97jhc" for this suite.
+Aug  8 20:11:47.307: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:11:47.365: INFO: namespace: e2e-tests-projected-97jhc, resource: bindings, ignored listing per whitelist
+Aug  8 20:11:47.402: INFO: namespace e2e-tests-projected-97jhc deletion completed in 6.104551604s
+
+• [SLOW TEST:10.278 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:11:47.402: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Aug  8 20:11:47.490: INFO: Waiting up to 5m0s for pod "pod-473ac33f-9b47-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-hqj7q" to be "success or failure"
+Aug  8 20:11:47.494: INFO: Pod "pod-473ac33f-9b47-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 3.915217ms
+Aug  8 20:11:49.497: INFO: Pod "pod-473ac33f-9b47-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007284429s
+Aug  8 20:11:51.505: INFO: Pod "pod-473ac33f-9b47-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015073918s
+STEP: Saw pod success
+Aug  8 20:11:51.505: INFO: Pod "pod-473ac33f-9b47-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:11:51.508: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-473ac33f-9b47-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:11:51.529: INFO: Waiting for pod pod-473ac33f-9b47-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:11:51.532: INFO: Pod pod-473ac33f-9b47-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:11:51.532: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-hqj7q" for this suite.
+Aug  8 20:11:57.552: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:11:57.595: INFO: namespace: e2e-tests-emptydir-hqj7q, resource: bindings, ignored listing per whitelist
+Aug  8 20:11:57.628: INFO: namespace e2e-tests-emptydir-hqj7q deletion completed in 6.092721309s
+
+• [SLOW TEST:10.227 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:11:57.629: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:12:57.720: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-nrl65" for this suite.
+Aug  8 20:13:19.733: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:13:19.785: INFO: namespace: e2e-tests-container-probe-nrl65, resource: bindings, ignored listing per whitelist
+Aug  8 20:13:19.810: INFO: namespace e2e-tests-container-probe-nrl65 deletion completed in 22.086908594s
+
+• [SLOW TEST:82.182 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:13:19.811: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-989s2
+Aug  8 20:13:23.899: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-989s2
+STEP: checking the pod's current state and verifying that restartCount is present
+Aug  8 20:13:23.901: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:17:24.355: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-989s2" for this suite.
+Aug  8 20:17:30.371: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:17:30.385: INFO: namespace: e2e-tests-container-probe-989s2, resource: bindings, ignored listing per whitelist
+Aug  8 20:17:30.456: INFO: namespace e2e-tests-container-probe-989s2 deletion completed in 6.096384792s
+
+• [SLOW TEST:250.645 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:17:30.456: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-xnlpk
+[It] Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Looking for a node to schedule stateful set and pod
+STEP: Creating pod with conflicting port in namespace e2e-tests-statefulset-xnlpk
+STEP: Creating statefulset with conflicting port in namespace e2e-tests-statefulset-xnlpk
+STEP: Waiting until pod test-pod will start running in namespace e2e-tests-statefulset-xnlpk
+STEP: Waiting until stateful pod ss-0 will be recreated and deleted at least once in namespace e2e-tests-statefulset-xnlpk
+Aug  8 20:17:36.564: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-xnlpk, name: ss-0, uid: 16d49d37-9b48-11e8-ad47-001dd8b71c0d, status phase: Pending. Waiting for statefulset controller to delete.
+Aug  8 20:17:36.760: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-xnlpk, name: ss-0, uid: 16d49d37-9b48-11e8-ad47-001dd8b71c0d, status phase: Failed. Waiting for statefulset controller to delete.
+Aug  8 20:17:36.766: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-xnlpk, name: ss-0, uid: 16d49d37-9b48-11e8-ad47-001dd8b71c0d, status phase: Failed. Waiting for statefulset controller to delete.
+Aug  8 20:17:36.770: INFO: Observed delete event for stateful pod ss-0 in namespace e2e-tests-statefulset-xnlpk
+STEP: Removing pod with conflicting port in namespace e2e-tests-statefulset-xnlpk
+STEP: Waiting when stateful pod ss-0 will be recreated in namespace e2e-tests-statefulset-xnlpk and will be in running state
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Aug  8 20:17:40.814: INFO: Deleting all statefulset in ns e2e-tests-statefulset-xnlpk
+Aug  8 20:17:40.817: INFO: Scaling statefulset ss to 0
+Aug  8 20:18:00.829: INFO: Waiting for statefulset status.replicas updated to 0
+Aug  8 20:18:00.832: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:18:00.843: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-xnlpk" for this suite.
+Aug  8 20:18:06.856: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:18:06.953: INFO: namespace: e2e-tests-statefulset-xnlpk, resource: bindings, ignored listing per whitelist
+Aug  8 20:18:06.953: INFO: namespace e2e-tests-statefulset-xnlpk deletion completed in 6.105239463s
+
+• [SLOW TEST:36.496 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Should recreate evicted statefulset [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Pods 
+  should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:18:06.953: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Aug  8 20:18:11.567: INFO: Successfully updated pod "pod-update-29753790-9b48-11e8-bae8-8697d7d38a55"
+STEP: verifying the updated pod is in kubernetes
+Aug  8 20:18:11.572: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:18:11.572: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-nfppd" for this suite.
+Aug  8 20:18:33.586: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:18:33.623: INFO: namespace: e2e-tests-pods-nfppd, resource: bindings, ignored listing per whitelist
+Aug  8 20:18:33.675: INFO: namespace e2e-tests-pods-nfppd deletion completed in 22.100479641s
+
+• [SLOW TEST:26.723 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:18:33.676: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for all pods to be garbage collected
+STEP: Gathering metrics
+W0808 20:18:43.775897      17 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Aug  8 20:18:43.775: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:18:43.776: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-rqrnh" for this suite.
+Aug  8 20:18:49.792: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:18:49.858: INFO: namespace: e2e-tests-gc-rqrnh, resource: bindings, ignored listing per whitelist
+Aug  8 20:18:49.886: INFO: namespace e2e-tests-gc-rqrnh deletion completed in 6.107828218s
+
+• [SLOW TEST:16.210 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:18:49.886: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc1
+STEP: create the rc2
+STEP: set half of pods created by rc simpletest-rc-to-be-deleted to have rc simpletest-rc-to-stay as owner as well
+STEP: delete the rc simpletest-rc-to-be-deleted
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0808 20:19:00.054928      17 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Aug  8 20:19:00.054: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:19:00.055: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-5ntzx" for this suite.
+Aug  8 20:19:06.068: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:19:06.080: INFO: namespace: e2e-tests-gc-5ntzx, resource: bindings, ignored listing per whitelist
+Aug  8 20:19:06.155: INFO: namespace e2e-tests-gc-5ntzx deletion completed in 6.09829096s
+
+• [SLOW TEST:16.269 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:19:06.156: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Aug  8 20:19:08.788: INFO: Successfully updated pod "annotationupdate4cc06f68-9b48-11e8-bae8-8697d7d38a55"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:19:10.814: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-mbd2l" for this suite.
+Aug  8 20:19:32.845: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:19:32.866: INFO: namespace: e2e-tests-projected-mbd2l, resource: bindings, ignored listing per whitelist
+Aug  8 20:19:32.953: INFO: namespace e2e-tests-projected-mbd2l deletion completed in 22.132963865s
+
+• [SLOW TEST:26.797 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:19:32.954: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Aug  8 20:19:33.040: INFO: Waiting up to 5m0s for pod "downward-api-5cb849a8-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-qmmp4" to be "success or failure"
+Aug  8 20:19:33.043: INFO: Pod "downward-api-5cb849a8-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 3.116904ms
+Aug  8 20:19:35.047: INFO: Pod "downward-api-5cb849a8-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007283288s
+Aug  8 20:19:37.050: INFO: Pod "downward-api-5cb849a8-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010728855s
+STEP: Saw pod success
+Aug  8 20:19:37.050: INFO: Pod "downward-api-5cb849a8-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:19:37.053: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downward-api-5cb849a8-9b48-11e8-bae8-8697d7d38a55 container dapi-container: <nil>
+STEP: delete the pod
+Aug  8 20:19:37.073: INFO: Waiting for pod downward-api-5cb849a8-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:19:37.075: INFO: Pod downward-api-5cb849a8-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:19:37.076: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-qmmp4" for this suite.
+Aug  8 20:19:43.087: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:19:43.155: INFO: namespace: e2e-tests-downward-api-qmmp4, resource: bindings, ignored listing per whitelist
+Aug  8 20:19:43.161: INFO: namespace e2e-tests-downward-api-qmmp4 deletion completed in 6.082940281s
+
+• [SLOW TEST:10.208 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:19:43.162: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:19:43.243: INFO: Waiting up to 5m0s for pod "downwardapi-volume-62cd8026-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-g775p" to be "success or failure"
+Aug  8 20:19:43.246: INFO: Pod "downwardapi-volume-62cd8026-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.175103ms
+Aug  8 20:19:45.250: INFO: Pod "downwardapi-volume-62cd8026-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006164702s
+Aug  8 20:19:47.253: INFO: Pod "downwardapi-volume-62cd8026-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009590486s
+STEP: Saw pod success
+Aug  8 20:19:47.253: INFO: Pod "downwardapi-volume-62cd8026-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:19:47.256: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-62cd8026-9b48-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:19:47.271: INFO: Waiting for pod downwardapi-volume-62cd8026-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:19:47.274: INFO: Pod downwardapi-volume-62cd8026-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:19:47.274: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-g775p" for this suite.
+Aug  8 20:19:53.287: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:19:53.356: INFO: namespace: e2e-tests-projected-g775p, resource: bindings, ignored listing per whitelist
+Aug  8 20:19:53.397: INFO: namespace e2e-tests-projected-g775p deletion completed in 6.120360769s
+
+• [SLOW TEST:10.235 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:19:53.397: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Aug  8 20:19:55.505: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-68e90cc1-9b48-11e8-bae8-8697d7d38a55", GenerateName:"", Namespace:"e2e-tests-pods-ssq8j", SelfLink:"/api/v1/namespaces/e2e-tests-pods-ssq8j/pods/pod-submit-remove-68e90cc1-9b48-11e8-bae8-8697d7d38a55", UID:"68eb2c3a-9b48-11e8-ad47-001dd8b71c0d", ResourceVersion:"8232", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63669356393, loc:(*time.Location)(0x64309a0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"485438551"}, Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-8mthw", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc4216caec0), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"k8s.gcr.io/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-8mthw", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"Always", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc4204dd9b8), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"k8s-linuxpool-37994001-1", HostNetwork:false, HostPID:false, HostIPC:false, ShareProcessNamespace:(*bool)(nil), SecurityContext:(*v1.PodSecurityContext)(0xc42126a7e0), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc4204ddd20)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc4204dddc0)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(0xc4204dddc8), DNSConfig:(*v1.PodDNSConfig)(nil), ReadinessGates:[]v1.PodReadinessGate(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63669356393, loc:(*time.Location)(0x64309a0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63669356395, loc:(*time.Location)(0x64309a0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"ContainersReady", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63669356393, loc:(*time.Location)(0x64309a0)}}, Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"", PodIP:"10.244.1.96", StartTime:(*v1.Time)(0xc4209a8f80), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc4209a8fa0), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"k8s.gcr.io/nginx-slim-amd64:0.20", ImageID:"docker-pullable://k8s.gcr.io/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://88ac3b11e347ae4ed353ef8c29140a0a60d748fde66264788b9d5f9f3541a442"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:20:03.486: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-ssq8j" for this suite.
+Aug  8 20:20:09.505: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:20:09.547: INFO: namespace: e2e-tests-pods-ssq8j, resource: bindings, ignored listing per whitelist
+Aug  8 20:20:09.591: INFO: namespace e2e-tests-pods-ssq8j deletion completed in 6.09517855s
+
+• [SLOW TEST:16.194 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:20:09.591: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override command
+Aug  8 20:20:09.698: INFO: Waiting up to 5m0s for pod "client-containers-729227cc-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-containers-pbx9t" to be "success or failure"
+Aug  8 20:20:09.704: INFO: Pod "client-containers-729227cc-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.485806ms
+Aug  8 20:20:11.707: INFO: Pod "client-containers-729227cc-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008635794s
+STEP: Saw pod success
+Aug  8 20:20:11.707: INFO: Pod "client-containers-729227cc-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:20:11.709: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod client-containers-729227cc-9b48-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:20:11.730: INFO: Waiting for pod client-containers-729227cc-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:20:11.732: INFO: Pod client-containers-729227cc-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:20:11.732: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-pbx9t" for this suite.
+Aug  8 20:20:17.746: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:20:17.790: INFO: namespace: e2e-tests-containers-pbx9t, resource: bindings, ignored listing per whitelist
+Aug  8 20:20:17.813: INFO: namespace e2e-tests-containers-pbx9t deletion completed in 6.075283937s
+
+• [SLOW TEST:8.221 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:20:17.813: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test use defaults
+Aug  8 20:20:17.882: INFO: Waiting up to 5m0s for pod "client-containers-777326bb-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-containers-lxwv6" to be "success or failure"
+Aug  8 20:20:17.887: INFO: Pod "client-containers-777326bb-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.020305ms
+Aug  8 20:20:19.891: INFO: Pod "client-containers-777326bb-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008316431s
+STEP: Saw pod success
+Aug  8 20:20:19.891: INFO: Pod "client-containers-777326bb-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:20:19.893: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod client-containers-777326bb-9b48-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:20:19.910: INFO: Waiting for pod client-containers-777326bb-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:20:19.914: INFO: Pod client-containers-777326bb-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:20:19.914: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-lxwv6" for this suite.
+Aug  8 20:20:25.925: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:20:25.957: INFO: namespace: e2e-tests-containers-lxwv6, resource: bindings, ignored listing per whitelist
+Aug  8 20:20:25.997: INFO: namespace e2e-tests-containers-lxwv6 deletion completed in 6.079323951s
+
+• [SLOW TEST:8.184 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:20:25.997: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Aug  8 20:20:26.081: INFO: (0) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 5.271305ms)
+Aug  8 20:20:26.084: INFO: (1) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 2.809402ms)
+Aug  8 20:20:26.087: INFO: (2) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.235603ms)
+Aug  8 20:20:26.090: INFO: (3) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.342503ms)
+Aug  8 20:20:26.094: INFO: (4) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.306904ms)
+Aug  8 20:20:26.097: INFO: (5) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.036602ms)
+Aug  8 20:20:26.100: INFO: (6) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.182103ms)
+Aug  8 20:20:26.103: INFO: (7) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 2.887703ms)
+Aug  8 20:20:26.106: INFO: (8) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 2.861603ms)
+Aug  8 20:20:26.109: INFO: (9) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.167603ms)
+Aug  8 20:20:26.112: INFO: (10) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.544703ms)
+Aug  8 20:20:26.116: INFO: (11) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.617403ms)
+Aug  8 20:20:26.119: INFO: (12) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.006303ms)
+Aug  8 20:20:26.123: INFO: (13) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.498404ms)
+Aug  8 20:20:26.126: INFO: (14) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.108103ms)
+Aug  8 20:20:26.129: INFO: (15) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 2.934502ms)
+Aug  8 20:20:26.132: INFO: (16) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.107303ms)
+Aug  8 20:20:26.135: INFO: (17) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 2.885403ms)
+Aug  8 20:20:26.138: INFO: (18) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.312503ms)
+Aug  8 20:20:26.141: INFO: (19) /api/v1/nodes/k8s-linuxpool-37994001-0/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.260403ms)
+[AfterEach] version v1
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:20:26.141: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-9xf5k" for this suite.
+Aug  8 20:20:32.157: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:20:32.180: INFO: namespace: e2e-tests-proxy-9xf5k, resource: bindings, ignored listing per whitelist
+Aug  8 20:20:32.232: INFO: namespace e2e-tests-proxy-9xf5k deletion completed in 6.085646714s
+
+• [SLOW TEST:6.236 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:20:32.233: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-map-800ba55c-9b48-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:20:32.306: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-800bfab3-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-r68n6" to be "success or failure"
+Aug  8 20:20:32.310: INFO: Pod "pod-projected-secrets-800bfab3-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 4.235104ms
+Aug  8 20:20:34.314: INFO: Pod "pod-projected-secrets-800bfab3-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007924622s
+Aug  8 20:20:36.317: INFO: Pod "pod-projected-secrets-800bfab3-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011475124s
+STEP: Saw pod success
+Aug  8 20:20:36.317: INFO: Pod "pod-projected-secrets-800bfab3-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:20:36.319: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-secrets-800bfab3-9b48-11e8-bae8-8697d7d38a55 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:20:36.334: INFO: Waiting for pod pod-projected-secrets-800bfab3-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:20:36.337: INFO: Pod pod-projected-secrets-800bfab3-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:20:36.337: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-r68n6" for this suite.
+Aug  8 20:20:42.347: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:20:42.393: INFO: namespace: e2e-tests-projected-r68n6, resource: bindings, ignored listing per whitelist
+Aug  8 20:20:42.423: INFO: namespace e2e-tests-projected-r68n6 deletion completed in 6.084320283s
+
+• [SLOW TEST:10.191 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:20:42.424: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Aug  8 20:20:42.507: INFO: Waiting up to 5m0s for pod "pod-86206623-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-9wg57" to be "success or failure"
+Aug  8 20:20:42.515: INFO: Pod "pod-86206623-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 7.977107ms
+Aug  8 20:20:44.519: INFO: Pod "pod-86206623-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01189655s
+Aug  8 20:20:46.525: INFO: Pod "pod-86206623-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01875238s
+STEP: Saw pod success
+Aug  8 20:20:46.525: INFO: Pod "pod-86206623-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:20:46.529: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-86206623-9b48-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:20:46.546: INFO: Waiting for pod pod-86206623-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:20:46.549: INFO: Pod pod-86206623-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:20:46.549: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-9wg57" for this suite.
+Aug  8 20:20:52.560: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:20:52.603: INFO: namespace: e2e-tests-emptydir-9wg57, resource: bindings, ignored listing per whitelist
+Aug  8 20:20:52.660: INFO: namespace e2e-tests-emptydir-9wg57 deletion completed in 6.108666679s
+
+• [SLOW TEST:10.237 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:20:52.661: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test substitution in container's args
+Aug  8 20:20:52.769: INFO: Waiting up to 5m0s for pod "var-expansion-8c3e1a3f-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-var-expansion-wctfc" to be "success or failure"
+Aug  8 20:20:52.777: INFO: Pod "var-expansion-8c3e1a3f-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 8.155907ms
+Aug  8 20:20:54.781: INFO: Pod "var-expansion-8c3e1a3f-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011876576s
+Aug  8 20:20:56.784: INFO: Pod "var-expansion-8c3e1a3f-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01507583s
+STEP: Saw pod success
+Aug  8 20:20:56.784: INFO: Pod "var-expansion-8c3e1a3f-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:20:56.787: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod var-expansion-8c3e1a3f-9b48-11e8-bae8-8697d7d38a55 container dapi-container: <nil>
+STEP: delete the pod
+Aug  8 20:20:56.806: INFO: Waiting for pod var-expansion-8c3e1a3f-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:20:56.808: INFO: Pod var-expansion-8c3e1a3f-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:20:56.808: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-wctfc" for this suite.
+Aug  8 20:21:02.821: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:21:02.880: INFO: namespace: e2e-tests-var-expansion-wctfc, resource: bindings, ignored listing per whitelist
+Aug  8 20:21:02.896: INFO: namespace e2e-tests-var-expansion-wctfc deletion completed in 6.084252736s
+
+• [SLOW TEST:10.235 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:21:02.896: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-9253b478-9b48-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:21:02.978: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-92542832-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-hwv8b" to be "success or failure"
+Aug  8 20:21:02.983: INFO: Pod "pod-projected-configmaps-92542832-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.016004ms
+Aug  8 20:21:04.987: INFO: Pod "pod-projected-configmaps-92542832-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008799801s
+Aug  8 20:21:06.991: INFO: Pod "pod-projected-configmaps-92542832-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012523283s
+STEP: Saw pod success
+Aug  8 20:21:06.991: INFO: Pod "pod-projected-configmaps-92542832-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:21:06.993: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-configmaps-92542832-9b48-11e8-bae8-8697d7d38a55 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:21:07.013: INFO: Waiting for pod pod-projected-configmaps-92542832-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:21:07.015: INFO: Pod pod-projected-configmaps-92542832-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:21:07.015: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hwv8b" for this suite.
+Aug  8 20:21:13.029: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:21:13.075: INFO: namespace: e2e-tests-projected-hwv8b, resource: bindings, ignored listing per whitelist
+Aug  8 20:21:13.131: INFO: namespace e2e-tests-projected-hwv8b deletion completed in 6.113459943s
+
+• [SLOW TEST:10.236 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:21:13.131: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-986ee100-9b48-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:21:13.228: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-986fea41-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-xx9bg" to be "success or failure"
+Aug  8 20:21:13.241: INFO: Pod "pod-projected-configmaps-986fea41-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 12.355309ms
+Aug  8 20:21:15.244: INFO: Pod "pod-projected-configmaps-986fea41-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.015380934s
+STEP: Saw pod success
+Aug  8 20:21:15.244: INFO: Pod "pod-projected-configmaps-986fea41-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:21:15.247: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-configmaps-986fea41-9b48-11e8-bae8-8697d7d38a55 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:21:15.262: INFO: Waiting for pod pod-projected-configmaps-986fea41-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:21:15.264: INFO: Pod pod-projected-configmaps-986fea41-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:21:15.264: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xx9bg" for this suite.
+Aug  8 20:21:21.275: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:21:21.314: INFO: namespace: e2e-tests-projected-xx9bg, resource: bindings, ignored listing per whitelist
+Aug  8 20:21:21.348: INFO: namespace e2e-tests-projected-xx9bg deletion completed in 6.080402446s
+
+• [SLOW TEST:8.216 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:21:21.348: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:80
+Aug  8 20:21:21.422: INFO: Waiting up to 1m0s for all nodes to be ready
+Aug  8 20:22:21.444: INFO: Waiting for terminating namespaces to be deleted...
+Aug  8 20:22:21.447: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Aug  8 20:22:21.457: INFO: 12 / 12 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Aug  8 20:22:21.457: INFO: expected 5 pod replicas in namespace 'kube-system', 5 are Running and Ready.
+Aug  8 20:22:21.459: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Aug  8 20:22:21.459: INFO: 
+Logging pods the kubelet thinks is on node k8s-linuxpool-37994001-0 before test
+Aug  8 20:22:21.466: INFO: tiller-deploy-54c57f6dc5-tzhx7 from kube-system started at 2018-08-08 19:43:12 +0000 UTC (1 container statuses recorded)
+Aug  8 20:22:21.466: INFO: 	Container tiller ready: true, restart count 0
+Aug  8 20:22:21.466: INFO: heapster-855c6c8b5b-hhzdf from kube-system started at 2018-08-08 19:43:17 +0000 UTC (2 container statuses recorded)
+Aug  8 20:22:21.466: INFO: 	Container heapster ready: true, restart count 0
+Aug  8 20:22:21.466: INFO: 	Container heapster-nanny ready: true, restart count 0
+Aug  8 20:22:21.466: INFO: kubernetes-dashboard-86cdd7799c-j47fh from kube-system started at 2018-08-08 19:43:18 +0000 UTC (1 container statuses recorded)
+Aug  8 20:22:21.466: INFO: 	Container kubernetes-dashboard ready: true, restart count 0
+Aug  8 20:22:21.466: INFO: kube-dns-5c89bdc645-zpbwn from kube-system started at 2018-08-08 19:43:18 +0000 UTC (3 container statuses recorded)
+Aug  8 20:22:21.466: INFO: 	Container dnsmasq ready: true, restart count 0
+Aug  8 20:22:21.466: INFO: 	Container kubedns ready: true, restart count 0
+Aug  8 20:22:21.466: INFO: 	Container sidecar ready: true, restart count 0
+Aug  8 20:22:21.466: INFO: kube-proxy-82rx2 from kube-system started at 2018-08-08 19:42:39 +0000 UTC (1 container statuses recorded)
+Aug  8 20:22:21.466: INFO: 	Container kube-proxy ready: true, restart count 0
+Aug  8 20:22:21.466: INFO: metrics-server-789c47657d-4z2vr from kube-system started at 2018-08-08 19:43:18 +0000 UTC (1 container statuses recorded)
+Aug  8 20:22:21.466: INFO: 	Container metrics-server ready: true, restart count 0
+Aug  8 20:22:21.466: INFO: sonobuoy-systemd-logs-daemon-set-806020c23a614e67-8xmpb from heptio-sonobuoy started at 2018-08-08 19:50:30 +0000 UTC (2 container statuses recorded)
+Aug  8 20:22:21.466: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 0
+Aug  8 20:22:21.466: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Aug  8 20:22:21.466: INFO: 
+Logging pods the kubelet thinks is on node k8s-linuxpool-37994001-1 before test
+Aug  8 20:22:21.471: INFO: sonobuoy-systemd-logs-daemon-set-806020c23a614e67-xhd79 from heptio-sonobuoy started at 2018-08-08 19:50:30 +0000 UTC (2 container statuses recorded)
+Aug  8 20:22:21.471: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 0
+Aug  8 20:22:21.471: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Aug  8 20:22:21.471: INFO: sonobuoy-e2e-job-d01c3492ba7e47ed from heptio-sonobuoy started at 2018-08-08 19:50:30 +0000 UTC (2 container statuses recorded)
+Aug  8 20:22:21.471: INFO: 	Container e2e ready: true, restart count 0
+Aug  8 20:22:21.471: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Aug  8 20:22:21.471: INFO: sonobuoy from heptio-sonobuoy started at 2018-08-08 19:50:24 +0000 UTC (1 container statuses recorded)
+Aug  8 20:22:21.471: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Aug  8 20:22:21.471: INFO: kube-proxy-mtjsn from kube-system started at 2018-08-08 19:42:39 +0000 UTC (1 container statuses recorded)
+Aug  8 20:22:21.471: INFO: 	Container kube-proxy ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: verifying the node has the label node k8s-linuxpool-37994001-0
+STEP: verifying the node has the label node k8s-linuxpool-37994001-1
+Aug  8 20:22:21.498: INFO: Pod sonobuoy requesting resource cpu=0m on Node k8s-linuxpool-37994001-1
+Aug  8 20:22:21.498: INFO: Pod sonobuoy-e2e-job-d01c3492ba7e47ed requesting resource cpu=0m on Node k8s-linuxpool-37994001-1
+Aug  8 20:22:21.498: INFO: Pod sonobuoy-systemd-logs-daemon-set-806020c23a614e67-8xmpb requesting resource cpu=0m on Node k8s-linuxpool-37994001-0
+Aug  8 20:22:21.498: INFO: Pod sonobuoy-systemd-logs-daemon-set-806020c23a614e67-xhd79 requesting resource cpu=0m on Node k8s-linuxpool-37994001-1
+Aug  8 20:22:21.498: INFO: Pod heapster-855c6c8b5b-hhzdf requesting resource cpu=176m on Node k8s-linuxpool-37994001-0
+Aug  8 20:22:21.498: INFO: Pod kube-dns-5c89bdc645-zpbwn requesting resource cpu=260m on Node k8s-linuxpool-37994001-0
+Aug  8 20:22:21.498: INFO: Pod kube-proxy-82rx2 requesting resource cpu=100m on Node k8s-linuxpool-37994001-0
+Aug  8 20:22:21.498: INFO: Pod kube-proxy-mtjsn requesting resource cpu=100m on Node k8s-linuxpool-37994001-1
+Aug  8 20:22:21.498: INFO: Pod kubernetes-dashboard-86cdd7799c-j47fh requesting resource cpu=300m on Node k8s-linuxpool-37994001-0
+Aug  8 20:22:21.498: INFO: Pod metrics-server-789c47657d-4z2vr requesting resource cpu=0m on Node k8s-linuxpool-37994001-0
+Aug  8 20:22:21.498: INFO: Pod tiller-deploy-54c57f6dc5-tzhx7 requesting resource cpu=50m on Node k8s-linuxpool-37994001-0
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-c1220e43-9b48-11e8-bae8-8697d7d38a55.1549025bd4144b61], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-glv29/filler-pod-c1220e43-9b48-11e8-bae8-8697d7d38a55 to k8s-linuxpool-37994001-0]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-c1220e43-9b48-11e8-bae8-8697d7d38a55.1549025c114ae0c6], Reason = [Pulling], Message = [pulling image "k8s.gcr.io/pause:3.1"]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-c1220e43-9b48-11e8-bae8-8697d7d38a55.1549025c2cb32f9c], Reason = [Pulled], Message = [Successfully pulled image "k8s.gcr.io/pause:3.1"]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-c1220e43-9b48-11e8-bae8-8697d7d38a55.1549025c3c5b62ad], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-c1220e43-9b48-11e8-bae8-8697d7d38a55.1549025c45e226e7], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-c12306d7-9b48-11e8-bae8-8697d7d38a55.1549025bd4559839], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-glv29/filler-pod-c12306d7-9b48-11e8-bae8-8697d7d38a55 to k8s-linuxpool-37994001-1]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-c12306d7-9b48-11e8-bae8-8697d7d38a55.1549025c10783dfb], Reason = [Pulling], Message = [pulling image "k8s.gcr.io/pause:3.1"]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-c12306d7-9b48-11e8-bae8-8697d7d38a55.1549025c2c683aca], Reason = [Pulled], Message = [Successfully pulled image "k8s.gcr.io/pause:3.1"]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-c12306d7-9b48-11e8-bae8-8697d7d38a55.1549025c3f84dfdf], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-c12306d7-9b48-11e8-bae8-8697d7d38a55.1549025c457bb2e1], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.1549025cc35b8e92], Reason = [FailedScheduling], Message = [0/3 nodes are available: 1 node(s) had taints that the pod didn't tolerate, 2 Insufficient cpu.]
+STEP: removing the label node off the node k8s-linuxpool-37994001-0
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node k8s-linuxpool-37994001-1
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:22:26.553: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-glv29" for this suite.
+Aug  8 20:22:32.566: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:22:32.603: INFO: namespace: e2e-tests-sched-pred-glv29, resource: bindings, ignored listing per whitelist
+Aug  8 20:22:32.661: INFO: namespace e2e-tests-sched-pred-glv29 deletion completed in 6.105525187s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:71
+
+• [SLOW TEST:71.314 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:22:32.662: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Aug  8 20:22:32.752: INFO: Waiting up to 5m0s for pod "pod-c7d69dc8-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-8lq5z" to be "success or failure"
+Aug  8 20:22:32.757: INFO: Pod "pod-c7d69dc8-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 4.135602ms
+Aug  8 20:22:34.760: INFO: Pod "pod-c7d69dc8-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007788723s
+STEP: Saw pod success
+Aug  8 20:22:34.760: INFO: Pod "pod-c7d69dc8-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:22:34.763: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-c7d69dc8-9b48-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:22:34.781: INFO: Waiting for pod pod-c7d69dc8-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:22:34.783: INFO: Pod pod-c7d69dc8-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:22:34.783: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-8lq5z" for this suite.
+Aug  8 20:22:40.795: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:22:40.854: INFO: namespace: e2e-tests-emptydir-8lq5z, resource: bindings, ignored listing per whitelist
+Aug  8 20:22:40.888: INFO: namespace e2e-tests-emptydir-8lq5z deletion completed in 6.101485638s
+
+• [SLOW TEST:8.226 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Watchers 
+  should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:22:40.888: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: modifying the configmap a second time
+STEP: deleting the configmap
+STEP: creating a watch on configmaps from the resource version returned by the first update
+STEP: Expecting to observe notifications for all changes to the configmap after the first update
+Aug  8 20:22:41.006: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-resource-version,GenerateName:,Namespace:e2e-tests-watch-9rrbk,SelfLink:/api/v1/namespaces/e2e-tests-watch-9rrbk/configmaps/e2e-watch-test-resource-version,UID:ccbfb1e0-9b48-11e8-ad47-001dd8b71c0d,ResourceVersion:8774,Generation:0,CreationTimestamp:2018-08-08 20:22:40 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: from-resource-version,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Aug  8 20:22:41.006: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-resource-version,GenerateName:,Namespace:e2e-tests-watch-9rrbk,SelfLink:/api/v1/namespaces/e2e-tests-watch-9rrbk/configmaps/e2e-watch-test-resource-version,UID:ccbfb1e0-9b48-11e8-ad47-001dd8b71c0d,ResourceVersion:8775,Generation:0,CreationTimestamp:2018-08-08 20:22:40 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: from-resource-version,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:22:41.006: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-9rrbk" for this suite.
+Aug  8 20:22:47.017: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:22:47.063: INFO: namespace: e2e-tests-watch-9rrbk, resource: bindings, ignored listing per whitelist
+Aug  8 20:22:47.097: INFO: namespace e2e-tests-watch-9rrbk deletion completed in 6.087752421s
+
+• [SLOW TEST:6.209 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:22:47.099: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:22:47.182: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d0707684-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-6skgs" to be "success or failure"
+Aug  8 20:22:47.184: INFO: Pod "downwardapi-volume-d0707684-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 1.807901ms
+Aug  8 20:22:49.188: INFO: Pod "downwardapi-volume-d0707684-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005854339s
+Aug  8 20:22:51.192: INFO: Pod "downwardapi-volume-d0707684-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009595165s
+STEP: Saw pod success
+Aug  8 20:22:51.192: INFO: Pod "downwardapi-volume-d0707684-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:22:51.195: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-d0707684-9b48-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:22:51.218: INFO: Waiting for pod downwardapi-volume-d0707684-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:22:51.221: INFO: Pod downwardapi-volume-d0707684-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:22:51.221: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-6skgs" for this suite.
+Aug  8 20:22:57.238: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:22:57.265: INFO: namespace: e2e-tests-downward-api-6skgs, resource: bindings, ignored listing per whitelist
+Aug  8 20:22:57.344: INFO: namespace e2e-tests-downward-api-6skgs deletion completed in 6.120124258s
+
+• [SLOW TEST:10.245 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:22:57.345: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-d68f8824-9b48-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:22:57.460: INFO: Waiting up to 5m0s for pod "pod-secrets-d690a911-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-secrets-txp2h" to be "success or failure"
+Aug  8 20:22:57.463: INFO: Pod "pod-secrets-d690a911-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.319901ms
+Aug  8 20:22:59.466: INFO: Pod "pod-secrets-d690a911-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005955981s
+Aug  8 20:23:01.470: INFO: Pod "pod-secrets-d690a911-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009349049s
+STEP: Saw pod success
+Aug  8 20:23:01.470: INFO: Pod "pod-secrets-d690a911-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:23:01.473: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-secrets-d690a911-9b48-11e8-bae8-8697d7d38a55 container secret-env-test: <nil>
+STEP: delete the pod
+Aug  8 20:23:01.491: INFO: Waiting for pod pod-secrets-d690a911-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:23:01.493: INFO: Pod pod-secrets-d690a911-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:23:01.493: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-txp2h" for this suite.
+Aug  8 20:23:07.507: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:23:07.561: INFO: namespace: e2e-tests-secrets-txp2h, resource: bindings, ignored listing per whitelist
+Aug  8 20:23:07.584: INFO: namespace e2e-tests-secrets-txp2h deletion completed in 6.089093171s
+
+• [SLOW TEST:10.240 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:23:07.584: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Aug  8 20:23:07.689: INFO: (0) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 4.103802ms)
+Aug  8 20:23:07.693: INFO: (1) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 4.205102ms)
+Aug  8 20:23:07.697: INFO: (2) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.481401ms)
+Aug  8 20:23:07.700: INFO: (3) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.735502ms)
+Aug  8 20:23:07.703: INFO: (4) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.107701ms)
+Aug  8 20:23:07.707: INFO: (5) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.460302ms)
+Aug  8 20:23:07.710: INFO: (6) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.052401ms)
+Aug  8 20:23:07.713: INFO: (7) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 2.910101ms)
+Aug  8 20:23:07.716: INFO: (8) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.399802ms)
+Aug  8 20:23:07.720: INFO: (9) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.547001ms)
+Aug  8 20:23:07.724: INFO: (10) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 4.328002ms)
+Aug  8 20:23:07.734: INFO: (11) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 9.354704ms)
+Aug  8 20:23:07.738: INFO: (12) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 4.017401ms)
+Aug  8 20:23:07.741: INFO: (13) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 2.971402ms)
+Aug  8 20:23:07.755: INFO: (14) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 13.848405ms)
+Aug  8 20:23:07.761: INFO: (15) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 5.840103ms)
+Aug  8 20:23:07.765: INFO: (16) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 4.321602ms)
+Aug  8 20:23:07.770: INFO: (17) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 4.525302ms)
+Aug  8 20:23:07.773: INFO: (18) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 3.096301ms)
+Aug  8 20:23:07.776: INFO: (19) /api/v1/nodes/k8s-linuxpool-37994001-0:10250/proxy/logs/: <pre>
+<a href="alternatives.log">alternatives.log</a>
+<a href="apt/">apt/</a>
+<a href="auth.log">... (200; 2.894501ms)
+[AfterEach] version v1
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:23:07.776: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-4pf2r" for this suite.
+Aug  8 20:23:13.785: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:23:13.857: INFO: namespace: e2e-tests-proxy-4pf2r, resource: bindings, ignored listing per whitelist
+Aug  8 20:23:13.871: INFO: namespace e2e-tests-proxy-4pf2r deletion completed in 6.092816167s
+
+• [SLOW TEST:6.286 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:23:13.872: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:23:13.953: INFO: Waiting up to 5m0s for pod "downwardapi-volume-e0655e03-9b48-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-dgq8f" to be "success or failure"
+Aug  8 20:23:13.957: INFO: Pod "downwardapi-volume-e0655e03-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 4.022201ms
+Aug  8 20:23:15.960: INFO: Pod "downwardapi-volume-e0655e03-9b48-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007690691s
+Aug  8 20:23:17.964: INFO: Pod "downwardapi-volume-e0655e03-9b48-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011138069s
+STEP: Saw pod success
+Aug  8 20:23:17.964: INFO: Pod "downwardapi-volume-e0655e03-9b48-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:23:17.966: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-e0655e03-9b48-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:23:17.983: INFO: Waiting for pod downwardapi-volume-e0655e03-9b48-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:23:17.985: INFO: Pod downwardapi-volume-e0655e03-9b48-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:23:17.985: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-dgq8f" for this suite.
+Aug  8 20:23:23.996: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:23:24.031: INFO: namespace: e2e-tests-projected-dgq8f, resource: bindings, ignored listing per whitelist
+Aug  8 20:23:24.084: INFO: namespace e2e-tests-projected-dgq8f deletion completed in 6.096483901s
+
+• [SLOW TEST:10.212 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:23:24.084: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-jngj7
+Aug  8 20:23:28.198: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-jngj7
+STEP: checking the pod's current state and verifying that restartCount is present
+Aug  8 20:23:28.202: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:27:28.657: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-jngj7" for this suite.
+Aug  8 20:27:34.670: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:27:34.737: INFO: namespace: e2e-tests-container-probe-jngj7, resource: bindings, ignored listing per whitelist
+Aug  8 20:27:34.745: INFO: namespace e2e-tests-container-probe-jngj7 deletion completed in 6.083097079s
+
+• [SLOW TEST:250.661 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:27:34.745: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-6kvv6.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-6kvv6.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-6kvv6.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-6kvv6.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-6kvv6.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-6kvv6.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Aug  8 20:27:48.931: INFO: DNS probes using dns-test-7be3edef-9b49-11e8-bae8-8697d7d38a55 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:27:48.945: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-6kvv6" for this suite.
+Aug  8 20:27:54.957: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:27:55.000: INFO: namespace: e2e-tests-dns-6kvv6, resource: bindings, ignored listing per whitelist
+Aug  8 20:27:55.038: INFO: namespace e2e-tests-dns-6kvv6 deletion completed in 6.090187879s
+
+• [SLOW TEST:20.293 seconds]
+[sig-network] DNS
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:27:55.038: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Aug  8 20:27:55.121: INFO: Waiting up to 5m0s for pod "pod-87fbf1fe-9b49-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-cpggt" to be "success or failure"
+Aug  8 20:27:55.124: INFO: Pod "pod-87fbf1fe-9b49-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 3.049199ms
+Aug  8 20:27:57.128: INFO: Pod "pod-87fbf1fe-9b49-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006675118s
+Aug  8 20:27:59.131: INFO: Pod "pod-87fbf1fe-9b49-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.00976343s
+STEP: Saw pod success
+Aug  8 20:27:59.131: INFO: Pod "pod-87fbf1fe-9b49-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:27:59.134: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-87fbf1fe-9b49-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:27:59.150: INFO: Waiting for pod pod-87fbf1fe-9b49-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:27:59.152: INFO: Pod pod-87fbf1fe-9b49-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:27:59.152: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-cpggt" for this suite.
+Aug  8 20:28:05.162: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:28:05.203: INFO: namespace: e2e-tests-emptydir-cpggt, resource: bindings, ignored listing per whitelist
+Aug  8 20:28:05.240: INFO: namespace e2e-tests-emptydir-cpggt deletion completed in 6.084840085s
+
+• [SLOW TEST:10.201 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:28:05.240: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap e2e-tests-configmap-8mrg2/configmap-test-8e1269ad-9b49-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:28:05.335: INFO: Waiting up to 5m0s for pod "pod-configmaps-8e12ccec-9b49-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-configmap-8mrg2" to be "success or failure"
+Aug  8 20:28:05.337: INFO: Pod "pod-configmaps-8e12ccec-9b49-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 1.5967ms
+Aug  8 20:28:07.340: INFO: Pod "pod-configmaps-8e12ccec-9b49-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004943387s
+Aug  8 20:28:09.346: INFO: Pod "pod-configmaps-8e12ccec-9b49-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010316268s
+STEP: Saw pod success
+Aug  8 20:28:09.346: INFO: Pod "pod-configmaps-8e12ccec-9b49-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:28:09.349: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-configmaps-8e12ccec-9b49-11e8-bae8-8697d7d38a55 container env-test: <nil>
+STEP: delete the pod
+Aug  8 20:28:09.370: INFO: Waiting for pod pod-configmaps-8e12ccec-9b49-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:28:09.374: INFO: Pod pod-configmaps-8e12ccec-9b49-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:28:09.374: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-8mrg2" for this suite.
+Aug  8 20:28:15.385: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:28:15.416: INFO: namespace: e2e-tests-configmap-8mrg2, resource: bindings, ignored listing per whitelist
+Aug  8 20:28:15.455: INFO: namespace e2e-tests-configmap-8mrg2 deletion completed in 6.078343291s
+
+• [SLOW TEST:10.215 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:28:15.455: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Aug  8 20:28:18.056: INFO: Successfully updated pod "annotationupdate9426a598-9b49-11e8-bae8-8697d7d38a55"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:28:20.072: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-wz7f7" for this suite.
+Aug  8 20:28:42.082: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:28:42.116: INFO: namespace: e2e-tests-downward-api-wz7f7, resource: bindings, ignored listing per whitelist
+Aug  8 20:28:42.153: INFO: namespace e2e-tests-downward-api-wz7f7 deletion completed in 22.079382933s
+
+• [SLOW TEST:26.699 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:28:42.154: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the pods
+STEP: Gathering metrics
+W0808 20:29:22.255760      17 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Aug  8 20:29:22.255: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:29:22.255: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-tj6qj" for this suite.
+Aug  8 20:29:28.268: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:29:28.342: INFO: namespace: e2e-tests-gc-tj6qj, resource: bindings, ignored listing per whitelist
+Aug  8 20:29:28.370: INFO: namespace e2e-tests-gc-tj6qj deletion completed in 6.111687258s
+
+• [SLOW TEST:46.216 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:29:28.370: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps with label A
+STEP: creating a watch on configmaps with label B
+STEP: creating a watch on configmaps with label A or B
+STEP: creating a configmap with label A and ensuring the correct watchers observe the notification
+Aug  8 20:29:28.469: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-94g99,SelfLink:/api/v1/namespaces/e2e-tests-watch-94g99/configmaps/e2e-watch-test-configmap-a,UID:bfa1cd07-9b49-11e8-ad47-001dd8b71c0d,ResourceVersion:9833,Generation:0,CreationTimestamp:2018-08-08 20:29:28 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Aug  8 20:29:28.469: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-94g99,SelfLink:/api/v1/namespaces/e2e-tests-watch-94g99/configmaps/e2e-watch-test-configmap-a,UID:bfa1cd07-9b49-11e8-ad47-001dd8b71c0d,ResourceVersion:9833,Generation:0,CreationTimestamp:2018-08-08 20:29:28 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+STEP: modifying configmap A and ensuring the correct watchers observe the notification
+Aug  8 20:29:38.475: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-94g99,SelfLink:/api/v1/namespaces/e2e-tests-watch-94g99/configmaps/e2e-watch-test-configmap-a,UID:bfa1cd07-9b49-11e8-ad47-001dd8b71c0d,ResourceVersion:9853,Generation:0,CreationTimestamp:2018-08-08 20:29:28 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+Aug  8 20:29:38.476: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-94g99,SelfLink:/api/v1/namespaces/e2e-tests-watch-94g99/configmaps/e2e-watch-test-configmap-a,UID:bfa1cd07-9b49-11e8-ad47-001dd8b71c0d,ResourceVersion:9853,Generation:0,CreationTimestamp:2018-08-08 20:29:28 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying configmap A again and ensuring the correct watchers observe the notification
+Aug  8 20:29:48.481: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-94g99,SelfLink:/api/v1/namespaces/e2e-tests-watch-94g99/configmaps/e2e-watch-test-configmap-a,UID:bfa1cd07-9b49-11e8-ad47-001dd8b71c0d,ResourceVersion:9868,Generation:0,CreationTimestamp:2018-08-08 20:29:28 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Aug  8 20:29:48.481: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-94g99,SelfLink:/api/v1/namespaces/e2e-tests-watch-94g99/configmaps/e2e-watch-test-configmap-a,UID:bfa1cd07-9b49-11e8-ad47-001dd8b71c0d,ResourceVersion:9868,Generation:0,CreationTimestamp:2018-08-08 20:29:28 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+STEP: deleting configmap A and ensuring the correct watchers observe the notification
+Aug  8 20:29:58.487: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-94g99,SelfLink:/api/v1/namespaces/e2e-tests-watch-94g99/configmaps/e2e-watch-test-configmap-a,UID:bfa1cd07-9b49-11e8-ad47-001dd8b71c0d,ResourceVersion:9883,Generation:0,CreationTimestamp:2018-08-08 20:29:28 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Aug  8 20:29:58.487: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-94g99,SelfLink:/api/v1/namespaces/e2e-tests-watch-94g99/configmaps/e2e-watch-test-configmap-a,UID:bfa1cd07-9b49-11e8-ad47-001dd8b71c0d,ResourceVersion:9883,Generation:0,CreationTimestamp:2018-08-08 20:29:28 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+STEP: creating a configmap with label B and ensuring the correct watchers observe the notification
+Aug  8 20:30:08.492: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-94g99,SelfLink:/api/v1/namespaces/e2e-tests-watch-94g99/configmaps/e2e-watch-test-configmap-b,UID:d77c9382-9b49-11e8-ad47-001dd8b71c0d,ResourceVersion:9898,Generation:0,CreationTimestamp:2018-08-08 20:30:08 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Aug  8 20:30:08.492: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-94g99,SelfLink:/api/v1/namespaces/e2e-tests-watch-94g99/configmaps/e2e-watch-test-configmap-b,UID:d77c9382-9b49-11e8-ad47-001dd8b71c0d,ResourceVersion:9898,Generation:0,CreationTimestamp:2018-08-08 20:30:08 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+STEP: deleting configmap B and ensuring the correct watchers observe the notification
+Aug  8 20:30:18.497: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-94g99,SelfLink:/api/v1/namespaces/e2e-tests-watch-94g99/configmaps/e2e-watch-test-configmap-b,UID:d77c9382-9b49-11e8-ad47-001dd8b71c0d,ResourceVersion:9913,Generation:0,CreationTimestamp:2018-08-08 20:30:08 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Aug  8 20:30:18.497: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-94g99,SelfLink:/api/v1/namespaces/e2e-tests-watch-94g99/configmaps/e2e-watch-test-configmap-b,UID:d77c9382-9b49-11e8-ad47-001dd8b71c0d,ResourceVersion:9913,Generation:0,CreationTimestamp:2018-08-08 20:30:08 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:30:28.498: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-94g99" for this suite.
+Aug  8 20:30:34.511: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:30:34.550: INFO: namespace: e2e-tests-watch-94g99, resource: bindings, ignored listing per whitelist
+Aug  8 20:30:34.584: INFO: namespace e2e-tests-watch-94g99 deletion completed in 6.08350437s
+
+• [SLOW TEST:66.215 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:30:34.585: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-e71688b3-9b49-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:30:34.683: INFO: Waiting up to 5m0s for pod "pod-configmaps-e7173849-9b49-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-configmap-p9rxj" to be "success or failure"
+Aug  8 20:30:34.688: INFO: Pod "pod-configmaps-e7173849-9b49-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 4.995698ms
+Aug  8 20:30:36.693: INFO: Pod "pod-configmaps-e7173849-9b49-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009714289s
+STEP: Saw pod success
+Aug  8 20:30:36.693: INFO: Pod "pod-configmaps-e7173849-9b49-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:30:36.695: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-configmaps-e7173849-9b49-11e8-bae8-8697d7d38a55 container configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:30:36.711: INFO: Waiting for pod pod-configmaps-e7173849-9b49-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:30:36.714: INFO: Pod pod-configmaps-e7173849-9b49-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:30:36.715: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-p9rxj" for this suite.
+Aug  8 20:30:42.728: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:30:42.736: INFO: namespace: e2e-tests-configmap-p9rxj, resource: bindings, ignored listing per whitelist
+Aug  8 20:30:42.814: INFO: namespace e2e-tests-configmap-p9rxj deletion completed in 6.097207409s
+
+• [SLOW TEST:8.230 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:30:42.815: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Aug  8 20:30:42.903: INFO: Waiting up to 5m0s for pod "pod-ebfd6929-9b49-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-w86t6" to be "success or failure"
+Aug  8 20:30:42.911: INFO: Pod "pod-ebfd6929-9b49-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 7.297097ms
+Aug  8 20:30:44.914: INFO: Pod "pod-ebfd6929-9b49-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011080168s
+Aug  8 20:30:46.918: INFO: Pod "pod-ebfd6929-9b49-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014386036s
+STEP: Saw pod success
+Aug  8 20:30:46.918: INFO: Pod "pod-ebfd6929-9b49-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:30:46.919: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-ebfd6929-9b49-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:30:46.942: INFO: Waiting for pod pod-ebfd6929-9b49-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:30:46.945: INFO: Pod pod-ebfd6929-9b49-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:30:46.945: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-w86t6" for this suite.
+Aug  8 20:30:52.961: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:30:52.987: INFO: namespace: e2e-tests-emptydir-w86t6, resource: bindings, ignored listing per whitelist
+Aug  8 20:30:53.085: INFO: namespace e2e-tests-emptydir-w86t6 deletion completed in 6.136755621s
+
+• [SLOW TEST:10.270 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:30:53.085: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Aug  8 20:30:57.713: INFO: Successfully updated pod "labelsupdatef21e7349-9b49-11e8-bae8-8697d7d38a55"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:30:59.730: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-wnsw5" for this suite.
+Aug  8 20:31:21.746: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:31:21.755: INFO: namespace: e2e-tests-downward-api-wnsw5, resource: bindings, ignored listing per whitelist
+Aug  8 20:31:21.815: INFO: namespace e2e-tests-downward-api-wnsw5 deletion completed in 22.078197228s
+
+• [SLOW TEST:28.730 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:31:21.815: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-dstnl
+[It] should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a new StatefulSet
+Aug  8 20:31:21.905: INFO: Found 0 stateful pods, waiting for 3
+Aug  8 20:31:31.909: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Aug  8 20:31:31.909: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Aug  8 20:31:31.909: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+Aug  8 20:31:31.916: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-dstnl ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Aug  8 20:31:32.128: INFO: stderr: ""
+Aug  8 20:31:32.128: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Aug  8 20:31:32.128: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+STEP: Updating StatefulSet template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Aug  8 20:31:42.156: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Updating Pods in reverse ordinal order
+Aug  8 20:31:52.181: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-dstnl ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Aug  8 20:31:52.396: INFO: stderr: ""
+Aug  8 20:31:52.396: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Aug  8 20:31:52.396: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Aug  8 20:32:02.416: INFO: Waiting for StatefulSet e2e-tests-statefulset-dstnl/ss2 to complete update
+Aug  8 20:32:02.416: INFO: Waiting for Pod e2e-tests-statefulset-dstnl/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Aug  8 20:32:02.416: INFO: Waiting for Pod e2e-tests-statefulset-dstnl/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Aug  8 20:32:02.416: INFO: Waiting for Pod e2e-tests-statefulset-dstnl/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Aug  8 20:32:12.423: INFO: Waiting for StatefulSet e2e-tests-statefulset-dstnl/ss2 to complete update
+Aug  8 20:32:12.423: INFO: Waiting for Pod e2e-tests-statefulset-dstnl/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Aug  8 20:32:12.423: INFO: Waiting for Pod e2e-tests-statefulset-dstnl/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Rolling back to a previous revision
+Aug  8 20:32:22.421: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-dstnl ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Aug  8 20:32:22.624: INFO: stderr: ""
+Aug  8 20:32:22.625: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Aug  8 20:32:22.625: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Aug  8 20:32:32.653: INFO: Updating stateful set ss2
+STEP: Rolling back update in reverse ordinal order
+Aug  8 20:32:42.670: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-499033417 exec --namespace=e2e-tests-statefulset-dstnl ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Aug  8 20:32:42.894: INFO: stderr: ""
+Aug  8 20:32:42.894: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Aug  8 20:32:42.894: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Aug  8 20:32:52.913: INFO: Waiting for StatefulSet e2e-tests-statefulset-dstnl/ss2 to complete update
+Aug  8 20:32:52.913: INFO: Waiting for Pod e2e-tests-statefulset-dstnl/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Aug  8 20:32:52.913: INFO: Waiting for Pod e2e-tests-statefulset-dstnl/ss2-1 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Aug  8 20:32:52.913: INFO: Waiting for Pod e2e-tests-statefulset-dstnl/ss2-2 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Aug  8 20:33:02.920: INFO: Waiting for StatefulSet e2e-tests-statefulset-dstnl/ss2 to complete update
+Aug  8 20:33:02.920: INFO: Waiting for Pod e2e-tests-statefulset-dstnl/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Aug  8 20:33:12.924: INFO: Waiting for StatefulSet e2e-tests-statefulset-dstnl/ss2 to complete update
+Aug  8 20:33:12.924: INFO: Waiting for Pod e2e-tests-statefulset-dstnl/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Aug  8 20:33:22.919: INFO: Deleting all statefulset in ns e2e-tests-statefulset-dstnl
+Aug  8 20:33:22.921: INFO: Scaling statefulset ss2 to 0
+Aug  8 20:34:02.936: INFO: Waiting for statefulset status.replicas updated to 0
+Aug  8 20:34:02.939: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:34:02.950: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-dstnl" for this suite.
+Aug  8 20:34:08.965: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:34:09.006: INFO: namespace: e2e-tests-statefulset-dstnl, resource: bindings, ignored listing per whitelist
+Aug  8 20:34:09.033: INFO: namespace e2e-tests-statefulset-dstnl deletion completed in 6.078887448s
+
+• [SLOW TEST:167.217 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should perform rolling updates and roll backs of template modifications [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:34:09.033: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-map-66e84864-9b4a-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:34:09.126: INFO: Waiting up to 5m0s for pod "pod-secrets-66e8b213-9b4a-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-secrets-j45zb" to be "success or failure"
+Aug  8 20:34:09.134: INFO: Pod "pod-secrets-66e8b213-9b4a-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 7.677495ms
+Aug  8 20:34:11.138: INFO: Pod "pod-secrets-66e8b213-9b4a-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011672885s
+Aug  8 20:34:13.141: INFO: Pod "pod-secrets-66e8b213-9b4a-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014966672s
+STEP: Saw pod success
+Aug  8 20:34:13.141: INFO: Pod "pod-secrets-66e8b213-9b4a-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:34:13.144: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-secrets-66e8b213-9b4a-11e8-bae8-8697d7d38a55 container secret-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:34:13.167: INFO: Waiting for pod pod-secrets-66e8b213-9b4a-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:34:13.174: INFO: Pod pod-secrets-66e8b213-9b4a-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:34:13.174: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-j45zb" for this suite.
+Aug  8 20:34:19.185: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:34:19.208: INFO: namespace: e2e-tests-secrets-j45zb, resource: bindings, ignored listing per whitelist
+Aug  8 20:34:19.286: INFO: namespace e2e-tests-secrets-j45zb deletion completed in 6.109529783s
+
+• [SLOW TEST:10.253 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:34:19.287: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:34:19.448: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-pc4b6" for this suite.
+Aug  8 20:34:25.472: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:34:25.531: INFO: namespace: e2e-tests-services-pc4b6, resource: bindings, ignored listing per whitelist
+Aug  8 20:34:25.551: INFO: namespace e2e-tests-services-pc4b6 deletion completed in 6.098370161s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:6.264 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Watchers 
+  should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:34:25.551: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps with a certain label
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: changing the label value of the configmap
+STEP: Expecting to observe a delete notification for the watched object
+Aug  8 20:34:25.636: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-w67pg,SelfLink:/api/v1/namespaces/e2e-tests-watch-w67pg/configmaps/e2e-watch-test-label-changed,UID:70c0850c-9b4a-11e8-ad47-001dd8b71c0d,ResourceVersion:10768,Generation:0,CreationTimestamp:2018-08-08 20:34:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Aug  8 20:34:25.637: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-w67pg,SelfLink:/api/v1/namespaces/e2e-tests-watch-w67pg/configmaps/e2e-watch-test-label-changed,UID:70c0850c-9b4a-11e8-ad47-001dd8b71c0d,ResourceVersion:10769,Generation:0,CreationTimestamp:2018-08-08 20:34:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+Aug  8 20:34:25.637: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-w67pg,SelfLink:/api/v1/namespaces/e2e-tests-watch-w67pg/configmaps/e2e-watch-test-label-changed,UID:70c0850c-9b4a-11e8-ad47-001dd8b71c0d,ResourceVersion:10770,Generation:0,CreationTimestamp:2018-08-08 20:34:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying the configmap a second time
+STEP: Expecting not to observe a notification because the object no longer meets the selector's requirements
+STEP: changing the label value of the configmap back
+STEP: modifying the configmap a third time
+STEP: deleting the configmap
+STEP: Expecting to observe an add notification for the watched object when the label value was restored
+Aug  8 20:34:35.656: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-w67pg,SelfLink:/api/v1/namespaces/e2e-tests-watch-w67pg/configmaps/e2e-watch-test-label-changed,UID:70c0850c-9b4a-11e8-ad47-001dd8b71c0d,ResourceVersion:10786,Generation:0,CreationTimestamp:2018-08-08 20:34:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Aug  8 20:34:35.656: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-w67pg,SelfLink:/api/v1/namespaces/e2e-tests-watch-w67pg/configmaps/e2e-watch-test-label-changed,UID:70c0850c-9b4a-11e8-ad47-001dd8b71c0d,ResourceVersion:10787,Generation:0,CreationTimestamp:2018-08-08 20:34:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 3,},BinaryData:map[string][]byte{},}
+Aug  8 20:34:35.656: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-w67pg,SelfLink:/api/v1/namespaces/e2e-tests-watch-w67pg/configmaps/e2e-watch-test-label-changed,UID:70c0850c-9b4a-11e8-ad47-001dd8b71c0d,ResourceVersion:10788,Generation:0,CreationTimestamp:2018-08-08 20:34:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 3,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:34:35.656: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-w67pg" for this suite.
+Aug  8 20:34:41.669: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:34:41.685: INFO: namespace: e2e-tests-watch-w67pg, resource: bindings, ignored listing per whitelist
+Aug  8 20:34:41.740: INFO: namespace e2e-tests-watch-w67pg deletion completed in 6.078924603s
+
+• [SLOW TEST:16.189 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:34:41.740: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:34:41.826: INFO: Waiting up to 5m0s for pod "downwardapi-volume-7a66553f-9b4a-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-hdj7m" to be "success or failure"
+Aug  8 20:34:41.830: INFO: Pod "downwardapi-volume-7a66553f-9b4a-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 3.718798ms
+Aug  8 20:34:43.833: INFO: Pod "downwardapi-volume-7a66553f-9b4a-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00732444s
+Aug  8 20:34:45.837: INFO: Pod "downwardapi-volume-7a66553f-9b4a-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010901179s
+STEP: Saw pod success
+Aug  8 20:34:45.837: INFO: Pod "downwardapi-volume-7a66553f-9b4a-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:34:45.839: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-7a66553f-9b4a-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:34:45.863: INFO: Waiting for pod downwardapi-volume-7a66553f-9b4a-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:34:45.865: INFO: Pod downwardapi-volume-7a66553f-9b4a-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:34:45.865: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hdj7m" for this suite.
+Aug  8 20:34:51.877: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:34:51.891: INFO: namespace: e2e-tests-projected-hdj7m, resource: bindings, ignored listing per whitelist
+Aug  8 20:34:51.957: INFO: namespace e2e-tests-projected-hdj7m deletion completed in 6.089080552s
+
+• [SLOW TEST:10.217 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:34:51.958: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-hcpqp
+Aug  8 20:34:54.051: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-hcpqp
+STEP: checking the pod's current state and verifying that restartCount is present
+Aug  8 20:34:54.054: INFO: Initial restart count of pod liveness-http is 0
+Aug  8 20:35:16.098: INFO: Restart count of pod e2e-tests-container-probe-hcpqp/liveness-http is now 1 (22.043217727s elapsed)
+Aug  8 20:35:36.137: INFO: Restart count of pod e2e-tests-container-probe-hcpqp/liveness-http is now 2 (42.082896963s elapsed)
+Aug  8 20:35:56.181: INFO: Restart count of pod e2e-tests-container-probe-hcpqp/liveness-http is now 3 (1m2.126326237s elapsed)
+Aug  8 20:36:16.221: INFO: Restart count of pod e2e-tests-container-probe-hcpqp/liveness-http is now 4 (1m22.167012568s elapsed)
+Aug  8 20:37:28.355: INFO: Restart count of pod e2e-tests-container-probe-hcpqp/liveness-http is now 5 (2m34.300643684s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:37:28.362: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-hcpqp" for this suite.
+Aug  8 20:37:34.373: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:37:34.392: INFO: namespace: e2e-tests-container-probe-hcpqp, resource: bindings, ignored listing per whitelist
+Aug  8 20:37:34.445: INFO: namespace e2e-tests-container-probe-hcpqp deletion completed in 6.080717967s
+
+• [SLOW TEST:162.488 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:37:34.446: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-e156abf8-9b4a-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:37:34.531: INFO: Waiting up to 5m0s for pod "pod-secrets-e157133a-9b4a-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-secrets-s2p7f" to be "success or failure"
+Aug  8 20:37:34.534: INFO: Pod "pod-secrets-e157133a-9b4a-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.388398ms
+Aug  8 20:37:36.537: INFO: Pod "pod-secrets-e157133a-9b4a-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005241834s
+Aug  8 20:37:38.540: INFO: Pod "pod-secrets-e157133a-9b4a-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008322367s
+STEP: Saw pod success
+Aug  8 20:37:38.540: INFO: Pod "pod-secrets-e157133a-9b4a-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:37:38.542: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-secrets-e157133a-9b4a-11e8-bae8-8697d7d38a55 container secret-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:37:38.557: INFO: Waiting for pod pod-secrets-e157133a-9b4a-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:37:38.560: INFO: Pod pod-secrets-e157133a-9b4a-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:37:38.560: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-s2p7f" for this suite.
+Aug  8 20:37:44.571: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:37:44.593: INFO: namespace: e2e-tests-secrets-s2p7f, resource: bindings, ignored listing per whitelist
+Aug  8 20:37:44.657: INFO: namespace e2e-tests-secrets-s2p7f deletion completed in 6.094959226s
+
+• [SLOW TEST:10.211 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:37:44.657: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-e76fba5d-9b4a-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:37:44.765: INFO: Waiting up to 5m0s for pod "pod-secrets-e7704406-9b4a-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-secrets-zp2tv" to be "success or failure"
+Aug  8 20:37:44.767: INFO: Pod "pod-secrets-e7704406-9b4a-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.695898ms
+Aug  8 20:37:46.771: INFO: Pod "pod-secrets-e7704406-9b4a-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006185723s
+Aug  8 20:37:48.774: INFO: Pod "pod-secrets-e7704406-9b4a-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009657046s
+STEP: Saw pod success
+Aug  8 20:37:48.774: INFO: Pod "pod-secrets-e7704406-9b4a-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:37:48.776: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-secrets-e7704406-9b4a-11e8-bae8-8697d7d38a55 container secret-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:37:48.796: INFO: Waiting for pod pod-secrets-e7704406-9b4a-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:37:48.800: INFO: Pod pod-secrets-e7704406-9b4a-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:37:48.800: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-zp2tv" for this suite.
+Aug  8 20:37:54.816: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:37:54.877: INFO: namespace: e2e-tests-secrets-zp2tv, resource: bindings, ignored listing per whitelist
+Aug  8 20:37:54.908: INFO: namespace e2e-tests-secrets-zp2tv deletion completed in 6.104052789s
+
+• [SLOW TEST:10.250 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:37:54.908: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Aug  8 20:37:55.009: INFO: Waiting up to 5m0s for pod "downward-api-ed8b3d03-9b4a-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-kx9k7" to be "success or failure"
+Aug  8 20:37:55.015: INFO: Pod "downward-api-ed8b3d03-9b4a-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.415096ms
+Aug  8 20:37:57.018: INFO: Pod "downward-api-ed8b3d03-9b4a-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008417812s
+Aug  8 20:37:59.024: INFO: Pod "downward-api-ed8b3d03-9b4a-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014313923s
+STEP: Saw pod success
+Aug  8 20:37:59.024: INFO: Pod "downward-api-ed8b3d03-9b4a-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:37:59.027: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downward-api-ed8b3d03-9b4a-11e8-bae8-8697d7d38a55 container dapi-container: <nil>
+STEP: delete the pod
+Aug  8 20:37:59.049: INFO: Waiting for pod downward-api-ed8b3d03-9b4a-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:37:59.052: INFO: Pod downward-api-ed8b3d03-9b4a-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:37:59.052: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-kx9k7" for this suite.
+Aug  8 20:38:05.072: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:38:05.081: INFO: namespace: e2e-tests-downward-api-kx9k7, resource: bindings, ignored listing per whitelist
+Aug  8 20:38:05.157: INFO: namespace e2e-tests-downward-api-kx9k7 deletion completed in 6.101962659s
+
+• [SLOW TEST:10.249 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:38:05.157: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-b8xbq
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Aug  8 20:38:05.253: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Aug  8 20:38:31.309: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.244.1.142:8080/dial?request=hostName&protocol=http&host=10.244.1.141&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-b8xbq PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:38:31.309: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:38:31.410: INFO: Waiting for endpoints: map[]
+Aug  8 20:38:31.413: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.244.1.142:8080/dial?request=hostName&protocol=http&host=10.244.0.34&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-b8xbq PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:38:31.413: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:38:31.516: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:38:31.516: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-b8xbq" for this suite.
+Aug  8 20:38:53.527: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:38:53.558: INFO: namespace: e2e-tests-pod-network-test-b8xbq, resource: bindings, ignored listing per whitelist
+Aug  8 20:38:53.598: INFO: namespace e2e-tests-pod-network-test-b8xbq deletion completed in 22.078855862s
+
+• [SLOW TEST:48.441 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:38:53.598: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-10853db7-9b4b-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:38:53.691: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-10859331-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-g4l4c" to be "success or failure"
+Aug  8 20:38:53.700: INFO: Pod "pod-projected-configmaps-10859331-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 8.450494ms
+Aug  8 20:38:55.704: INFO: Pod "pod-projected-configmaps-10859331-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011988055s
+Aug  8 20:38:57.707: INFO: Pod "pod-projected-configmaps-10859331-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015188315s
+STEP: Saw pod success
+Aug  8 20:38:57.707: INFO: Pod "pod-projected-configmaps-10859331-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:38:57.710: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-configmaps-10859331-9b4b-11e8-bae8-8697d7d38a55 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:38:57.728: INFO: Waiting for pod pod-projected-configmaps-10859331-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:38:57.735: INFO: Pod pod-projected-configmaps-10859331-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:38:57.735: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-g4l4c" for this suite.
+Aug  8 20:39:03.753: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:39:03.829: INFO: namespace: e2e-tests-projected-g4l4c, resource: bindings, ignored listing per whitelist
+Aug  8 20:39:03.857: INFO: namespace e2e-tests-projected-g4l4c deletion completed in 6.119887284s
+
+• [SLOW TEST:10.259 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:39:03.859: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Aug  8 20:39:03.968: INFO: Waiting up to 5m0s for pod "pod-16a58fda-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-v2rgp" to be "success or failure"
+Aug  8 20:39:03.973: INFO: Pod "pod-16a58fda-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.478496ms
+Aug  8 20:39:05.977: INFO: Pod "pod-16a58fda-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009523148s
+STEP: Saw pod success
+Aug  8 20:39:05.977: INFO: Pod "pod-16a58fda-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:39:05.980: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-16a58fda-9b4b-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:39:06.003: INFO: Waiting for pod pod-16a58fda-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:39:06.005: INFO: Pod pod-16a58fda-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:39:06.005: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-v2rgp" for this suite.
+Aug  8 20:39:12.017: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:39:12.084: INFO: namespace: e2e-tests-emptydir-v2rgp, resource: bindings, ignored listing per whitelist
+Aug  8 20:39:12.094: INFO: namespace e2e-tests-emptydir-v2rgp deletion completed in 6.08568819s
+
+• [SLOW TEST:8.235 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:39:12.095: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-projected-all-test-volume-1b894b1e-9b4b-11e8-bae8-8697d7d38a55
+STEP: Creating secret with name secret-projected-all-test-volume-1b894b02-9b4b-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Aug  8 20:39:12.176: INFO: Waiting up to 5m0s for pod "projected-volume-1b894ad7-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-tpfcl" to be "success or failure"
+Aug  8 20:39:12.180: INFO: Pod "projected-volume-1b894ad7-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 4.196197ms
+Aug  8 20:39:14.187: INFO: Pod "projected-volume-1b894ad7-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01122574s
+Aug  8 20:39:16.190: INFO: Pod "projected-volume-1b894ad7-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014314685s
+STEP: Saw pod success
+Aug  8 20:39:16.190: INFO: Pod "projected-volume-1b894ad7-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:39:16.193: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod projected-volume-1b894ad7-9b4b-11e8-bae8-8697d7d38a55 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:39:16.209: INFO: Waiting for pod projected-volume-1b894ad7-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:39:16.212: INFO: Pod projected-volume-1b894ad7-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:39:16.212: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-tpfcl" for this suite.
+Aug  8 20:39:22.223: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:39:22.295: INFO: namespace: e2e-tests-projected-tpfcl, resource: bindings, ignored listing per whitelist
+Aug  8 20:39:22.304: INFO: namespace e2e-tests-projected-tpfcl deletion completed in 6.089330062s
+
+• [SLOW TEST:10.210 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:39:22.305: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-svkrq
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Aug  8 20:39:22.387: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Aug  8 20:39:42.450: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 10.244.1.147 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-svkrq PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:39:42.450: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:39:43.557: INFO: Found all expected endpoints: [netserver-0]
+Aug  8 20:39:43.561: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 10.244.0.35 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-svkrq PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:39:43.561: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:39:44.661: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:39:44.661: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-svkrq" for this suite.
+Aug  8 20:40:06.674: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:40:06.685: INFO: namespace: e2e-tests-pod-network-test-svkrq, resource: bindings, ignored listing per whitelist
+Aug  8 20:40:06.750: INFO: namespace e2e-tests-pod-network-test-svkrq deletion completed in 22.085122995s
+
+• [SLOW TEST:44.445 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:40:06.750: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Aug  8 20:40:06.845: INFO: Creating daemon "daemon-set" with a node selector
+STEP: Initially, daemon pods should not be running on any nodes.
+Aug  8 20:40:06.851: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:06.851: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Change node label to blue, check that daemon pod is launched.
+Aug  8 20:40:06.869: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:06.869: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:07.879: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:07.879: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:08.874: INFO: Number of nodes with available pods: 1
+Aug  8 20:40:08.874: INFO: Number of running nodes: 1, number of available pods: 1
+STEP: Update the node label to green, and wait for daemons to be unscheduled
+Aug  8 20:40:08.893: INFO: Number of nodes with available pods: 1
+Aug  8 20:40:08.893: INFO: Number of running nodes: 0, number of available pods: 1
+Aug  8 20:40:09.897: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:09.897: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Update DaemonSet node selector to green, and change its update strategy to RollingUpdate
+Aug  8 20:40:09.908: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:09.908: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:10.912: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:10.912: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:11.911: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:11.911: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:12.913: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:12.913: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:13.911: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:13.911: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:14.912: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:14.912: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:15.912: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:15.912: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:16.912: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:16.912: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:17.912: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:17.912: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:18.912: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:18.912: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:19.912: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:19.912: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:20.912: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:20.912: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:21.912: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:21.912: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:22.912: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:22.912: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:23.915: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:23.915: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:24.913: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:24.913: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:40:25.913: INFO: Number of nodes with available pods: 1
+Aug  8 20:40:25.913: INFO: Number of running nodes: 1, number of available pods: 1
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-wt96d, will wait for the garbage collector to delete the pods
+Aug  8 20:40:25.976: INFO: Deleting {extensions DaemonSet} daemon-set took: 5.459396ms
+Aug  8 20:40:26.076: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.204319ms
+Aug  8 20:40:29.079: INFO: Number of nodes with available pods: 0
+Aug  8 20:40:29.079: INFO: Number of running nodes: 0, number of available pods: 0
+Aug  8 20:40:29.083: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-wt96d/daemonsets","resourceVersion":"11772"},"items":null}
+
+Aug  8 20:40:29.086: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-wt96d/pods","resourceVersion":"11772"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:40:29.103: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-wt96d" for this suite.
+Aug  8 20:40:35.112: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:40:35.177: INFO: namespace: e2e-tests-daemonsets-wt96d, resource: bindings, ignored listing per whitelist
+Aug  8 20:40:35.200: INFO: namespace e2e-tests-daemonsets-wt96d deletion completed in 6.095096987s
+
+• [SLOW TEST:28.450 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:40:35.200: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:40:35.282: INFO: Waiting up to 5m0s for pod "downwardapi-volume-4d12d9e1-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-q47gf" to be "success or failure"
+Aug  8 20:40:35.284: INFO: Pod "downwardapi-volume-4d12d9e1-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.469698ms
+Aug  8 20:40:37.290: INFO: Pod "downwardapi-volume-4d12d9e1-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008466878s
+Aug  8 20:40:39.295: INFO: Pod "downwardapi-volume-4d12d9e1-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013060258s
+STEP: Saw pod success
+Aug  8 20:40:39.295: INFO: Pod "downwardapi-volume-4d12d9e1-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:40:39.297: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-4d12d9e1-9b4b-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:40:39.318: INFO: Waiting for pod downwardapi-volume-4d12d9e1-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:40:39.319: INFO: Pod downwardapi-volume-4d12d9e1-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:40:39.320: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-q47gf" for this suite.
+Aug  8 20:40:45.330: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:40:45.369: INFO: namespace: e2e-tests-projected-q47gf, resource: bindings, ignored listing per whitelist
+Aug  8 20:40:45.401: INFO: namespace e2e-tests-projected-q47gf deletion completed in 6.078809178s
+
+• [SLOW TEST:10.201 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:40:45.401: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-53279634-9b4b-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:40:45.482: INFO: Waiting up to 5m0s for pod "pod-secrets-5327f73c-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-secrets-tlv8b" to be "success or failure"
+Aug  8 20:40:45.486: INFO: Pod "pod-secrets-5327f73c-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 3.713597ms
+Aug  8 20:40:47.490: INFO: Pod "pod-secrets-5327f73c-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008221271s
+Aug  8 20:40:49.495: INFO: Pod "pod-secrets-5327f73c-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012382844s
+STEP: Saw pod success
+Aug  8 20:40:49.495: INFO: Pod "pod-secrets-5327f73c-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:40:49.498: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-secrets-5327f73c-9b4b-11e8-bae8-8697d7d38a55 container secret-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:40:49.513: INFO: Waiting for pod pod-secrets-5327f73c-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:40:49.521: INFO: Pod pod-secrets-5327f73c-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:40:49.521: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-tlv8b" for this suite.
+Aug  8 20:40:55.536: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:40:55.615: INFO: namespace: e2e-tests-secrets-tlv8b, resource: bindings, ignored listing per whitelist
+Aug  8 20:40:55.615: INFO: namespace e2e-tests-secrets-tlv8b deletion completed in 6.090802616s
+
+• [SLOW TEST:10.214 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:40:55.615: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-593d878a-9b4b-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:40:55.699: INFO: Waiting up to 5m0s for pod "pod-configmaps-593dfe78-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-configmap-7vzkb" to be "success or failure"
+Aug  8 20:40:55.704: INFO: Pod "pod-configmaps-593dfe78-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.465598ms
+Aug  8 20:40:57.707: INFO: Pod "pod-configmaps-593dfe78-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008588503s
+Aug  8 20:40:59.711: INFO: Pod "pod-configmaps-593dfe78-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012044881s
+STEP: Saw pod success
+Aug  8 20:40:59.711: INFO: Pod "pod-configmaps-593dfe78-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:40:59.713: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-configmaps-593dfe78-9b4b-11e8-bae8-8697d7d38a55 container configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:40:59.731: INFO: Waiting for pod pod-configmaps-593dfe78-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:40:59.733: INFO: Pod pod-configmaps-593dfe78-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:40:59.733: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-7vzkb" for this suite.
+Aug  8 20:41:05.753: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:41:05.830: INFO: namespace: e2e-tests-configmap-7vzkb, resource: bindings, ignored listing per whitelist
+Aug  8 20:41:05.842: INFO: namespace e2e-tests-configmap-7vzkb deletion completed in 6.105014221s
+
+• [SLOW TEST:10.227 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:41:05.842: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:41:05.943: INFO: Waiting up to 5m0s for pod "downwardapi-volume-5f59e339-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-p4shv" to be "success or failure"
+Aug  8 20:41:05.955: INFO: Pod "downwardapi-volume-5f59e339-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 11.438502ms
+Aug  8 20:41:07.958: INFO: Pod "downwardapi-volume-5f59e339-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.014438636s
+STEP: Saw pod success
+Aug  8 20:41:07.958: INFO: Pod "downwardapi-volume-5f59e339-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:41:07.960: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-5f59e339-9b4b-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:41:07.980: INFO: Waiting for pod downwardapi-volume-5f59e339-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:41:07.983: INFO: Pod downwardapi-volume-5f59e339-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:41:07.983: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-p4shv" for this suite.
+Aug  8 20:41:13.996: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:41:14.041: INFO: namespace: e2e-tests-downward-api-p4shv, resource: bindings, ignored listing per whitelist
+Aug  8 20:41:14.070: INFO: namespace e2e-tests-downward-api-p4shv deletion completed in 6.083327216s
+
+• [SLOW TEST:8.228 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:41:14.071: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:36
+[It] should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test hostPath mode
+Aug  8 20:41:14.144: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-6wvnl" to be "success or failure"
+Aug  8 20:41:14.148: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 4.047471ms
+Aug  8 20:41:16.151: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006988878s
+Aug  8 20:41:18.154: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010333265s
+STEP: Saw pod success
+Aug  8 20:41:18.154: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Aug  8 20:41:18.159: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Aug  8 20:41:18.174: INFO: Waiting for pod pod-host-path-test to disappear
+Aug  8 20:41:18.176: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:41:18.176: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-6wvnl" for this suite.
+Aug  8 20:41:24.189: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:41:24.241: INFO: namespace: e2e-tests-hostpath-6wvnl, resource: bindings, ignored listing per whitelist
+Aug  8 20:41:24.270: INFO: namespace e2e-tests-hostpath-6wvnl deletion completed in 6.091121584s
+
+• [SLOW TEST:10.199 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:33
+  should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:41:24.270: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Aug  8 20:41:24.366: INFO: Waiting up to 5m0s for pod "pod-6a54f9ae-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-jjlhg" to be "success or failure"
+Aug  8 20:41:24.371: INFO: Pod "pod-6a54f9ae-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.211189ms
+Aug  8 20:41:26.376: INFO: Pod "pod-6a54f9ae-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010216287s
+STEP: Saw pod success
+Aug  8 20:41:26.376: INFO: Pod "pod-6a54f9ae-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:41:26.380: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-6a54f9ae-9b4b-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:41:26.399: INFO: Waiting for pod pod-6a54f9ae-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:41:26.402: INFO: Pod pod-6a54f9ae-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:41:26.402: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-jjlhg" for this suite.
+Aug  8 20:41:32.415: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:41:32.493: INFO: namespace: e2e-tests-emptydir-jjlhg, resource: bindings, ignored listing per whitelist
+Aug  8 20:41:32.498: INFO: namespace e2e-tests-emptydir-jjlhg deletion completed in 6.092794554s
+
+• [SLOW TEST:8.228 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:41:32.499: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-fxmnz
+Aug  8 20:41:36.589: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-fxmnz
+STEP: checking the pod's current state and verifying that restartCount is present
+Aug  8 20:41:36.592: INFO: Initial restart count of pod liveness-exec is 0
+Aug  8 20:42:30.694: INFO: Restart count of pod e2e-tests-container-probe-fxmnz/liveness-exec is now 1 (54.102132898s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:42:30.702: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-fxmnz" for this suite.
+Aug  8 20:42:36.715: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:42:36.771: INFO: namespace: e2e-tests-container-probe-fxmnz, resource: bindings, ignored listing per whitelist
+Aug  8 20:42:36.795: INFO: namespace e2e-tests-container-probe-fxmnz deletion completed in 6.089229634s
+
+• [SLOW TEST:64.296 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:42:36.795: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-map-958d3f5f-9b4b-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:42:36.878: INFO: Waiting up to 5m0s for pod "pod-secrets-958d9f30-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-secrets-dv5t7" to be "success or failure"
+Aug  8 20:42:36.887: INFO: Pod "pod-secrets-958d9f30-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 9.33914ms
+Aug  8 20:42:38.891: INFO: Pod "pod-secrets-958d9f30-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013197604s
+Aug  8 20:42:40.894: INFO: Pod "pod-secrets-958d9f30-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016513151s
+STEP: Saw pod success
+Aug  8 20:42:40.894: INFO: Pod "pod-secrets-958d9f30-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:42:40.899: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-secrets-958d9f30-9b4b-11e8-bae8-8697d7d38a55 container secret-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:42:40.916: INFO: Waiting for pod pod-secrets-958d9f30-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:42:40.918: INFO: Pod pod-secrets-958d9f30-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:42:40.918: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-dv5t7" for this suite.
+Aug  8 20:42:46.929: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:42:46.985: INFO: namespace: e2e-tests-secrets-dv5t7, resource: bindings, ignored listing per whitelist
+Aug  8 20:42:46.999: INFO: namespace e2e-tests-secrets-dv5t7 deletion completed in 6.077439387s
+
+• [SLOW TEST:10.204 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:42:46.999: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Aug  8 20:42:47.112: INFO: Waiting up to 5m0s for pod "pod-9ba59a58-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-87gpm" to be "success or failure"
+Aug  8 20:42:47.115: INFO: Pod "pod-9ba59a58-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.793841ms
+Aug  8 20:42:49.119: INFO: Pod "pod-9ba59a58-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006576655s
+Aug  8 20:42:51.122: INFO: Pod "pod-9ba59a58-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01019236s
+STEP: Saw pod success
+Aug  8 20:42:51.123: INFO: Pod "pod-9ba59a58-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:42:51.126: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-9ba59a58-9b4b-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:42:51.139: INFO: Waiting for pod pod-9ba59a58-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:42:51.141: INFO: Pod pod-9ba59a58-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:42:51.141: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-87gpm" for this suite.
+Aug  8 20:42:57.155: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:42:57.239: INFO: namespace: e2e-tests-emptydir-87gpm, resource: bindings, ignored listing per whitelist
+Aug  8 20:42:57.241: INFO: namespace e2e-tests-emptydir-87gpm deletion completed in 6.097393332s
+
+• [SLOW TEST:10.242 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:42:57.241: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:42:57.333: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a1be7fa8-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-4mxkl" to be "success or failure"
+Aug  8 20:42:57.343: INFO: Pod "downwardapi-volume-a1be7fa8-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 10.486751ms
+Aug  8 20:42:59.347: INFO: Pod "downwardapi-volume-a1be7fa8-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01371112s
+Aug  8 20:43:01.350: INFO: Pod "downwardapi-volume-a1be7fa8-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017302791s
+STEP: Saw pod success
+Aug  8 20:43:01.350: INFO: Pod "downwardapi-volume-a1be7fa8-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:43:01.353: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-a1be7fa8-9b4b-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:43:01.381: INFO: Waiting for pod downwardapi-volume-a1be7fa8-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:43:01.383: INFO: Pod downwardapi-volume-a1be7fa8-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:43:01.383: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-4mxkl" for this suite.
+Aug  8 20:43:07.393: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:43:07.424: INFO: namespace: e2e-tests-downward-api-4mxkl, resource: bindings, ignored listing per whitelist
+Aug  8 20:43:07.481: INFO: namespace e2e-tests-downward-api-4mxkl deletion completed in 6.095486488s
+
+• [SLOW TEST:10.240 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:43:07.482: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Aug  8 20:43:07.573: INFO: Waiting up to 5m0s for pod "pod-a7d8de22-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-vt6ll" to be "success or failure"
+Aug  8 20:43:07.576: INFO: Pod "pod-a7d8de22-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.796139ms
+Aug  8 20:43:09.581: INFO: Pod "pod-a7d8de22-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007934909s
+STEP: Saw pod success
+Aug  8 20:43:09.581: INFO: Pod "pod-a7d8de22-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:43:09.583: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-a7d8de22-9b4b-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:43:09.603: INFO: Waiting for pod pod-a7d8de22-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:43:09.605: INFO: Pod pod-a7d8de22-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:43:09.605: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-vt6ll" for this suite.
+Aug  8 20:43:15.617: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:43:15.631: INFO: namespace: e2e-tests-emptydir-vt6ll, resource: bindings, ignored listing per whitelist
+Aug  8 20:43:15.683: INFO: namespace e2e-tests-emptydir-vt6ll deletion completed in 6.075037928s
+
+• [SLOW TEST:8.202 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:43:15.684: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the rs
+STEP: Gathering metrics
+W0808 20:43:46.277528      17 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Aug  8 20:43:46.277: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:43:46.277: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-lnhgj" for this suite.
+Aug  8 20:43:52.287: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:43:52.308: INFO: namespace: e2e-tests-gc-lnhgj, resource: bindings, ignored listing per whitelist
+Aug  8 20:43:52.370: INFO: namespace e2e-tests-gc-lnhgj deletion completed in 6.090673306s
+
+• [SLOW TEST:36.686 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:43:52.370: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name s-test-opt-del-c29a6545-9b4b-11e8-bae8-8697d7d38a55
+STEP: Creating secret with name s-test-opt-upd-c29a658e-9b4b-11e8-bae8-8697d7d38a55
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-c29a6545-9b4b-11e8-bae8-8697d7d38a55
+STEP: Updating secret s-test-opt-upd-c29a658e-9b4b-11e8-bae8-8697d7d38a55
+STEP: Creating secret with name s-test-opt-create-c29a65a5-9b4b-11e8-bae8-8697d7d38a55
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:44:00.556: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-7rblb" for this suite.
+Aug  8 20:44:22.569: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:44:22.640: INFO: namespace: e2e-tests-secrets-7rblb, resource: bindings, ignored listing per whitelist
+Aug  8 20:44:22.645: INFO: namespace e2e-tests-secrets-7rblb deletion completed in 22.085010978s
+
+• [SLOW TEST:30.275 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:44:22.647: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Aug  8 20:44:22.722: INFO: Requires at least 2 nodes (not -1)
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+Aug  8 20:44:22.726: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-wbbvz/daemonsets","resourceVersion":"12567"},"items":null}
+
+Aug  8 20:44:22.728: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-wbbvz/pods","resourceVersion":"12567"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:44:22.735: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-wbbvz" for this suite.
+Aug  8 20:44:28.747: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:44:28.785: INFO: namespace: e2e-tests-daemonsets-wbbvz, resource: bindings, ignored listing per whitelist
+Aug  8 20:44:28.831: INFO: namespace e2e-tests-daemonsets-wbbvz deletion completed in 6.09448422s
+
+S [SKIPPING] [6.185 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should rollback without unnecessary restarts [Conformance] [It]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+
+  Aug  8 20:44:22.722: Requires at least 2 nodes (not -1)
+
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:305
+------------------------------
+SSS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:44:28.831: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating replication controller my-hostname-basic-d8546a42-9b4b-11e8-bae8-8697d7d38a55
+Aug  8 20:44:28.911: INFO: Pod name my-hostname-basic-d8546a42-9b4b-11e8-bae8-8697d7d38a55: Found 0 pods out of 1
+Aug  8 20:44:33.914: INFO: Pod name my-hostname-basic-d8546a42-9b4b-11e8-bae8-8697d7d38a55: Found 1 pods out of 1
+Aug  8 20:44:33.914: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-d8546a42-9b4b-11e8-bae8-8697d7d38a55" are running
+Aug  8 20:44:33.916: INFO: Pod "my-hostname-basic-d8546a42-9b4b-11e8-bae8-8697d7d38a55-mkp6z" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-08-08 20:44:28 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-08-08 20:44:31 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-08-08 20:44:28 +0000 UTC Reason: Message:}])
+Aug  8 20:44:33.916: INFO: Trying to dial the pod
+Aug  8 20:44:38.932: INFO: Controller my-hostname-basic-d8546a42-9b4b-11e8-bae8-8697d7d38a55: Got expected result from replica 1 [my-hostname-basic-d8546a42-9b4b-11e8-bae8-8697d7d38a55-mkp6z]: "my-hostname-basic-d8546a42-9b4b-11e8-bae8-8697d7d38a55-mkp6z", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:44:38.932: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-f2ckp" for this suite.
+Aug  8 20:44:44.957: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:44:44.989: INFO: namespace: e2e-tests-replication-controller-f2ckp, resource: bindings, ignored listing per whitelist
+Aug  8 20:44:45.032: INFO: namespace e2e-tests-replication-controller-f2ckp deletion completed in 6.091594659s
+
+• [SLOW TEST:16.201 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:44:45.032: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-e1fcd709-9b4b-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:44:45.116: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-e1fd3193-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-rlzb4" to be "success or failure"
+Aug  8 20:44:45.118: INFO: Pod "pod-projected-configmaps-e1fd3193-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 1.69842ms
+Aug  8 20:44:47.121: INFO: Pod "pod-projected-configmaps-e1fd3193-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004823937s
+Aug  8 20:44:49.125: INFO: Pod "pod-projected-configmaps-e1fd3193-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008553576s
+STEP: Saw pod success
+Aug  8 20:44:49.125: INFO: Pod "pod-projected-configmaps-e1fd3193-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:44:49.128: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-configmaps-e1fd3193-9b4b-11e8-bae8-8697d7d38a55 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:44:49.146: INFO: Waiting for pod pod-projected-configmaps-e1fd3193-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:44:49.148: INFO: Pod pod-projected-configmaps-e1fd3193-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:44:49.148: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rlzb4" for this suite.
+Aug  8 20:44:55.161: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:44:55.179: INFO: namespace: e2e-tests-projected-rlzb4, resource: bindings, ignored listing per whitelist
+Aug  8 20:44:55.237: INFO: namespace e2e-tests-projected-rlzb4 deletion completed in 6.085216278s
+
+• [SLOW TEST:10.205 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:44:55.237: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:44:55.321: INFO: Waiting up to 5m0s for pod "downwardapi-volume-e8121e70-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-tmvrt" to be "success or failure"
+Aug  8 20:44:55.329: INFO: Pod "downwardapi-volume-e8121e70-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 8.288097ms
+Aug  8 20:44:57.332: INFO: Pod "downwardapi-volume-e8121e70-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011651091s
+Aug  8 20:44:59.336: INFO: Pod "downwardapi-volume-e8121e70-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015121003s
+STEP: Saw pod success
+Aug  8 20:44:59.336: INFO: Pod "downwardapi-volume-e8121e70-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:44:59.339: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-e8121e70-9b4b-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:44:59.360: INFO: Waiting for pod downwardapi-volume-e8121e70-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:44:59.365: INFO: Pod downwardapi-volume-e8121e70-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:44:59.365: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-tmvrt" for this suite.
+Aug  8 20:45:05.385: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:45:05.403: INFO: namespace: e2e-tests-projected-tmvrt, resource: bindings, ignored listing per whitelist
+Aug  8 20:45:05.474: INFO: namespace e2e-tests-projected-tmvrt deletion completed in 6.100221972s
+
+• [SLOW TEST:10.237 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:45:05.474: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:45:05.587: INFO: Waiting up to 5m0s for pod "downwardapi-volume-ee3009ba-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-tqsgk" to be "success or failure"
+Aug  8 20:45:05.589: INFO: Pod "downwardapi-volume-ee3009ba-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.626131ms
+Aug  8 20:45:07.593: INFO: Pod "downwardapi-volume-ee3009ba-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005970105s
+Aug  8 20:45:09.596: INFO: Pod "downwardapi-volume-ee3009ba-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009428299s
+STEP: Saw pod success
+Aug  8 20:45:09.596: INFO: Pod "downwardapi-volume-ee3009ba-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:45:09.598: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-ee3009ba-9b4b-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:45:09.612: INFO: Waiting for pod downwardapi-volume-ee3009ba-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:45:09.614: INFO: Pod downwardapi-volume-ee3009ba-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:45:09.614: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-tqsgk" for this suite.
+Aug  8 20:45:15.626: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:45:15.681: INFO: namespace: e2e-tests-downward-api-tqsgk, resource: bindings, ignored listing per whitelist
+Aug  8 20:45:15.706: INFO: namespace e2e-tests-downward-api-tqsgk deletion completed in 6.088783884s
+
+• [SLOW TEST:10.232 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:45:15.706: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Aug  8 20:45:15.801: INFO: Waiting up to 5m0s for pod "pod-f4469658-9b4b-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-m6rg8" to be "success or failure"
+Aug  8 20:45:15.806: INFO: Pod "pod-f4469658-9b4b-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.073757ms
+Aug  8 20:45:17.809: INFO: Pod "pod-f4469658-9b4b-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008385022s
+STEP: Saw pod success
+Aug  8 20:45:17.809: INFO: Pod "pod-f4469658-9b4b-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:45:17.811: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-f4469658-9b4b-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:45:17.826: INFO: Waiting for pod pod-f4469658-9b4b-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:45:17.829: INFO: Pod pod-f4469658-9b4b-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:45:17.829: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-m6rg8" for this suite.
+Aug  8 20:45:23.845: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:45:23.891: INFO: namespace: e2e-tests-emptydir-m6rg8, resource: bindings, ignored listing per whitelist
+Aug  8 20:45:23.915: INFO: namespace e2e-tests-emptydir-m6rg8 deletion completed in 6.079143687s
+
+• [SLOW TEST:8.209 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:45:23.916: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-f928b43c-9b4b-11e8-bae8-8697d7d38a55
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-f928b43c-9b4b-11e8-bae8-8697d7d38a55
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:45:28.030: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-mfttz" for this suite.
+Aug  8 20:45:50.041: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:45:50.075: INFO: namespace: e2e-tests-projected-mfttz, resource: bindings, ignored listing per whitelist
+Aug  8 20:45:50.111: INFO: namespace e2e-tests-projected-mfttz deletion completed in 22.078554179s
+
+• [SLOW TEST:26.196 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:45:50.112: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Aug  8 20:45:50.193: INFO: Waiting up to 5m0s for pod "pod-08c6eeb4-9b4c-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-emptydir-mnq7w" to be "success or failure"
+Aug  8 20:45:50.199: INFO: Pod "pod-08c6eeb4-9b4c-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 6.469668ms
+Aug  8 20:45:52.203: INFO: Pod "pod-08c6eeb4-9b4c-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010275319s
+STEP: Saw pod success
+Aug  8 20:45:52.203: INFO: Pod "pod-08c6eeb4-9b4c-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:45:52.205: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-08c6eeb4-9b4c-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:45:52.225: INFO: Waiting for pod pod-08c6eeb4-9b4c-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:45:52.227: INFO: Pod pod-08c6eeb4-9b4c-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:45:52.227: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-mnq7w" for this suite.
+Aug  8 20:45:58.238: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:45:58.347: INFO: namespace: e2e-tests-emptydir-mnq7w, resource: bindings, ignored listing per whitelist
+Aug  8 20:45:58.362: INFO: namespace e2e-tests-emptydir-mnq7w deletion completed in 6.132614174s
+
+• [SLOW TEST:8.250 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:45:58.362: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap e2e-tests-configmap-h44dt/configmap-test-0db857fc-9b4c-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:45:58.496: INFO: Waiting up to 5m0s for pod "pod-configmaps-0db9da77-9b4c-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-configmap-h44dt" to be "success or failure"
+Aug  8 20:45:58.500: INFO: Pod "pod-configmaps-0db9da77-9b4c-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 3.452636ms
+Aug  8 20:46:00.504: INFO: Pod "pod-configmaps-0db9da77-9b4c-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007757487s
+Aug  8 20:46:02.508: INFO: Pod "pod-configmaps-0db9da77-9b4c-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011859662s
+STEP: Saw pod success
+Aug  8 20:46:02.508: INFO: Pod "pod-configmaps-0db9da77-9b4c-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:46:02.513: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-configmaps-0db9da77-9b4c-11e8-bae8-8697d7d38a55 container env-test: <nil>
+STEP: delete the pod
+Aug  8 20:46:02.533: INFO: Waiting for pod pod-configmaps-0db9da77-9b4c-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:46:02.535: INFO: Pod pod-configmaps-0db9da77-9b4c-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:46:02.535: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-h44dt" for this suite.
+Aug  8 20:46:08.549: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:46:08.596: INFO: namespace: e2e-tests-configmap-h44dt, resource: bindings, ignored listing per whitelist
+Aug  8 20:46:08.645: INFO: namespace e2e-tests-configmap-h44dt deletion completed in 6.105887351s
+
+• [SLOW TEST:10.283 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:46:08.646: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-tbnlj
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Aug  8 20:46:08.733: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Aug  8 20:46:28.791: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://10.244.1.175:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-tbnlj PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:46:28.791: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:46:28.892: INFO: Found all expected endpoints: [netserver-0]
+Aug  8 20:46:28.894: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://10.244.0.39:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-tbnlj PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:46:28.894: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:46:28.998: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:46:28.999: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-tbnlj" for this suite.
+Aug  8 20:46:51.012: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:46:51.048: INFO: namespace: e2e-tests-pod-network-test-tbnlj, resource: bindings, ignored listing per whitelist
+Aug  8 20:46:51.096: INFO: namespace e2e-tests-pod-network-test-tbnlj deletion completed in 22.093285767s
+
+• [SLOW TEST:42.450 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:46:51.096: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:46:51.180: INFO: Waiting up to 5m0s for pod "downwardapi-volume-2d20d32d-9b4c-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-2xm8j" to be "success or failure"
+Aug  8 20:46:51.185: INFO: Pod "downwardapi-volume-2d20d32d-9b4c-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.056848ms
+Aug  8 20:46:53.187: INFO: Pod "downwardapi-volume-2d20d32d-9b4c-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007570054s
+Aug  8 20:46:55.190: INFO: Pod "downwardapi-volume-2d20d32d-9b4c-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010818002s
+STEP: Saw pod success
+Aug  8 20:46:55.190: INFO: Pod "downwardapi-volume-2d20d32d-9b4c-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:46:55.193: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-2d20d32d-9b4c-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:46:55.208: INFO: Waiting for pod downwardapi-volume-2d20d32d-9b4c-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:46:55.211: INFO: Pod downwardapi-volume-2d20d32d-9b4c-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:46:55.211: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-2xm8j" for this suite.
+Aug  8 20:47:01.228: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:47:01.276: INFO: namespace: e2e-tests-downward-api-2xm8j, resource: bindings, ignored listing per whitelist
+Aug  8 20:47:01.314: INFO: namespace e2e-tests-downward-api-2xm8j deletion completed in 6.099278289s
+
+• [SLOW TEST:10.218 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:47:01.315: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:80
+Aug  8 20:47:01.404: INFO: Waiting up to 1m0s for all nodes to be ready
+Aug  8 20:48:01.435: INFO: Waiting for terminating namespaces to be deleted...
+Aug  8 20:48:01.440: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Aug  8 20:48:01.455: INFO: 12 / 12 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Aug  8 20:48:01.455: INFO: expected 5 pod replicas in namespace 'kube-system', 5 are Running and Ready.
+Aug  8 20:48:01.461: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Aug  8 20:48:01.461: INFO: 
+Logging pods the kubelet thinks is on node k8s-linuxpool-37994001-0 before test
+Aug  8 20:48:01.470: INFO: tiller-deploy-54c57f6dc5-tzhx7 from kube-system started at 2018-08-08 19:43:12 +0000 UTC (1 container statuses recorded)
+Aug  8 20:48:01.470: INFO: 	Container tiller ready: true, restart count 0
+Aug  8 20:48:01.470: INFO: heapster-855c6c8b5b-hhzdf from kube-system started at 2018-08-08 19:43:17 +0000 UTC (2 container statuses recorded)
+Aug  8 20:48:01.470: INFO: 	Container heapster ready: true, restart count 0
+Aug  8 20:48:01.470: INFO: 	Container heapster-nanny ready: true, restart count 0
+Aug  8 20:48:01.470: INFO: kubernetes-dashboard-86cdd7799c-j47fh from kube-system started at 2018-08-08 19:43:18 +0000 UTC (1 container statuses recorded)
+Aug  8 20:48:01.470: INFO: 	Container kubernetes-dashboard ready: true, restart count 0
+Aug  8 20:48:01.470: INFO: kube-dns-5c89bdc645-zpbwn from kube-system started at 2018-08-08 19:43:18 +0000 UTC (3 container statuses recorded)
+Aug  8 20:48:01.470: INFO: 	Container dnsmasq ready: true, restart count 0
+Aug  8 20:48:01.470: INFO: 	Container kubedns ready: true, restart count 0
+Aug  8 20:48:01.470: INFO: 	Container sidecar ready: true, restart count 0
+Aug  8 20:48:01.470: INFO: kube-proxy-82rx2 from kube-system started at 2018-08-08 19:42:39 +0000 UTC (1 container statuses recorded)
+Aug  8 20:48:01.470: INFO: 	Container kube-proxy ready: true, restart count 0
+Aug  8 20:48:01.470: INFO: metrics-server-789c47657d-4z2vr from kube-system started at 2018-08-08 19:43:18 +0000 UTC (1 container statuses recorded)
+Aug  8 20:48:01.470: INFO: 	Container metrics-server ready: true, restart count 0
+Aug  8 20:48:01.470: INFO: sonobuoy-systemd-logs-daemon-set-806020c23a614e67-8xmpb from heptio-sonobuoy started at 2018-08-08 19:50:30 +0000 UTC (2 container statuses recorded)
+Aug  8 20:48:01.470: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 0
+Aug  8 20:48:01.470: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Aug  8 20:48:01.470: INFO: 
+Logging pods the kubelet thinks is on node k8s-linuxpool-37994001-1 before test
+Aug  8 20:48:01.477: INFO: sonobuoy-e2e-job-d01c3492ba7e47ed from heptio-sonobuoy started at 2018-08-08 19:50:30 +0000 UTC (2 container statuses recorded)
+Aug  8 20:48:01.477: INFO: 	Container e2e ready: true, restart count 0
+Aug  8 20:48:01.477: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Aug  8 20:48:01.477: INFO: sonobuoy-systemd-logs-daemon-set-806020c23a614e67-xhd79 from heptio-sonobuoy started at 2018-08-08 19:50:30 +0000 UTC (2 container statuses recorded)
+Aug  8 20:48:01.477: INFO: 	Container sonobuoy-systemd-logs-config ready: true, restart count 0
+Aug  8 20:48:01.477: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Aug  8 20:48:01.477: INFO: kube-proxy-mtjsn from kube-system started at 2018-08-08 19:42:39 +0000 UTC (1 container statuses recorded)
+Aug  8 20:48:01.477: INFO: 	Container kube-proxy ready: true, restart count 0
+Aug  8 20:48:01.477: INFO: sonobuoy from heptio-sonobuoy started at 2018-08-08 19:50:24 +0000 UTC (1 container statuses recorded)
+Aug  8 20:48:01.477: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.154903c26326cb1c], Reason = [FailedScheduling], Message = [0/3 nodes are available: 3 node(s) didn't match node selector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:48:02.515: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-7xxp4" for this suite.
+Aug  8 20:48:08.529: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:48:08.541: INFO: namespace: e2e-tests-sched-pred-7xxp4, resource: bindings, ignored listing per whitelist
+Aug  8 20:48:08.631: INFO: namespace e2e-tests-sched-pred-7xxp4 deletion completed in 6.112329454s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:71
+
+• [SLOW TEST:67.317 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:48:08.632: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test substitution in container's command
+Aug  8 20:48:08.728: INFO: Waiting up to 5m0s for pod "var-expansion-5b59a8cb-9b4c-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-var-expansion-5qfdh" to be "success or failure"
+Aug  8 20:48:08.739: INFO: Pod "var-expansion-5b59a8cb-9b4c-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 10.608489ms
+Aug  8 20:48:10.742: INFO: Pod "var-expansion-5b59a8cb-9b4c-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013644932s
+Aug  8 20:48:12.746: INFO: Pod "var-expansion-5b59a8cb-9b4c-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017375924s
+STEP: Saw pod success
+Aug  8 20:48:12.746: INFO: Pod "var-expansion-5b59a8cb-9b4c-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:48:12.748: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod var-expansion-5b59a8cb-9b4c-11e8-bae8-8697d7d38a55 container dapi-container: <nil>
+STEP: delete the pod
+Aug  8 20:48:12.762: INFO: Waiting for pod var-expansion-5b59a8cb-9b4c-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:48:12.765: INFO: Pod var-expansion-5b59a8cb-9b4c-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:48:12.765: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-5qfdh" for this suite.
+Aug  8 20:48:18.776: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:48:18.871: INFO: namespace: e2e-tests-var-expansion-5qfdh, resource: bindings, ignored listing per whitelist
+Aug  8 20:48:18.888: INFO: namespace e2e-tests-var-expansion-5qfdh deletion completed in 6.119929534s
+
+• [SLOW TEST:10.256 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:48:18.888: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-upd-61790744-9b4c-11e8-bae8-8697d7d38a55
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-61790744-9b4c-11e8-bae8-8697d7d38a55
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:49:33.372: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-cxp8w" for this suite.
+Aug  8 20:49:55.383: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:49:55.399: INFO: namespace: e2e-tests-configmap-cxp8w, resource: bindings, ignored listing per whitelist
+Aug  8 20:49:55.475: INFO: namespace e2e-tests-configmap-cxp8w deletion completed in 22.100320579s
+
+• [SLOW TEST:96.587 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:49:55.476: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating secret e2e-tests-secrets-mxsmn/secret-test-9b075342-9b4c-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:49:55.565: INFO: Waiting up to 5m0s for pod "pod-configmaps-9b07f36e-9b4c-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-secrets-mxsmn" to be "success or failure"
+Aug  8 20:49:55.567: INFO: Pod "pod-configmaps-9b07f36e-9b4c-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 1.939214ms
+Aug  8 20:49:57.571: INFO: Pod "pod-configmaps-9b07f36e-9b4c-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005642335s
+Aug  8 20:49:59.574: INFO: Pod "pod-configmaps-9b07f36e-9b4c-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008772407s
+STEP: Saw pod success
+Aug  8 20:49:59.574: INFO: Pod "pod-configmaps-9b07f36e-9b4c-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:49:59.576: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-configmaps-9b07f36e-9b4c-11e8-bae8-8697d7d38a55 container env-test: <nil>
+STEP: delete the pod
+Aug  8 20:49:59.601: INFO: Waiting for pod pod-configmaps-9b07f36e-9b4c-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:49:59.603: INFO: Pod pod-configmaps-9b07f36e-9b4c-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:49:59.603: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-mxsmn" for this suite.
+Aug  8 20:50:05.618: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:50:05.684: INFO: namespace: e2e-tests-secrets-mxsmn, resource: bindings, ignored listing per whitelist
+Aug  8 20:50:05.719: INFO: namespace e2e-tests-secrets-mxsmn deletion completed in 6.113002055s
+
+• [SLOW TEST:10.243 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:50:05.719: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-a12337dc-9b4c-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:50:05.822: INFO: Waiting up to 5m0s for pod "pod-configmaps-a123c425-9b4c-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-configmap-9hvtn" to be "success or failure"
+Aug  8 20:50:05.826: INFO: Pod "pod-configmaps-a123c425-9b4c-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 3.442424ms
+Aug  8 20:50:07.829: INFO: Pod "pod-configmaps-a123c425-9b4c-11e8-bae8-8697d7d38a55": Phase="Running", Reason="", readiness=true. Elapsed: 2.007052812s
+Aug  8 20:50:09.833: INFO: Pod "pod-configmaps-a123c425-9b4c-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011132158s
+STEP: Saw pod success
+Aug  8 20:50:09.833: INFO: Pod "pod-configmaps-a123c425-9b4c-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:50:09.835: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-configmaps-a123c425-9b4c-11e8-bae8-8697d7d38a55 container configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:50:09.849: INFO: Waiting for pod pod-configmaps-a123c425-9b4c-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:50:09.851: INFO: Pod pod-configmaps-a123c425-9b4c-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:50:09.851: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-9hvtn" for this suite.
+Aug  8 20:50:15.863: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:50:15.885: INFO: namespace: e2e-tests-configmap-9hvtn, resource: bindings, ignored listing per whitelist
+Aug  8 20:50:15.935: INFO: namespace e2e-tests-configmap-9hvtn deletion completed in 6.080491432s
+
+• [SLOW TEST:10.217 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:50:15.935: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name s-test-opt-del-a739a3b5-9b4c-11e8-bae8-8697d7d38a55
+STEP: Creating secret with name s-test-opt-upd-a739a3f4-9b4c-11e8-bae8-8697d7d38a55
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-a739a3b5-9b4c-11e8-bae8-8697d7d38a55
+STEP: Updating secret s-test-opt-upd-a739a3f4-9b4c-11e8-bae8-8697d7d38a55
+STEP: Creating secret with name s-test-opt-create-a739a410-9b4c-11e8-bae8-8697d7d38a55
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:51:28.398: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8rv7b" for this suite.
+Aug  8 20:51:50.414: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:51:50.498: INFO: namespace: e2e-tests-projected-8rv7b, resource: bindings, ignored listing per whitelist
+Aug  8 20:51:50.500: INFO: namespace e2e-tests-projected-8rv7b deletion completed in 22.099865067s
+
+• [SLOW TEST:94.564 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:51:50.501: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-df96badb-9b4c-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:51:50.593: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-df973be9-9b4c-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-csqq4" to be "success or failure"
+Aug  8 20:51:50.596: INFO: Pod "pod-projected-secrets-df973be9-9b4c-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.669416ms
+Aug  8 20:51:52.599: INFO: Pod "pod-projected-secrets-df973be9-9b4c-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006029171s
+STEP: Saw pod success
+Aug  8 20:51:52.599: INFO: Pod "pod-projected-secrets-df973be9-9b4c-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:51:52.601: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-secrets-df973be9-9b4c-11e8-bae8-8697d7d38a55 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:51:52.616: INFO: Waiting for pod pod-projected-secrets-df973be9-9b4c-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:51:52.618: INFO: Pod pod-projected-secrets-df973be9-9b4c-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:51:52.618: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-csqq4" for this suite.
+Aug  8 20:51:58.632: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:51:58.642: INFO: namespace: e2e-tests-projected-csqq4, resource: bindings, ignored listing per whitelist
+Aug  8 20:51:58.724: INFO: namespace e2e-tests-projected-csqq4 deletion completed in 6.103690583s
+
+• [SLOW TEST:8.223 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:51:58.725: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-e47d1788-9b4c-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume secrets
+Aug  8 20:51:58.821: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-e47df829-9b4c-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-5qtxl" to be "success or failure"
+Aug  8 20:51:58.832: INFO: Pod "pod-projected-secrets-e47df829-9b4c-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 11.273865ms
+Aug  8 20:52:00.836: INFO: Pod "pod-projected-secrets-e47df829-9b4c-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.015125573s
+STEP: Saw pod success
+Aug  8 20:52:00.836: INFO: Pod "pod-projected-secrets-e47df829-9b4c-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:52:00.839: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-secrets-e47df829-9b4c-11e8-bae8-8697d7d38a55 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:52:00.863: INFO: Waiting for pod pod-projected-secrets-e47df829-9b4c-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:52:00.865: INFO: Pod pod-projected-secrets-e47df829-9b4c-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:52:00.865: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5qtxl" for this suite.
+Aug  8 20:52:06.879: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:52:06.923: INFO: namespace: e2e-tests-projected-5qtxl, resource: bindings, ignored listing per whitelist
+Aug  8 20:52:06.965: INFO: namespace e2e-tests-projected-5qtxl deletion completed in 6.094604279s
+
+• [SLOW TEST:8.240 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:52:06.965: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0808 20:52:13.096191      17 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Aug  8 20:52:13.096: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:52:13.096: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-jnjzr" for this suite.
+Aug  8 20:52:19.107: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:52:19.142: INFO: namespace: e2e-tests-gc-jnjzr, resource: bindings, ignored listing per whitelist
+Aug  8 20:52:19.190: INFO: namespace e2e-tests-gc-jnjzr deletion completed in 6.091369703s
+
+• [SLOW TEST:12.225 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:52:19.190: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Aug  8 20:52:23.801: INFO: Successfully updated pod "labelsupdatef0b1150e-9b4c-11e8-bae8-8697d7d38a55"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:52:25.821: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fvtdt" for this suite.
+Aug  8 20:52:43.835: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:52:43.892: INFO: namespace: e2e-tests-projected-fvtdt, resource: bindings, ignored listing per whitelist
+Aug  8 20:52:43.927: INFO: namespace e2e-tests-projected-fvtdt deletion completed in 18.102751951s
+
+• [SLOW TEST:24.738 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:52:43.928: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Aug  8 20:52:44.022: INFO: Creating simple daemon set daemon-set
+STEP: Check that daemon pods launch on every node of the cluster.
+Aug  8 20:52:44.029: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:44.031: INFO: Number of nodes with available pods: 0
+Aug  8 20:52:44.031: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:52:45.035: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:45.038: INFO: Number of nodes with available pods: 0
+Aug  8 20:52:45.038: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:52:46.034: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:46.039: INFO: Number of nodes with available pods: 0
+Aug  8 20:52:46.039: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:52:47.035: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:47.038: INFO: Number of nodes with available pods: 2
+Aug  8 20:52:47.038: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Update daemon pods image.
+STEP: Check that daemon pods images are updated.
+Aug  8 20:52:47.058: INFO: Wrong image for pod: daemon-set-2k4bv. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:47.058: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:47.067: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:48.071: INFO: Wrong image for pod: daemon-set-2k4bv. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:48.071: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:48.076: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:49.071: INFO: Wrong image for pod: daemon-set-2k4bv. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:49.071: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:49.074: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:50.071: INFO: Wrong image for pod: daemon-set-2k4bv. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:50.071: INFO: Pod daemon-set-2k4bv is not available
+Aug  8 20:52:50.071: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:50.074: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:51.070: INFO: Wrong image for pod: daemon-set-2k4bv. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:51.070: INFO: Pod daemon-set-2k4bv is not available
+Aug  8 20:52:51.070: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:51.076: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:52.071: INFO: Wrong image for pod: daemon-set-2k4bv. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:52.071: INFO: Pod daemon-set-2k4bv is not available
+Aug  8 20:52:52.071: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:52.074: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:53.071: INFO: Wrong image for pod: daemon-set-2k4bv. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:53.071: INFO: Pod daemon-set-2k4bv is not available
+Aug  8 20:52:53.071: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:53.074: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:54.071: INFO: Pod daemon-set-m2vh5 is not available
+Aug  8 20:52:54.071: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:54.076: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:55.072: INFO: Pod daemon-set-m2vh5 is not available
+Aug  8 20:52:55.072: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:55.077: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:56.074: INFO: Pod daemon-set-m2vh5 is not available
+Aug  8 20:52:56.074: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:56.079: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:57.071: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:57.075: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:58.070: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:58.070: INFO: Pod daemon-set-t5chf is not available
+Aug  8 20:52:58.073: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:52:59.070: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:52:59.070: INFO: Pod daemon-set-t5chf is not available
+Aug  8 20:52:59.073: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:53:00.070: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:53:00.070: INFO: Pod daemon-set-t5chf is not available
+Aug  8 20:53:00.074: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:53:01.070: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:53:01.070: INFO: Pod daemon-set-t5chf is not available
+Aug  8 20:53:01.075: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:53:02.071: INFO: Wrong image for pod: daemon-set-t5chf. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Aug  8 20:53:02.071: INFO: Pod daemon-set-t5chf is not available
+Aug  8 20:53:02.074: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:53:03.071: INFO: Pod daemon-set-rk8dj is not available
+Aug  8 20:53:03.074: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+STEP: Check that daemon pods are still running on every node of the cluster.
+Aug  8 20:53:03.077: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:53:03.080: INFO: Number of nodes with available pods: 1
+Aug  8 20:53:03.080: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:53:04.084: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:53:04.086: INFO: Number of nodes with available pods: 1
+Aug  8 20:53:04.086: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:53:05.084: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:53:05.088: INFO: Number of nodes with available pods: 1
+Aug  8 20:53:05.088: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:53:06.084: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:53:06.087: INFO: Number of nodes with available pods: 1
+Aug  8 20:53:06.087: INFO: Node k8s-linuxpool-37994001-0 is running more than one daemon pod
+Aug  8 20:53:07.084: INFO: DaemonSet pods can't tolerate node k8s-master-37994001-0 with taints [{Key:node-role.kubernetes.io/master Value:true Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Aug  8 20:53:07.087: INFO: Number of nodes with available pods: 2
+Aug  8 20:53:07.087: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-z5n92, will wait for the garbage collector to delete the pods
+Aug  8 20:53:07.158: INFO: Deleting {extensions DaemonSet} daemon-set took: 4.777425ms
+Aug  8 20:53:07.259: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.485719ms
+Aug  8 20:53:13.562: INFO: Number of nodes with available pods: 0
+Aug  8 20:53:13.563: INFO: Number of running nodes: 0, number of available pods: 0
+Aug  8 20:53:13.566: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-z5n92/daemonsets","resourceVersion":"14315"},"items":null}
+
+Aug  8 20:53:13.569: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-z5n92/pods","resourceVersion":"14315"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:53:13.576: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-z5n92" for this suite.
+Aug  8 20:53:19.591: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:53:19.642: INFO: namespace: e2e-tests-daemonsets-z5n92, resource: bindings, ignored listing per whitelist
+Aug  8 20:53:19.677: INFO: namespace e2e-tests-daemonsets-z5n92 deletion completed in 6.098359009s
+
+• [SLOW TEST:35.749 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:53:19.677: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:53:19.763: INFO: Waiting up to 5m0s for pod "downwardapi-volume-14be1d89-9b4d-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-fdwfb" to be "success or failure"
+Aug  8 20:53:19.767: INFO: Pod "downwardapi-volume-14be1d89-9b4d-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 4.715723ms
+Aug  8 20:53:21.770: INFO: Pod "downwardapi-volume-14be1d89-9b4d-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007121874s
+STEP: Saw pod success
+Aug  8 20:53:21.770: INFO: Pod "downwardapi-volume-14be1d89-9b4d-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:53:21.772: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-14be1d89-9b4d-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:53:21.786: INFO: Waiting for pod downwardapi-volume-14be1d89-9b4d-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:53:21.788: INFO: Pod downwardapi-volume-14be1d89-9b4d-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:53:21.788: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-fdwfb" for this suite.
+Aug  8 20:53:27.797: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:53:27.815: INFO: namespace: e2e-tests-downward-api-fdwfb, resource: bindings, ignored listing per whitelist
+Aug  8 20:53:27.873: INFO: namespace e2e-tests-downward-api-fdwfb deletion completed in 6.083332149s
+
+• [SLOW TEST:8.197 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:53:27.873: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-hdqxc in namespace e2e-tests-proxy-8d7ql
+I0808 20:53:27.957498      17 runners.go:177] Created replication controller with name: proxy-service-hdqxc, namespace: e2e-tests-proxy-8d7ql, replica count: 1
+I0808 20:53:29.007887      17 runners.go:177] proxy-service-hdqxc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0808 20:53:30.008126      17 runners.go:177] proxy-service-hdqxc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0808 20:53:31.008332      17 runners.go:177] proxy-service-hdqxc Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0808 20:53:32.008573      17 runners.go:177] proxy-service-hdqxc Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0808 20:53:33.008788      17 runners.go:177] proxy-service-hdqxc Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0808 20:53:34.009012      17 runners.go:177] proxy-service-hdqxc Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0808 20:53:35.009241      17 runners.go:177] proxy-service-hdqxc Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0808 20:53:36.009510      17 runners.go:177] proxy-service-hdqxc Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0808 20:53:37.009757      17 runners.go:177] proxy-service-hdqxc Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0808 20:53:38.010015      17 runners.go:177] proxy-service-hdqxc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Aug  8 20:53:38.012: INFO: setup took 10.066405696s, starting test cases
+STEP: running 16 cases, 20 attempts per case, 320 total attempts
+Aug  8 20:53:38.018: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 5.037525ms)
+Aug  8 20:53:38.018: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 5.393026ms)
+Aug  8 20:53:38.018: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 5.573628ms)
+Aug  8 20:53:38.024: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 11.469956ms)
+Aug  8 20:53:38.026: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 13.469967ms)
+Aug  8 20:53:38.026: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 13.443866ms)
+Aug  8 20:53:38.027: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 14.19037ms)
+Aug  8 20:53:38.027: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 14.330771ms)
+Aug  8 20:53:38.027: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 14.321571ms)
+Aug  8 20:53:38.027: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 14.366571ms)
+Aug  8 20:53:38.028: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 14.868874ms)
+Aug  8 20:53:38.028: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 15.431576ms)
+Aug  8 20:53:38.029: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 16.08248ms)
+Aug  8 20:53:38.029: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 16.677082ms)
+Aug  8 20:53:38.030: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 17.746988ms)
+Aug  8 20:53:38.031: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 18.597291ms)
+Aug  8 20:53:38.039: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 7.565737ms)
+Aug  8 20:53:38.041: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 8.896244ms)
+Aug  8 20:53:38.042: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 10.19245ms)
+Aug  8 20:53:38.042: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 10.367351ms)
+Aug  8 20:53:38.042: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 10.870454ms)
+Aug  8 20:53:38.042: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 10.688953ms)
+Aug  8 20:53:38.042: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 10.27835ms)
+Aug  8 20:53:38.043: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 10.681153ms)
+Aug  8 20:53:38.043: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 10.904954ms)
+Aug  8 20:53:38.043: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 11.175055ms)
+Aug  8 20:53:38.043: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 11.108555ms)
+Aug  8 20:53:38.043: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 11.609757ms)
+Aug  8 20:53:38.043: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 11.776059ms)
+Aug  8 20:53:38.044: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 11.704157ms)
+Aug  8 20:53:38.044: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 11.873959ms)
+Aug  8 20:53:38.044: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 12.30816ms)
+Aug  8 20:53:38.051: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 6.851834ms)
+Aug  8 20:53:38.052: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 6.878434ms)
+Aug  8 20:53:38.052: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 7.506237ms)
+Aug  8 20:53:38.052: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 5.136826ms)
+Aug  8 20:53:38.053: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 5.701928ms)
+Aug  8 20:53:38.053: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 8.034039ms)
+Aug  8 20:53:38.054: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 7.323136ms)
+Aug  8 20:53:38.054: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 7.378336ms)
+Aug  8 20:53:38.054: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 8.01704ms)
+Aug  8 20:53:38.054: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 9.671248ms)
+Aug  8 20:53:38.055: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 8.218041ms)
+Aug  8 20:53:38.057: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 10.531152ms)
+Aug  8 20:53:38.057: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 12.10476ms)
+Aug  8 20:53:38.057: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 12.26156ms)
+Aug  8 20:53:38.058: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 11.615557ms)
+Aug  8 20:53:38.060: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 15.811678ms)
+Aug  8 20:53:38.065: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 4.236821ms)
+Aug  8 20:53:38.068: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 7.143535ms)
+Aug  8 20:53:38.068: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 7.207235ms)
+Aug  8 20:53:38.068: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 7.384937ms)
+Aug  8 20:53:38.068: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 7.444037ms)
+Aug  8 20:53:38.068: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 7.211136ms)
+Aug  8 20:53:38.068: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 7.546837ms)
+Aug  8 20:53:38.068: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 7.330936ms)
+Aug  8 20:53:38.069: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 8.469542ms)
+Aug  8 20:53:38.069: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 8.616042ms)
+Aug  8 20:53:38.069: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 8.382941ms)
+Aug  8 20:53:38.070: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 8.818743ms)
+Aug  8 20:53:38.070: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 9.624547ms)
+Aug  8 20:53:38.071: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 10.258851ms)
+Aug  8 20:53:38.074: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 13.754168ms)
+Aug  8 20:53:38.074: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 13.745468ms)
+Aug  8 20:53:38.081: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 6.048229ms)
+Aug  8 20:53:38.081: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 5.891929ms)
+Aug  8 20:53:38.081: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 6.23913ms)
+Aug  8 20:53:38.081: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 6.345032ms)
+Aug  8 20:53:38.082: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 7.200736ms)
+Aug  8 20:53:38.082: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 7.220336ms)
+Aug  8 20:53:38.082: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 7.397236ms)
+Aug  8 20:53:38.082: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 7.592138ms)
+Aug  8 20:53:38.083: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 8.019039ms)
+Aug  8 20:53:38.083: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 8.10674ms)
+Aug  8 20:53:38.083: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 8.08094ms)
+Aug  8 20:53:38.086: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 10.934354ms)
+Aug  8 20:53:38.086: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 11.241756ms)
+Aug  8 20:53:38.086: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 11.336856ms)
+Aug  8 20:53:38.087: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 12.04436ms)
+Aug  8 20:53:38.087: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 12.16886ms)
+Aug  8 20:53:38.099: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 10.933454ms)
+Aug  8 20:53:38.099: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 11.825959ms)
+Aug  8 20:53:38.099: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 12.09866ms)
+Aug  8 20:53:38.100: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 12.863864ms)
+Aug  8 20:53:38.101: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 13.730567ms)
+Aug  8 20:53:38.101: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 13.519967ms)
+Aug  8 20:53:38.102: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 14.22647ms)
+Aug  8 20:53:38.102: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 14.16407ms)
+Aug  8 20:53:38.102: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 14.322371ms)
+Aug  8 20:53:38.102: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 14.439171ms)
+Aug  8 20:53:38.102: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 14.20597ms)
+Aug  8 20:53:38.102: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 14.18937ms)
+Aug  8 20:53:38.102: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 14.305271ms)
+Aug  8 20:53:38.102: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 14.561372ms)
+Aug  8 20:53:38.102: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 14.825873ms)
+Aug  8 20:53:38.102: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 15.189775ms)
+Aug  8 20:53:38.109: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 6.548333ms)
+Aug  8 20:53:38.110: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 7.202636ms)
+Aug  8 20:53:38.110: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 7.706638ms)
+Aug  8 20:53:38.111: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 8.439442ms)
+Aug  8 20:53:38.111: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 8.572842ms)
+Aug  8 20:53:38.112: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 9.412747ms)
+Aug  8 20:53:38.112: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 9.547047ms)
+Aug  8 20:53:38.112: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 9.618948ms)
+Aug  8 20:53:38.112: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 9.651048ms)
+Aug  8 20:53:38.112: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 9.874248ms)
+Aug  8 20:53:38.112: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 9.98555ms)
+Aug  8 20:53:38.117: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 14.040569ms)
+Aug  8 20:53:38.117: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 14.530872ms)
+Aug  8 20:53:38.117: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 14.790373ms)
+Aug  8 20:53:38.117: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 14.725172ms)
+Aug  8 20:53:38.119: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 16.326481ms)
+Aug  8 20:53:38.132: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 13.205366ms)
+Aug  8 20:53:38.133: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 13.933569ms)
+Aug  8 20:53:38.133: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 14.353471ms)
+Aug  8 20:53:38.134: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 14.464171ms)
+Aug  8 20:53:38.134: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 14.586872ms)
+Aug  8 20:53:38.134: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 15.075775ms)
+Aug  8 20:53:38.134: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 15.075875ms)
+Aug  8 20:53:38.134: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 15.130475ms)
+Aug  8 20:53:38.134: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 15.104075ms)
+Aug  8 20:53:38.134: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 15.096875ms)
+Aug  8 20:53:38.134: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 15.082375ms)
+Aug  8 20:53:38.134: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 15.213375ms)
+Aug  8 20:53:38.134: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 15.194875ms)
+Aug  8 20:53:38.134: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 15.189975ms)
+Aug  8 20:53:38.134: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 15.120475ms)
+Aug  8 20:53:38.135: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 15.956679ms)
+Aug  8 20:53:38.141: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 5.453027ms)
+Aug  8 20:53:38.141: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 5.634927ms)
+Aug  8 20:53:38.144: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 8.553042ms)
+Aug  8 20:53:38.144: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 8.625143ms)
+Aug  8 20:53:38.144: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 8.622842ms)
+Aug  8 20:53:38.144: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 8.524742ms)
+Aug  8 20:53:38.144: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 8.725343ms)
+Aug  8 20:53:38.144: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 9.151945ms)
+Aug  8 20:53:38.144: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 9.472346ms)
+Aug  8 20:53:38.145: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 9.390446ms)
+Aug  8 20:53:38.145: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 9.457947ms)
+Aug  8 20:53:38.145: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 9.770749ms)
+Aug  8 20:53:38.152: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 16.737583ms)
+Aug  8 20:53:38.154: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 18.926893ms)
+Aug  8 20:53:38.155: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 19.704697ms)
+Aug  8 20:53:38.156: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 21.291905ms)
+Aug  8 20:53:38.165: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 8.322041ms)
+Aug  8 20:53:38.165: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 8.440741ms)
+Aug  8 20:53:38.166: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 9.414046ms)
+Aug  8 20:53:38.166: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 9.903349ms)
+Aug  8 20:53:38.173: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 16.767183ms)
+Aug  8 20:53:38.174: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 16.881183ms)
+Aug  8 20:53:38.174: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 17.442586ms)
+Aug  8 20:53:38.176: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 19.622097ms)
+Aug  8 20:53:38.177: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 20.3262ms)
+Aug  8 20:53:38.178: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 21.680307ms)
+Aug  8 20:53:38.179: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 22.45941ms)
+Aug  8 20:53:38.179: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 22.752712ms)
+Aug  8 20:53:38.181: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 24.622121ms)
+Aug  8 20:53:38.183: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 26.811133ms)
+Aug  8 20:53:38.183: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 26.848133ms)
+Aug  8 20:53:38.191: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 34.783572ms)
+Aug  8 20:53:38.201: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 9.229146ms)
+Aug  8 20:53:38.201: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 9.727048ms)
+Aug  8 20:53:38.202: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 10.930254ms)
+Aug  8 20:53:38.203: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 11.670958ms)
+Aug  8 20:53:38.203: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 11.667258ms)
+Aug  8 20:53:38.204: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 11.870359ms)
+Aug  8 20:53:38.205: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 12.898764ms)
+Aug  8 20:53:38.205: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 13.812268ms)
+Aug  8 20:53:38.205: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 13.768668ms)
+Aug  8 20:53:38.206: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 13.942369ms)
+Aug  8 20:53:38.206: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 14.16627ms)
+Aug  8 20:53:38.206: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 14.20047ms)
+Aug  8 20:53:38.207: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 15.079174ms)
+Aug  8 20:53:38.207: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 15.362776ms)
+Aug  8 20:53:38.207: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 15.354975ms)
+Aug  8 20:53:38.207: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 15.271375ms)
+Aug  8 20:53:38.221: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 13.794468ms)
+Aug  8 20:53:38.224: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 16.629582ms)
+Aug  8 20:53:38.224: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 16.668182ms)
+Aug  8 20:53:38.224: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 16.616582ms)
+Aug  8 20:53:38.224: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 17.284686ms)
+Aug  8 20:53:38.230: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 22.662312ms)
+Aug  8 20:53:38.230: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 22.655012ms)
+Aug  8 20:53:38.230: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 23.033813ms)
+Aug  8 20:53:38.230: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 23.191115ms)
+Aug  8 20:53:38.231: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 23.878717ms)
+Aug  8 20:53:38.231: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 24.062519ms)
+Aug  8 20:53:38.231: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 23.987718ms)
+Aug  8 20:53:38.232: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 25.062223ms)
+Aug  8 20:53:38.232: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 25.274124ms)
+Aug  8 20:53:38.233: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 25.903828ms)
+Aug  8 20:53:38.239: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 31.917558ms)
+Aug  8 20:53:38.248: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 8.698443ms)
+Aug  8 20:53:38.248: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 8.887044ms)
+Aug  8 20:53:38.250: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 10.980554ms)
+Aug  8 20:53:38.252: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 12.988764ms)
+Aug  8 20:53:38.252: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 13.272366ms)
+Aug  8 20:53:38.253: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 13.330966ms)
+Aug  8 20:53:38.253: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 13.639667ms)
+Aug  8 20:53:38.253: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 14.006969ms)
+Aug  8 20:53:38.253: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 14.104769ms)
+Aug  8 20:53:38.253: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 14.098469ms)
+Aug  8 20:53:38.253: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 14.15857ms)
+Aug  8 20:53:38.254: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 14.747473ms)
+Aug  8 20:53:38.254: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 14.923274ms)
+Aug  8 20:53:38.254: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 14.935874ms)
+Aug  8 20:53:38.254: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 15.178674ms)
+Aug  8 20:53:38.254: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 15.388875ms)
+Aug  8 20:53:38.258: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 3.938419ms)
+Aug  8 20:53:38.261: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 5.978529ms)
+Aug  8 20:53:38.264: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 9.292546ms)
+Aug  8 20:53:38.266: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 11.666758ms)
+Aug  8 20:53:38.267: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 12.674263ms)
+Aug  8 20:53:38.268: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 12.811563ms)
+Aug  8 20:53:38.268: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 12.990464ms)
+Aug  8 20:53:38.269: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 13.914569ms)
+Aug  8 20:53:38.270: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 15.676377ms)
+Aug  8 20:53:38.270: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 15.691777ms)
+Aug  8 20:53:38.272: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 17.039485ms)
+Aug  8 20:53:38.272: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 17.330985ms)
+Aug  8 20:53:38.274: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 18.754092ms)
+Aug  8 20:53:38.274: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 18.764292ms)
+Aug  8 20:53:38.274: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 18.835093ms)
+Aug  8 20:53:38.274: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 19.549497ms)
+Aug  8 20:53:38.280: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 5.866029ms)
+Aug  8 20:53:38.281: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 6.364232ms)
+Aug  8 20:53:38.281: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 6.976634ms)
+Aug  8 20:53:38.282: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 7.279036ms)
+Aug  8 20:53:38.282: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 7.831239ms)
+Aug  8 20:53:38.282: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 7.907739ms)
+Aug  8 20:53:38.284: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 9.046144ms)
+Aug  8 20:53:38.284: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 9.086844ms)
+Aug  8 20:53:38.284: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 9.367247ms)
+Aug  8 20:53:38.284: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 9.200245ms)
+Aug  8 20:53:38.284: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 9.116145ms)
+Aug  8 20:53:38.285: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 10.488952ms)
+Aug  8 20:53:38.287: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 12.956764ms)
+Aug  8 20:53:38.288: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 13.118565ms)
+Aug  8 20:53:38.288: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 13.100564ms)
+Aug  8 20:53:38.296: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 21.813608ms)
+Aug  8 20:53:38.310: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 13.024764ms)
+Aug  8 20:53:38.310: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 13.151365ms)
+Aug  8 20:53:38.310: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 13.092064ms)
+Aug  8 20:53:38.310: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 13.789368ms)
+Aug  8 20:53:38.310: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 13.615867ms)
+Aug  8 20:53:38.311: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 13.957869ms)
+Aug  8 20:53:38.311: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 13.988469ms)
+Aug  8 20:53:38.311: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 14.592672ms)
+Aug  8 20:53:38.311: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 14.558372ms)
+Aug  8 20:53:38.311: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 14.530772ms)
+Aug  8 20:53:38.312: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 15.129175ms)
+Aug  8 20:53:38.312: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 15.468876ms)
+Aug  8 20:53:38.312: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 15.426076ms)
+Aug  8 20:53:38.312: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 15.661677ms)
+Aug  8 20:53:38.312: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 15.721078ms)
+Aug  8 20:53:38.312: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 15.766678ms)
+Aug  8 20:53:38.323: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 10.845853ms)
+Aug  8 20:53:38.324: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 11.073054ms)
+Aug  8 20:53:38.324: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 11.171655ms)
+Aug  8 20:53:38.324: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 11.247855ms)
+Aug  8 20:53:38.324: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 11.377857ms)
+Aug  8 20:53:38.324: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 11.717358ms)
+Aug  8 20:53:38.325: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 11.979559ms)
+Aug  8 20:53:38.325: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 12.13196ms)
+Aug  8 20:53:38.325: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 12.031159ms)
+Aug  8 20:53:38.325: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 12.33676ms)
+Aug  8 20:53:38.325: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 12.521462ms)
+Aug  8 20:53:38.325: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 12.427862ms)
+Aug  8 20:53:38.326: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 13.048664ms)
+Aug  8 20:53:38.326: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 13.222665ms)
+Aug  8 20:53:38.326: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 13.424466ms)
+Aug  8 20:53:38.326: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 13.528267ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 10.358652ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 10.05535ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 10.671753ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 10.628253ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 10.537552ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 10.498152ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 10.418351ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 10.278451ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 10.640552ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 10.976755ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 10.607953ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 10.505252ms)
+Aug  8 20:53:38.337: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 10.315451ms)
+Aug  8 20:53:38.339: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 12.16716ms)
+Aug  8 20:53:38.339: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 12.323961ms)
+Aug  8 20:53:38.339: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 12.03766ms)
+Aug  8 20:53:38.345: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 5.384027ms)
+Aug  8 20:53:38.345: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 6.06593ms)
+Aug  8 20:53:38.345: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 6.04293ms)
+Aug  8 20:53:38.346: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 6.320731ms)
+Aug  8 20:53:38.346: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 6.796534ms)
+Aug  8 20:53:38.346: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 6.939534ms)
+Aug  8 20:53:38.346: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 6.913035ms)
+Aug  8 20:53:38.346: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 7.085835ms)
+Aug  8 20:53:38.347: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 7.636438ms)
+Aug  8 20:53:38.347: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 7.810738ms)
+Aug  8 20:53:38.347: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 7.903439ms)
+Aug  8 20:53:38.347: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 7.851539ms)
+Aug  8 20:53:38.347: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 7.962339ms)
+Aug  8 20:53:38.347: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 7.894739ms)
+Aug  8 20:53:38.347: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 7.909439ms)
+Aug  8 20:53:38.348: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 8.09624ms)
+Aug  8 20:53:38.357: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname2/proxy/: bar (200; 8.978945ms)
+Aug  8 20:53:38.357: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname1/proxy/: tls baz (200; 9.129745ms)
+Aug  8 20:53:38.358: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname1/proxy/: foo (200; 10.12115ms)
+Aug  8 20:53:38.358: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 10.17145ms)
+Aug  8 20:53:38.358: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/https:proxy-service-hdqxc:tlsportname2/proxy/: tls qux (200; 10.13325ms)
+Aug  8 20:53:38.358: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:462/proxy/: tls qux (200; 10.246451ms)
+Aug  8 20:53:38.358: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:1080/proxy/rewri... (200; 10.535752ms)
+Aug  8 20:53:38.358: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:1080/proxy/... (200; 10.636152ms)
+Aug  8 20:53:38.359: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 11.150855ms)
+Aug  8 20:53:38.359: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/proxy-service-hdqxc:portname1/proxy/: foo (200; 11.225555ms)
+Aug  8 20:53:38.359: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/services/http:proxy-service-hdqxc:portname2/proxy/: bar (200; 11.349456ms)
+Aug  8 20:53:38.359: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj/proxy/rewriteme"... (200; 11.523757ms)
+Aug  8 20:53:38.359: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:460/proxy/: tls baz (200; 11.581957ms)
+Aug  8 20:53:38.360: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/proxy-service-hdqxc-k6smj:162/proxy/: bar (200; 12.05216ms)
+Aug  8 20:53:38.360: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/http:proxy-service-hdqxc-k6smj:160/proxy/: foo (200; 12.363861ms)
+Aug  8 20:53:38.360: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-8d7ql/pods/https:proxy-service-hdqxc-k6smj:443/proxy/... (200; 12.27096ms)
+STEP: deleting { ReplicationController} proxy-service-hdqxc in namespace e2e-tests-proxy-8d7ql, will wait for the garbage collector to delete the pods
+Aug  8 20:53:38.418: INFO: Deleting { ReplicationController} proxy-service-hdqxc took: 5.97293ms
+Aug  8 20:53:38.518: INFO: Terminating { ReplicationController} proxy-service-hdqxc pods took: 100.205794ms
+[AfterEach] version v1
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:53:43.519: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-8d7ql" for this suite.
+Aug  8 20:53:49.536: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:53:49.593: INFO: namespace: e2e-tests-proxy-8d7ql, resource: bindings, ignored listing per whitelist
+Aug  8 20:53:49.637: INFO: namespace e2e-tests-proxy-8d7ql deletion completed in 6.114434913s
+
+• [SLOW TEST:21.764 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:53:49.638: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Aug  8 20:53:49.737: INFO: Waiting up to 5m0s for pod "downwardapi-volume-269affc8-9b4d-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-downward-api-6bbrr" to be "success or failure"
+Aug  8 20:53:49.742: INFO: Pod "downwardapi-volume-269affc8-9b4d-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 5.106625ms
+Aug  8 20:53:51.745: INFO: Pod "downwardapi-volume-269affc8-9b4d-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008725933s
+Aug  8 20:53:53.749: INFO: Pod "downwardapi-volume-269affc8-9b4d-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01192941s
+STEP: Saw pod success
+Aug  8 20:53:53.749: INFO: Pod "downwardapi-volume-269affc8-9b4d-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:53:53.753: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod downwardapi-volume-269affc8-9b4d-11e8-bae8-8697d7d38a55 container client-container: <nil>
+STEP: delete the pod
+Aug  8 20:53:53.765: INFO: Waiting for pod downwardapi-volume-269affc8-9b4d-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:53:53.767: INFO: Pod downwardapi-volume-269affc8-9b4d-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:53:53.767: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-6bbrr" for this suite.
+Aug  8 20:53:59.778: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:53:59.834: INFO: namespace: e2e-tests-downward-api-6bbrr, resource: bindings, ignored listing per whitelist
+Aug  8 20:53:59.872: INFO: namespace e2e-tests-downward-api-6bbrr deletion completed in 6.102637903s
+
+• [SLOW TEST:10.234 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:53:59.872: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name cm-test-opt-del-2cb57baa-9b4d-11e8-bae8-8697d7d38a55
+STEP: Creating configMap with name cm-test-opt-upd-2cb57c2d-9b4d-11e8-bae8-8697d7d38a55
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-2cb57baa-9b4d-11e8-bae8-8697d7d38a55
+STEP: Updating configmap cm-test-opt-upd-2cb57c2d-9b4d-11e8-bae8-8697d7d38a55
+STEP: Creating configMap with name cm-test-opt-create-2cb57c52-9b4d-11e8-bae8-8697d7d38a55
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:54:06.059: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-hjmg7" for this suite.
+Aug  8 20:54:28.071: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:54:28.093: INFO: namespace: e2e-tests-configmap-hjmg7, resource: bindings, ignored listing per whitelist
+Aug  8 20:54:28.154: INFO: namespace e2e-tests-configmap-hjmg7 deletion completed in 22.091824436s
+
+• [SLOW TEST:28.282 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:54:28.155: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:54:28.243: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-cc5z4" for this suite.
+Aug  8 20:54:50.257: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:54:50.324: INFO: namespace: e2e-tests-pods-cc5z4, resource: bindings, ignored listing per whitelist
+Aug  8 20:54:50.344: INFO: namespace e2e-tests-pods-cc5z4 deletion completed in 22.097874062s
+
+• [SLOW TEST:22.189 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:54:50.344: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override arguments
+Aug  8 20:54:50.442: INFO: Waiting up to 5m0s for pod "client-containers-4aca85ba-9b4d-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-containers-2ld7k" to be "success or failure"
+Aug  8 20:54:50.444: INFO: Pod "client-containers-4aca85ba-9b4d-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 1.963209ms
+Aug  8 20:54:52.448: INFO: Pod "client-containers-4aca85ba-9b4d-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005842287s
+Aug  8 20:54:54.451: INFO: Pod "client-containers-4aca85ba-9b4d-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009093537s
+STEP: Saw pod success
+Aug  8 20:54:54.451: INFO: Pod "client-containers-4aca85ba-9b4d-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:54:54.453: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod client-containers-4aca85ba-9b4d-11e8-bae8-8697d7d38a55 container test-container: <nil>
+STEP: delete the pod
+Aug  8 20:54:54.466: INFO: Waiting for pod client-containers-4aca85ba-9b4d-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:54:54.469: INFO: Pod client-containers-4aca85ba-9b4d-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:54:54.469: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-2ld7k" for this suite.
+Aug  8 20:55:00.480: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:55:00.515: INFO: namespace: e2e-tests-containers-2ld7k, resource: bindings, ignored listing per whitelist
+Aug  8 20:55:00.571: INFO: namespace e2e-tests-containers-2ld7k deletion completed in 6.098796784s
+
+• [SLOW TEST:10.227 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:55:00.572: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Aug  8 20:55:00.645: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:55:01.730: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-h8v5d" for this suite.
+Aug  8 20:55:07.744: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:55:07.782: INFO: namespace: e2e-tests-custom-resource-definition-h8v5d, resource: bindings, ignored listing per whitelist
+Aug  8 20:55:07.818: INFO: namespace e2e-tests-custom-resource-definition-h8v5d deletion completed in 6.084646943s
+
+• [SLOW TEST:7.247 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:55:07.819: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Aug  8 20:55:07.936: INFO: pod1.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod3", UID:"55381d80-9b4d-11e8-ad47-001dd8b71c0d", Controller:(*bool)(0xc422450696), BlockOwnerDeletion:(*bool)(0xc422450697)}}
+Aug  8 20:55:07.945: INFO: pod2.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod1", UID:"5536def4-9b4d-11e8-ad47-001dd8b71c0d", Controller:(*bool)(0xc422166e36), BlockOwnerDeletion:(*bool)(0xc422166e37)}}
+Aug  8 20:55:07.949: INFO: pod3.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod2", UID:"553775f1-9b4d-11e8-ad47-001dd8b71c0d", Controller:(*bool)(0xc4221a130e), BlockOwnerDeletion:(*bool)(0xc4221a130f)}}
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:55:12.960: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-nqkjv" for this suite.
+Aug  8 20:55:18.973: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:55:18.983: INFO: namespace: e2e-tests-gc-nqkjv, resource: bindings, ignored listing per whitelist
+Aug  8 20:55:19.057: INFO: namespace e2e-tests-gc-nqkjv deletion completed in 6.09427396s
+
+• [SLOW TEST:11.239 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:55:19.058: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-5be65cf9-9b4d-11e8-bae8-8697d7d38a55
+STEP: Creating a pod to test consume configMaps
+Aug  8 20:55:19.153: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-5be7008c-9b4d-11e8-bae8-8697d7d38a55" in namespace "e2e-tests-projected-tn4bj" to be "success or failure"
+Aug  8 20:55:19.157: INFO: Pod "pod-projected-configmaps-5be7008c-9b4d-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 3.461715ms
+Aug  8 20:55:21.160: INFO: Pod "pod-projected-configmaps-5be7008c-9b4d-11e8-bae8-8697d7d38a55": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007149932s
+Aug  8 20:55:23.164: INFO: Pod "pod-projected-configmaps-5be7008c-9b4d-11e8-bae8-8697d7d38a55": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010480024s
+STEP: Saw pod success
+Aug  8 20:55:23.164: INFO: Pod "pod-projected-configmaps-5be7008c-9b4d-11e8-bae8-8697d7d38a55" satisfied condition "success or failure"
+Aug  8 20:55:23.166: INFO: Trying to get logs from node k8s-linuxpool-37994001-1 pod pod-projected-configmaps-5be7008c-9b4d-11e8-bae8-8697d7d38a55 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Aug  8 20:55:23.181: INFO: Waiting for pod pod-projected-configmaps-5be7008c-9b4d-11e8-bae8-8697d7d38a55 to disappear
+Aug  8 20:55:23.183: INFO: Pod pod-projected-configmaps-5be7008c-9b4d-11e8-bae8-8697d7d38a55 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:55:23.183: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-tn4bj" for this suite.
+Aug  8 20:55:29.202: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:55:29.250: INFO: namespace: e2e-tests-projected-tn4bj, resource: bindings, ignored listing per whitelist
+Aug  8 20:55:29.277: INFO: namespace e2e-tests-projected-tn4bj deletion completed in 6.090113665s
+
+• [SLOW TEST:10.218 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Aug  8 20:55:29.277: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-v9c72
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Aug  8 20:55:29.363: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Aug  8 20:55:51.459: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.244.1.208:8080/dial?request=hostName&protocol=udp&host=10.244.1.207&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-v9c72 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:55:51.459: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:55:51.587: INFO: Waiting for endpoints: map[]
+Aug  8 20:55:51.591: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.244.1.208:8080/dial?request=hostName&protocol=udp&host=10.244.0.46&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-v9c72 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Aug  8 20:55:51.591: INFO: >>> kubeConfig: /tmp/kubeconfig-499033417
+Aug  8 20:55:51.708: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Aug  8 20:55:51.708: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-v9c72" for this suite.
+Aug  8 20:56:13.725: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Aug  8 20:56:13.774: INFO: namespace: e2e-tests-pod-network-test-v9c72, resource: bindings, ignored listing per whitelist
+Aug  8 20:56:13.812: INFO: namespace e2e-tests-pod-network-test-v9c72 deletion completed in 22.100208053s
+
+• [SLOW TEST:44.536 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.1-beta.0.115+b1b29978270dc2/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSAug  8 20:56:13.813: INFO: Running AfterSuite actions on all node
+Aug  8 20:56:13.813: INFO: Running AfterSuite actions on node 1
+Aug  8 20:56:13.813: INFO: Skipping dumping logs from cluster
+
+Ran 143 of 999 Specs in 3889.271 seconds
+SUCCESS! -- 143 Passed | 0 Failed | 0 Pending | 856 Skipped PASS
+
+Ginkgo ran 1 suite in 1h4m49.657579566s
+Test Suite Passed

--- a/v1.11/acs-engine-azurestack/junit_01.xml
+++ b/v1.11/acs-engine-azurestack/junit_01.xml
@@ -1,0 +1,2714 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="143" failures="0" time="3889.271332846">
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Change stubDomain should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="55.222893375"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete another node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.202584567"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.2657195"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications [Conformance]" classname="Kubernetes e2e suite" time="116.378663859"></testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that PVC in active use by a pod is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]" classname="Kubernetes e2e suite" time="88.120638858"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should be able to restart watching from the last resource version observed by the previous watch [Conformance]" classname="Kubernetes e2e suite" time="6.197551954"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume expand [Slow] Verify if editing PVC allows resize" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.224557229"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="26.361663794"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.213589439"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.216022632"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes CSI plugin test using CSI driver: hostPath should provision storage" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] master upgrade should NOT disrupt gpu pod [Feature:GPUMasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.233120857"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for external metrics [Feature:StackdriverExternalMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.215890852"></testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="12.697596582"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="76.276972523"></testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] [Feature:PerformanceDNS] Should answer DNS query for maximum number of services per cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="30.216434235"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.237749546"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Upgrade [Feature:IngressUpgrade] ingress upgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should fail substituting values in a volume subpath with absolute path [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with projected pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.208131244"></testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="18.815838166"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="59.451282961"></testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 Scalability GCE [Slow] [Serial] [Feature:IngressScale] Creating and updating ingresses should happen promptly with small/medium/large amount of ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] cluster upgrade should be able to run gpu pod after upgrade [Feature:GPUClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.201596622"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.231121994"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support orphan deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.2236482"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.228693253"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod [NodeConformance] should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should support configurable pod resolv.conf" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow][NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should not create local persistent volume for filesystem volume that was not bind mounted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="46.198826985"></testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.242714488"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="22.747378505"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existing configmap should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="31.366850992"></testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition Watch CustomResourceDefinition Watch watch on custom resource definition objects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape metrics from annotated services." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.212147464"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.217269797"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Forward PTR lookup should forward PTR records lookup to upstream nameserver [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.214192656"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]" classname="Kubernetes e2e suite" time="21.00734134"></testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="30.279264704"></testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="36.27623993"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.197170362"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="30.315790832"></testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape metrics from annotated pods." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.240386323"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pvc count metrics for pvc controller after creating pvc only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.242188553"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.21221813"></testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="32.893476408"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.282572073"></testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods [Conformance]" classname="Kubernetes e2e suite" time="20.342062112"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.228763993"></testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.237534909"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create another node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods [Conformance]" classname="Kubernetes e2e suite" time="67.805088424"></testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster [Feature:InfluxdbMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with secret pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify that PV bound to a PVC is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="114.631512444"></testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Downgrade [Feature:IngressDowngrade] ingress downgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="7.207147909"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with downward pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.268789522"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.277855947"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existing secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.226545137"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create none metrics for pvc controller before creating any PV or PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="82.181957066"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="250.645285874"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset [Conformance]" classname="Kubernetes e2e suite" time="36.496469781"></testcase>
+      <testcase name="[k8s.io] Pods should be updated [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.722552882"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="16.210066589"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted [Conformance]" classname="Kubernetes e2e suite" time="16.269337573"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with External Metric with target average value from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD RegionalPD should provision storage [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.797100291"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.207883266"></testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.234524269"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="16.19401206"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command (docker entrypoint) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.221446667"></testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should be able to switch between HTTPS and HTTP2 modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.183770174"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.235814854"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should support https-only annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.190888894"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.236874054"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.234559978"></testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.235695014"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.216089672"></testcase>
+      <testcase name="[sig-storage] Regional PD RegionalPD should failover to a different zone when all nodes in one zone become unreachable [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should not reconcile manually modified health check for ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="71.31387639"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.22593522"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for new resource model [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should be able to start watching from a specific resource version [Conformance]" classname="Kubernetes e2e suite" time="6.20914678"></testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates lower priority pod preemption by critical pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  StatefulSet with pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.245399777"></testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.239527082"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should support multiple TLS certs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have accelerator metrics [Feature:StackdriverAcceleratorMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should not be able to prevent deleting validating-webhook-configurations or mutating-webhook-configurations" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha runtime/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.286279347"></testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.212035111"></testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="250.660815137"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="20.293467696"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.201216195"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.214945732"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] single and multi-cluster ingresses should be able to exist together" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.698531801"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so [Conformance]" classname="Kubernetes e2e suite" time="46.215868455"></testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should update ingress while sync failures occur on other ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should observe add, update, and delete watch notifications on configmaps [Conformance]" classname="Kubernetes e2e suite" time="66.214722353"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.229642348"></testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] cluster downgrade should be able to run gpu pod after downgrade [Feature:GPUClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify &#34;immediate&#34; deletion of a PVC that is not in active use by a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning [k8s.io] GlusterDynamicProvisioner should create and delete persistent volumes [fast]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support subPath [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Verify Volume Attach Through vpxd Restart [Feature:vsphere][Serial][Disruptive] verify volume remains attached through vpxd restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.269817509"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.729988086"></testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance]" classname="Kubernetes e2e suite" time="167.217466318"></testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.253467577"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.26411856"></testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should observe an object deletion if it stops meeting the requirements of the selector [Conformance]" classname="Kubernetes e2e suite" time="16.188848146"></testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.217345658"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner deletion should be idempotent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pv count metrics for pvc controller after creating pv only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="162.487977114"></testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.211417315"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.250232934"></testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.249015484"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : projected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="48.441009947"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.259081404"></testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.23544033"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection][NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.209885364"></testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow][NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="44.444859566"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should create ingress with backend HTTPS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]" classname="Kubernetes e2e suite" time="28.449929181999998"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod with mountPath of existing file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.200731948"></testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.213509372"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.227423986"></testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.228443761"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.198983742"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.228323681"></testcase>
+      <testcase name="[k8s.io] Variable Expansion should fail substituting values in a volume subpath with backticks [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="64.296091465"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes CSI plugin test using CSI driver: [Feature: GCE PD CSI Plugin] gcePD should provision storage" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for service with type clusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.203568979"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.241833364"></testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should successfully scrape all targets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.240377717"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.20177222"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]" classname="Kubernetes e2e suite" time="36.68632579"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="30.274794329"></testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Stress with local volume provisioner [Serial] should use be able to process many pods and reuse local volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.184871841">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.200555884"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.204727473"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.236806293"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.231567113"></testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.209421684"></testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.195959016"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.250475335"></testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [DisabledForLargeClusters] kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.283386745"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to create a ClusterIP service [Unreleased]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="42.450266538"></testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.217954619"></testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="67.316750164"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for old resource model [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.255902251"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support proportional scaling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should deny crd creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="96.58661511"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should discover dynamicly created local persistent volume mountpoint in discovery directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Mounted volume expand[Slow] Should verify mounted devices can be resized" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.242679809"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.216636251"></testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="94.564455653"></testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should contain correct container CPU metric." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive] node unregister" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.223422017"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify &#34;immediate&#34; deletion of a PV that is not bound to a PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] PodPriorityResolution [Serial] [Feature:PodPreemption] validates critical system priorities are created and resolved" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Forward external name lookup should forward externalname lookup to upstream nameserver [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for service with type clusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap binary data should be reflected in volume [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape container metrics from all nodes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two External metrics from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with External Metric with target value from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.240267702"></testcase>
+      <testcase name="[sig-storage] HostPath should support r/w [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with backend HTTPS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should remove clusters as expected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]" classname="Kubernetes e2e suite" time="12.224545068"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="24.73751793"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]" classname="Kubernetes e2e suite" time="35.749026657"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.196596262"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="21.764159776"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.234391995"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.282011489"></testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning Block volume provisioning [Feature:BlockVolume] should create and delete block persistent volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a volume subpath [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.18925888"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.226973349"></testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="7.24677402"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle [Conformance]" classname="Kubernetes e2e suite" time="11.238907639"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent configmap should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate custom resource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.218491189"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="44.535656606"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.11/acs-engine-azurestack/version.txt
+++ b/v1.11/acs-engine-azurestack/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"11+", GitVersion:"v1.11.2-azs-1808", GitCommit:"338185543ea790085bf27a88d4fadafb4b114190", GitTreeState:"clean", BuildDate:"2018-08-08T19:01:59Z", GoVersion:"go1.10.3", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"11+", GitVersion:"v1.11.2-azs-1808", GitCommit:"338185543ea790085bf27a88d4fadafb4b114190", GitTreeState:"clean", BuildDate:"2018-08-08T19:01:59Z", GoVersion:"go1.10.3", Compiler:"gc", Platform:"linux/amd64"}


### PR DESCRIPTION
Contains the test results for the Azure Stack cloud provider seeking certification on v1.11. For information on Azure Stack see: https://azure.microsoft.com/en-us/overview/azure-stack/. For information on Azure Stack acs-engine see readme.md provided in the PR